### PR TITLE
🐛 Cancel spans from the DatadogTracingHttpClient when RUM is enabled

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Cancel spans on DatadogTrackingHttpClient when RUM is enabled (prevent spans
+  from leaking native resources)
+
 ## 1.0.0-alpha.1
 
 * Support for Logging, Tracing (including Datadog Distributed Tracing) and RUM

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogTracesPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogTracesPlugin.kt
@@ -252,6 +252,10 @@ class DatadogTracesPlugin(
                     result.missingParameter(call.method)
                 }
             }
+            "span.cancel" -> {
+                spanRegistry.remove(callingSpanInfo.handle)
+                result.success(null)
+            }
         }
     }
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogTracesPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogTracesPluginTest.kt
@@ -185,6 +185,5 @@ class DatadogTracesPluginTest {
             mockResult,
             description("span.finish did not throw a contract violation when missing finishTime")
         ).error(eq(DatadogSdkPlugin.CONTRACT_VIOLATION), any(), anyOrNull())
-
     }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogTracesPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogTracesPlugin.swift
@@ -86,6 +86,7 @@ public class DatadogTracesPlugin: NSObject, FlutterPlugin {
 
   private func createSpan(arguments: [String: Any], isRootSpan: Bool, result: @escaping FlutterResult) {
     guard let tracer = tracer else {
+      result(FlutterError.invalidOperation(message: "Datadog tracer is not initialized"))
       return
     }
 
@@ -211,6 +212,10 @@ public class DatadogTracesPlugin: NSObject, FlutterPlugin {
           FlutterError.missingParameter(methodName: method)
         )
       }
+
+    case "span.cancel":
+      spanRegistry[calledSpan.handle] = nil
+      result(nil)
 
     default:
       result(FlutterMethodNotImplemented)

--- a/packages/datadog_flutter_plugin/lib/src/datadog_tracking_http_client.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_tracking_http_client.dart
@@ -117,6 +117,7 @@ class DatadogTrackingHttpClient implements HttpClient {
           attributes[DatadogPlatformAttributeKey.spanID] = spanId;
 
           // Discard the tracing span, we don't need it if RUM is tracking the resource
+          tracingSpan.cancel();
           tracingSpan = null;
         }
 

--- a/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
+++ b/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
@@ -187,6 +187,22 @@ class DdSpan {
       await _platform.spanFinish(currentHandle, resolvedTime);
     });
   }
+
+  /// Cancel a span without sending it to Datadog. This will also release any
+  /// native resources associated with the span.
+  void cancel() {
+    if (_handle <= 0 || _logger == null) {
+      _logger?.warn(closedSpanWarning('cancel'));
+      return;
+    }
+
+    final currentHandle = _handle;
+    _handle = -1;
+
+    wrap('span.cancel', _logger!, () async {
+      await _platform.spanCancel(currentHandle);
+    });
+  }
 }
 
 class DdTraces {

--- a/packages/datadog_flutter_plugin/lib/src/traces/ddtraces_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/traces/ddtraces_method_channel.dart
@@ -121,4 +121,11 @@ class DdTracesMethodChannel extends DdTracesPlatform {
       'finishTime': finishTime.microsecondsSinceEpoch
     });
   }
+
+  @override
+  Future<void> spanCancel(int spanHandle) {
+    return methodChannel.invokeMethod('span.cancel', {
+      'spanHandle': spanHandle,
+    });
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/src/traces/ddtraces_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/traces/ddtraces_platform_interface.dart
@@ -40,4 +40,5 @@ abstract class DdTracesPlatform extends PlatformInterface {
       DdSpan span, String kind, String message, String? stack);
   Future<void> spanLog(DdSpan span, Map<String, Object?> fields);
   Future<void> spanFinish(int spanHandle, DateTime finishTime);
+  Future<void> spanCancel(int spanHandle);
 }

--- a/packages/datadog_flutter_plugin/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_tracking_http_client_test.dart
@@ -572,7 +572,9 @@ void main() {
       await mockResponse.streamController.close();
       // Drain any awaiting futures.
       await Future.microtask(() {});
-      verifyZeroInteractions(span);
+
+      verify(() => span.cancel());
+      verifyNoMoreInteractions(span);
     });
 
     test('sets trace headers for first party urls', () async {

--- a/packages/datadog_flutter_plugin/test/traces/ddtraces_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/traces/ddtraces_method_channel_test.dart
@@ -44,6 +44,7 @@ void main() {
     badSpan.setError(Exception());
     badSpan.setErrorInfo('Kind', 'Message', null);
     badSpan.finish();
+    badSpan.cancel();
 
     expect(log.length, 0);
   });
@@ -274,5 +275,16 @@ void main() {
         'fields': {'message': 'my message', 'value': 0.24}
       }),
     );
+  });
+
+  test('spanCancel calls platform', () async {
+    final span = DdSpan(ddTracesPlatform, systemTimeProvider, 12, ddLogger);
+    await ddTracesPlatform.spanCancel(span.handle);
+
+    expect(log, [
+      isMethodCall('span.cancel', arguments: {
+        'spanHandle': span.handle,
+      })
+    ]);
   });
 }

--- a/packages/datadog_flutter_plugin/test/traces/ddtraces_test.dart
+++ b/packages/datadog_flutter_plugin/test/traces/ddtraces_test.dart
@@ -29,6 +29,8 @@ void main() {
         .thenAnswer((invocation) => Future.value(true));
     when(() => mockPlatform.spanSetError(any(), any(), any(), any()))
         .thenAnswer((invocation) => Future.value());
+    when(() => mockPlatform.spanCancel(any()))
+        .thenAnswer((invocation) => Future.value());
   });
 
   test('setError passes null stack trace by default', () async {
@@ -75,5 +77,15 @@ void main() {
 
     verify(() => mockPlatform.spanSetError(
         span, 'kind', 'my message', any<String>(that: isNotNull)));
+  });
+
+  test('cancel calls through to platform', () async {
+    final traces = DdTraces(InternalLogger());
+
+    final span = traces.startSpan('span operation');
+    final spanHandle = span.handle;
+    span.cancel();
+
+    verify(() => mockPlatform.spanCancel(spanHandle));
   });
 }


### PR DESCRIPTION
### What and why?

This prevents the spans from leaking native resources.

### How?

Added a `cancel` method to Spans that does nothing but remove the span from the map. Since we're not holding onto the span, GCs on the platforms should take care of cleaning them up.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue