### PR TITLE
RUMM-1963 Use a single variable to set the Android SDK dependency version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,9 @@
-group 'com.datadoghq.flutter'
-version '1.0-SNAPSHOT'
+group "com.datadoghq.flutter"
+version "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = "1.5.31"
+    ext.datadog_sdk_version = "1.12.0-alpha2"
     repositories {
         google()
         mavenCentral()
@@ -10,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath "com.android.tools.build:gradle:4.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -23,8 +24,8 @@ rootProject.allprojects {
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
 
 android {
     compileSdkVersion 30
@@ -35,7 +36,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = "1.8"
     }
 
     testOptions {
@@ -43,7 +44,7 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+        main.java.srcDirs += "src/main/kotlin"
     }
 
     defaultConfig {
@@ -53,8 +54,8 @@ android {
 }
 
 dependencies {
-    implementation "com.datadoghq:dd-sdk-android:1.12.0-alpha2"
-    implementation 'com.datadoghq:dd-sdk-android-ndk:1.12.0-alpha2'
+    implementation "com.datadoghq:dd-sdk-android:$datadog_sdk_version"
+    implementation "com.datadoghq:dd-sdk-android-ndk:$datadog_sdk_version"
     
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -63,7 +64,7 @@ dependencies {
     testImplementation "com.github.xgouchet.Elmyr:core:1.3.1"
     testImplementation "com.github.xgouchet.Elmyr:junit5:1.3.1"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-    testImplementation 'com.willowtreeapps.assertk:assertk-jvm:0.25'
+    testImplementation "com.willowtreeapps.assertk:assertk-jvm:0.25"
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
### What and why?

Using this will simplify the automatic PR creation to update the dependency whenever a new Android SDK version is released.