### PR TITLE
Fixes to support deploying tracking_http_client package

### DIFF
--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -12,8 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-alpha.2    
-
+  datadog_flutter_plugin: ^1.0.0-alpha.2
+  uuid: ^3.0.5
 
 dev_dependencies:
   flutter_test:

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -20,10 +20,8 @@ class UpdateVersionsCommand extends Command {
       return false;
     }
 
-    if (!await _updateVersionDartFile(
-        args.packageRoot, args.version, logger, args.dryRun)) {
-      return false;
-    }
+    await _updateVersionDartFile(
+        args.packageRoot, args.version, logger, args.dryRun);
 
     if (!await _updateChangelog(
         args.packageRoot, args.version, logger, args.dryRun)) {
@@ -84,6 +82,7 @@ class UpdateVersionsCommand extends Command {
     final versionFile = File(path.join(packageRoot, 'lib/src/version.dart'));
     if (!versionFile.existsSync()) {
       logger.shout('⁉️ Could not find version.dart at ${versionFile.path}');
+      logger.shout('This is ignored as it is expected for non-core packages.');
       return false;
     }
 


### PR DESCRIPTION
### What and why?

Packages that are not the core package do not need `version.dart` files. This file is only used.to set the version of the SDK during DdSdk initialization.

Additionally, add a direct dependency for tracking_http_client that was missing from the pubspec. 

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue