### PR TITLE
🚀 Preparing for release of datadog_tracking_http_client 1.0.0-alpha.1

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+## 1.0.0-alpha.1
+
 * Initial split of DatadogTrackingHttpClient into its own package


### PR DESCRIPTION
### What and why?

Prepare datadog_tracking_http_client release.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue