### PR TITLE
👷 Move flutter install to repo hosted bitrise script

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -117,7 +117,7 @@ workflows:
   setup:
     before_run:
     - _pub_get
-    steps:    
+    steps:
     - script:
         title: Generate env files
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,6 +6,7 @@ project_type: flutter
 workflows:
   primary:
     before_run:
+    - _flutter_install
     - setup
     - check_dependencies
     - build
@@ -21,6 +22,12 @@ workflows:
     - setup
     - nightly_ios
     - nightly_android
+
+  _flutter_install:
+    steps:
+    - flutter-installer@0:
+        inputs:
+        - version: stable
     
   _prepare_gradle_wrapper:
     steps:
@@ -110,7 +117,7 @@ workflows:
   setup:
     before_run:
     - _pub_get
-    steps:
+    steps:    
     - script:
         title: Generate env files
         inputs:


### PR DESCRIPTION
### What and why?

Moving the flutter install (which is currently hosted on the bitrise site) into the script hosted in the repo.

This is so that we can install the beta channel for the datadog_tracking_http_client package release.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue