### PR TITLE
👩‍💻 Fix the deploy script

### DIFF
--- a/tools/releaser/README.md
+++ b/tools/releaser/README.md
@@ -30,13 +30,13 @@ Still TODO:
 After the PR to `main` is merged, the CI (or a person?) should run:
 
 ```bash
-dart ./bin/deployer.dart
+dart ./bin/deployer.dart datadog_flutter_plugin
 ```
 
 which perform the following tasks:
 
-* Checks the commit message for the package name and version that was just
-  deployed, and compares that to the pubspec.yaml to make sure they match.
+* Checks that you are on `main` or a `release` branch, that your working tree is
+  clean and up to date with the origin
 * Tags main with the package / version number and pushes the changes
 * Creates a github release for that tag / version number (marked as a
   pre-release as needed)


### PR DESCRIPTION
### What and why?

Since depoyments are made after a merge of a PR on main, the commit message wasn't the "Preparing" commit message expected. So we no longer check for it, and instead rely on a package name argument.

Also added a change to add the change log for the version to the release body.


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue