### PR TITLE
🐛 Disable native view tracking on android.

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Cancel spans on DatadogTrackingHttpClient when RUM is enabled (prevent spans
   from leaking native resources)
+* Remove native view tracking (Activities and Fragments) from Android by default
 
 ## 1.0.0-alpha.1
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -5,6 +5,7 @@
  */
 package com.datadoghq.flutter
 
+import android.content.Context
 import android.util.Log
 import com.datadog.android.DatadogSite
 import com.datadog.android.core.configuration.BatchSize
@@ -14,6 +15,7 @@ import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.ndk.NdkCrashReportsPlugin
 import com.datadog.android.plugin.Feature
 import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.tracking.ViewTrackingStrategy
 
 // Duplicated strings in this file do not mean they are being used in the same context
 @Suppress("StringLiteralDuplication")
@@ -134,6 +136,7 @@ data class DatadogFlutterConfiguration(
         uploadFrequency?.let { configBuilder.setUploadFrequency(it) }
         rumConfiguration?.let {
             configBuilder.sampleRumSessions(it.sampleRate)
+            configBuilder.useViewTrackingStrategy(NoOpViewTrackingStrategy)
         }
         customEndpoint?.let {
             configBuilder.useCustomLogsEndpoint(it)
@@ -142,6 +145,16 @@ data class DatadogFlutterConfiguration(
         }
 
         return configBuilder.build()
+    }
+}
+
+object NoOpViewTrackingStrategy : ViewTrackingStrategy {
+    override fun register(context: Context) {
+        // Nop
+    }
+
+    override fun unregister(context: Context?) {
+        // Nop
     }
 }
 


### PR DESCRIPTION
### What and why?

Native view tracking will start the MainActivity view and won't show the active Flutter view if a user starts a secondary Activity (like a chrome custom tab).

We may want to add native view tracking in as an option later (similar to RN).

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue