### PR TITLE
🐛 Remove stack trace from resource loading errors

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -55,7 +55,7 @@ class DatadogRumPlugin(
         GlobalRum.registerIfAbsent(rum!!)
     }
 
-    @Suppress("LongMethod", "ComplexMethod")
+    @Suppress("LongMethod", "ComplexMethod", "ComplexCondition")
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         try {
             when (call.method) {
@@ -127,12 +127,12 @@ class DatadogRumPlugin(
                 "stopResourceLoadingWithError" -> {
                     val key = call.argument<String>(PARAM_KEY)
                     val message = call.argument<String>(PARAM_MESSAGE)
+                    val errorType = call.argument<String>(PARAM_TYPE)
                     val attributes = call.argument<Map<String, Any?>>(PARAM_ATTRIBUTES)
-                    if (key != null && message != null && attributes != null) {
-                        val throwable = Throwable()
+                    if (key != null && message != null && errorType != null && attributes != null) {
                         rum?.stopResourceWithError(
                             key, null, message, RumErrorSource.NETWORK,
-                            throwable, attributes
+                            "", errorType, attributes
                         )
                         result.success(null)
                     } else {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -293,6 +293,7 @@ class DatadogRumPluginTest {
     fun `M call monitor stopResourceWithError W stopResourceLoadingWithError is called`(
         @StringForgery resourceKey: String,
         @StringForgery message: String,
+        @StringForgery errorType: String,
         @StringForgery attributeKey: String,
         @StringForgery attributeValue: String
     ) {
@@ -300,6 +301,7 @@ class DatadogRumPluginTest {
         val call = MethodCall("stopResourceLoadingWithError", mapOf(
             "key" to resourceKey,
             "message" to message,
+            "type" to errorType,
             "attributes" to mapOf(
                 attributeKey to attributeValue
             )
@@ -311,7 +313,8 @@ class DatadogRumPluginTest {
 
         // THEN
         verify(mockRumMonitor).stopResourceWithError(eq(resourceKey), isNull(), eq(message),
-            eq(RumErrorSource.NETWORK), any(), eq(mapOf(attributeKey to attributeValue)))
+            eq(RumErrorSource.NETWORK), eq(""), eq(errorType),
+            eq(mapOf(attributeKey to attributeValue)))
         verify(mockResult).success(null)
     }
 
@@ -447,6 +450,7 @@ class DatadogRumPluginTest {
         Contract("stopResourceLoadingWithError", mapOf(
             "key" to ContractParameter.Type(SupportedContractType.STRING),
             "message" to ContractParameter.Type(SupportedContractType.STRING),
+            "type" to ContractParameter.Type(SupportedContractType.STRING),
             "attributes" to ContractParameter.Type(SupportedContractType.MAP),
         )),
         Contract("addError", mapOf(

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/rum/rum_monitor_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/rum/rum_monitor_test.dart
@@ -325,7 +325,7 @@ void main() {
 
     await measure('flutter_stop_resource_with_error', () {
       datadog.rum!.stopResourceLoadingWithErrorInfo(
-          resourceKey, randomString(), e2eAttributes(tester));
+          resourceKey, randomString(), randomString(), e2eAttributes(tester));
     });
 
     datadog.rum!.stopView(viewKey);

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -119,7 +119,7 @@ class DatadogRumPluginTests: XCTestCase {
       "key": .string, "kind": .string, "attributes": .map
     ]),
     Contract(methodName: "stopResourceLoadingWithError", requiredParameters: [
-      "key": .string, "message": .string, "attributes": .map
+      "key": .string, "message": .string, "type": .string, "attributes": .map
     ]),
     Contract(methodName: "addError", requiredParameters: [
       "message": .string, "source": .string, "attributes": .map
@@ -269,6 +269,7 @@ class DatadogRumPluginTests: XCTestCase {
     let call = FlutterMethodCall(methodName: "stopResourceLoadingWithError", arguments: [
       "key": "resource_key",
       "message": "error message",
+      "type": "error kind",
       "attributes": [
         "attribute_key": "attribute_value"
       ]
@@ -282,7 +283,7 @@ class DatadogRumPluginTests: XCTestCase {
     XCTAssertEqual(mock.callLog, [
       .stopResourceLoadingWithErrorMessage(key: "resource_key",
                                            errorMessage: "error message",
-                                           type: nil,
+                                           type: "error kind",
                                            response: nil,
                                            attributes: [
         "attribute_key": "attribute_value"

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum/rum_manual_test.dart
@@ -103,6 +103,7 @@ void main() {
     expect(view1.errorEvents.length, 1);
     expect(view1.errorEvents[0].resourceUrl, 'https://fake_url/resource/2');
     expect(view1.errorEvents[0].message, 'Status code 400');
+    expect(view1.errorEvents[0].errorType, 'ErrorLoading');
     expect(view1.errorEvents[0].source, 'network');
     expect(view1.errorEvents[0].context[contextKey], expectedContextValue);
     expect(view1, becameInactive);
@@ -125,7 +126,6 @@ void main() {
     // TODO: Figure out why occasionally these have really high values
     // expect(view1.actionEvents[0].loadingTime,
     //     lessThan(3 * 1000 * 1000 * 1000)); // 3s
-    //     14,836,966,000
     expect(view2.actionEvents[0].context[contextKey], expectedContextValue);
     expect(view2.actionEvents[1].actionName, 'Next Screen');
     expect(view2.actionEvents[1].context[contextKey], expectedContextValue);

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -112,7 +112,7 @@ class _RumManualInstrumentationScenarioState
     await Future.delayed(const Duration(milliseconds: 100));
     rum?.stopResourceLoading(simulatedResourceKey1, 200, RumResourceType.image);
     rum?.stopResourceLoadingWithErrorInfo(
-        simulatedResourceKey2, 'Status code 400');
+        simulatedResourceKey2, 'Status code 400', 'ErrorLoading');
 
     setState(() {
       _contentReady = true;

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-dev.1"
+    version: "1.0.0-alpha.1"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -132,9 +132,10 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
     case "stopResourceLoadingWithError":
       if let key = arguments["key"] as? String,
          let message = arguments["message"] as? String,
+         let errorType = arguments["type"] as? String,
          let attributes = arguments["attributes"] as? [String: Any?] {
         let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.stopResourceLoadingWithError(resourceKey: key, errorMessage: message, response: nil,
+        rum.stopResourceLoadingWithError(resourceKey: key, errorMessage: message, type: errorType, response: nil,
                                          attributes: encodedAttributes)
         result(nil)
       } else {

--- a/packages/datadog_flutter_plugin/lib/src/datadog_tracking_http_client.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_tracking_http_client.dart
@@ -144,7 +144,8 @@ class DatadogTrackingHttpClient implements HttpClient {
     } catch (e) {
       if (rumKey != null) {
         try {
-          rum?.stopResourceLoadingWithErrorInfo(rumKey, e.toString());
+          rum?.stopResourceLoadingWithErrorInfo(
+              rumKey, e.toString(), e.runtimeType.toString());
         } catch (innerE) {
           datadogSdk.internalLogger.sendToDatadog(
               '$DatadogTrackingHttpClient encountered an error while attempting '
@@ -319,7 +320,8 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
   void _onStreamError(Object e, StackTrace? st) {
     try {
       if (rumKey != null) {
-        datadogSdk.rum?.stopResourceLoadingWithErrorInfo(rumKey!, e.toString());
+        datadogSdk.rum?.stopResourceLoadingWithErrorInfo(
+            rumKey!, e.toString(), e.runtimeType.toString());
       }
       tracingContext?.setErrorInfo(
         e.runtimeType.toString(),
@@ -471,8 +473,8 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
 
       if (rumKey != null) {
         if (lastError != null) {
-          datadogSdk.rum
-              ?.stopResourceLoadingWithErrorInfo(rumKey!, lastError.toString());
+          datadogSdk.rum?.stopResourceLoadingWithErrorInfo(
+              rumKey!, lastError.toString(), lastError.runtimeType.toString());
         } else {
           var resourceType = resourceTypeFromContentType(headers.contentType);
           var size = innerResponse.contentLength > 0

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -206,11 +206,11 @@ class DdRum {
   /// Notifies that the Resource identified by [key] stopped being loaded with
   /// the supplied [message]. You can optionally supply custom [attributes] to
   /// attach to this Resource.
-  void stopResourceLoadingWithErrorInfo(String key, String message,
+  void stopResourceLoadingWithErrorInfo(String key, String message, String type,
       [Map<String, dynamic> attributes = const {}]) {
     wrap('rum.stopResourceLoadingWithErrorInfo', logger, () {
       return _platform.stopResourceLoadingWithErrorInfo(
-          key, message, attributes);
+          key, message, type, attributes);
     });
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -69,14 +69,23 @@ class DdRumMethodChannel extends DdRumPlatform {
   @override
   Future<void> stopResourceLoadingWithError(String key, Exception error,
       [Map<String, dynamic> attributes = const {}]) {
-    return stopResourceLoadingWithErrorInfo(key, error.toString(), attributes);
+    return stopResourceLoadingWithErrorInfo(
+        key, error.toString(), error.runtimeType.toString(), attributes);
   }
 
   @override
-  Future<void> stopResourceLoadingWithErrorInfo(String key, String message,
-      [Map<String, dynamic> attributes = const {}]) {
-    return methodChannel.invokeMethod('stopResourceLoadingWithError',
-        {'key': key, 'message': message, 'attributes': attributes});
+  Future<void> stopResourceLoadingWithErrorInfo(
+    String key,
+    String message,
+    String type, [
+    Map<String, dynamic> attributes = const {},
+  ]) {
+    return methodChannel.invokeMethod('stopResourceLoadingWithError', {
+      'key': key,
+      'message': message,
+      'type': type,
+      'attributes': attributes,
+    });
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -33,7 +33,7 @@ abstract class DdRumPlatform extends PlatformInterface {
   Future<void> stopResourceLoadingWithError(
       String key, Exception error, Map<String, dynamic> attributes);
   Future<void> stopResourceLoadingWithErrorInfo(
-      String key, String message, Map<String, dynamic> attributes);
+      String key, String message, String type, Map<String, dynamic> attributes);
 
   Future<void> addError(Object error, RumErrorSource source,
       StackTrace? stackTrace, Map<String, dynamic> attributes);

--- a/packages/datadog_flutter_plugin/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_tracking_http_client_test.dart
@@ -479,9 +479,7 @@ void main() {
 
       expect(caughtError, error);
       verify(() => mockRum.stopResourceLoadingWithErrorInfo(
-            capturedKey,
-            error.toString(),
-          ));
+          capturedKey, error.toString(), error.runtimeType.toString()));
     });
 
     test('calls stop resource with error for response error', () async {
@@ -513,6 +511,7 @@ void main() {
       verify(() => mockRum.stopResourceLoadingWithErrorInfo(
             capturedKey,
             error.toString(),
+            error.runtimeType.toString(),
           ));
     });
   });
@@ -614,7 +613,10 @@ void main() {
               captureAny(), RumHttpMethod.get, url.toString(), any()))
           .captured[0] as String;
       verify(() => mockRum.stopResourceLoadingWithErrorInfo(
-          capturedKey, error.toString()));
+            capturedKey,
+            error.toString(),
+            error.runtimeType.toString(),
+          ));
     });
   });
 }

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -108,19 +108,24 @@ void main() {
       isMethodCall('stopResourceLoadingWithError', arguments: {
         'key': 'resource_key',
         'message': exception.toString(),
+        'type': exception.runtimeType.toString(),
         'attributes': {'attribute_key': 'attribute_value'}
       })
     ]);
   });
 
   test('stopResourceLoadingWithErrorInfo calls to platform', () async {
-    await ddRumPlatform.stopResourceLoadingWithErrorInfo('resource_key',
-        'Exception message', {'attribute_key': 'attribute_value'});
+    await ddRumPlatform.stopResourceLoadingWithErrorInfo(
+        'resource_key',
+        'Exception message',
+        'Exception type',
+        {'attribute_key': 'attribute_value'});
 
     expect(log, [
       isMethodCall('stopResourceLoadingWithError', arguments: {
         'key': 'resource_key',
         'message': 'Exception message',
+        'type': 'Exception type',
         'attributes': {'attribute_key': 'attribute_value'}
       })
     ]);


### PR DESCRIPTION
### What and why?

On Android this was creating a Throwable that made it look like the SDK was the source of the error.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue