### PR TITLE
🚀 Preparing for release of datadog_flutter_plugin 1.0.0-alpha.2

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.0-alpha.2
+
 * Cancel spans on DatadogTrackingHttpClient when RUM is enabled (prevent spans
   from leaking native resources)
 * Remove native view tracking (Activities and Fragments) from Android by default

--- a/packages/datadog_flutter_plugin/lib/src/version.dart
+++ b/packages/datadog_flutter_plugin/lib/src/version.dart
@@ -2,4 +2,4 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
-const ddPackageVersion = '1.0.0-alpha.1';
+const ddPackageVersion = '1.0.0-alpha.2';

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_flutter_plugin
 description: Flutter bindings and tools for utilizing Datadog Mobile SDks
-version: 1.0.0-alpha.1
+version: 1.0.0-alpha.2
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:


### PR DESCRIPTION
### What and why?

Changes specifically to release 1.0.0-alpha.2
