### PR TITLE
🧹 Cleanup resource name on traces, add IGNORE for e2e monitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ android/ndk_crash_reports/network_information
 **/.cxx/
 tools/e2e_generator/main.tf
 tools/e2e_generator/secrets.tf
+.terraform*
+tools/e2e_generator/terraform.tfstate

--- a/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -78,11 +78,7 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
                 result.success(null)
             }
             "flushAndDeinitialize" -> {
-                if (BuildConfig.DEBUG) {
-                    invokePrivateShutdown(result)
-                } else {
-                    result.notImplemented()
-                }
+                invokePrivateShutdown(result)
             }
             else -> {
                 result.notImplemented()

--- a/android/src/main/kotlin/com/datadoghq/flutter/DatadogTracesPlugin.kt
+++ b/android/src/main/kotlin/com/datadoghq/flutter/DatadogTracesPlugin.kt
@@ -6,6 +6,7 @@
 package com.datadoghq.flutter
 
 import com.datadog.android.tracing.AndroidTracer
+import com.datadog.opentracing.DDTracer
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -27,6 +28,7 @@ class DatadogTracesPlugin : MethodChannel.MethodCallHandler {
         const val PARAM_SPAN_HANDLE = "spanHandle"
         const val PARAM_PARENT_SPAN = "parentSpan"
         const val PARAM_OPERATION_NAME = "operationName"
+        const val PARAM_RESOURCE_NAME = "resourceName"
         const val PARAM_START_TIME = "startTime"
         const val PARAM_TAGS = "tags"
         const val PARAM_MESSAGE = "message"
@@ -76,6 +78,10 @@ class DatadogTracesPlugin : MethodChannel.MethodCallHandler {
 
                 val spanBuilder = tracer.buildSpan(operationName)
                     .ignoreActiveSpan()
+                call.argument<String>(PARAM_RESOURCE_NAME)?.let {
+                    val ddBuilder = spanBuilder as DDTracer.DDSpanBuilder
+                    ddBuilder.withResourceName(it)
+                }
                 call.argument<Number>(PARAM_START_TIME)?.let {
                     spanBuilder.withStartTimestamp(TimeUnit.MILLISECONDS.toMicros(it.toLong()))
                 }
@@ -92,6 +98,10 @@ class DatadogTracesPlugin : MethodChannel.MethodCallHandler {
                 val operationName = call.argument<String>(PARAM_OPERATION_NAME)
 
                 val spanBuilder = tracer.buildSpan(operationName)
+                call.argument<String>(PARAM_RESOURCE_NAME)?.let {
+                    val ddBuilder = spanBuilder as DDTracer.DDSpanBuilder
+                    ddBuilder.withResourceName(it)
+                }
                 call.argument<Number>(PARAM_START_TIME)?.let {
                     spanBuilder.withStartTimestamp(TimeUnit.MILLISECONDS.toMicros(it.toLong()))
                 }

--- a/e2e_test_app/integration_test/logs/logger_test.dart
+++ b/e2e_test_app/integration_test/logs/logger_test.dart
@@ -47,13 +47,13 @@ void main() {
   /// ```
   ///
   /// - performance monitor:
-  /// ```apm
-  /// $monitor_id = ${{monitor_prefix}}_performance
+  /// ```apm(ios, android) IGNORE
+  /// $monitor_id = ${{monitor_prefix}}_performance_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} Performance - ${{test_description}}: has a high average execution time"
-  /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:\\\"${{test_description}}\\\",service:${{service}}} > 0.024"
+  /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},@resource_name:flutter_log_debug_logs,service:${{service}}} > 0.024"
   /// ```
   testWidgets('logger - debug logs', (WidgetTester tester) async {
-    await measure(tester.testDescription, () async {
+    await measure('flutter_log_debug_logs', () async {
       await datadog.logs?.debug('fake message', {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem
@@ -73,14 +73,14 @@ void main() {
   /// ```
   ///
   /// - performance monitor:
-  /// ```apm
+  /// ```apm(ios, android) IGNORE
   /// $feature = logs
-  /// $monitor_id = ${{monitor_prefix}}_performance
+  /// $monitor_id = ${{monitor_prefix}}_performance_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} Performance - ${{test_description}}: has a high average execution time"
-  /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,resource_name:\\\"${{test_description}}\\\",service:${{test_description}}} > 0.024"
+  /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},@resource_name:flutter_log_info_logs,service:${{service}}} > 0.024"
   /// ```
   testWidgets('logger - info logs', (WidgetTester tester) async {
-    await measure(tester.testDescription, () async {
+    await measure('flutter_log_info_logs', () async {
       await datadog.logs?.info('fake info message', {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,

--- a/e2e_test_app/integration_test/test_utils.dart
+++ b/e2e_test_app/integration_test/test_utils.dart
@@ -2,6 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
 
+import 'dart:io';
+
 import 'package:datadog_sdk/datadog_sdk.dart';
 import 'package:datadog_sdk/src/internal_attributes.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -36,7 +38,9 @@ Future<void> measure(String resourceName, AsyncVoidCallback callback) async {
   // TODO: Find a way to do more accurate measurement instead of relying on Spans to do the measure
   var span =
       await DatadogSdk.instance.traces?.startRootSpan('perf_measure', tags: {
-    DdTags.resource: resourceName,
+    // TODO - Android doesn't put the resource tag onto the span
+    'resource_name': resourceName,
+    'operating_system': Platform.operatingSystem
   });
   await callback();
   await span?.finish();

--- a/e2e_test_app/test_driver/integration_test.dart
+++ b/e2e_test_app/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/example/lib/tracing_screen.dart
+++ b/example/lib/tracing_screen.dart
@@ -144,10 +144,10 @@ class _TracingScreenState extends State<TracingScreen> {
 
     final tracing = DatadogSdk.instance.traces;
     if (tracing != null) {
-      var span = await tracing.startSpan(operationName);
-      if (_resourceName.isNotEmpty) {
-        await span.setTag(DdTags.resource, _resourceName);
-      }
+      var span = await tracing.startSpan(
+        operationName,
+        resourceName: _resourceName.isNotEmpty ? _resourceName : null,
+      );
       await Future.delayed(const Duration(seconds: 1));
       await span.finish();
     }

--- a/integration_test_app/integration_test/tracing/traces_test.dart
+++ b/integration_test_app/integration_test/tracing/traces_test.dart
@@ -93,12 +93,7 @@ void main() {
     expect(downloadingSpan.getTag<String>('data.kind'), 'image');
     expect(downloadingSpan.getTag<String>('data.url'),
         'https://example.com/image.png');
-    // TODO: Android may not recognize 'resource.name' as a tag to set on the root object
-    if (Platform.isIOS) {
-      expect(downloadingSpan.resource, 'GET /image.png');
-    } else if (Platform.isAndroid) {
-      expect(downloadingSpan.getTag<String>('resource.name'), 'GET /image.png');
-    }
+    expect(downloadingSpan.resource, 'GET /image.png');
 
     expect(presentationSpan.resource, presentationSpan.name);
     expect(rootSpan.resource, rootSpan.name);

--- a/integration_test_app/lib/integration_scenarios/traces_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/traces_scenario.dart
@@ -30,11 +30,11 @@ class _TracesScenarioState extends State<TracesScenario> {
 
       await viewLoadingSpan?.setBaggageItem('class', runtimeType.toString());
 
-      dataDownloadingSpan = await traces.startSpan('data downloading');
+      dataDownloadingSpan = await traces.startSpan('data downloading',
+          resourceName: 'GET /image.png');
       await dataDownloadingSpan?.setTag('data.kind', 'image');
       await dataDownloadingSpan?.setTag(
           'data.url', 'https://example.com/image.png');
-      await dataDownloadingSpan?.setTag(DdTags.resource, 'GET /image.png');
       await dataDownloadingSpan?.setActive();
 
       unawaited(_simulateDataDownload());

--- a/ios/Classes/DatadogTracesPlugin.swift
+++ b/ios/Classes/DatadogTracesPlugin.swift
@@ -75,6 +75,9 @@ public class DatadogTracesPlugin: NSObject, FlutterPlugin {
         operationName: operationName,
         tags: tags,
         startTime: startTime)
+      if let resourceName = arguments["resourceName"] as? String {
+        span.setTag(key: DDTags.resource, value: resourceName)
+      }
 
       let spanHandle = storeSpan(span)
       result(spanHandle)
@@ -102,6 +105,9 @@ public class DatadogTracesPlugin: NSObject, FlutterPlugin {
         childOf: parentSpan?.context,
         tags: tags,
         startTime: startTime)
+      if let resourceName = arguments["resourceName"] as? String {
+        span.setTag(key: DDTags.resource, value: resourceName)
+      }
 
       let spanHandle = storeSpan(span)
       result(spanHandle)

--- a/lib/datadog_sdk.dart
+++ b/lib/datadog_sdk.dart
@@ -30,7 +30,7 @@ export 'src/rum/navigation_observer.dart'
         DatadogNavigationObserverProvider,
         RumViewInfo,
         DatadogRouteAwareMixin;
-export 'src/traces/ddtraces.dart' show DdSpan, DdTags, OTTags, OTLogFields;
+export 'src/traces/ddtraces.dart' show DdSpan, OTTags, OTLogFields;
 
 typedef AppRunner = void Function();
 

--- a/lib/src/datadog_tracking_http_client.dart
+++ b/lib/src/datadog_tracking_http_client.dart
@@ -489,9 +489,6 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
       if (span != null) {
         await span.setTag(OTTags.httpStatusCode, statusCode);
         if (statusCode >= 400 && statusCode < 500) {
-          if (statusCode == 404) {
-            await span.setTag(DdTags.resource, '404');
-          }
           await span.setErrorInfo('HttpStatusCode',
               '$statusCode - ${innerResponse.reasonPhrase}', null);
         }

--- a/lib/src/traces/ddtraces.dart
+++ b/lib/src/traces/ddtraces.dart
@@ -2,21 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2021 Datadog, Inc.
 
-import 'ddtraces_platform_interface.dart';
-
 import '../internal_helpers.dart';
 import '../internal_logger.dart';
-
-/// Datadog - specific span `tags` to be used with [DdTraces.startSpan]
-/// and [DdSpan.setTag].
-class DdTags {
-  /// A Datadog-specific span tag, which sets the value appearing in the "RESOURCE" column
-  /// in traces explorer on [app.datadoghq.com](https://app.datadoghq.com/)
-  /// Can be used to customize the resource names grouped under the same operation name.
-  ///
-  /// Expects `String` value set for a tag.
-  static const resource = 'resource.name';
-}
+import 'ddtraces_platform_interface.dart';
 
 /// A collection of standard `Span` tag keys defined by Open Tracing.
 /// Use them as the `key` in [DdSpan.setTag]. Use the expected type for the `value`.
@@ -189,13 +177,16 @@ class DdTraces {
 
   DdTraces(this._logger);
 
-  Future<DdSpan> startSpan(String operationName,
-      {DdSpan? parentSpan,
-      Map<String, dynamic>? tags,
-      DateTime? startTime}) async {
+  Future<DdSpan> startSpan(
+    String operationName, {
+    DdSpan? parentSpan,
+    String? resourceName,
+    Map<String, dynamic>? tags,
+    DateTime? startTime,
+  }) async {
     final span = await wrap('traces.startSpan', _logger, () async {
-      var span =
-          await _platform.startSpan(operationName, parentSpan, tags, startTime);
+      var span = await _platform.startSpan(
+          operationName, parentSpan, resourceName, tags, startTime);
       if (span != null) {
         span._logger = _logger;
       } else {
@@ -210,10 +201,15 @@ class DdTraces {
     return span ?? DdSpan(_platform, 0);
   }
 
-  Future<DdSpan> startRootSpan(String operationName,
-      {Map<String, dynamic>? tags, DateTime? startTime}) async {
+  Future<DdSpan> startRootSpan(
+    String operationName, {
+    String? resourceName,
+    Map<String, dynamic>? tags,
+    DateTime? startTime,
+  }) async {
     final span = await wrap('traces.startRootSpan', _logger, () async {
-      var span = await _platform.startRootSpan(operationName, tags, startTime);
+      var span = await _platform.startRootSpan(
+          operationName, resourceName, tags, startTime);
       if (span != null) {
         span._logger = _logger;
       } else {

--- a/lib/src/traces/ddtraces_method_channel.dart
+++ b/lib/src/traces/ddtraces_method_channel.dart
@@ -14,10 +14,11 @@ class DdTracesMethodChannel extends DdTracesPlatform {
       const MethodChannel('datadog_sdk_flutter.traces');
 
   @override
-  Future<DdSpan?> startRootSpan(String operationName,
+  Future<DdSpan?> startRootSpan(String operationName, String? resourceName,
       Map<String, dynamic>? tags, DateTime? startTime) async {
     var result = await methodChannel.invokeMethod('startRootSpan', {
       'operationName': operationName,
+      'resourceName': resourceName,
       'tags': tags,
       'startTime': startTime?.millisecondsSinceEpoch
     }) as int;
@@ -26,11 +27,16 @@ class DdTracesMethodChannel extends DdTracesPlatform {
   }
 
   @override
-  Future<DdSpan?> startSpan(String operationName, DdSpan? parentSpan,
-      Map<String, dynamic>? tags, DateTime? startTime) async {
+  Future<DdSpan?> startSpan(
+      String operationName,
+      DdSpan? parentSpan,
+      String? resourceName,
+      Map<String, dynamic>? tags,
+      DateTime? startTime) async {
     var result = await methodChannel.invokeMethod('startSpan', {
       'operationName': operationName,
       'parentSpan': parentSpan?.handle,
+      'resourceName': resourceName,
       'tags': tags,
       'startTime': startTime?.millisecondsSinceEpoch
     }) as int;

--- a/lib/src/traces/ddtraces_platform_interface.dart
+++ b/lib/src/traces/ddtraces_platform_interface.dart
@@ -22,9 +22,9 @@ abstract class DdTracesPlatform extends PlatformInterface {
   }
 
   Future<DdSpan?> startSpan(String operationName, DdSpan? parentSpan,
+      String? resourceName, Map<String, dynamic>? tags, DateTime? startTime);
+  Future<DdSpan?> startRootSpan(String operationName, String? resourceName,
       Map<String, dynamic>? tags, DateTime? startTime);
-  Future<DdSpan?> startRootSpan(
-      String operationName, Map<String, dynamic>? tags, DateTime? startTime);
   Future<Map<String, String>> getTracePropagationHeaders(DdSpan span);
 
   // Span methods

--- a/test/datadog_tracking_http_client_test.dart
+++ b/test/datadog_tracking_http_client_test.dart
@@ -327,26 +327,6 @@ void main() {
           'HttpStatusCode', '403 - ${response.reasonPhrase}', any()));
     });
 
-    test('status code 404 sets resource tag to 404', () async {
-      final completer = _setupMockRequest();
-      var mockSpan = _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-
-      var mockResponse = _setupMockClientResponse(404);
-      completer.complete(mockResponse);
-      var response = await request.done;
-
-      // Listen / close the response
-      response.listen((event) {});
-      await mockResponse.streamController.close();
-
-      verify(() => mockSpan.setTag(DdTags.resource, '404'));
-    });
-
     test('error in stream sets errors on trace', () async {
       final completer = _setupMockRequest();
       var mockSpan = _enableTracing();

--- a/tools/e2e_generator/lib/templates/monitor-apm.tf.src
+++ b/tools/e2e_generator/lib/templates/monitor-apm.tf.src
@@ -23,7 +23,6 @@ EOT
   timeout_h           = 0
   include_tags        = true
   require_full_window = false
-  new_host_delay      = 300
   monitor_thresholds {
     critical = ${{monitor_threshold:-0.024}}
   }

--- a/tools/e2e_generator/lib/templates/monitor-logs.tf.src
+++ b/tools/e2e_generator/lib/templates/monitor-logs.tf.src
@@ -22,7 +22,6 @@ EOT
   notify_audit      = false
   timeout_h         = 0
   include_tags      = true
-  new_host_delay    = 300
   monitor_thresholds {
     critical = ${{monitor_threshold:-1.0}}
   }

--- a/tools/e2e_generator/lib/templates/monitor-rum.tf.src
+++ b/tools/e2e_generator/lib/templates/monitor-rum.tf.src
@@ -22,7 +22,6 @@ EOT
   notify_audit      = false
   timeout_h         = 0
   include_tags      = true
-  new_host_delay    = 300
   monitor_thresholds {
     critical = ${{monitor_threshold:-1.0}}
   }

--- a/tools/e2e_generator/lib/terraform_renderer.dart
+++ b/tools/e2e_generator/lib/terraform_renderer.dart
@@ -98,6 +98,8 @@ class MonitorTemplate {
     List<MonitorVariable> globalVars,
     IssueReporter issueReporter,
   ) {
+    if (configuration.shouldIgnore) return '';
+
     issueReporter.pushReference(configuration.codeReference);
 
     if (configuration.variants.isEmpty) {

--- a/tools/e2e_generator/test/monitor_configuration_test.dart
+++ b/tools/e2e_generator/test/monitor_configuration_test.dart
@@ -29,6 +29,7 @@ void main() {
 
     var config = configList[0];
     expect(config.type, MonitorType.logs);
+    expect(config.shouldIgnore, false);
     expect(config.variables.length, 1);
     expect(config.variables[0].name, 'foo');
     expect(config.variables[0].value, 'bar1');
@@ -135,7 +136,40 @@ void main() {
     expect(configList.length, 1);
 
     var config = configList[0];
+    expect(config.shouldIgnore, false);
     expect(config.variants, ['ios', 'android']);
+  });
+
+  test('Monitors with IGNORE set should ignore', () {
+    final testComment = r'''/// ```logs IGNORE
+/// $foo = bar1
+/// $var2 = bar2
+/// ```
+''';
+
+    final configList = MonitorConfiguration.fromComment(
+        testComment, mockCodeReference, issueReporter);
+    expect(configList, isNotNull);
+    expect(configList.length, 1);
+
+    var config = configList[0];
+    expect(config.shouldIgnore, true);
+  });
+
+  test('Monitors with variants and IGNORE set should ignore', () {
+    final testComment = r'''/// ```logs(ios, android) IGNORE
+/// $foo = bar1
+/// $var2 = bar2
+/// ```
+''';
+
+    final configList = MonitorConfiguration.fromComment(
+        testComment, mockCodeReference, issueReporter);
+    expect(configList, isNotNull);
+    expect(configList.length, 1);
+
+    var config = configList[0];
+    expect(config.shouldIgnore, true);
   });
 
   test('Parser ignores comments between monitors', () {

--- a/tools/e2e_generator/test/terraform_renderer_test.dart
+++ b/tools/e2e_generator/test/terraform_renderer_test.dart
@@ -23,6 +23,7 @@ void main() {
         MonitorVariable(name: 'argument_value', value: 'fake value');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [variable],
       variants: [],
       codeReference: mockCodeReference,
@@ -39,6 +40,7 @@ void main() {
 
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [],
       variants: [],
       codeReference: mockCodeReference,
@@ -57,6 +59,7 @@ void main() {
         MonitorVariable(name: 'argument_value', value: 'provided user value');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [variable],
       variants: [],
       codeReference: mockCodeReference,
@@ -79,6 +82,7 @@ void main() {
         MonitorVariable(name: 'argument1_value', value: 'my argument variable');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [var1, var2],
       variants: [],
       codeReference: mockCodeReference,
@@ -106,6 +110,7 @@ void main() {
         name: 'argument1_value', value: 'my argument \${{variant}}');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [var1, var2],
       variants: ['ios', 'web'],
       codeReference: mockCodeReference,
@@ -129,6 +134,7 @@ resource "datadog_monitor" user monitor id web {
 
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [],
       variants: [],
       codeReference: mockCodeReference,
@@ -146,6 +152,7 @@ resource "datadog_monitor" user monitor id web {
 
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [
         MonitorVariable(
             name: 'argument_value', value: 'test value with \${{variant}}')
@@ -170,6 +177,7 @@ resource "datadog_monitor" user monitor id web {
         name: 'argument2_value', value: 'extra argument variable');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [var1, var2],
       variants: [],
       codeReference: mockCodeReference,
@@ -193,6 +201,7 @@ resource "datadog_monitor" user monitor id web {
         name: 'argument1_value', value: '\${{global1}}, \${{global2}}');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [var1, var2],
       variants: [],
       codeReference: mockCodeReference,
@@ -226,6 +235,7 @@ resource "datadog_monitor" user monitor id web {
         name: 'argument1_value', value: '\${{global1}}, \${{global2}}');
     final configuration = MonitorConfiguration(
       type: MonitorType.logs,
+      shouldIgnore: false,
       variables: [var1, var2],
       variants: [],
       codeReference: CodeReference(
@@ -242,6 +252,35 @@ resource "datadog_monitor" user monitor id web {
 
   Code for the code god.
 }''';
+
+    final result =
+        template.render(configuration, globalVariables, issueReporter).trim();
+    expect(result, expectedResult);
+  });
+
+  test('render ignores when MonitorConfiguration.shouldIgnore = true', () {
+    final template =
+        MonitorTemplate(r'''resource "datadog_monitor" ${{monitor_id}} {
+  argument1 = ${{argument1_value}} # comment
+}''');
+
+    final var1 =
+        MonitorVariable(name: 'monitor_id', value: 'test_\${{global1}}');
+    final var2 = MonitorVariable(
+        name: 'argument1_value', value: '\${{global1}}, \${{global2}}');
+    final configuration = MonitorConfiguration(
+        type: MonitorType.logs,
+        shouldIgnore: true,
+        variables: [var1, var2],
+        variants: [],
+        codeReference: mockCodeReference);
+
+    final globalVariables = [
+      MonitorVariable(name: 'global1', value: 'global_value_1'),
+      MonitorVariable(name: 'global2', value: 'second global value'),
+    ];
+
+    final expectedResult = '';
 
     final result =
         template.render(configuration, globalVariables, issueReporter).trim();


### PR DESCRIPTION
In order to do trace measurement, we need a "resource name" which iOS and Android do slightly differently. Added a `resourceName` parameter to traces to support handling this cross platform.

Since performance on Android is outside where we want it so we're ignoring performance metrics at the moment, until we can push to the plugin without awaiting future. Added IGNORE as a specifier for monitors to support this

### What and why?

What changes does this pull request introduce and why is it necessary?

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue