### PR TITLE
♻️ Simplify logs/traces/rum members on DatadogSdk

### DIFF
--- a/example/lib/crash_reporting_screen.dart
+++ b/example/lib/crash_reporting_screen.dart
@@ -87,7 +87,7 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
   }
 
   Future<void> _crashAfterRumSession(bool native) async {
-    await DatadogSdk.instance.ddRum?.startView(_viewName, _viewName);
+    await DatadogSdk.instance.rum?.startView(_viewName, _viewName);
     await Future.delayed(const Duration(milliseconds: 100));
 
     if (native) {

--- a/example/lib/logging_screen.dart
+++ b/example/lib/logging_screen.dart
@@ -35,19 +35,19 @@ class _LoggingScreenState extends State<LoggingScreen> {
     for (var i = 0; i < count; ++i) {
       switch (_selectedLevel) {
         case LogLevel.debug:
-          ddSdk.ddLogs?.debug(message);
+          ddSdk.logs?.debug(message);
           break;
         case LogLevel.info:
-          ddSdk.ddLogs?.info(message);
+          ddSdk.logs?.info(message);
           break;
         case LogLevel.notice:
-          ddSdk.ddLogs?.info(message);
+          ddSdk.logs?.info(message);
           break;
         case LogLevel.warn:
-          ddSdk.ddLogs?.warn(message);
+          ddSdk.logs?.warn(message);
           break;
         case LogLevel.error:
-          ddSdk.ddLogs?.error(message);
+          ddSdk.logs?.error(message);
           break;
       }
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,12 +28,12 @@ void main() async {
 
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.presentError(details);
-      ddsdk.ddRum?.handleFlutterError(details);
+      ddsdk.rum?.handleFlutterError(details);
     };
 
     runApp(const ExampleApp());
   }, (e, s) {
-    DatadogSdk.instance.ddRum
+    DatadogSdk.instance.rum
         ?.addErrorInfo(e.toString(), RumErrorSource.source, stackTrace: s);
   });
 }

--- a/example/lib/rum_screen.dart
+++ b/example/lib/rum_screen.dart
@@ -28,7 +28,7 @@ class _RumScreenState extends State<RumScreen> {
 
     var actualKey = viewKey.isEmpty ? 'FooRumScreen' : viewKey;
     var actualViewName = viewName.isEmpty ? null : viewName;
-    var rum = DatadogSdk.instance.ddRum;
+    var rum = DatadogSdk.instance.rum;
     if (rum != null) {
       await rum.startView(actualKey, actualViewName);
       await Future.delayed(const Duration(seconds: 2));

--- a/example/lib/tracing_screen.dart
+++ b/example/lib/tracing_screen.dart
@@ -142,7 +142,7 @@ class _TracingScreenState extends State<TracingScreen> {
     final operationName =
         _operationName.isEmpty ? 'single span' : _operationName;
 
-    final tracing = DatadogSdk.instance.ddTraces;
+    final tracing = DatadogSdk.instance.traces;
     if (tracing != null) {
       var span = await tracing.startSpan(operationName);
       if (_resourceName.isNotEmpty) {
@@ -165,7 +165,7 @@ class _TracingScreenState extends State<TracingScreen> {
     final operationName =
         _rootOperationName.isEmpty ? 'complex span' : _rootOperationName;
 
-    final tracing = DatadogSdk.instance.ddTraces;
+    final tracing = DatadogSdk.instance.traces;
     if (tracing != null) {
       final rootSpan = await tracing.startRootSpan(operationName);
       await Future.delayed(const Duration(milliseconds: 500));

--- a/integration_test_app/integration_test/rum/rum_manual_test.dart
+++ b/integration_test_app/integration_test/rum/rum_manual_test.dart
@@ -62,7 +62,7 @@ void main() {
 
     const contextKey = 'onboarding_stage';
     const expectedContextValue = 1;
-    // TODO: Start checking "side effectless" actions dd-sdk-android 1.12 comes out.
+    // TODO: Start checking "side effect-less" actions dd-sdk-android 1.12 comes out.
     final shouldCheckExtraActions = !Platform.isAndroid;
 
     final session = RumSessionDecoder.fromEvents(rumLog);

--- a/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -13,7 +13,7 @@ class _LoggingScenarioState extends State<LoggingScenario> {
   void initState() {
     super.initState();
 
-    var logger = DatadogSdk.instance.ddLogs;
+    var logger = DatadogSdk.instance.logs;
     if (logger != null) {
       logger.addTag('tag1', 'tag-value');
       logger.addTag('my-tag');

--- a/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -18,13 +18,13 @@ class _RumManualErrorReportingScenarioState
   void initState() {
     super.initState();
 
-    DatadogSdk.instance.ddRum
+    DatadogSdk.instance.rum
         ?.startView('my-key', 'RumManualErrorReportingScenario')
         .then((_) => _addErrors());
   }
 
   Future<void> _addErrors() async {
-    final rum = DatadogSdk.instance.ddRum;
+    final rum = DatadogSdk.instance.rum;
     if (rum != null) {
       await rum.addError(NullThrownError(), RumErrorSource.source);
       await rum.addErrorInfo('Rum error message', RumErrorSource.network);
@@ -35,7 +35,7 @@ class _RumManualErrorReportingScenarioState
     try {
       throw const OSError('This was an error!', 200);
     } catch (e, s) {
-      await DatadogSdk.instance.ddRum
+      await DatadogSdk.instance.rum
           ?.addError(e, RumErrorSource.source, stackTrace: s);
     }
   }

--- a/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -27,7 +27,7 @@ class _RumManualInstrumentationScenarioState
     super.initState();
 
     _viewKey = widget.runtimeType.toString();
-    DatadogSdk.instance.ddRum?.addAttribute('onboarding_stage', 1);
+    DatadogSdk.instance.rum?.addAttribute('onboarding_stage', 1);
 
     _fakeLoading();
   }
@@ -48,22 +48,22 @@ class _RumManualInstrumentationScenarioState
 
   @override
   void didPop() {
-    DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 
   @override
   void didPopNext() {
-    DatadogSdk.instance.ddRum?.startView(_viewKey);
+    DatadogSdk.instance.rum?.startView(_viewKey);
   }
 
   @override
   void didPush() {
-    DatadogSdk.instance.ddRum?.startView(_viewKey);
+    DatadogSdk.instance.rum?.startView(_viewKey);
   }
 
   @override
   void didPushNext() {
-    DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 
   @override
@@ -91,11 +91,11 @@ class _RumManualInstrumentationScenarioState
 
   Future<void> _fakeLoading() async {
     await Future.delayed(const Duration(milliseconds: 50));
-    DatadogSdk.instance.ddRum?.addTiming('content-ready');
+    DatadogSdk.instance.rum?.addTiming('content-ready');
   }
 
   void _simulateResourceDownload() async {
-    final rum = DatadogSdk.instance.ddRum;
+    final rum = DatadogSdk.instance.rum;
 
     await rum?.addTiming('first-interaction');
     await rum?.addUserAction(RumUserActionType.tap, 'Tapped Download');
@@ -120,7 +120,7 @@ class _RumManualInstrumentationScenarioState
   }
 
   Future<void> _onNextTapped() async {
-    await DatadogSdk.instance.ddRum
+    await DatadogSdk.instance.rum
         ?.addUserAction(RumUserActionType.tap, 'Next Screen');
     Navigator.push(
       context,
@@ -167,22 +167,22 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
 
   @override
   void didPop() {
-    DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 
   @override
   void didPopNext() {
-    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.rum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPush() {
-    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.rum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPushNext() {
-    DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 
   @override
@@ -202,12 +202,12 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
 
   Future<void> _simulateActions() async {
     await Future.delayed(const Duration(seconds: 1));
-    await DatadogSdk.instance.ddRum
+    await DatadogSdk.instance.rum
         ?.addErrorInfo('Simulated view error', RumErrorSource.source);
-    await DatadogSdk.instance.ddRum
+    await DatadogSdk.instance.rum
         ?.startUserAction(RumUserActionType.scroll, 'User Scrolling');
     await Future.delayed(const Duration(seconds: 2));
-    await DatadogSdk.instance.ddRum?.stopUserAction(
+    await DatadogSdk.instance.rum?.stopUserAction(
         RumUserActionType.scroll, 'User Scrolling', {'scroll_distance': 12.2});
 
     setState(() {
@@ -216,7 +216,7 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
   }
 
   Future<void> _onNextTapped() async {
-    await DatadogSdk.instance.ddRum
+    await DatadogSdk.instance.rum
         ?.addUserAction(RumUserActionType.tap, 'Next Screen');
     Navigator.push(
       context,
@@ -261,23 +261,23 @@ class _RumManualInstrumentation3State extends State<RumManualInstrumentation3>
 
   @override
   void didPop() {
-    DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 
   @override
   void didPopNext() {
-    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.rum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPush() {
-    DatadogSdk.instance.ddRum?.removeAttribute('onboarding_stage');
-    DatadogSdk.instance.ddRum?.startView(_viewKey, _viewName);
+    DatadogSdk.instance.rum?.removeAttribute('onboarding_stage');
+    DatadogSdk.instance.rum?.startView(_viewKey, _viewName);
   }
 
   @override
   void didPushNext() {
-    DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 
   @override
@@ -293,10 +293,10 @@ class _RumManualInstrumentation3State extends State<RumManualInstrumentation3>
   }
 
   void _simulateActions() async {
-    await DatadogSdk.instance.ddRum?.addTiming('content-ready');
+    await DatadogSdk.instance.rum?.addTiming('content-ready');
 
     // Stop the view to make sure it doesn't get held over to the next session.
     await Future.delayed(Duration(milliseconds: 500));
-    await DatadogSdk.instance.ddRum?.stopView(_viewKey);
+    await DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 }

--- a/integration_test_app/lib/integration_scenarios/traces_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/traces_scenario.dart
@@ -22,7 +22,7 @@ class _TracesScenarioState extends State<TracesScenario> {
   }
 
   Future<void> _simulateTraces() async {
-    var traces = DatadogSdk.instance.ddTraces;
+    var traces = DatadogSdk.instance.traces;
     if (traces != null) {
       viewLoadingSpan = await traces.startRootSpan('view loading');
       await viewLoadingSpan?.setActive();
@@ -47,7 +47,7 @@ class _TracesScenarioState extends State<TracesScenario> {
     });
     dataDownloadingSpan?.finish();
 
-    var traces = DatadogSdk.instance.ddTraces;
+    var traces = DatadogSdk.instance.traces;
     if (traces != null) {
       final dataPresentationSpan = await traces.startSpan('data presentation');
       await Future.delayed(const Duration(milliseconds: 60));

--- a/lib/datadog_sdk.dart
+++ b/lib/datadog_sdk.dart
@@ -89,14 +89,14 @@ class DatadogSdk {
 
   DatadogSdk._();
 
-  DdLogs? _ddLogs;
-  DdLogs? get ddLogs => _ddLogs;
+  DdLogs? _logs;
+  DdLogs? get logs => _logs;
 
-  DdTraces? _ddTraces;
-  DdTraces? get ddTraces => _ddTraces;
+  DdTraces? _traces;
+  DdTraces? get traces => _traces;
 
-  DdRum? _ddRum;
-  DdRum? get ddRum => _ddRum;
+  DdRum? _rum;
+  DdRum? get rum => _rum;
 
   String get version => ddSdkVersion;
 
@@ -106,8 +106,8 @@ class DatadogSdk {
 
     await _platform.initialize(configuration);
 
-    _ddLogs = DdLogs();
-    _ddTraces = DdTraces();
-    _ddRum = DdRum();
+    _logs = DdLogs();
+    _traces = DdTraces();
+    _rum = DdRum();
   }
 }


### PR DESCRIPTION
### What and why?

Have members on DatadogSdk be "logs", "traces" and "rum" instead of ddLogs, ddTrace, ddRum. This makes using them simpler.

### How?

This is a straight name change.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue