### PR TITLE
💚Fix nightly e2e

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,7 @@ workflows:
   
   nightly:
     before_run:
+    - _flutter_install
     - setup
     - nightly_ios
     - nightly_android

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">=2.16.1 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
### What and why?

Set the required Flutter version down to 2.16.1 on the gRPC plugin.
Install flutter version manually in the bitrise.yaml.  

Nightly e2e is currently failing because the version bitrise is installing is 2.16.1, where latest is 2.16.2, which is what the gRPC plugin was set to.


### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue