### PR TITLE
+ Adding ndk / native crash handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .bitrise.secrets.yml
 *flutter_junit_test_results.xml
 android/ndk_crash_reports/network_information
+**/.cxx/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,6 +54,7 @@ android {
 
 dependencies {
     implementation "com.datadoghq:dd-sdk-android:1.12.0-alpha2"
+    implementation 'com.datadoghq:dd-sdk-android-ndk:1.12.0-alpha2'
     
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -11,6 +11,8 @@ import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.ndk.NdkCrashReportsPlugin
+import com.datadog.android.plugin.Feature
 import com.datadog.android.privacy.TrackingConsent
 
 // Duplicated strings in this file do not mean they are being used in the same context
@@ -123,6 +125,10 @@ data class DatadogFlutterConfiguration(
                     ?.filterValues { it != null }
                     ?.mapValues { it.value!! } ?: emptyMap()
             )
+        if (nativeCrashReportEnabled) {
+            configBuilder.addPlugin(NdkCrashReportsPlugin(), Feature.CRASH)
+        }
+
         site?.let { configBuilder.useSite(it) }
         batchSize?.let { configBuilder.setBatchSize(it) }
         uploadFrequency?.let { configBuilder.setUploadFrequency(it) }
@@ -179,6 +185,7 @@ internal fun parseSite(site: String): DatadogSite {
 
 internal fun parseVerbosity(verbosity: String): Int {
     return when (verbosity) {
+        "Verbosity.verbose" -> Log.VERBOSE
         "Verbosity.debug" -> Log.DEBUG
         "Verbosity.info" -> Log.INFO
         "Verbosity.warn" -> Log.WARN

--- a/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -81,6 +81,7 @@ class DatadogConfigurationTest {
     @Test
     fun `M parse all Verbosity W parseVerbosity`() {
         // WHEN
+        val verbose = parseVerbosity("Verbosity.verbose")
         val debug = parseVerbosity("Verbosity.debug")
         val info = parseVerbosity("Verbosity.info")
         val warn = parseVerbosity("Verbosity.warn")
@@ -88,6 +89,7 @@ class DatadogConfigurationTest {
         val none = parseVerbosity("Verbosity.none")
         val unknown = parseVerbosity("unknown")
 
+        assertThat(verbose).isEqualTo(Log.VERBOSE)
         assertThat(debug).isEqualTo(Log.DEBUG)
         assertThat(info).isEqualTo(Log.INFO)
         assertThat(warn).isEqualTo(Log.WARN)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -41,6 +41,12 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
+    externalNativeBuild {
+        cmake {
+            path '../../cpp/CMakeLists.txt'
+        }
+    }
+
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.datadoghq.example.flutter"
@@ -65,6 +71,8 @@ flutter {
 }
 
 dependencies {
+    implementation "com.datadoghq:dd-sdk-android:1.12.0-alpha2"
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.work:work-runtime-ktx:2.7.0'
 }

--- a/example/android/app/src/main/kotlin/com/datadoghq/example/flutter/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/datadoghq/example/flutter/MainActivity.kt
@@ -8,24 +8,74 @@ package com.datadoghq.example.flutter
 import android.os.Handler
 import android.os.Looper
 import androidx.annotation.NonNull
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumErrorSource
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 private const val CRASH_CHANNEL = "datadog_sdk_flutter.example.crash"
 
 class MainActivity : FlutterActivity() {
+    lateinit var methodChannel: MethodChannel
+
     override fun configureFlutterEngine(@NonNull flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CRASH_CHANNEL)
-            .setMethodCallHandler { _, result ->
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CRASH_CHANNEL)
+        methodChannel.setMethodCallHandler { call, result ->
+            methodCallHandler(call, result)
+        }
+    }
+
+    private fun methodCallHandler(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "crashNative" -> {
                 Handler(Looper.getMainLooper()).postDelayed({
                     @Suppress("TooGenericExceptionThrown")
                     throw RuntimeException("Test crash")
                 }, 100)
-
-                result.success(null)
             }
+            "throwException" -> {
+                throw NullPointerException("Test exception")
+            }
+            "performCallback" -> {
+                val callbackId = call.argument<Int>("callbackId")
+
+                val result = object : MethodChannel.Result {
+                    override fun error(
+                        errorCode: String?,
+                        errorMessage: String?,
+                        errorDetails: Any?
+                    ) {
+                        // Creating the throwable here isn't a great idea, however the point of this
+                        // is to see what the combined stack trace looks like, so that's why it's here.
+                        GlobalRum.get().addError(
+                            errorMessage ?: "Unknown Dart error",
+                            RumErrorSource.SOURCE, Throwable(),
+                            mapOf(
+                                "errorCode" to errorCode,
+                                "errorDetails" to errorDetails
+                            )
+                        )
+                    }
+
+                    override fun success(result: Any?) {}
+                    override fun notImplemented() {}
+                }
+
+                methodChannel.invokeMethod(
+                    "nativeCallback",
+                    mapOf(
+                        "callbackId" to callbackId,
+                        "callbackValue" to "Value String"
+                    ),
+                    result
+                )
+            }
+        }
+
+        result.success(null)
     }
 }

--- a/example/android/settings-gradle.lockfile
+++ b/example/android/settings-gradle.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+empty=incomingCatalogForLibs0

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -9,3 +9,10 @@ localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+
+//includeBuild('../../../dd-sdk-android') {
+//    dependencySubstitution {
+//        substitute module('com.datadoghq:dd-sdk-android') using project(':dd-sdk-android')
+//        substitute module('com.datadoghq:dd-sdk-android-ndk') using project(':dd-sdk-android-ndk')
+//    }
+//}

--- a/example/cpp/CMakeLists.txt
+++ b/example/cpp/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+cmake_minimum_required(VERSION 3.4.1)
+
+add_library( 
+    ffi_crash_test
+    SHARED
+    ffi_crash_test.cpp
+    )

--- a/example/cpp/ffi_crash_test.cpp
+++ b/example/cpp/ffi_crash_test.cpp
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-2022 Datadog, Inc.
+
+#include <stdint.h>
+
+void internal_function(int32_t attribute, int32_t* assignee) {
+    *assignee = attribute;
+}
+
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
+int32_t ffi_callback_test(int32_t attribute, int32_t (*callback)(int32_t attribute)) {
+    attribute *= 5;
+    int32_t value = callback(attribute);
+
+    return value;
+}
+
+extern "C" __attribute__((visibility("default"))) __attribute__((used))
+void ffi_crash_test(int32_t attribute) {
+    int32_t* assignee = nullptr;
+
+    internal_function(attribute, assignee);
+}

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4959779C279209C90022AFE6 /* DatadogConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4959779B279209C90022AFE6 /* DatadogConfigurationTests.swift */; };
 		4962A36F276D322E00507AFD /* DatadogSdkPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4962A36E276D322E00507AFD /* DatadogSdkPluginTests.swift */; };
 		4962A3AD277109C400507AFD /* FlutterSdkAttibutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4962A3AC277109C400507AFD /* FlutterSdkAttibutesTests.swift */; };
+		496AAFBA27B4496400236887 /* ffi_crash_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 496AAFB927B4496400236887 /* ffi_crash_test.cpp */; };
 		49D7C98927834F7600A03589 /* DatadogRumPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D7C98827834F7600A03589 /* DatadogRumPluginTests.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -54,6 +55,7 @@
 		4962A36C276D322E00507AFD /* flutter_sdk_tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = flutter_sdk_tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4962A36E276D322E00507AFD /* DatadogSdkPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogSdkPluginTests.swift; sourceTree = "<group>"; };
 		4962A3AC277109C400507AFD /* FlutterSdkAttibutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSdkAttibutesTests.swift; sourceTree = "<group>"; };
+		496AAFB927B4496400236887 /* ffi_crash_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ffi_crash_test.cpp; path = ../../cpp/ffi_crash_test.cpp; sourceTree = "<group>"; };
 		49D7C98827834F7600A03589 /* DatadogRumPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogRumPluginTests.swift; sourceTree = "<group>"; };
 		4B3455B21F76D2056794CEF9 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		5CB69C94E4F5075A1B956D69 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				496AAFB927B4496400236887 /* ffi_crash_test.cpp */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
@@ -418,6 +421,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
+				496AAFBA27B4496400236887 /* ffi_crash_test.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -521,6 +525,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.example.flutter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				STRIP_STYLE = "non-global";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_COMPILED_FOR_TESTING;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -771,6 +776,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.example.flutter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				STRIP_STYLE = "non-global";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_COMPILED_FOR_TESTING;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -799,6 +805,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.datadoghq.example.flutter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = AdHocFlutter;
+				STRIP_STYLE = "non-global";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DD_SDK_COMPILED_FOR_TESTING;
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -4,9 +4,16 @@
 
 import UIKit
 import Flutter
+import Datadog
+
+enum InternalError: Error {
+  case pluginError
+}
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
+  var methodChannel: FlutterMethodChannel!
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -18,14 +25,49 @@ import Flutter
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
-    @objc func registerCrashPlugin(with registrar: FlutterPluginRegistrar) {
-      let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.example.crash",
-                                         binaryMessenger: registrar.messenger())
-      channel.setMethodCallHandler { _, result in
-        let crashValue: Int? = nil
-        _ = crashValue! + 5
-
-        result(nil)
-      }
+  @objc func registerCrashPlugin(with registrar: FlutterPluginRegistrar) {
+    methodChannel = FlutterMethodChannel(name: "datadog_sdk_flutter.example.crash",
+                                       binaryMessenger: registrar.messenger())
+    methodChannel.setMethodCallHandler { call, result in
+      // swiftlint:disable:next force_try
+      try! self.handle(methodCall: call, result: result)
     }
+  }
+
+  func handle(methodCall: FlutterMethodCall, result: FlutterResult) throws {
+    switch methodCall.method {
+    case "crashNative":
+      let crashValue: Int? = nil
+      _ = crashValue! + 5
+
+    case "throwException":
+      throw InternalError.pluginError
+
+    case "performCallback":
+      let arguments = methodCall.arguments as! [String: Any?]
+      let callbackId = arguments["callbackId"] as! Int
+
+      methodChannel.invokeMethod("nativeCallback", arguments: [
+        "callbackId": callbackId,
+        "callbackValue": "Value String"
+      ]) { callbackResult in
+        switch callbackResult {
+        case let error as FlutterError:
+          Global.rum.addError(message: error.message ?? "Unknown Dart Error",
+                              source: RUMErrorSource.source,
+                              stack: nil,
+                              attributes: [
+                                "errorCode": error.code
+                              ])
+        default:
+          break
+        }
+      }
+
+    default:
+      break
+    }
+
+    result(nil)
+  }
 }

--- a/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/example/ios/Tests/DatadogConfigurationTests.swift
@@ -54,6 +54,7 @@ class DatadogConfigurationTests: XCTestCase {
   }
 
   func testAllVerbosityLevels_AreParsedCorrectly() {
+    let verbose = LogLevel.parseFromFlutter("Verbosity.verbose")
     let debug = LogLevel.parseFromFlutter("Verbosity.debug")
     let info = LogLevel.parseFromFlutter("Verbosity.info")
     let warn = LogLevel.parseFromFlutter("Verbosity.warn")
@@ -61,6 +62,8 @@ class DatadogConfigurationTests: XCTestCase {
     let none = LogLevel.parseFromFlutter("Verbosity.none")
     let unknown = LogLevel.parseFromFlutter("unknown")
 
+    // iOS doesn't have .verbose so use .debug
+    XCTAssertEqual(verbose, .debug)
     XCTAssertEqual(debug, .debug)
     XCTAssertEqual(info, .info)
     XCTAssertEqual(warn, .warn)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,7 +35,9 @@ void main() async {
     );
 
     final ddsdk = DatadogSdk.instance;
-    await ddsdk.initialize(configuration);
+    ddsdk.sdkVerbosity = Verbosity.verbose;
+
+    DatadogSdk.instance.initialize(configuration);
 
     FlutterError.onError = (FlutterErrorDetails details) {
       FlutterError.presentError(details);
@@ -46,5 +48,6 @@ void main() async {
   }, (e, s) {
     DatadogSdk.instance.rum
         ?.addErrorInfo(e.toString(), RumErrorSource.source, stackTrace: s);
+    throw e;
   });
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -121,6 +121,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -188,7 +195,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test_app/integration_test/rum/rum_manual_test.dart
+++ b/integration_test_app/integration_test/rum/rum_manual_test.dart
@@ -119,7 +119,7 @@ void main() {
     expect(view2.errorEvents[0].context[contextKey], expectedContextValue);
     expect(view2.actionEvents[0].actionType, 'scroll');
     expect(view2.actionEvents[0].actionName, 'User Scrolling');
-    expect(view2.actionEvents[0].loadingTime, closeTo(2000000000, 50000000));
+    expect(view2.actionEvents[0].loadingTime, closeTo(2000000000, 100000000));
     expect(view2.actionEvents[0].context[contextKey], expectedContextValue);
     expect(view2.actionEvents[1].actionName, 'Next Screen');
     expect(view2.actionEvents[1].context[contextKey], expectedContextValue);

--- a/integration_test_app/pubspec.lock
+++ b/integration_test_app/pubspec.lock
@@ -164,6 +164,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -184,7 +191,7 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -252,7 +259,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   transparent_image:
     dependency: "direct main"
     description:
@@ -287,7 +294,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.3.0"
+    version: "7.5.0"
   webdriver:
     dependency: transitive
     description:

--- a/ios/Classes/DatadogFlutterModels.swift
+++ b/ios/Classes/DatadogFlutterModels.swift
@@ -267,6 +267,7 @@ public extension Datadog.Configuration.DatadogEndpoint {
 public extension LogLevel {
   static func parseFromFlutter(_ value: String) -> Self? {
     switch value {
+    case "Verbosity.verbose": return .debug
     case "Verbosity.debug": return .debug
     case "Verbosity.info": return .info
     case "Verbosity.warn": return .warn

--- a/lib/src/datadog_configuration.dart
+++ b/lib/src/datadog_configuration.dart
@@ -73,7 +73,7 @@ enum DatadogSite {
   us1Fed
 }
 
-enum Verbosity { debug, info, warn, error, none }
+enum Verbosity { verbose, debug, info, warn, error, none }
 
 /// Configuration options for the Datadog Logging feature.
 class LoggingConfiguration {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,6 +289,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: "direct main"
     description:
@@ -331,13 +338,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
   plugin_platform_interface:
     dependency: "direct main"
     description:
@@ -461,21 +461,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.12"
+    version: "1.19.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:

--- a/test/rum/navigation_observer_test.dart
+++ b/test/rum/navigation_observer_test.dart
@@ -191,6 +191,8 @@ void main() {
       } else if (name != null) {
         return RumViewInfo(name: name);
       }
+
+      return null;
     }
 
     var observer = DatadogNavigationObserver(


### PR DESCRIPTION
### What and why?

This adds the ndk crash handler and adds FFI testing to the crash RUM page.

### How?

Note -- the native crash handler for Android is flakey on Flutter, but I'm not sure why. We're still looking into it.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue