### PR TITLE
♻️ Change Android contract testing to support values

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
@@ -54,31 +54,36 @@ class DatadogLogsPluginTest {
 
     private val contracts = listOf(
         Contract("debug", mapOf(
-            "message" to typeOf<String>(), "context" to typeOf<Map<String, Any?>>()
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "context" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("info", mapOf(
-            "message" to typeOf<String>(), "context" to typeOf<Map<String, Any?>>()
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "context" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("warn", mapOf(
-            "message" to typeOf<String>(), "context" to typeOf<Map<String, Any?>>()
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "context" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("error", mapOf(
-            "message" to typeOf<String>(), "context" to typeOf<Map<String, Any?>>()
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "context" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addAttribute", mapOf(
-            "key" to typeOf<String>(), "value" to typeOf<Map<String, Any?>>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "value" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addTag", mapOf(
-            "tag" to typeOf<String>()
+            "tag" to ContractParameter.Type(SupportedContractType.STRING)
         )),
         Contract("removeAttribute", mapOf(
-            "key" to typeOf<String>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING)
         )),
         Contract("removeTag", mapOf(
-            "tag" to typeOf<String>()
+            "tag" to ContractParameter.Type(SupportedContractType.STRING)
         )),
         Contract("removeTagWithKey", mapOf(
-            "key" to typeOf<String>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING)
         )),
     )
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -422,46 +422,59 @@ class DatadogRumPluginTest {
 
     val contracts = listOf(
         Contract("startView", mapOf(
-            "key" to typeOf<String>(), "name" to typeOf<String>(), "attributes" to typeOf<Map<String, Any?>>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "name" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("stopView", mapOf(
-            "key" to typeOf<String>(), "attributes" to typeOf<Map<String, Any?>>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addTiming", mapOf(
-            "name" to typeOf<String>(),
+            "name" to ContractParameter.Type(SupportedContractType.STRING),
         )),
         Contract("startResourceLoading", mapOf(
-            "key" to typeOf<String>(), "url" to typeOf<String>(), "httpMethod" to typeOf<String>(),
-            "attributes" to typeOf<Map<String, Any?>>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "url" to ContractParameter.Type(SupportedContractType.STRING),
+            "httpMethod" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("stopResourceLoading", mapOf(
-            "key" to typeOf<String>(), "kind" to typeOf<String>(),
-            "attributes" to typeOf<Map<String, Any?>>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "kind" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("stopResourceLoadingWithError", mapOf(
-            "key" to typeOf<String>(), "message" to typeOf<String>(), "attributes" to typeOf<Map<String, Any?>>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addError", mapOf(
-            "message" to typeOf<String>(), "source" to typeOf<String>(),
-            "attributes" to typeOf<Map<String, Any?>>()
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "source" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addUserAction", mapOf(
-            "type" to typeOf<String>(), "name" to typeOf<String>(),
-            "attributes" to typeOf<Map<String, Any?>>()
+            "type" to ContractParameter.Type(SupportedContractType.STRING),
+            "name" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("startUserAction", mapOf(
-            "type" to typeOf<String>(), "name" to typeOf<String>(),
-            "attributes" to typeOf<Map<String, Any?>>()
+            "type" to ContractParameter.Type(SupportedContractType.STRING),
+            "name" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("stopUserAction", mapOf(
-            "type" to typeOf<String>(), "name" to typeOf<String>(),
-            "attributes" to typeOf<Map<String, Any?>>()
+            "type" to ContractParameter.Type(SupportedContractType.STRING),
+            "name" to ContractParameter.Type(SupportedContractType.STRING),
+            "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addAttribute", mapOf(
-            "key" to typeOf<String>(), "value" to typeOf<String>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "value" to ContractParameter.Type(SupportedContractType.STRING),
         )),
         Contract("removeAttribute", mapOf(
-            "key" to typeOf<String>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING)
         ))
     )
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogTracesPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogTracesPluginTest.kt
@@ -45,14 +45,14 @@ class DatadogTracesPluginTest {
 
     private val contracts = listOf(
         Contract("startRootSpan", mapOf(
-            "spanHandle" to typeOf<Long>(),
-            "operationName" to typeOf<String>(),
-            "startTime" to typeOf<Long>()
+            "spanHandle" to ContractParameter.Type(SupportedContractType.LONG),
+            "operationName" to ContractParameter.Type(SupportedContractType.STRING),
+            "startTime" to ContractParameter.Type(SupportedContractType.LONG),
         )),
         Contract("startSpan", mapOf(
-            "spanHandle" to typeOf<Long>(),
-            "operationName" to typeOf<String>(),
-            "startTime" to typeOf<Long>()
+            "spanHandle" to ContractParameter.Type(SupportedContractType.LONG),
+            "operationName" to ContractParameter.Type(SupportedContractType.STRING),
+            "startTime" to ContractParameter.Type(SupportedContractType.LONG),
         )),
     )
 
@@ -144,16 +144,19 @@ class DatadogTracesPluginTest {
 
     private val spanContracts = listOf(
         Contract("span.setError", mapOf(
-            "kind" to typeOf<String>(), "message" to typeOf<String>()
+            "kind" to ContractParameter.Type(SupportedContractType.STRING),
+            "message" to ContractParameter.Type(SupportedContractType.STRING),
         )),
         Contract("span.setTag", mapOf(
-            "key" to typeOf<String>(), "value" to typeOf<String>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "value" to ContractParameter.Type(SupportedContractType.STRING),
         )),
         Contract("span.setBaggageItem", mapOf(
-            "key" to typeOf<String>(), "value" to typeOf<String>()
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "value" to ContractParameter.Type(SupportedContractType.STRING),
         )),
         Contract("span.log", mapOf(
-            "fields" to typeOf<Map<String, Any?>>()
+            "fields" to ContractParameter.Type(SupportedContractType.MAP),
         ))
     )
 


### PR DESCRIPTION
### What and why?

Instead of depending on KType, use an enum in conjunction with a sealed class to support specific values. This is needed so that we can properly create a logger with a fixed key as part of the test.

This is in service to RUMM-2083

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue