### PR TITLE
♻️ Remove async from most public methods

### DIFF
--- a/e2e_test_app/integration_test/logs/logger_config_test.dart
+++ b/e2e_test_app/integration_test/logs/logger_config_test.dart
@@ -39,7 +39,7 @@ void main() {
           'com.datadog.flutter.nightly.custom',
     );
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   // - data monitor:
@@ -58,7 +58,7 @@ void main() {
       (config) => config.loggingConfiguration!.sendNetworkInfo = true,
     );
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   // - data monitor:
@@ -74,7 +74,7 @@ void main() {
       (config) => config.loggingConfiguration!.sendNetworkInfo = false,
     );
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   // - data monitor:
@@ -89,9 +89,9 @@ void main() {
     );
 
     final viewKey = randomString();
-    await datadog.rum?.startView(viewKey);
-    await sendRandomLog(tester);
-    await datadog.rum?.stopView(viewKey);
+    datadog.rum?.startView(viewKey);
+    sendRandomLog(tester);
+    datadog.rum?.stopView(viewKey);
   });
 
   // - data monitor:
@@ -108,8 +108,8 @@ void main() {
     );
 
     final viewKey = randomString();
-    await datadog.rum?.startView(viewKey);
-    await sendRandomLog(tester);
-    await datadog.rum?.stopView(viewKey);
+    datadog.rum?.startView(viewKey);
+    sendRandomLog(tester);
+    datadog.rum?.stopView(viewKey);
   });
 }

--- a/e2e_test_app/integration_test/logs/logger_consent_test.dart
+++ b/e2e_test_app/integration_test/logs/logger_consent_test.dart
@@ -41,7 +41,7 @@ void main() {
   testWidgets('logger consent - granted', (tester) async {
     await initializeDatadog();
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -61,7 +61,7 @@ void main() {
       (config) => config.trackingConsent = TrackingConsent.notGranted,
     );
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -81,7 +81,7 @@ void main() {
       (config) => config.trackingConsent = TrackingConsent.pending,
     );
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -100,11 +100,11 @@ void main() {
     await initializeDatadog(
       (config) => config.trackingConsent = TrackingConsent.granted,
     );
-    await measure('flutter_log_consent_set_tracking_consent', () async {
-      await datadog.setTrackingConsent(TrackingConsent.notGranted);
+    await measure('flutter_log_consent_set_tracking_consent', () {
+      datadog.setTrackingConsent(TrackingConsent.notGranted);
     });
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -123,11 +123,11 @@ void main() {
     await initializeDatadog(
       (config) => config.trackingConsent = TrackingConsent.granted,
     );
-    await measure('flutter_log_consent_set_tracking_consent', () async {
-      await datadog.setTrackingConsent(TrackingConsent.pending);
+    await measure('flutter_log_consent_set_tracking_consent', () {
+      datadog.setTrackingConsent(TrackingConsent.pending);
     });
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -144,11 +144,11 @@ void main() {
     await initializeDatadog(
       (config) => config.trackingConsent = TrackingConsent.notGranted,
     );
-    await measure('flutter_log_consent_set_tracking_consent', () async {
-      await datadog.setTrackingConsent(TrackingConsent.granted);
+    await measure('flutter_log_consent_set_tracking_consent', () {
+      datadog.setTrackingConsent(TrackingConsent.granted);
     });
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -167,11 +167,11 @@ void main() {
     await initializeDatadog(
       (config) => config.trackingConsent = TrackingConsent.notGranted,
     );
-    await measure('flutter_log_consent_set_tracking_consent', () async {
-      await datadog.setTrackingConsent(TrackingConsent.pending);
+    await measure('flutter_log_consent_set_tracking_consent', () {
+      datadog.setTrackingConsent(TrackingConsent.pending);
     });
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -188,11 +188,11 @@ void main() {
     await initializeDatadog(
       (config) => config.trackingConsent = TrackingConsent.pending,
     );
-    await measure('flutter_log_consent_set_tracking_consent', () async {
-      await datadog.setTrackingConsent(TrackingConsent.granted);
+    await measure('flutter_log_consent_set_tracking_consent', () {
+      datadog.setTrackingConsent(TrackingConsent.granted);
     });
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 
   /// ```global
@@ -211,10 +211,10 @@ void main() {
     await initializeDatadog(
       (config) => config.trackingConsent = TrackingConsent.pending,
     );
-    await measure('flutter_log_consent_set_tracking_consent', () async {
-      await datadog.setTrackingConsent(TrackingConsent.notGranted);
+    await measure('flutter_log_consent_set_tracking_consent', () {
+      datadog.setTrackingConsent(TrackingConsent.notGranted);
     });
 
-    await sendRandomLog(tester);
+    sendRandomLog(tester);
   });
 }

--- a/e2e_test_app/integration_test/logs/logger_test.dart
+++ b/e2e_test_app/integration_test/logs/logger_test.dart
@@ -58,8 +58,8 @@ void main() {
   /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},resource_name:flutter_log_debug_logs,service:${{service}}} > 0.024"
   /// ```
   testWidgets('logger - debug logs', (tester) async {
-    await measure('flutter_log_debug_logs', () async {
-      await datadog.logs?.debug('fake message', {
+    await measure('flutter_log_debug_logs', () {
+      datadog.logs?.debug('fake message', {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem
       });
@@ -86,7 +86,7 @@ void main() {
   /// ```
   testWidgets('logger - info logs', (tester) async {
     await measure('flutter_log_info_logs', () async {
-      await datadog.logs?.info('fake info message', {
+      datadog.logs?.info('fake info message', {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,
       });
@@ -113,7 +113,7 @@ void main() {
   /// ```
   testWidgets('logger - warn logs', (tester) async {
     await measure('flutter_log_warn_logs', () async {
-      await datadog.logs?.warn('fake warn message', {
+      datadog.logs?.warn('fake warn message', {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,
       });
@@ -140,7 +140,7 @@ void main() {
   /// ```
   testWidgets('logger - error logs', (tester) async {
     await measure('flutter_log_error_logs', () async {
-      await datadog.logs?.error('fake error message', {
+      datadog.logs?.error('fake error message', {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,
       });
@@ -168,12 +168,11 @@ void main() {
   testWidgets('logger - add string attribute', (tester) async {
     final attributeValue = 'customAttribute' + randomString();
     await measure('flutter_log_add_string_attribute', () async {
-      await datadog.logs
-          ?.addAttribute(specialStringAttributeKey, attributeValue);
+      datadog.logs?.addAttribute(specialStringAttributeKey, attributeValue);
     });
 
-    await sendRandomLog(tester);
-    await datadog.logs?.removeAttribute(specialStringAttributeKey);
+    sendRandomLog(tester);
+    datadog.logs?.removeAttribute(specialStringAttributeKey);
   });
 
   /// ```global
@@ -197,11 +196,11 @@ void main() {
   testWidgets('logger - add int attribute', (tester) async {
     final attributeValue = random.nextInt(10000) + 11;
     await measure('flutter_log_add_int_attribute', () async {
-      await datadog.logs?.addAttribute(specialIntAttributeKey, attributeValue);
+      datadog.logs?.addAttribute(specialIntAttributeKey, attributeValue);
     });
 
-    await sendRandomLog(tester);
-    await datadog.logs?.removeAttribute(specialIntAttributeKey);
+    sendRandomLog(tester);
+    datadog.logs?.removeAttribute(specialIntAttributeKey);
   });
 
   /// ```global
@@ -225,12 +224,11 @@ void main() {
   testWidgets('logger - add double attribute', (tester) async {
     final attributeValue = random.nextDouble() * double.maxFinite;
     await measure('flutter_log_add_double_attribute', () async {
-      await datadog.logs
-          ?.addAttribute(specialDoubleAttributeKey, attributeValue);
+      datadog.logs?.addAttribute(specialDoubleAttributeKey, attributeValue);
     });
 
-    await sendRandomLog(tester);
-    await datadog.logs?.removeAttribute(specialDoubleAttributeKey);
+    sendRandomLog(tester);
+    datadog.logs?.removeAttribute(specialDoubleAttributeKey);
   });
 
   /// ```global
@@ -254,11 +252,11 @@ void main() {
   testWidgets('logger - add bool attribute', (tester) async {
     final attributeValue = random.nextInt(100) < 50 ? true : false;
     await measure('flutter_log_add_bool_attribute', () async {
-      await datadog.logs?.addAttribute(specialBoolAttributeKey, attributeValue);
+      datadog.logs?.addAttribute(specialBoolAttributeKey, attributeValue);
     });
 
-    await sendRandomLog(tester);
-    await datadog.logs?.removeAttribute(specialBoolAttributeKey);
+    sendRandomLog(tester);
+    datadog.logs?.removeAttribute(specialBoolAttributeKey);
   });
 
   /// ```global
@@ -282,11 +280,11 @@ void main() {
   testWidgets('logger - add tag value', (tester) async {
     final tagValue = 'customTag' + randomString();
     await measure('flutter_log_add_tag_value', () async {
-      await datadog.logs?.addTag(specialTagKey, tagValue);
+      datadog.logs?.addTag(specialTagKey, tagValue);
     });
 
-    await sendRandomLog(tester);
-    await datadog.logs?.removeTagWithKey(specialTagKey);
+    sendRandomLog(tester);
+    datadog.logs?.removeTagWithKey(specialTagKey);
   });
 
   /// ```global
@@ -309,10 +307,10 @@ void main() {
   /// ```
   testWidgets('logger - add tag', (tester) async {
     await measure('flutter_log_add_tag', () async {
-      await datadog.logs?.addTag(specialTagKey);
+      datadog.logs?.addTag(specialTagKey);
     });
 
-    await sendRandomLog(tester);
-    await datadog.logs?.removeTag(specialTagKey);
+    sendRandomLog(tester);
+    datadog.logs?.removeTag(specialTagKey);
   });
 }

--- a/e2e_test_app/integration_test/rum/rum_consent_test.dart
+++ b/e2e_test_app/integration_test/rum/rum_consent_test.dart
@@ -32,34 +32,34 @@ void main() {
     final viewName = randomString();
 
     final rumEvents = [
-      () async {
-        await datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
-        await datadog.rum!.stopView(viewKey);
+      () {
+        datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
+        datadog.rum!.stopView(viewKey);
       },
-      () async {
+      () {
         final resourceKey = randomString();
-        await datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
-        await datadog.rum!.startResourceLoading(
+        datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
+        datadog.rum!.startResourceLoading(
             resourceKey, RumHttpMethod.get, randomString());
-        await datadog.rum!.stopResourceLoading(
+        datadog.rum!.stopResourceLoading(
             resourceKey, 200, RumResourceType.values.randomElement());
-        await datadog.rum!.stopView(viewKey);
+        datadog.rum!.stopView(viewKey);
       },
-      () async {
-        await datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
-        await datadog.rum!.addErrorInfo(randomString(), RumErrorSource.custom);
-        await datadog.rum!.stopView(viewKey);
+      () {
+        datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
+        datadog.rum!.addErrorInfo(randomString(), RumErrorSource.custom);
+        datadog.rum!.stopView(viewKey);
       },
-      () async {
+      () {
         final actionName = randomString();
-        await datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
-        await datadog.rum!.addUserAction(RumUserActionType.custom, actionName);
-        await datadog.rum!.stopView(viewKey);
+        datadog.rum!.startView(viewKey, viewName, e2eAttributes(tester));
+        datadog.rum!.addUserAction(RumUserActionType.custom, actionName);
+        datadog.rum!.stopView(viewKey);
       }
     ];
 
     final event = rumEvents.randomElement();
-    await event();
+    event();
   }
 
   /// - data monitor:
@@ -118,6 +118,6 @@ void main() {
 
     await sendRandomRumEvent(tester);
 
-    await datadog.setTrackingConsent(TrackingConsent.granted);
+    datadog.setTrackingConsent(TrackingConsent.granted);
   });
 }

--- a/e2e_test_app/integration_test/rum/rum_monitor_test.dart
+++ b/e2e_test_app/integration_test/rum/rum_monitor_test.dart
@@ -51,15 +51,15 @@ void main() {
   /// ```
   testWidgets('rum - start view', (tester) async {
     final viewKey = randomString();
-    await measure('flutter_rum_start_view', () async {
-      await datadog.rum!.startView(
+    await measure('flutter_rum_start_view', () {
+      datadog.rum!.startView(
         viewKey,
         randomString(),
         e2eAttributes(tester),
       );
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -83,18 +83,18 @@ void main() {
   testWidgets('rum - add timing', (tester) async {
     final viewKey = randomString();
     final delay = random.nextInt(500) + 200;
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
     await Future.delayed(Duration(seconds: delay));
-    await measure('flutter_rum_add_timing', () async {
-      await datadog.rum!.addTiming('time_event');
+    await measure('flutter_rum_add_timing', () {
+      datadog.rum!.addTiming('time_event');
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -117,16 +117,16 @@ void main() {
   testWidgets('rum - add attribute for view', (tester) async {
     final viewKey = randomString();
 
-    await measure('flutter_rum_add_attribute', () async {
-      await datadog.rum!.addAttribute('custom_attribute', randomString());
+    await measure('flutter_rum_add_attribute', () {
+      datadog.rum!.addAttribute('custom_attribute', randomString());
     });
 
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -150,18 +150,18 @@ void main() {
   testWidgets('rum - add attribute for view', (tester) async {
     final viewKey = randomString();
 
-    await datadog.rum!.addAttribute('custom_attribute', randomString());
+    datadog.rum!.addAttribute('custom_attribute', randomString());
 
-    await measure('flutter_rum_remove_attribute', () async {
-      await datadog.rum!.removeAttribute('custom_attribute');
+    await measure('flutter_rum_remove_attribute', () {
+      datadog.rum!.removeAttribute('custom_attribute');
     });
 
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -183,17 +183,17 @@ void main() {
   /// ```
   testWidgets('rum - simple action', (tester) async {
     final viewKey = randomString();
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
-    await measure('flutter_rum_simple_action', () async {
-      await datadog.rum!.addUserAction(RumUserActionType.tap, randomString());
+    await measure('flutter_rum_simple_action', () {
+      datadog.rum!.addUserAction(RumUserActionType.tap, randomString());
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -209,37 +209,37 @@ void main() {
   ///
   /// - performance monitors:
   /// ```apm(ios, android) IGNORE
-  /// $monitor_id = ${{monitor_prefix}}_performance_${{variant}}
+  /// $monitor_id = ${{monitor_prefix}}_start_performance_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} Performance: has a high average execution time"
   /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},resource_name:flutter_start_user_action,service:${{service}}} > 0.024"
   /// ```
   /// ```apm(ios, android) IGNORE
-  /// $monitor_id = ${{monitor_prefix}}_performance_${{variant}}
+  /// $monitor_id = ${{monitor_prefix}}_stop_performance_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} Performance: has a high average execution time"
   /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},resource_name:flutter_stop_user_action,service:${{service}}} > 0.024"
   /// ```
   testWidgets('rum - long action', (tester) async {
     final viewKey = randomString();
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
     final actionName = randomString();
-    await measure('flutter_start_user_action', () async {
-      await datadog.rum!.startUserAction(
+    await measure('flutter_start_user_action', () {
+      datadog.rum!.startUserAction(
         RumUserActionType.scroll,
         actionName,
         e2eAttributes(tester),
       );
     });
 
-    await measure('flutter_stop_user_action', () async {
-      await datadog.rum!.stopUserAction(RumUserActionType.scroll, actionName);
+    await measure('flutter_stop_user_action', () {
+      datadog.rum!.stopUserAction(RumUserActionType.scroll, actionName);
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -255,26 +255,26 @@ void main() {
   ///
   /// - performance monitors:
   /// ```apm(ios, android) IGNORE
-  /// $monitor_id = ${{monitor_prefix}}_performance_${{variant}}
+  /// $monitor_id = ${{monitor_prefix}}_start_performance_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} Performance: has a high average execution time"
   /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},resource_name:flutter_start_resource,service:${{service}}} > 0.024"
   /// ```
   /// ```apm(ios, android) IGNORE
-  /// $monitor_id = ${{monitor_prefix}}_performance_${{variant}}
+  /// $monitor_id = ${{monitor_prefix}}_stop_performance_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} Performance: has a high average execution time"
   /// $monitor_query = "avg(last_1d):p50:trace.perf_measure{env:instrumentation,@operating_system:${{variant}},resource_name:flutter_stop_resource,service:${{service}}} > 0.024"
   /// ```
   testWidgets('rum - resource loading', (tester) async {
     final viewKey = randomString();
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
     final resourceKey = randomString();
-    await measure('flutter_start_resource', () async {
-      await datadog.rum!.startResourceLoading(
+    await measure('flutter_start_resource', () {
+      datadog.rum!.startResourceLoading(
         resourceKey,
         RumHttpMethod.get,
         randomString(),
@@ -282,12 +282,12 @@ void main() {
       );
     });
 
-    await measure('flutter_stop_resource', () async {
-      await datadog.rum!.stopResourceLoading(
+    await measure('flutter_stop_resource', () {
+      datadog.rum!.stopResourceLoading(
           resourceKey, 200, RumResourceType.values.randomElement());
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -309,26 +309,26 @@ void main() {
   /// ```
   testWidgets('rum - resource loading with error', (tester) async {
     final viewKey = randomString();
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
     final resourceKey = randomString();
-    await datadog.rum!.startResourceLoading(
+    datadog.rum!.startResourceLoading(
       resourceKey,
       RumHttpMethod.get,
       randomString(),
       e2eAttributes(tester),
     );
 
-    await measure('flutter_stop_resource_with_error', () async {
-      await datadog.rum!.stopResourceLoadingWithErrorInfo(
+    await measure('flutter_stop_resource_with_error', () {
+      datadog.rum!.stopResourceLoadingWithErrorInfo(
           resourceKey, randomString(), e2eAttributes(tester));
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -350,18 +350,18 @@ void main() {
   /// ```
   testWidgets('rum - add error', (tester) async {
     final viewKey = randomString();
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
-    await measure('flutter_add_error', () async {
-      await datadog.rum!
+    await measure('flutter_add_error', () {
+      datadog.rum!
           .addErrorInfo(randomString(), RumErrorSource.values.randomElement());
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 
   /// ```global
@@ -383,19 +383,19 @@ void main() {
   /// ```
   testWidgets('rum - add error with stacktrace', (tester) async {
     final viewKey = randomString();
-    await datadog.rum!.startView(
+    datadog.rum!.startView(
       viewKey,
       randomString(),
       e2eAttributes(tester),
     );
 
     final stackTrace = StackTrace.current;
-    await measure('flutter_add_error_with_stacktrace', () async {
-      await datadog.rum!.addErrorInfo(
+    await measure('flutter_add_error_with_stacktrace', () {
+      datadog.rum!.addErrorInfo(
           randomString(), RumErrorSource.values.randomElement(),
           stackTrace: stackTrace);
     });
 
-    await datadog.rum!.stopView(viewKey);
+    datadog.rum!.stopView(viewKey);
   });
 }

--- a/e2e_test_app/integration_test/test_utils.dart
+++ b/e2e_test_app/integration_test/test_utils.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
 
+import 'dart:async';
 import 'dart:io';
 import 'dart:math';
 
@@ -9,7 +10,7 @@ import 'package:datadog_sdk/datadog_sdk.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-typedef AsyncVoidCallback = Future<void> Function();
+typedef AsyncVoidCallback = FutureOr<void> Function();
 typedef DatadogConfigCallback = void Function(DdSdkConfiguration config);
 
 Future<void> initializeDatadog([DatadogConfigCallback? configCallback]) async {
@@ -78,7 +79,7 @@ Map<String, Object> e2eAttributes(WidgetTester tester) {
   };
 }
 
-Future<void> sendRandomLog(WidgetTester tester) async {
+void sendRandomLog(WidgetTester tester) {
   var methods = [
     DatadogSdk.instance.logs?.debug,
     DatadogSdk.instance.logs?.info,
@@ -88,7 +89,7 @@ Future<void> sendRandomLog(WidgetTester tester) async {
 
   var method = methods.randomElement();
 
-  await method!(
+  method!(
     randomString(),
     e2eAttributes(tester),
   );

--- a/e2e_test_app/integration_test/traces/traces_config_test.dart
+++ b/e2e_test_app/integration_test/traces/traces_config_test.dart
@@ -68,11 +68,11 @@ void main() {
 
     final viewKey = randomString();
 
-    await datadog.rum?.startView(viewKey);
+    datadog.rum?.startView(viewKey);
     final span = await startSpan('traces_config_bundle_with_rum_enabled');
     await span.finish();
 
-    await datadog.rum?.stopView(viewKey);
+    datadog.rum?.stopView(viewKey);
   });
 
   /// ```global
@@ -93,11 +93,11 @@ void main() {
 
     final viewKey = randomString();
 
-    await datadog.rum?.startView(viewKey);
+    datadog.rum?.startView(viewKey);
     final span = await startSpan('traces_config_bundle_with_rum_disabled');
     await span.finish();
 
-    await datadog.rum?.stopView(viewKey);
+    datadog.rum?.stopView(viewKey);
   });
 
   /// ```global
@@ -114,7 +114,7 @@ void main() {
   testWidgets('traces config - set_user_info', (tester) async {
     await initializeDatadog();
 
-    await datadog.setUserInfo(
+    datadog.setUserInfo(
       id: 'some-id-${randomString()}',
       name: 'some-name-${randomString()}',
       email: 'some-email@${randomString()}.com',

--- a/example/lib/crash_reporting_screen.dart
+++ b/example/lib/crash_reporting_screen.dart
@@ -181,7 +181,7 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
 
   Future<void> _crashAfterRumSession(CrashType crashType) async {
     final viewName = _viewName.isEmpty ? 'Rum Crash View' : _viewName;
-    await DatadogSdk.instance.rum?.startView(viewName, viewName);
+    DatadogSdk.instance.rum?.startView(viewName, viewName);
     await Future.delayed(const Duration(milliseconds: 100));
 
     _crash(crashType);

--- a/example/lib/rum_screen.dart
+++ b/example/lib/rum_screen.dart
@@ -30,9 +30,9 @@ class _RumScreenState extends State<RumScreen> {
     var actualViewName = viewName.isEmpty ? null : viewName;
     var rum = DatadogSdk.instance.rum;
     if (rum != null) {
-      await rum.startView(actualKey, actualViewName);
+      rum.startView(actualKey, actualViewName);
       await Future.delayed(const Duration(seconds: 2));
-      await rum.stopView(actualKey);
+      rum.stopView(actualKey);
     }
 
     setState(() {

--- a/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -18,15 +18,15 @@ class _RumManualErrorReportingScenarioState
     super.initState();
 
     DatadogSdk.instance.rum
-        ?.startView('my-key', 'RumManualErrorReportingScenario')
-        .then((_) => _addErrors());
+        ?.startView('my-key', 'RumManualErrorReportingScenario');
+    _addErrors();
   }
 
-  Future<void> _addErrors() async {
+  void _addErrors() {
     final rum = DatadogSdk.instance.rum;
     if (rum != null) {
-      await rum.addError(NullThrownError(), RumErrorSource.source);
-      await rum.addErrorInfo('Rum error message', RumErrorSource.network);
+      rum.addError(NullThrownError(), RumErrorSource.source);
+      rum.addErrorInfo('Rum error message', RumErrorSource.network);
     }
   }
 
@@ -34,7 +34,7 @@ class _RumManualErrorReportingScenarioState
     try {
       throw const OSError('This was an error!', 200);
     } catch (e, s) {
-      await DatadogSdk.instance.rum
+      DatadogSdk.instance.rum
           ?.addError(e, RumErrorSource.source, stackTrace: s);
     }
   }

--- a/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -92,27 +92,26 @@ class _RumManualInstrumentationScenarioState
 
   Future<void> _fakeLoading() async {
     await Future.delayed(const Duration(milliseconds: 50));
-    await DatadogSdk.instance.rum?.addTiming('content-ready');
+    DatadogSdk.instance.rum?.addTiming('content-ready');
   }
 
   void _simulateResourceDownload() async {
     final rum = DatadogSdk.instance.rum;
 
-    await rum?.addTiming('first-interaction');
-    await rum?.addUserAction(RumUserActionType.tap, 'Tapped Download');
+    rum?.addTiming('first-interaction');
+    rum?.addUserAction(RumUserActionType.tap, 'Tapped Download');
 
     var simulatedResourceKey1 = '/resource/1';
     var simulatedResourceKey2 = '/resource/2';
 
-    await rum?.startResourceLoading(simulatedResourceKey1, RumHttpMethod.get,
+    rum?.startResourceLoading(simulatedResourceKey1, RumHttpMethod.get,
         '$fakeRootUrl$simulatedResourceKey1');
-    await rum?.startResourceLoading(simulatedResourceKey2, RumHttpMethod.get,
+    rum?.startResourceLoading(simulatedResourceKey2, RumHttpMethod.get,
         '$fakeRootUrl$simulatedResourceKey2');
 
     await Future.delayed(const Duration(milliseconds: 100));
-    await rum?.stopResourceLoading(
-        simulatedResourceKey1, 200, RumResourceType.image);
-    await rum?.stopResourceLoadingWithErrorInfo(
+    rum?.stopResourceLoading(simulatedResourceKey1, 200, RumResourceType.image);
+    rum?.stopResourceLoadingWithErrorInfo(
         simulatedResourceKey2, 'Status code 400');
 
     setState(() {
@@ -121,7 +120,7 @@ class _RumManualInstrumentationScenarioState
   }
 
   Future<void> _onNextTapped() async {
-    await DatadogSdk.instance.rum
+    DatadogSdk.instance.rum
         ?.addUserAction(RumUserActionType.tap, 'Next Screen');
     unawaited(Navigator.push(
       context,
@@ -203,12 +202,12 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
 
   Future<void> _simulateActions() async {
     await Future.delayed(const Duration(seconds: 1));
-    await DatadogSdk.instance.rum
+    DatadogSdk.instance.rum
         ?.addErrorInfo('Simulated view error', RumErrorSource.source);
-    await DatadogSdk.instance.rum
+    DatadogSdk.instance.rum
         ?.startUserAction(RumUserActionType.scroll, 'User Scrolling');
     await Future.delayed(const Duration(seconds: 2));
-    await DatadogSdk.instance.rum?.stopUserAction(
+    DatadogSdk.instance.rum?.stopUserAction(
         RumUserActionType.scroll, 'User Scrolling', {'scroll_distance': 12.2});
 
     setState(() {
@@ -216,15 +215,15 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
     });
   }
 
-  Future<void> _onNextTapped() async {
-    await DatadogSdk.instance.rum
+  void _onNextTapped() {
+    DatadogSdk.instance.rum
         ?.addUserAction(RumUserActionType.tap, 'Next Screen');
-    unawaited(Navigator.push(
+    Navigator.push(
       context,
       MaterialPageRoute(
         builder: (_) => const RumManualInstrumentation3(),
       ),
-    ));
+    );
   }
 }
 
@@ -294,10 +293,10 @@ class _RumManualInstrumentation3State extends State<RumManualInstrumentation3>
   }
 
   void _simulateActions() async {
-    await DatadogSdk.instance.rum?.addTiming('content-ready');
+    DatadogSdk.instance.rum?.addTiming('content-ready');
 
     // Stop the view to make sure it doesn't get held over to the next session.
     await Future.delayed(const Duration(milliseconds: 500));
-    await DatadogSdk.instance.rum?.stopView(_viewKey);
+    DatadogSdk.instance.rum?.stopView(_viewKey);
   }
 }

--- a/lib/datadog_sdk.dart
+++ b/lib/datadog_sdk.dart
@@ -159,7 +159,7 @@ class DatadogSdk {
 
   /// Sets current user information. User information will be added traces and
   /// RUM events automatically.
-  Future<void> setUserInfo({
+  void setUserInfo({
     String? id,
     String? name,
     String? email,
@@ -170,8 +170,8 @@ class DatadogSdk {
     });
   }
 
-  Future<void> setTrackingConsent(TrackingConsent trackingConsent) {
-    return wrap('setTrackingConsent', internalLogger, () {
+  void setTrackingConsent(TrackingConsent trackingConsent) {
+    wrap('setTrackingConsent', internalLogger, () {
       return _platform.setTrackingConsent(trackingConsent);
     });
   }

--- a/lib/src/datadog_tracking_http_client.dart
+++ b/lib/src/datadog_tracking_http_client.dart
@@ -122,7 +122,7 @@ class DatadogTrackingHttpClient implements HttpClient {
 
         rumKey = uuid.v1();
         final rumHttpMethod = rumMethodFromMethodString(method);
-        await rum.startResourceLoading(
+        rum.startResourceLoading(
             rumKey, rumHttpMethod, url.toString(), attributes);
       }
     } catch (e) {
@@ -143,7 +143,7 @@ class DatadogTrackingHttpClient implements HttpClient {
     } catch (e) {
       if (rumKey != null) {
         try {
-          await rum?.stopResourceLoadingWithErrorInfo(rumKey, e.toString());
+          rum?.stopResourceLoadingWithErrorInfo(rumKey, e.toString());
         } catch (innerE) {
           datadogSdk.internalLogger.sendToDatadog(
               '$DatadogTrackingHttpClient encountered an error while attempting '
@@ -318,8 +318,7 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
   Future<void> _onStreamError(Object e, StackTrace? st) async {
     try {
       if (rumKey != null) {
-        await datadogSdk.rum
-            ?.stopResourceLoadingWithErrorInfo(rumKey!, e.toString());
+        datadogSdk.rum?.stopResourceLoadingWithErrorInfo(rumKey!, e.toString());
       }
       await tracingContext?.setErrorInfo(
         e.runtimeType.toString(),
@@ -471,14 +470,14 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
 
       if (rumKey != null) {
         if (lastError != null) {
-          await datadogSdk.rum
+          datadogSdk.rum
               ?.stopResourceLoadingWithErrorInfo(rumKey!, lastError.toString());
         } else {
           var resourceType = resourceTypeFromContentType(headers.contentType);
           var size = innerResponse.contentLength > 0
               ? innerResponse.contentLength
               : null;
-          await datadogSdk.rum
+          datadogSdk.rum
               ?.stopResourceLoading(rumKey!, statusCode, resourceType, size);
         }
       }

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -2,25 +2,52 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
 
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 import 'internal_logger.dart';
 
-typedef WrappedCall<T> = Future<T?> Function();
+typedef WrappedCall<T> = FutureOr<T?> Function();
 
-/// Wraps a call to a platform channel with common error handling and telemetry.
-Future<T?> wrap<T>(
-    String methodName, InternalLogger logger, WrappedCall<T> call) async {
-  try {
-    return await call();
-  } on ArgumentError catch (e) {
-    logger.warn(InternalLogger.argumentWarning(methodName, e));
-  } on PlatformException catch (e) {
-    logger.error('Datadog experienced a PlatformException - ${e.message}');
+void _handleError(Object error, StackTrace stackTrace, String methodName,
+    InternalLogger logger) {
+  if (error is ArgumentError) {
+    logger.warn(InternalLogger.argumentWarning(methodName, error));
+  } else if (error is PlatformException) {
+    logger.error('Datadog experienced a PlatformException - ${error.message}');
     logger.error(
         'This may be a bug in the Datadog SDK. Please report it to Datadog.');
-    logger
-        .sendToDatadog('Platform exception caught by wrap(): ${e.toString()}');
+    logger.sendToDatadog(
+        'Platform exception caught by wrap(): ${error.toString()}');
+  } else {
+    throw error;
   }
-  return null;
+}
+
+/// Wraps a call to a platform channel with common error handling and telemetry.
+void wrap(String methodName, InternalLogger logger, WrappedCall<void> call) {
+  try {
+    var result = call();
+    if (result is Future) {
+      result.catchError((e, st) => _handleError(e, st, methodName, logger));
+    }
+  } catch (e, st) {
+    _handleError(e, st, methodName, logger);
+  }
+}
+
+/// Wraps a call to a platform channel that must return a value, with common
+/// error handling and telemetry. If you do not need to get a value back from
+/// your call, use [wrap] instead.
+Future<T?> wrapAsync<T>(
+    String methodName, InternalLogger logger, WrappedCall<T> call) async {
+  T? result;
+  try {
+    result = await call();
+  } catch (e, st) {
+    _handleError(e, st, methodName, logger);
+  }
+
+  return result;
 }

--- a/lib/src/internal_logger.dart
+++ b/lib/src/internal_logger.dart
@@ -28,7 +28,7 @@ class InternalLogger {
   void log(Verbosity verbosity, String message) {
     if (kDebugMode && verbosity.index >= sdkVerbosity.index) {
       final prefixString = useEmoji
-          ? '[Datadog 🐶${_emojiMap[verbosity]}]'
+          ? '[Datadog 🐶${_emojiMap[verbosity]} ]'
           : '[Datadog - ${verbosity.name}]';
       // ignore: avoid_print
       print('$prefixString $message');

--- a/lib/src/logs/ddlogs.dart
+++ b/lib/src/logs/ddlogs.dart
@@ -14,61 +14,57 @@ class DdLogs {
     return DdLogsPlatform.instance;
   }
 
-  Future<void> debug(String message,
-      [Map<String, Object?> context = const {}]) async {
-    return wrap('logs.debug', _logger, () async {
-      await _platform.debug(message, context);
+  void debug(String message, [Map<String, Object?> context = const {}]) {
+    wrap('logs.debug', _logger, () {
+      return _platform.debug(message, context);
     });
   }
 
-  Future<void> info(String message,
-      [Map<String, Object?> context = const {}]) async {
-    return wrap('logs.info', _logger, () async {
-      await _platform.info(message, context);
+  void info(String message, [Map<String, Object?> context = const {}]) {
+    wrap('logs.info', _logger, () {
+      return _platform.info(message, context);
     });
   }
 
-  Future<void> warn(String message,
-      [Map<String, Object?> context = const {}]) async {
-    return wrap('logs.warn', _logger, () async {
-      await _platform.warn(message, context);
+  void warn(String message, [Map<String, Object?> context = const {}]) {
+    wrap('logs.warn', _logger, () {
+      return _platform.warn(message, context);
     });
   }
 
-  Future<void> error(String message,
-      [Map<String, Object?> context = const {}]) async {
-    return wrap('logs.error', _logger, () async {
-      await _platform.error(message, context);
+  void error(String message, [Map<String, Object?> context = const {}]) {
+    wrap('logs.error', _logger, () {
+      return _platform.error(message, context);
     });
   }
 
-  Future<void> addAttribute(String key, Object value) async {
-    return wrap('logs.addAttribute', _logger, () async {
-      await _platform.addAttribute(key, value);
+  void addAttribute(String key, Object value) {
+    wrap('logs.addAttribute', _logger, () {
+      return _platform.addAttribute(key, value);
     });
   }
 
-  Future<void> removeAttribute(String key) async {
-    return wrap('logs.removeAttribute', _logger, () async {
-      await _platform.removeAttribute(key);
+  void removeAttribute(String key) {
+    wrap('logs.removeAttribute', _logger, () {
+      return _platform.removeAttribute(key);
     });
   }
 
-  Future<void> addTag(String key, [String? value]) async {
-    return wrap('logs.addTag', _logger, () async {
-      await _platform.addTag(key, value);
+  void addTag(String key, [String? value]) {
+    wrap('logs.addTag', _logger, () {
+      return _platform.addTag(key, value);
     });
   }
 
-  Future<void> removeTag(String tag) async {
-    return wrap('logs.removeTag', _logger, () async {
-      await _platform.removeTag(tag);
+  void removeTag(String tag) {
+    wrap('logs.removeTag', _logger, () {
+      return _platform.removeTag(tag);
     });
   }
 
-  Future<void> removeTagWithKey(String key) async {
-    return wrap('logs.removeTagWithKey', _logger, () async {
-      await _platform.removeTagWithKey(key);
+  void removeTagWithKey(String key) {
+    wrap('logs.removeTagWithKey', _logger, () {
+      return _platform.removeTagWithKey(key);
     });
   }
 }

--- a/lib/src/rum/ddrum.dart
+++ b/lib/src/rum/ddrum.dart
@@ -94,10 +94,10 @@ class DdRum {
   /// who's values must be supported by [StandardMessageCodec].
   ///
   /// The [key] passed here must match the [key] passed to [stopView] later.
-  Future<void> startView(String key,
+  void startView(String key,
       [String? name, Map<String, dynamic> attributes = const {}]) {
     name ??= key;
-    return wrap('rum.startView', logger, () {
+    wrap('rum.startView', logger, () {
       return _platform.startView(key, name!, attributes);
     });
   }
@@ -107,9 +107,8 @@ class DdRum {
   /// supported by [StandardMessageCodec].
   ///
   /// The [key] passed here must match the [key] passed to [startView].
-  Future<void> stopView(String key,
-      [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.stopView', logger, () {
+  void stopView(String key, [Map<String, dynamic> attributes = const {}]) {
+    wrap('rum.stopView', logger, () {
       return _platform.stopView(key, attributes);
     });
   }
@@ -117,8 +116,8 @@ class DdRum {
   /// Adds a specific timing named [name] in the currently presented View. The
   /// timing duration will be computed as the number of nanoseconds between the
   /// time the View was started and the time the timing was added.
-  Future<void> addTiming(String name) {
-    return wrap('rum.addTiming', logger, () {
+  void addTiming(String name) {
+    wrap('rum.addTiming', logger, () {
       return _platform.addTiming(name);
     });
   }
@@ -126,9 +125,9 @@ class DdRum {
   /// Notifies that the Exception or Error [error] occurred in currently
   /// presented View, with an origin of [source]. You can optionally set
   /// additional [attributes] for this error
-  Future<void> addError(Object error, RumErrorSource source,
+  void addError(Object error, RumErrorSource source,
       {StackTrace? stackTrace, Map<String, dynamic> attributes = const {}}) {
-    return wrap('rum.addError', logger, () {
+    wrap('rum.addError', logger, () {
       return _platform.addError(error, source, stackTrace, {
         DatadogPlatformAttributeKey.errorSourceType: 'flutter',
         ...attributes
@@ -139,9 +138,9 @@ class DdRum {
   /// Notifies that an error occurred in currently presented View, with the
   /// supplied [message] and with an origin of [source]. You can optionally
   /// supply a [stackTrace] and send additional [attributes] for this error
-  Future<void> addErrorInfo(String message, RumErrorSource source,
+  void addErrorInfo(String message, RumErrorSource source,
       {StackTrace? stackTrace, Map<String, dynamic> attributes = const {}}) {
-    return wrap('rum.addErrorInfo', logger, () {
+    wrap('rum.addErrorInfo', logger, () {
       return _platform.addErrorInfo(message, source, stackTrace, {
         DatadogPlatformAttributeKey.errorSourceType: 'flutter',
         ...attributes
@@ -158,8 +157,8 @@ class DdRum {
   ///    DatadogSdk.instance..rum?.handleFlutterError(details);
   /// };
   /// ```
-  Future<void> handleFlutterError(FlutterErrorDetails details) {
-    return addErrorInfo(
+  void handleFlutterError(FlutterErrorDetails details) {
+    addErrorInfo(
       details.exceptionAsString(),
       RumErrorSource.source,
       stackTrace: details.stack,
@@ -175,10 +174,9 @@ class DdRum {
   /// and should be sent to [stopResourceLoading] or
   /// [stopResourceLoadingWithError] / [stopResourceLoadingWithErrorInfo] when
   /// resource loading is complete.
-  Future<void> startResourceLoading(
-      String key, RumHttpMethod httpMethod, String url,
+  void startResourceLoading(String key, RumHttpMethod httpMethod, String url,
       [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.startResourceLoading', logger, () {
+    wrap('rum.startResourceLoading', logger, () {
       return _platform.startResourceLoading(key, httpMethod, url, attributes);
     });
   }
@@ -187,10 +185,9 @@ class DdRum {
   /// successfully and supplies additional information about the Resource loaded,
   /// including its [kind], the [statusCode] of the response, the [size] of the
   /// Resource, and any other custom [attributes] to attach to the resource.
-  Future<void> stopResourceLoading(
-      String key, int? statusCode, RumResourceType kind,
+  void stopResourceLoading(String key, int? statusCode, RumResourceType kind,
       [int? size, Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.stopResourceLoading', logger, () {
+    wrap('rum.stopResourceLoading', logger, () {
       return _platform.stopResourceLoading(
           key, statusCode, kind, size, attributes);
     });
@@ -199,9 +196,9 @@ class DdRum {
   /// Notifies that the Resource identified by [key] stopped being loaded with an
   /// Exception specified by [error]. You can optionally supply custom
   /// [attributes] to attach to this Resource.
-  Future<void> stopResourceLoadingWithError(String key, Exception error,
+  void stopResourceLoadingWithError(String key, Exception error,
       [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.stopResourceLoadingWithError', logger, () {
+    wrap('rum.stopResourceLoadingWithError', logger, () {
       return _platform.stopResourceLoadingWithError(key, error, attributes);
     });
   }
@@ -209,9 +206,9 @@ class DdRum {
   /// Notifies that the Resource identified by [key] stopped being loaded with
   /// the supplied [message]. You can optionally supply custom [attributes] to
   /// attach to this Resource.
-  Future<void> stopResourceLoadingWithErrorInfo(String key, String message,
+  void stopResourceLoadingWithErrorInfo(String key, String message,
       [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.stopResourceLoadingWithErrorInfo', logger, () {
+    wrap('rum.stopResourceLoadingWithErrorInfo', logger, () {
       return _platform.stopResourceLoadingWithErrorInfo(
           key, message, attributes);
     });
@@ -222,9 +219,9 @@ class DdRum {
   /// This is used to a track discrete User Actions (e.g. "tap") specified by
   /// [type]. The [name] and [attributes] supplied will be associated with this
   /// user action.
-  Future<void> addUserAction(RumUserActionType type, String name,
+  void addUserAction(RumUserActionType type, String name,
       [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.addUserAction', logger, () {
+    wrap('rum.addUserAction', logger, () {
       return _platform.addUserAction(type, name, attributes);
     });
   }
@@ -234,9 +231,9 @@ class DdRum {
   /// Action must be stopped with [stopUserAction], and will be stopped
   /// automatically if it lasts for more than 10 seconds. You can optionally
   /// provide custom [attributes].
-  Future<void> startUserAction(RumUserActionType type, String name,
+  void startUserAction(RumUserActionType type, String name,
       [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.startUserAction', logger, () {
+    wrap('rum.startUserAction', logger, () {
       return _platform.startUserAction(type, name, attributes);
     });
   }
@@ -244,9 +241,9 @@ class DdRum {
   /// Notifies that the User Action of [type], named [name] has stopped.
   /// This is used to stop tracking long running user actions (e.g. "scroll"),
   /// started with [startUserAction].
-  Future<void> stopUserAction(RumUserActionType type, String name,
+  void stopUserAction(RumUserActionType type, String name,
       [Map<String, dynamic> attributes = const {}]) {
-    return wrap('rum.stopUserAction', logger, () {
+    wrap('rum.stopUserAction', logger, () {
       return _platform.stopUserAction(type, name, attributes);
     });
   }
@@ -254,16 +251,16 @@ class DdRum {
   /// Adds a custom attribute with [key] and [value] to all future events sent
   /// by the RUM monitor. Note that [value] must be supported by
   /// [StandardMessageCodec].
-  Future<void> addAttribute(String key, dynamic value) {
-    return wrap('rum.addAttributes', logger, () {
+  void addAttribute(String key, dynamic value) {
+    wrap('rum.addAttributes', logger, () {
       return _platform.addAttribute(key, value);
     });
   }
 
   /// Removes the custom attribute [key] from all future events sent by the RUM
   /// monitor. Events created prior to this call will not lose this attribute.
-  Future<void> removeAttribute(String key) {
-    return wrap('rum.removeAttribute', logger, () {
+  void removeAttribute(String key) {
+    wrap('rum.removeAttribute', logger, () {
       return _platform.removeAttribute(key);
     });
   }

--- a/lib/src/rum/navigation_observer.dart
+++ b/lib/src/rum/navigation_observer.dart
@@ -55,15 +55,15 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
     this.viewInfoExtractor = defaultViewInfoExtractor,
   });
 
-  Future<void> _sendScreenView(Route? newRoute, Route? oldRoute) async {
+  void _sendScreenView(Route? newRoute, Route? oldRoute) {
     final oldRouteInfo = oldRoute != null ? viewInfoExtractor(oldRoute) : null;
     final newRouteInfo = newRoute != null ? viewInfoExtractor(newRoute) : null;
 
     if (oldRouteInfo != null) {
-      await datadogSdk.rum?.stopView(oldRouteInfo.name);
+      datadogSdk.rum?.stopView(oldRouteInfo.name);
     }
     if (newRouteInfo != null) {
-      await datadogSdk.rum
+      datadogSdk.rum
           ?.startView(newRouteInfo.name, null, newRouteInfo.attributes);
     }
   }

--- a/lib/src/traces/ddtraces.dart
+++ b/lib/src/traces/ddtraces.dart
@@ -184,7 +184,7 @@ class DdTraces {
     Map<String, dynamic>? tags,
     DateTime? startTime,
   }) async {
-    final span = await wrap('traces.startSpan', _logger, () async {
+    final span = await wrapAsync('traces.startSpan', _logger, () async {
       var span = await _platform.startSpan(
           operationName, parentSpan, resourceName, tags, startTime);
       if (span != null) {
@@ -206,7 +206,7 @@ class DdTraces {
     Map<String, dynamic>? tags,
     DateTime? startTime,
   }) async {
-    final span = await wrap('traces.startRootSpan', _logger, () async {
+    final span = await wrapAsync('traces.startRootSpan', _logger, () async {
       var span = await _platform.startRootSpan(
           operationName, resourceName, tags, startTime);
       if (span != null) {
@@ -224,7 +224,7 @@ class DdTraces {
 
   Future<Map<String, String>> getTracePropagationHeaders(DdSpan span) async {
     final headers =
-        await wrap('traces.getTracePropagationHeaders', _logger, () async {
+        await wrapAsync('traces.getTracePropagationHeaders', _logger, () {
       return _platform.getTracePropagationHeaders(span);
     });
 

--- a/test/logs/ddlogs_test.dart
+++ b/test/logs/ddlogs_test.dart
@@ -44,25 +44,25 @@ void main() {
   });
 
   test('debug logs pass to platform', () async {
-    await ddLogs.debug('debug message', {'attribute': 'value'});
+    ddLogs.debug('debug message', {'attribute': 'value'});
 
     verify(() => mockPlatform.debug('debug message', {'attribute': 'value'}));
   });
 
   test('info logs pass to platform', () async {
-    await ddLogs.info('info message', {'attribute': 'value'});
+    ddLogs.info('info message', {'attribute': 'value'});
 
     verify(() => mockPlatform.info('info message', {'attribute': 'value'}));
   });
 
   test('warn logs pass to platform', () async {
-    await ddLogs.warn('warn message', {'attribute': 'value'});
+    ddLogs.warn('warn message', {'attribute': 'value'});
 
     verify(() => mockPlatform.warn('warn message', {'attribute': 'value'}));
   });
 
   test('error logs pass to platform', () async {
-    await ddLogs.error('error message', {'attribute': 'value'});
+    ddLogs.error('error message', {'attribute': 'value'});
 
     verify(() => mockPlatform.error('error message', {'attribute': 'value'}));
   });
@@ -70,7 +70,7 @@ void main() {
   test('addAttribute argumentError sent to logger', () async {
     when(() => mockPlatform.addAttribute(any(), any()))
         .thenThrow(ArgumentError());
-    await ddLogs.addAttribute('My key', 'Any Value');
+    ddLogs.addAttribute('My key', 'Any Value');
 
     assert(logger.logs.isNotEmpty);
   });


### PR DESCRIPTION
### What and why?

For most methods, we are fine sending information off to the Native libraries for processing asynchronously, and not waiting for the result. Since the default platform method channels supplied by Flutter are guaranteed FIFO processing, we can 'Fire and Forget' these requests and still get the data we need in the right order.

In cases where an error occurs in our native methods, we still handle those errors and send proper logs.

We are still using `await` on all trace / span methods, since those methods still return relevant data. That should be fixed in RUMM-2031

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue