### PR TITLE
🐛 Add back flutter `source` types

### DIFF
--- a/integration_test_app/integration_test/rum/rum_decoder.dart
+++ b/integration_test_app/integration_test/rum/rum_decoder.dart
@@ -120,6 +120,7 @@ class RumErrorEventDecoder extends RumEventDecoder {
   String get message => rumEvent['error']['message'];
   String get stack => rumEvent['error']['stack'];
   String get source => rumEvent['error']['source'];
+  String get sourceType => rumEvent['error']['source_type'];
 
   String? get resourceUrl => rumEvent['error']['resource']?['url'];
   String? get resourceMethod => rumEvent['error']['resource']?['method'];

--- a/integration_test_app/integration_test/rum/rum_manual_error_reporting_test.dart
+++ b/integration_test_app/integration_test/rum/rum_manual_error_reporting_test.dart
@@ -32,7 +32,8 @@ void main() {
             rumLog.add(RumEventDecoder(jsonValue));
           }
         });
-        return RumSessionDecoder.fromEvents(rumLog).visits.length == 1;
+        var visits = RumSessionDecoder.fromEvents(rumLog).visits;
+        return visits.length == 1 && visits[0].errorEvents.length == 3;
       },
     );
 
@@ -46,6 +47,7 @@ void main() {
     var exceptionError = view.errorEvents[0];
     expect(exceptionError.message, NullThrownError().toString());
     expect(exceptionError.source, 'source');
+    expect(exceptionError.sourceType, 'flutter');
 
     var manualError = view.errorEvents[1];
     expect(manualError.message, 'Rum error message');

--- a/integration_test_app/integration_test/tracing/traces_test.dart
+++ b/integration_test_app/integration_test/tracing/traces_test.dart
@@ -18,11 +18,7 @@ void _assertCommonSpanMetadata(SpanDecoder span) {
   expect(span.type, 'custom');
   expect(span.environment, 'prod');
 
-  // TODO: RUMM-1853 Android does not properly override 'source' on traces
-  // Also RUM does not recognize flutter as a source yet. Re-enable when it's ready
-  // if (Platform.isIOS) {
-  //   expect(span.source, 'flutter');
-  // }
+  expect(span.source, 'flutter');
   expect(span.tracerVersion, DatadogSdk.instance.version);
   expect(span.appVersion, '1.0.0');
   expect(span.metaClass, '_TracesScenarioState');

--- a/lib/datadog_sdk.dart
+++ b/lib/datadog_sdk.dart
@@ -124,7 +124,7 @@ class DatadogSdk {
 
   /// Initialize the DatadogSdk with the provided [configuration].
   Future<void> initialize(DdSdkConfiguration configuration) async {
-    //configuration.additionalConfig[DatadogConfigKey.source] = 'flutter';
+    configuration.additionalConfig[DatadogConfigKey.source] = 'flutter';
     configuration.additionalConfig[DatadogConfigKey.version] = ddSdkVersion;
 
     firstPartyHosts = configuration.firstPartyHosts;

--- a/lib/src/rum/ddrum.dart
+++ b/lib/src/rum/ddrum.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
+import '../internal_attributes.dart';
 import '../internal_helpers.dart';
 import '../internal_logger.dart';
 import 'ddrum_platform_interface.dart';
@@ -128,9 +129,10 @@ class DdRum {
   Future<void> addError(Object error, RumErrorSource source,
       {StackTrace? stackTrace, Map<String, dynamic> attributes = const {}}) {
     return wrap('rum.addError', logger, () {
-      // TODO: RUMM-1899 / RUMM-1900 - add flutter as an error source_type
-      //attributes[_ddRumErrorTypeKey] = 'flutter';
-      return _platform.addError(error, source, stackTrace, attributes);
+      return _platform.addError(error, source, stackTrace, {
+        DatadogPlatformAttributeKey.errorSourceType: 'flutter',
+        ...attributes
+      });
     });
   }
 
@@ -140,9 +142,10 @@ class DdRum {
   Future<void> addErrorInfo(String message, RumErrorSource source,
       {StackTrace? stackTrace, Map<String, dynamic> attributes = const {}}) {
     return wrap('rum.addErrorInfo', logger, () {
-      // TODO: RUMM-1899 / RUMM-1900 - add flutter as an error source_type
-      //attributes[_ddRumErrorTypeKey] = 'flutter';
-      return _platform.addErrorInfo(message, source, stackTrace, attributes);
+      return _platform.addErrorInfo(message, source, stackTrace, {
+        DatadogPlatformAttributeKey.errorSourceType: 'flutter',
+        ...attributes
+      });
     });
   }
 


### PR DESCRIPTION
Add flutter as the `source` at the high level, and add flutter errors as the `source_type` attribute on error messages.

### What and why?

RUM, Logging, and Tracing should now all support `source` being set to flutter, and the RUM schema supports flutter in the `source_type` attribute. This sets these all up properly and removes the TODOs associated with them.  

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue