### PR TITLE
🌜 Hopefully fixing most monitors for nightly tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tools/e2e_generator/main.tf
 tools/e2e_generator/secrets.tf
 .terraform*
 tools/e2e_generator/terraform.tfstate
+*.backup

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/rum/rum_consent_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/rum/rum_consent_test.dart
@@ -67,7 +67,7 @@ void main() {
   /// $monitor_prefix = ${{feature}}_granted
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @context.operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   testWidgets('rum consent - granted', (tester) async {
     await initializeDatadog();
@@ -80,7 +80,7 @@ void main() {
   /// $monitor_prefix = ${{feature}}_not_granted
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of views is above expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") > 0"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @context.operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") > 0"
   /// $monitor_threshold = 0.0
   /// ```
   testWidgets('rum consent - not granted', (tester) async {
@@ -95,7 +95,7 @@ void main() {
   /// $monitor_prefix = ${{feature}}_pending
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of views is above expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") > 0"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @context.operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") > 0"
   /// $monitor_threshold = 0.0
   /// ```
   testWidgets('rum consent - pending', (tester) async {
@@ -110,7 +110,7 @@ void main() {
   /// $monitor_prefix = ${{feature}}_pending_to_granted
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @context.operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   testWidgets('rum consent - pending to granted', (tester) async {
     await initializeDatadog(

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/rum/rum_monitor_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/rum/rum_monitor_test.dart
@@ -40,7 +40,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @context.operating_system:${{variant}}\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitor:
@@ -70,7 +70,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: custom timing value is high than expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @operating_system:${{variant}}\").rollup(\"avg\", \"@view.custom_timings.time_event\").last(\"1d\") > 700000000"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:view @context.operating_system:${{variant}}\").rollup(\"avg\", \"@view.custom_timings.time_event\").last(\"1d\") > 700000000"
   /// $monitor_threshold = 700000000
   /// ```
   ///
@@ -172,7 +172,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:action @operating_system:${{variant}}\").rollup(\"count\").by(\"@type\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:action @context.operating_system:${{variant}}\").rollup(\"count\").by(\"@type\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitor:
@@ -204,7 +204,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:action @operating_system:${{variant}}\").rollup(\"count\").by(\"@type\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:action @context.operating_system:${{variant}}\").rollup(\"count\").by(\"@type\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitors:
@@ -250,7 +250,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:resource @operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:resource @context.operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitors:
@@ -298,7 +298,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:error @operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:error @context.operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitors:
@@ -339,7 +339,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:error @operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:error @context.operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitors:
@@ -372,7 +372,7 @@ void main() {
   /// ```rum(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of views is below expected value"
-  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:error @operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
+  /// $monitor_query = "rum(\"service:${{service}} @context.test_method_name:\\\"${{test_description}}\\\" @type:error @context.operating_system:${{variant}}\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
   ///
   /// - performance monitors:

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/traces/traces_config_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/traces/traces_config_test.dart
@@ -83,7 +83,7 @@ void main() {
   /// ```apm(ios, android)
   /// $monitor_id = ${{monitor_prefix}}_data_${{variant}}
   /// $monitor_name = "${{monitor_name_prefix}}: number of hits is above expected value"
-  /// $monitor_query = "sum(last_1d):avg:flutter_${{variant}}_traces_bundle_with_rum_enabled.hits_with_proper_payload{*}.as_count() > 0"
+  /// $monitor_query = "sum(last_1d):avg:flutter_${{variant}}_traces_bundle_with_rum_disabled.hits_with_proper_payload{*}.as_count() > 0"
   /// $monitor_threshold = 0
   /// ```
   testWidgets('traces config - bundle with rum disabled', (tester) async {

--- a/tools/e2e_generator/README.md
+++ b/tools/e2e_generator/README.md
@@ -39,5 +39,5 @@ There are several predefined variables as well
 To regenerate the Terraform files, run the following command from this directory
 
 ```bash
-dart ./bin/e2e_generator ../../packages/datadog_flutter_plugin/e2e_test_app/test
+dart ./bin/e2e_generator ../../packages/datadog_flutter_plugin/e2e_test_app/integration_test
 ```


### PR DESCRIPTION
### What and why?

Change RUM monitors to look for `@context.operating_system` over `@operating_system`. Also changed `@context.operating_system` into a facet on the integration site.

Also add a disabled trace metric.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue