### PR TITLE
🗒 Add @mustCallSuper to the mixin

### DIFF
--- a/lib/src/rum/navigation_observer.dart
+++ b/lib/src/rum/navigation_observer.dart
@@ -162,24 +162,28 @@ mixin DatadogRouteAwareMixin<T extends StatefulWidget> on State<T>, RouteAware {
   }
 
   @override
+  @mustCallSuper
   void didPush() {
     _startView();
     super.didPush();
   }
 
   @override
+  @mustCallSuper
   void didPop() {
     super.didPop();
     _stopView();
   }
 
   @override
+  @mustCallSuper
   void didPushNext() {
     super.didPushNext();
     _stopView();
   }
 
   @override
+  @mustCallSuper
   void didPopNext() {
     _startView();
     super.didPopNext();


### PR DESCRIPTION
### What and why?

Not calling super on the mixin methods makes them not track view start / stops properly.

### How?

Just add the annotation that the analyzer should be able to pick up.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue