### PR TITLE
💥 Change Datadog() to Datadog.instance

### DIFF
--- a/example/lib/crash_reporting_screen.dart
+++ b/example/lib/crash_reporting_screen.dart
@@ -87,7 +87,7 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
   }
 
   Future<void> _crashAfterRumSession(bool native) async {
-    await DatadogSdk().ddRum?.startView(_viewName, _viewName);
+    await DatadogSdk.instance.ddRum?.startView(_viewName, _viewName);
     await Future.delayed(const Duration(milliseconds: 100));
 
     if (native) {

--- a/example/lib/logging_screen.dart
+++ b/example/lib/logging_screen.dart
@@ -31,7 +31,7 @@ class _LoggingScreenState extends State<LoggingScreen> {
       _disableSendingLogs = true;
     });
     final message = _message ?? 'Default Message';
-    final ddSdk = DatadogSdk();
+    final ddSdk = DatadogSdk.instance;
     for (var i = 0; i < count; ++i) {
       switch (_selectedLevel) {
         case LogLevel.debug:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ void main() async {
       trackingConsent: TrackingConsent.granted,
     );
 
-    final ddsdk = DatadogSdk();
+    final ddsdk = DatadogSdk.instance;
     await ddsdk.initialize(configuration);
 
     FlutterError.onError = (FlutterErrorDetails details) {
@@ -33,8 +33,7 @@ void main() async {
 
     runApp(const ExampleApp());
   }, (e, s) {
-    DatadogSdk()
-        .ddRum
+    DatadogSdk.instance.ddRum
         ?.addErrorInfo(e.toString(), RumErrorSource.source, stackTrace: s);
   });
 }

--- a/example/lib/rum_screen.dart
+++ b/example/lib/rum_screen.dart
@@ -28,7 +28,7 @@ class _RumScreenState extends State<RumScreen> {
 
     var actualKey = viewKey.isEmpty ? 'FooRumScreen' : viewKey;
     var actualViewName = viewName.isEmpty ? null : viewName;
-    var rum = DatadogSdk().ddRum;
+    var rum = DatadogSdk.instance.ddRum;
     if (rum != null) {
       await rum.startView(actualKey, actualViewName);
       await Future.delayed(const Duration(seconds: 2));

--- a/example/lib/tracing_screen.dart
+++ b/example/lib/tracing_screen.dart
@@ -142,7 +142,7 @@ class _TracingScreenState extends State<TracingScreen> {
     final operationName =
         _operationName.isEmpty ? 'single span' : _operationName;
 
-    final tracing = DatadogSdk().ddTraces;
+    final tracing = DatadogSdk.instance.ddTraces;
     if (tracing != null) {
       var span = await tracing.startSpan(operationName);
       if (_resourceName.isNotEmpty) {
@@ -165,7 +165,7 @@ class _TracingScreenState extends State<TracingScreen> {
     final operationName =
         _rootOperationName.isEmpty ? 'complex span' : _rootOperationName;
 
-    final tracing = DatadogSdk().ddTraces;
+    final tracing = DatadogSdk.instance.ddTraces;
     if (tracing != null) {
       final rootSpan = await tracing.startRootSpan(operationName);
       await Future.delayed(const Duration(milliseconds: 500));

--- a/integration_test_app/integration_test/tracing/traces_test.dart
+++ b/integration_test_app/integration_test/tracing/traces_test.dart
@@ -18,12 +18,12 @@ void _assertCommonSpanMetadata(SpanDecoder span) {
   expect(span.type, 'custom');
   expect(span.environment, 'prod');
 
-  // RUMM-1853 Android does not properly override 'source' on traces
+  // TODO: RUMM-1853 Android does not properly override 'source' on traces
   // Also RUM does not recognize flutter as a source yet. Re-enable when it's ready
   // if (Platform.isIOS) {
   //   expect(span.source, 'flutter');
   // }
-  expect(span.tracerVersion, DatadogSdk().version);
+  expect(span.tracerVersion, DatadogSdk.instance.version);
   expect(span.appVersion, '1.0.0');
 }
 

--- a/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -13,7 +13,7 @@ class _LoggingScenarioState extends State<LoggingScenario> {
   void initState() {
     super.initState();
 
-    var logger = DatadogSdk().ddLogs;
+    var logger = DatadogSdk.instance.ddLogs;
     if (logger != null) {
       logger.addTag('tag1', 'tag-value');
       logger.addTag('my-tag');

--- a/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -18,14 +18,13 @@ class _RumManualErrorReportingScenarioState
   void initState() {
     super.initState();
 
-    DatadogSdk()
-        .ddRum
+    DatadogSdk.instance.ddRum
         ?.startView('my-key', 'RumManualErrorReportingScenario')
         .then((_) => _addErrors());
   }
 
   Future<void> _addErrors() async {
-    final rum = DatadogSdk().ddRum;
+    final rum = DatadogSdk.instance.ddRum;
     if (rum != null) {
       await rum.addError(NullThrownError(), RumErrorSource.source);
       await rum.addErrorInfo('Rum error message', RumErrorSource.network);
@@ -36,8 +35,7 @@ class _RumManualErrorReportingScenarioState
     try {
       throw const OSError('This was an error!', 200);
     } catch (e, s) {
-      await DatadogSdk()
-          .ddRum
+      await DatadogSdk.instance.ddRum
           ?.addError(e, RumErrorSource.source, stackTrace: s);
     }
   }

--- a/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -27,7 +27,7 @@ class _RumManualInstrumentationScenarioState
     super.initState();
 
     _viewKey = widget.runtimeType.toString();
-    DatadogSdk().ddRum?.addAttribute('onboarding_stage', 1);
+    DatadogSdk.instance.ddRum?.addAttribute('onboarding_stage', 1);
 
     _fakeLoading();
   }
@@ -48,22 +48,22 @@ class _RumManualInstrumentationScenarioState
 
   @override
   void didPop() {
-    DatadogSdk().ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 
   @override
   void didPopNext() {
-    DatadogSdk().ddRum?.startView(_viewKey);
+    DatadogSdk.instance.ddRum?.startView(_viewKey);
   }
 
   @override
   void didPush() {
-    DatadogSdk().ddRum?.startView(_viewKey);
+    DatadogSdk.instance.ddRum?.startView(_viewKey);
   }
 
   @override
   void didPushNext() {
-    DatadogSdk().ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 
   @override
@@ -91,11 +91,11 @@ class _RumManualInstrumentationScenarioState
 
   Future<void> _fakeLoading() async {
     await Future.delayed(const Duration(milliseconds: 50));
-    DatadogSdk().ddRum?.addTiming('content-ready');
+    DatadogSdk.instance.ddRum?.addTiming('content-ready');
   }
 
   void _simulateResourceDownload() async {
-    final rum = DatadogSdk().ddRum;
+    final rum = DatadogSdk.instance.ddRum;
 
     await rum?.addTiming('first-interaction');
     await rum?.addUserAction(RumUserActionType.tap, 'Tapped Download');
@@ -120,8 +120,7 @@ class _RumManualInstrumentationScenarioState
   }
 
   Future<void> _onNextTapped() async {
-    await DatadogSdk()
-        .ddRum
+    await DatadogSdk.instance.ddRum
         ?.addUserAction(RumUserActionType.tap, 'Next Screen');
     Navigator.push(
       context,
@@ -168,22 +167,22 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
 
   @override
   void didPop() {
-    DatadogSdk().ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 
   @override
   void didPopNext() {
-    DatadogSdk().ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPush() {
-    DatadogSdk().ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPushNext() {
-    DatadogSdk().ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 
   @override
@@ -203,14 +202,12 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
 
   Future<void> _simulateActions() async {
     await Future.delayed(const Duration(seconds: 1));
-    await DatadogSdk()
-        .ddRum
+    await DatadogSdk.instance.ddRum
         ?.addErrorInfo('Simulated view error', RumErrorSource.source);
-    await DatadogSdk()
-        .ddRum
+    await DatadogSdk.instance.ddRum
         ?.startUserAction(RumUserActionType.scroll, 'User Scrolling');
     await Future.delayed(const Duration(seconds: 2));
-    await DatadogSdk().ddRum?.stopUserAction(
+    await DatadogSdk.instance.ddRum?.stopUserAction(
         RumUserActionType.scroll, 'User Scrolling', {'scroll_distance': 12.2});
 
     setState(() {
@@ -219,8 +216,7 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
   }
 
   Future<void> _onNextTapped() async {
-    await DatadogSdk()
-        .ddRum
+    await DatadogSdk.instance.ddRum
         ?.addUserAction(RumUserActionType.tap, 'Next Screen');
     Navigator.push(
       context,
@@ -265,23 +261,23 @@ class _RumManualInstrumentation3State extends State<RumManualInstrumentation3>
 
   @override
   void didPop() {
-    DatadogSdk().ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 
   @override
   void didPopNext() {
-    DatadogSdk().ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPush() {
-    DatadogSdk().ddRum?.removeAttribute('onboarding_stage');
-    DatadogSdk().ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.ddRum?.removeAttribute('onboarding_stage');
+    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPushNext() {
-    DatadogSdk().ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 
   @override
@@ -297,10 +293,10 @@ class _RumManualInstrumentation3State extends State<RumManualInstrumentation3>
   }
 
   void _simulateActions() async {
-    await DatadogSdk().ddRum?.addTiming('content-ready');
+    await DatadogSdk.instance.ddRum?.addTiming('content-ready');
 
     // Stop the view to make sure it doesn't get held over to the next session.
     await Future.delayed(Duration(milliseconds: 500));
-    await DatadogSdk().ddRum?.stopView(_viewKey);
+    await DatadogSdk.instance.ddRum?.stopView(_viewKey);
   }
 }

--- a/integration_test_app/lib/integration_scenarios/traces_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/traces_scenario.dart
@@ -22,7 +22,7 @@ class _TracesScenarioState extends State<TracesScenario> {
   }
 
   Future<void> _simulateTraces() async {
-    var traces = DatadogSdk().ddTraces;
+    var traces = DatadogSdk.instance.ddTraces;
     if (traces != null) {
       viewLoadingSpan = await traces.startRootSpan('view loading');
       await viewLoadingSpan?.setActive();
@@ -47,7 +47,7 @@ class _TracesScenarioState extends State<TracesScenario> {
     });
     dataDownloadingSpan?.finish();
 
-    var traces = DatadogSdk().ddTraces;
+    var traces = DatadogSdk.instance.ddTraces;
     if (traces != null) {
       final dataPresentationSpan = await traces.startSpan('data presentation');
       await Future.delayed(const Duration(milliseconds: 60));

--- a/integration_test_app/lib/main.dart
+++ b/integration_test_app/lib/main.dart
@@ -55,8 +55,7 @@ Future<void> main() async {
     }
   }
 
-  final ddsdk = DatadogSdk();
-  await ddsdk.initialize(configuration);
+  await DatadogSdk.instance.initialize(configuration);
 
   runApp(const DatadogIntegrationTestApp());
 }

--- a/lib/datadog_sdk.dart
+++ b/lib/datadog_sdk.dart
@@ -82,7 +82,7 @@ class DatadogSdk {
   }
 
   static DatadogSdk? _singleton;
-  factory DatadogSdk() {
+  static DatadogSdk get instance {
     _singleton ??= DatadogSdk._();
     return _singleton!;
   }

--- a/test/datadog_sdk_test.dart
+++ b/test/datadog_sdk_test.dart
@@ -26,7 +26,7 @@ void main() {
   setUp(() {
     fakePlatform = MockDatadogSdkPlatform();
     DatadogSdkPlatform.instance = fakePlatform;
-    datadogSdk = DatadogSdk();
+    datadogSdk = DatadogSdk.instance;
   });
 
   test('initialize passes configuration to platform', () async {


### PR DESCRIPTION
Make it clearer that the Datadog SDK is a singleton.

### What and why?

Recreating the DatadogSdk instance every time seemed weird. This makes it clear that DatadogSdk is a singleton (for now).

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue