### PR TITLE
🐛 Set firstPartyHosts on Native SDKs during initialization

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Send `firstPartyHosts` to NativeSDKs during initialization. Make
+* Send `firstPartyHosts` to Native SDKs during initialization. Make
   `firstPartyHosts` property on read only `DatadogSdk` read only. 
 
 ## 1.0.0-alpha.2

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Send `firstPartyHosts` to NativeSDKs during initialization. Make
+  `firstPartyHosts` property on read only `DatadogSdk` read only. 
+
 ## 1.0.0-alpha.2
 
 * Cancel spans on DatadogTrackingHttpClient when RUM is enabled (prevent spans

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -46,6 +46,7 @@ data class DatadogFlutterConfiguration(
     var batchSize: BatchSize? = null,
     var uploadFrequency: UploadFrequency? = null,
     var customEndpoint: String? = null,
+    var firstPartyHosts: List<String> = listOf(),
     var additionalConfig: Map<String, Any?> = mapOf(),
 
     var tracingConfiguration: TracingConfiguration? = null,
@@ -90,6 +91,9 @@ data class DatadogFlutterConfiguration(
             uploadFrequency = parseUploadFrequency(it)
         }
         customEndpoint = encoded["customEndpoint"] as? String
+        (encoded["firstPartyHosts"] as? List<String>)?.let {
+            firstPartyHosts = it
+        }
 
         @Suppress("UNCHECKED_CAST")
         additionalConfig = (encoded["additionalConfig"] as? Map<String, Any?>) ?: mapOf()
@@ -144,6 +148,7 @@ data class DatadogFlutterConfiguration(
             configBuilder.useCustomTracesEndpoint(it)
             configBuilder.useCustomRumEndpoint(it)
         }
+        configBuilder.setFirstPartyHosts(firstPartyHosts)
 
         return configBuilder.build()
     }

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -115,6 +115,7 @@ class DatadogConfigurationTest {
             "uploadFrequency" to null,
             "trackingConsent" to "TrackingConsent.granted",
             "customEndpoint" to null,
+            "firstPartyHosts" to listOf<String>(),
             "tracingConfiguration" to null,
             "rumConfiguration" to null,
             "additionalConfig" to mapOf<String, Any?>()
@@ -137,7 +138,8 @@ class DatadogConfigurationTest {
         @StringForgery clientToken: String,
         @StringForgery environment: String,
         @StringForgery additionalKey: String,
-        @StringForgery additionalValue: String
+        @StringForgery additionalValue: String,
+        @StringForgery firstPartyHost: String,
     ) {
         // GIVEN
         val encoded = mapOf<String, Any?>(
@@ -149,6 +151,7 @@ class DatadogConfigurationTest {
             "uploadFrequency" to "UploadFrequency.frequent",
             "trackingConsent" to "TrackingConsent.granted",
             "customEndpoint" to "customEndpoint",
+            "firstPartyHosts" to listOf(firstPartyHost),
             "tracingConfiguration" to null,
             "rumConfiguration" to null,
             "additionalConfig" to mapOf<String, Any?>(
@@ -167,13 +170,15 @@ class DatadogConfigurationTest {
         assertThat(config.additionalConfig).isEqualTo(mapOf(
             additionalKey to additionalValue
         ))
+        assertThat(config.firstPartyHosts).isEqualTo(listOf(firstPartyHost))
     }
 
     @Test
     fun `M decode nestedConfiguration W fromEncoded {tracingConfiguration, rumConfiguration}`(
         @StringForgery clientToken: String,
         @StringForgery environment: String,
-        @StringForgery applicationId: String
+        @StringForgery applicationId: String,
+        @StringForgery firstPartyHost: String
     ) {
         // GIVEN
         val encoded = mapOf(
@@ -185,6 +190,7 @@ class DatadogConfigurationTest {
             "uploadFrequency" to null,
             "trackingConsent" to "TrackingConsent.pending",
             "customEndpoint" to null,
+            "firstPartyHosts" to listOf<String>(),
             "tracingConfiguration" to mapOf(
                 "sendNetworkInfo" to true,
                 "bundleWithRum" to false,

--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-alpha.1"
+    version: "1.0.0-alpha.2"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
@@ -94,6 +94,7 @@ class DatadogConfigurationTests: XCTestCase {
       "uploadFrequency": nil,
       "trackingConsent": "TrackingConsent.pending",
       "customEndpoint": nil,
+      "firstPartyHosts": [],
       "loggingConfiguration": nil,
       "tracingConfiguration": nil,
       "rumConfiguration": nil,
@@ -106,6 +107,36 @@ class DatadogConfigurationTests: XCTestCase {
     XCTAssertEqual(config.clientToken, "fakeClientToken")
     XCTAssertEqual(config.env, "fakeEnvironment")
     XCTAssertEqual(config.nativeCrashReportingEnabled, false)
+    XCTAssertEqual(config.trackingConsent, TrackingConsent.pending)
+
+    XCTAssertNil(config.tracingConfiguration)
+    XCTAssertNil(config.rumConfiguration)
+  }
+
+  func testConfiguration_Values_AreDecoded() {
+    let encoded: [String: Any?]  = [
+      "clientToken": "fakeClientToken",
+      "env": "fakeEnvironment",
+      "nativeCrashReportEnabled": NSNumber(false),
+      "site": "DatadogSite.eu1",
+      "batchSize": "BatchSize.small",
+      "uploadFrequency": "UploadFrequency.frequent",
+      "trackingConsent": "TrackingConsent.pending",
+      "customEndpoint": nil,
+      "firstPartyHosts": [ "first_party.com" ],
+      "loggingConfiguration": nil,
+      "tracingConfiguration": nil,
+      "rumConfiguration": nil,
+      "additionalConfig": [:]
+    ]
+
+    let config = DatadogFlutterConfiguration(fromEncoded: encoded)!
+
+    XCTAssertNotNil(config)
+    XCTAssertEqual(config.site, .eu1)
+    XCTAssertEqual(config.batchSize, .small)
+    XCTAssertEqual(config.uploadFrequency, .frequent)
+    XCTAssertEqual(config.firstPartyHosts, ["first_party.com"])
     XCTAssertEqual(config.trackingConsent, TrackingConsent.pending)
 
     XCTAssertNil(config.tracingConfiguration)

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -310,5 +310,5 @@ packages:
     source: hosted
     version: "3.0.0"
 sdks:
-  dart: ">=2.16.2 <3.0.0"
+  dart: ">=2.16.1 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
@@ -84,6 +84,7 @@ class DatadogFlutterConfiguration {
   let site: Datadog.Configuration.DatadogEndpoint?
   let batchSize: Datadog.Configuration.BatchSize?
   let uploadFrequency: Datadog.Configuration.UploadFrequency?
+  let firstPartyHosts: [String]
   let customEndpoint: String?
   let additionalConfig: [String: Any]
 
@@ -98,6 +99,7 @@ class DatadogFlutterConfiguration {
     site: Datadog.Configuration.DatadogEndpoint? = nil,
     batchSize: Datadog.Configuration.BatchSize? = nil,
     uploadFrequency: Datadog.Configuration.UploadFrequency? = nil,
+    firstPartyHosts: [String] = [],
     customEndpoint: String? = nil,
     additionalConfig: [String: Any] = [:],
     tracingConfiguration: TracingConfiguration? = nil,
@@ -110,6 +112,7 @@ class DatadogFlutterConfiguration {
     self.site = site
     self.batchSize = batchSize
     self.uploadFrequency = uploadFrequency
+    self.firstPartyHosts = firstPartyHosts
     self.customEndpoint = customEndpoint
     self.additionalConfig = additionalConfig
     self.tracingConfiguration = tracingConfiguration
@@ -137,6 +140,7 @@ class DatadogFlutterConfiguration {
       .parseFromFlutter($0)
     })
     customEndpoint = encoded["customEndpoint"] as? String
+    firstPartyHosts = encoded["firstPartyHosts"] as? [String] ?? []
     additionalConfig = encoded["additionalConfig"] as? [String: Any] ?? [:]
 
     tracingConfiguration = convertOptional(encoded["tracingConfiguration"]) {

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -129,6 +129,10 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
       _ = ddConfigBuilder.set(uploadFrequency: uploadFrequency)
     }
 
+    if !flutterConfig.firstPartyHosts.isEmpty {
+      _ = ddConfigBuilder.trackURLSession(firstPartyHosts: Set(flutterConfig.firstPartyHosts))
+    }
+
     if let customEndpoint = flutterConfig.customEndpoint,
        let customEndpointUrl = URL(string: customEndpoint) {
       _ = ddConfigBuilder

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -74,10 +74,9 @@ class DatadogSdk {
 
   final Map<Type, DatadogPlugin> _plugins = {};
 
-  /// A list of first party hosts for tracing. Note that this is an unmodifiable
-  /// list. If you need to add a host, call the setter for [firstPartyHosts]
+  /// An unmodifiable list of first party hosts for tracing.
   List<String> get firstPartyHosts => List.unmodifiable(_firstPartyHosts);
-  set firstPartyHosts(List<String> value) {
+  void _setFirstPartyHosts(List<String> value) {
     _firstPartyHosts = value;
     if (value.isNotEmpty) {
       // pattern = "^(.*\\.)*tracedHost1$|tracedHost2$|...$"
@@ -150,7 +149,7 @@ class DatadogSdk {
     configuration.additionalConfig[DatadogConfigKey.source] = 'flutter';
     configuration.additionalConfig[DatadogConfigKey.version] = version;
 
-    firstPartyHosts = configuration.firstPartyHosts;
+    _setFirstPartyHosts(configuration.firstPartyHosts);
 
     await _platform.initialize(configuration, logCallback: _platformLog);
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -290,6 +290,7 @@ class DdSdkConfiguration {
       'batchSize': batchSize?.toString(),
       'uploadFrequency': uploadFrequency?.toString(),
       'trackingConsent': trackingConsent.toString(),
+      'firstPartyHosts': firstPartyHosts,
       'customEndpoint': customEndpoint,
       'tracingConfiguration': tracingConfiguration?.encode(),
       'rumConfiguration': rumConfiguration?.encode(),

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -76,6 +76,7 @@ void main() {
       'customEndpoint': null,
       'batchSize': null,
       'uploadFrequency': null,
+      'firstPartyHosts': [],
       'tracingConfiguration': null,
       'rumConfiguration': null,
       'additionalConfig': {},
@@ -153,6 +154,21 @@ void main() {
     await datadogSdk.initialize(configuration);
 
     expect(datadogSdk.firstPartyHosts, firstPartyHosts);
+  });
+
+  test('first party hosts are encoded', () async {
+    var firstPartyHosts = ['example.com', 'datadoghq.com'];
+
+    final configuration = DdSdkConfiguration(
+      clientToken: 'clientToken',
+      env: 'env',
+      site: DatadogSite.us1,
+      trackingConsent: TrackingConsent.pending,
+      firstPartyHosts: firstPartyHosts,
+    );
+
+    final encoded = configuration.encode();
+    expect(encoded['firstPartyHosts'], firstPartyHosts);
   });
 
   test('isFirstPartyHost with no hosts returns false', () async {

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
@@ -19,7 +19,7 @@ Future<void> performRumUserFlow(WidgetTester tester) async {
   await tester.tap(topItem);
   await tester.pumpAndSettle();
 
-  var readyText = find.text('All Done');
+  //var readyText = find.text('All Done');
   //await tester.waitFor(readyText, const Duration(seconds: 100), (e) => true);
 
   var nextButton = find.text('Next Page');


### PR DESCRIPTION
### What and why?

Instead of only holding firstPartyHosts on the Flutter side, send them to the Native SDKs during initialization, and make them readonly on the Flutter side.

This should help correctly classify first party resources on dashboards.

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue