### PR TITLE
Remove tracing calls from DatadogTracingHttpClient

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -37,7 +37,8 @@ export 'src/rum/navigation_observer.dart'
         DatadogNavigationObserverProvider,
         RumViewInfo,
         DatadogRouteAwareMixin;
-export 'src/traces/ddtraces.dart' show DdSpan, OTTags, OTLogFields;
+export 'src/traces/ddtraces.dart'
+    show DdSpan, OTTags, OTLogFields, generateTraceId;
 
 typedef AppRunner = void Function();
 

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -1,0 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// NB: This import is meant to be used by Datadog for implementation of
+// extension packages, and is not meant for public use. Anything exposed by this
+// file has the potential to change without notice.
+
+export 'src/rum/attributes.dart';

--- a/packages/datadog_flutter_plugin/lib/src/rum/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/attributes.dart
@@ -5,9 +5,12 @@
 class DatadogTracingHeaders {
   static const traceId = 'x-datadog-trace-id';
   static const parentId = 'x-datadog-parent-id';
+
+  static const samplingPriority = 'x-datadog-sampling-priority';
+  static const origin = 'x-datadog-origin';
 }
 
-class DatadogPlatformAttributeKey {
+class DatadogRumPlatformAttributeKey {
   /// Trace ID. Used in RUM resources created by automatic resource tracking.
   /// Expects `String` value.
   static const traceID = '_dd.trace_id';

--- a/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
+++ b/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
@@ -2,6 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2021 Datadog, Inc.
 
+import 'dart:math';
+
 import '../helpers.dart';
 import '../internal_logger.dart';
 import 'ddtraces_platform_interface.dart';
@@ -281,4 +283,16 @@ class DdTraces {
 
     return headers ?? {};
   }
+}
+
+final _traceRandom = Random();
+
+String generateTraceId() {
+  final highBits = _traceRandom.nextInt(1 << 32);
+  final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+
+  var traceId = BigInt.from(highBits) << 32;
+  traceId += lowBits;
+
+  return traceId.toString();
 }

--- a/packages/datadog_grpc_interceptor/analysis_options.yaml
+++ b/packages/datadog_grpc_interceptor/analysis_options.yaml
@@ -1,4 +1,4 @@
 include: package:flutter_lints/flutter.yaml
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  exclude: ['**/src/generated/**']

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -100,7 +100,6 @@ void main() {
         RumHttpMethod.get,
         'localhost:$port/helloworld.Greeter/SayHello',
         captureAny())).captured;
-    final key = captures[0];
     final attributes = captures[1];
     expect(attributes['_dd.trace_id'], isNull);
     expect(attributes['_dd.span_id'], isNull);
@@ -126,7 +125,6 @@ void main() {
         RumHttpMethod.get,
         'localhost:$port/helloworld.Greeter/SayHello',
         captureAny())).captured;
-    final key = captures[0];
     final attributes = captures[1];
     expect(attributes['_dd.trace_id'], isNotNull);
     expect(BigInt.tryParse(attributes['_dd.trace_id'] as String), isNotNull);
@@ -226,7 +224,6 @@ void main() {
         RumHttpMethod.get,
         'localhost:$port/helloworld.Greeter/SayHello',
         captureAny())).captured;
-    final key = captures[0];
     final attributes = captures[1];
     expect(attributes['_dd.trace_id'], isNull);
     expect(attributes['_dd.span_id'], isNull);

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Removed using platform traces / spans in DatadogTrackingHttpClient
+
 ## 1.0.0-alpha.1
 
 * Initial split of DatadogTrackingHttpClient into its own package

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
@@ -110,7 +110,6 @@ void main() async {
     for (var testRequest in testRequests) {
       expect(testRequest.requestHeaders['x-datadog-sampling-priority']?.first,
           '1');
-      expect(testRequest.requestHeaders['x-datadog-sampled']?.first, '1');
       expect(testRequest.requestHeaders['x-datadog-origin']?.first, 'rum');
     }
 

--- a/packages/datadog_tracking_http_client/example/ios/Podfile.lock
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - datadog_flutter_plugin (0.0.1):
-    - DatadogSDK (= 1.9.0)
-    - DatadogSDKCrashReporting (= 1.9.0)
+    - DatadogSDK (= 1.11.0-beta1)
+    - DatadogSDKCrashReporting (= 1.11.0-beta1)
     - Flutter
-  - DatadogSDK (1.9.0)
-  - DatadogSDKCrashReporting (1.9.0):
-    - DatadogSDK (= 1.9.0)
+  - DatadogSDK (1.11.0-beta1)
+  - DatadogSDKCrashReporting (1.11.0-beta1):
+    - DatadogSDK (= 1.11.0-beta1)
     - PLCrashReporter (~> 1.10.1)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -32,13 +32,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: e5183a8db2ed5c2690b661e446fc2b4479e7ae70
-  DatadogSDK: 8fbd60a904489d4f930173b9723d6bb381c13920
-  DatadogSDKCrashReporting: 684346cb6cc9957f6e428558ef2245469910f16e
+  datadog_flutter_plugin: 6ff5d76155d4907f3db70dc81e80d2fbc9abdebd
+  DatadogSDK: 1e1cdbb2344d1a6a1b1134d4ce3c664f0b877e8e
+  DatadogSDKCrashReporting: 89cb8ab99fca11c47b3016ece5c0414ac7069c0c
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   PLCrashReporter: b30195e509f07299ea277d1997b3a39449d05698
 
 PODFILE CHECKSUM: 7368163408c647b7eb699d0d788ba6718e18fb8d
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -72,11 +72,11 @@ packages:
     source: path
     version: "0.0.1"
   datadog_flutter_plugin:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: datadog_flutter_plugin
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../datadog_flutter_plugin"
+      relative: true
+    source: path
     version: "1.0.0-alpha.2"
   datadog_tracking_http_client:
     dependency: "direct main"
@@ -318,4 +318,4 @@ packages:
     version: "3.0.0"
 sdks:
   dart: ">=2.16.1 <2.17.0"
-  flutter: ">=1.20.0"
+  flutter: ">=1.17.0"

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -32,3 +32,8 @@ flutter:
 
   assets:
     - .env
+
+# TODO: For development of alpha.2. Remove once dd_flutter_plugin is alpha.3 
+dependency_overrides:
+  datadog_flutter_plugin:
+    path: ../../datadog_flutter_plugin

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -6,7 +6,6 @@ import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 
 import 'src/tracking_http_client_plugin.dart';
 
-export 'src/tracing_headers.dart';
 export 'src/tracking_http_client.dart';
 
 extension TrackingExtension on DdSdkConfiguration {

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -9,9 +9,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:uuid/uuid.dart';
-
-import 'tracing_headers.dart';
 
 /// Overrides to supply the [DatadogTrackingHttpClient] instead of the default
 /// HttpClient
@@ -88,38 +87,22 @@ class DatadogTrackingHttpClient implements HttpClient {
   }
 
   Future<HttpClientRequest> _openUrl(String method, Uri url) async {
-    final tracer = datadogSdk.traces;
     final rum = datadogSdk.rum;
     String? rumKey;
-    DdSpan? tracingSpan;
     String? traceId, spanId;
-    Map<String, String>? spanHeaders;
 
     try {
       bool isFirstParty = datadogSdk.isFirstPartyHost(url);
-      if (tracer != null) {
-        if (isFirstParty) {
-          tracingSpan = tracer.startSpan('flutter.http_client', tags: {
-            'http.method': method.toUpperCase(),
-            'http.url': url.toString(),
-          });
-
-          spanHeaders = await tracer.getTracePropagationHeaders(tracingSpan);
-          // extract trace / span from the headers in case we need them for RUM
-          traceId = spanHeaders[DatadogTracingHeaders.traceId];
-          spanId = spanHeaders[DatadogTracingHeaders.parentId];
-        }
+      if (isFirstParty) {
+        traceId = generateTraceId();
+        spanId = generateTraceId();
       }
 
       if (rum != null) {
         final attributes = <String, dynamic>{};
-        if (tracingSpan != null) {
-          attributes[DatadogPlatformAttributeKey.traceID] = traceId;
-          attributes[DatadogPlatformAttributeKey.spanID] = spanId;
-
-          // Discard the tracing span, we don't need it if RUM is tracking the resource
-          tracingSpan.cancel();
-          tracingSpan = null;
+        if (traceId != null) {
+          attributes[DatadogRumPlatformAttributeKey.traceID] = traceId;
+          attributes[DatadogRumPlatformAttributeKey.spanID] = spanId;
         }
 
         rumKey = uuid.v1();
@@ -136,11 +119,11 @@ class DatadogTrackingHttpClient implements HttpClient {
     HttpClientRequest request;
     try {
       request = await innerClient.openUrl(method, url);
-      request.headers.add('x-datadog-origin', 'rum');
-      if (spanHeaders != null) {
-        for (var header in spanHeaders.entries) {
-          request.headers.add(header.key, header.value);
-        }
+      request.headers.add(DatadogTracingHeaders.origin, 'rum');
+      if (traceId != null) {
+        request.headers.add(DatadogTracingHeaders.traceId, traceId);
+        request.headers.add(DatadogTracingHeaders.parentId, spanId!);
+        request.headers.add(DatadogTracingHeaders.samplingPriority, '1');
       }
     } catch (e) {
       if (rumKey != null) {
@@ -156,9 +139,8 @@ class DatadogTrackingHttpClient implements HttpClient {
       rethrow;
     }
 
-    if (rumKey != null || tracingSpan != null) {
-      request =
-          _DatadogTrackingHttpRequest(datadogSdk, request, tracingSpan, rumKey);
+    if (rumKey != null) {
+      request = _DatadogTrackingHttpRequest(datadogSdk, request, rumKey);
     }
 
     return request;
@@ -285,13 +267,11 @@ class DatadogTrackingHttpClient implements HttpClient {
 class _DatadogTrackingHttpRequest implements HttpClientRequest {
   final DatadogSdk datadogSdk;
   final HttpClientRequest innerContext;
-  final DdSpan? tracingContext;
   final String? rumKey;
 
   _DatadogTrackingHttpRequest(
     this.datadogSdk,
     this.innerContext,
-    this.tracingContext,
     this.rumKey,
   );
 
@@ -299,8 +279,7 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
   Future<HttpClientResponse> get done {
     final innerFuture = innerContext.done;
     return innerFuture.then((value) {
-      return _DatadogTrackingHttpResponse(
-          datadogSdk, value, tracingContext, rumKey);
+      return _DatadogTrackingHttpResponse(datadogSdk, value, rumKey);
     }, onError: (e, st) {
       _onStreamError(e, st);
       throw e;
@@ -310,8 +289,7 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
   @override
   Future<HttpClientResponse> close() {
     return innerContext.close().then((value) {
-      return _DatadogTrackingHttpResponse(
-          datadogSdk, value, tracingContext, rumKey);
+      return _DatadogTrackingHttpResponse(datadogSdk, value, rumKey);
     }, onError: (e, st) async {
       _onStreamError(e, st);
       throw e;
@@ -324,11 +302,6 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
         datadogSdk.rum?.stopResourceLoadingWithErrorInfo(
             rumKey!, e.toString(), e.runtimeType.toString());
       }
-      tracingContext?.setErrorInfo(
-        e.runtimeType.toString(),
-        e.toString(),
-        st,
-      );
     } catch (e) {
       datadogSdk.internalLogger.sendToDatadog(
           '$DatadogTrackingHttpClient encountered an error attempting to report a stream error; $e');
@@ -416,14 +389,12 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
     implements HttpClientResponse {
   final DatadogSdk datadogSdk;
   final HttpClientResponse innerResponse;
-  final DdSpan? tracingContext;
   final String? rumKey;
   Object? lastError;
 
   _DatadogTrackingHttpResponse(
     this.datadogSdk,
     this.innerResponse,
-    this.tracingContext,
     this.rumKey,
   );
 
@@ -458,14 +429,6 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
   // error will be sent.
   void _onError(Object error, StackTrace? stackTrace) {
     lastError = error;
-    try {
-      tracingContext?.setErrorInfo(
-          error.runtimeType.toString(), error.toString(), stackTrace);
-    } catch (e) {
-      datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error while attempting '
-          ' to report a resource error: $e');
-    }
   }
 
   void _onFinish(Object? error, StackTrace? stackTrace) {
@@ -484,16 +447,6 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
           datadogSdk.rum
               ?.stopResourceLoading(rumKey!, statusCode, resourceType, size);
         }
-      }
-
-      final span = tracingContext;
-      if (span != null) {
-        span.setTag(OTTags.httpStatusCode, statusCode);
-        if (statusCode >= 400 && statusCode < 500) {
-          span.setErrorInfo('HttpStatusCode',
-              '$statusCode - ${innerResponse.reasonPhrase}', null);
-        }
-        span.finish();
       }
     } catch (e) {
       datadogSdk.internalLogger.sendToDatadog(

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -23,3 +23,7 @@ dev_dependencies:
 
 flutter:
 
+# TODO: For development of alpha.2. Remove once dd_flutter_plugin is alpha.3 
+dependency_overrides:
+  datadog_flutter_plugin:
+    path: ../datadog_flutter_plugin

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -6,9 +6,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
-import 'package:datadog_flutter_plugin/src/traces/ddtraces.dart';
-import 'package:datadog_tracking_http_client/src/tracing_headers.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,12 +15,6 @@ import 'package:mocktail/mocktail.dart';
 class MockDatadogSdk extends Mock implements DatadogSdk {}
 
 class MockDdRum extends Mock implements DdRum {}
-
-class MockDdTraces extends Mock implements DdTraces {}
-
-class MockDdSpan extends Mock implements DdSpan {}
-
-class FakeDdSpan extends Fake implements DdSpan {}
 
 class MockHttpClient extends Mock implements HttpClient {}
 
@@ -56,13 +49,11 @@ class HasHost extends CustomMatcher {
 
 void main() {
   late MockDatadogSdk mockDatadog;
-  late MockDdTraces mockTraces;
   late MockDdRum mockRum;
   late MockHttpClient mockClient;
 
   setUpAll(() {
     registerFallbackValue(Uri());
-    registerFallbackValue(FakeDdSpan());
     registerFallbackValue(RumHttpMethod.get);
     registerFallbackValue(RumResourceType.beacon);
   });
@@ -73,7 +64,6 @@ void main() {
         any(that: HasHost(equals('test_url'))))).thenReturn(true);
     when(() => mockDatadog.isFirstPartyHost(
         any(that: HasHost(equals('non_first_party'))))).thenReturn(false);
-    mockTraces = MockDdTraces();
     mockRum = MockDdRum();
 
     mockClient = MockHttpClient();
@@ -109,7 +99,7 @@ void main() {
     return mockResponse;
   }
 
-  group('when tracing and rum are disabled', () {
+  group('when rum is disabled', () {
     setUp(() {
       when(() => mockDatadog.traces).thenReturn(null);
       when(() => mockDatadog.rum).thenReturn(null);
@@ -155,206 +145,22 @@ void main() {
     });
   });
 
-  // Although mocked, these are the real headers we expect from tracing
-  const fakeTraceHeaders = {
-    'x-datadog-trace-id': 'fake-trace-id',
-    'x-datadog-parent-id': 'fake-span-id',
-    'x-datadog-sampling-priority': '1',
-    'x-datadog-sampled': '1',
-  };
+  void _verifyHeaders(HttpHeaders headers) {
+    verify(() => headers.add('x-datadog-sampling-priority', '1'));
+    var traceValue =
+        verify(() => headers.add('x-datadog-trace-id', captureAny()))
+            .captured[0];
+    var traceInt = BigInt.tryParse(traceValue);
+    expect(traceInt, isNotNull);
+    expect(traceInt?.bitLength, lessThanOrEqualTo(64));
 
-  MockDdSpan _enableTracing() {
-    final span = MockDdSpan();
-    when(() => mockTraces.startSpan(
-          any(),
-          parentSpan: any(named: 'parentSpan'),
-          tags: any(named: 'tags'),
-          startTime: any(named: 'startTime'),
-        )).thenAnswer((_) => span);
-    when(() => mockTraces.getTracePropagationHeaders(any()))
-        .thenAnswer((_) => Future.value(fakeTraceHeaders));
-    when(() => mockDatadog.traces).thenReturn(mockTraces);
-    when(() => span.finish()).thenAnswer((_) => Future.value());
-    when(() => span.setTag(any(), any())).thenAnswer((_) => Future.value());
-    when(() => span.setErrorInfo(any(), any(), any()))
-        .thenAnswer((_) => Future.value());
-    when(() => mockDatadog.traces).thenReturn(mockTraces);
-
-    return span;
+    var spanValue =
+        verify(() => headers.add('x-datadog-parent-id', captureAny()))
+            .captured[0] as String;
+    var spanInt = BigInt.tryParse(spanValue);
+    expect(spanInt, isNotNull);
+    expect(spanInt?.bitLength, lessThanOrEqualTo(64));
   }
-
-  group('when only tracing is enabled', () {
-    setUp(() {
-      when(() => mockDatadog.rum).thenReturn(null);
-    });
-
-    test('rum is not called', () async {
-      final completer = _setupMockRequest();
-      _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-
-      completer.complete(MockHttpClientResponse());
-      var _ = await request.done;
-      verifyZeroInteractions(mockRum);
-    });
-
-    test('open starts trace and calls through for first party url', () async {
-      final completer = _setupMockRequest();
-      final mockSpan = _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-
-      verify(() => mockClient.openUrl('get', url));
-      verify(() => mockTraces.startSpan('flutter.http_client', tags: {
-            'http.method': 'GET',
-            'http.url': url.toString(),
-          }));
-      final requestHeaders = request.headers;
-      for (var header in fakeTraceHeaders.entries) {
-        verify(() => requestHeaders.add(header.key, header.value));
-      }
-
-      // Finish not called until response is closed
-      verifyNever(() => mockSpan.finish());
-
-      final mockResponse = _setupMockClientResponse(200);
-      completer.complete(mockResponse);
-      var response = await request.done;
-
-      // Still not done...
-      verifyNever(() => mockSpan.finish());
-      response.listen((event) {});
-      await mockResponse.streamController.close();
-      verify(() => mockSpan.setTag(OTTags.httpStatusCode, 200));
-      verify(() => mockSpan.finish());
-    });
-
-    test('tracing still passes through data on stream', () async {
-      final completer = _setupMockRequest();
-      _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-      final mockResponse = _setupMockClientResponse(200);
-
-      completer.complete(mockResponse);
-      var response = await request.done;
-      List<int>? data;
-      response.listen((event) {
-        data = event;
-      });
-      mockResponse.streamController.sink.add([12, 1, 2]);
-      await mockResponse.streamController.close();
-      expect(data, [12, 1, 2]);
-    });
-
-    test('open does not start trace and calls through for non-first party url',
-        () async {
-      final completer = _setupMockRequest();
-      // ignore: unused_local_variable
-      final mockSpan = _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://non_first_party/path');
-      var request = await client.openUrl('get', url);
-
-      verify(() => mockClient.openUrl('get', url));
-
-      completer.complete(MockHttpClientResponse());
-      var _ = await request.done;
-
-      verifyNever(() => mockTraces.startSpan(
-            any(),
-            parentSpan: any(named: 'parentSpan'),
-            tags: any(named: 'tags'),
-            startTime: any(named: 'startTime'),
-          ));
-    });
-
-    test('error opening passes sets trace errors', () async {
-      final completer = _setupMockRequest();
-      var mockSpan = _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-
-      var error = Error();
-      Object? caughtError;
-      completer.completeError(error);
-      try {
-        await request.done;
-      } catch (e) {
-        caughtError = e;
-      }
-
-      expect(caughtError, error, reason: 'Error should be rethrown');
-      verify(() => mockSpan.setErrorInfo(
-          error.runtimeType.toString(), error.toString(), any()));
-    });
-
-    test('error status codes set errors on trace', () async {
-      final completer = _setupMockRequest();
-      var mockSpan = _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-
-      var mockResponse = _setupMockClientResponse(403);
-      completer.complete(mockResponse);
-      var response = await request.done;
-
-      // Listen / close the response
-      response.listen((event) {});
-      await mockResponse.streamController.close();
-
-      expect(response.statusCode, 403);
-      verify(() => mockSpan.setTag(OTTags.httpStatusCode, 403));
-      verify(() => mockSpan.setErrorInfo(
-          'HttpStatusCode', '403 - ${response.reasonPhrase}', any()));
-    });
-
-    test('error in stream sets errors on trace', () async {
-      final completer = _setupMockRequest();
-      var mockSpan = _enableTracing();
-
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-
-      var mockResponse = _setupMockClientResponse(200);
-      completer.complete(mockResponse);
-      var response = await request.done;
-
-      // Listen / close the response
-      var error = Error();
-      Object? caughtError;
-      response.listen((event) {}, onError: (e) {
-        caughtError = e;
-      });
-      mockResponse.streamController.addError(error);
-      await mockResponse.streamController.close();
-
-      expect(caughtError, error);
-      verify(() => mockSpan.setTag(OTTags.httpStatusCode, 200));
-      verify(() => mockSpan.setErrorInfo(
-          error.runtimeType.toString(), error.toString(), any()));
-    });
-  });
 
   void _enableRum() {
     when(() => mockDatadog.traces).thenReturn(null);
@@ -367,7 +173,7 @@ void main() {
         .thenAnswer((_) => Future.value());
   }
 
-  group('when only rum is enabled', () {
+  group('when rum is enabled', () {
     setUp(() {
       _enableRum();
     });
@@ -385,7 +191,7 @@ void main() {
       verify(() => mockClient.openUrl('get', url));
       var capturedKey = verify(
         () => mockRum.startResourceLoading(
-            captureAny(), RumHttpMethod.get, url.toString()),
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
       ).captured[0] as String;
 
       verifyNever(() => mockRum.stopResourceLoading(any(), any(), any()));
@@ -416,7 +222,7 @@ void main() {
       verify(() => mockClient.openUrl('get', url));
       var capturedKey = verify(
         () => mockRum.startResourceLoading(
-            captureAny(), RumHttpMethod.get, url.toString()),
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
       ).captured[0] as String;
 
       verifyNever(() => mockRum.stopResourceLoading(any(), any(), any()));
@@ -442,7 +248,7 @@ void main() {
       verify(() => mockClient.openUrl('get', url));
       var capturedKey = verify(
         () => mockRum.startResourceLoading(
-            captureAny(), RumHttpMethod.get, url.toString()),
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
       ).captured[0] as String;
 
       final mockResponse = _setupMockClientResponse(200, mimeType: 'video/mp4');
@@ -465,7 +271,7 @@ void main() {
       var request = await client.openUrl('get', url);
       var capturedKey = verify(
         () => mockRum.startResourceLoading(
-            captureAny(), RumHttpMethod.get, url.toString()),
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
       ).captured[0] as String;
 
       var error = Error();
@@ -490,7 +296,7 @@ void main() {
       var request = await client.openUrl('get', url);
       var capturedKey = verify(
         () => mockRum.startResourceLoading(
-            captureAny(), RumHttpMethod.get, url.toString()),
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
       ).captured[0] as String;
 
       var mockResponse = _setupMockClientResponse(200);
@@ -513,14 +319,6 @@ void main() {
             error.toString(),
             error.runtimeType.toString(),
           ));
-    });
-  });
-
-  group('when rum and tracing are enabled', () {
-    late DdSpan span;
-    setUp(() {
-      _enableRum();
-      span = _enableTracing();
     });
 
     test('start and stop resource loading set tracing attributes', () async {
@@ -551,29 +349,15 @@ void main() {
       verify(() => mockRum.stopResourceLoading(
           capturedKey, 200, RumResourceType.image, 12345));
 
-      expect(capturedStartAttributes[DatadogPlatformAttributeKey.traceID],
-          'fake-trace-id');
-      expect(capturedStartAttributes[DatadogPlatformAttributeKey.spanID],
-          'fake-span-id');
-    });
+      var traceInt = BigInt.parse(
+          capturedStartAttributes[DatadogRumPlatformAttributeKey.traceID]);
+      expect(traceInt, isNotNull);
+      expect(traceInt.bitLength, lessThanOrEqualTo(64));
 
-    test('does not start perform operations on spans', () async {
-      final completer = _setupMockRequest();
-      final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
-
-      var url = Uri.parse('https://test_url/path');
-      var request = await client.openUrl('get', url);
-      var mockResponse = _setupMockClientResponse(200);
-
-      completer.complete(mockResponse);
-      var response = await request.done;
-      response.listen((event) {});
-      await mockResponse.streamController.close();
-      // Drain any awaiting futures.
-      await Future.microtask(() {});
-
-      verify(() => span.cancel());
-      verifyNoMoreInteractions(span);
+      var spanInt = BigInt.parse(
+          capturedStartAttributes[DatadogRumPlatformAttributeKey.spanID]);
+      expect(spanInt, isNotNull);
+      expect(spanInt.bitLength, lessThanOrEqualTo(64));
     });
 
     test('sets trace headers for first party urls', () async {
@@ -583,9 +367,7 @@ void main() {
       var url = Uri.parse('https://test_url/path');
       var request = await client.openUrl('get', url);
       final requestHeaders = request.headers;
-      for (var header in fakeTraceHeaders.entries) {
-        verify(() => requestHeaders.add(header.key, header.value));
-      }
+      _verifyHeaders(requestHeaders);
     });
 
     test('does not set trace headers for third party urls', () async {
@@ -595,8 +377,14 @@ void main() {
       var url = Uri.parse('https://non_first_party/path');
       var request = await client.openUrl('get', url);
       final requestHeaders = request.headers;
-      for (var header in fakeTraceHeaders.entries) {
-        verifyNever(() => requestHeaders.add(header.key, header.value));
+
+      var headers = [
+        'x-datadog-sampling-priority',
+        'x-datadog-trace-id',
+        'x-datadog-parent-id'
+      ];
+      for (var header in headers) {
+        verifyNever(() => requestHeaders.add(header, any()));
       }
     });
 


### PR DESCRIPTION
### What and why?

This is a first step for removing the Tracer. Generate Span / Trace IDs on the Dart side and use those when sending resource to RUM.

Integration tests are passing but I need to check E2E in Shopist as well.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue