### PR TITLE
🐛 Fix TraceId to be a 63-bit integer.

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
+++ b/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
@@ -289,7 +289,10 @@ class DdTraces {
 final _traceRandom = Random();
 
 String generateTraceId() {
-  final highBits = _traceRandom.nextInt(1 << 32);
+  // Though traceid is an unsigned 64-bit int, for compatibility
+  // we assume it needs to be a positive signed 64-bit int, so only
+  // use 63-bits.
+  final highBits = _traceRandom.nextInt(1 << 31);
   final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
 
   var traceId = BigInt.from(highBits) << 32;

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -151,14 +151,14 @@ void main() {
             .captured[0];
     var traceInt = BigInt.tryParse(traceValue);
     expect(traceInt, isNotNull);
-    expect(traceInt?.bitLength, lessThanOrEqualTo(64));
+    expect(traceInt?.bitLength, lessThanOrEqualTo(63));
 
     var spanValue =
         verify(() => headers.add('x-datadog-parent-id', captureAny()))
             .captured[0] as String;
     var spanInt = BigInt.tryParse(spanValue);
     expect(spanInt, isNotNull);
-    expect(spanInt?.bitLength, lessThanOrEqualTo(64));
+    expect(spanInt?.bitLength, lessThanOrEqualTo(63));
   }
 
   void _enableRum() {
@@ -350,12 +350,12 @@ void main() {
       var traceInt = BigInt.parse(
           capturedStartAttributes[DatadogRumPlatformAttributeKey.traceID]);
       expect(traceInt, isNotNull);
-      expect(traceInt.bitLength, lessThanOrEqualTo(64));
+      expect(traceInt.bitLength, lessThanOrEqualTo(63));
 
       var spanInt = BigInt.parse(
           capturedStartAttributes[DatadogRumPlatformAttributeKey.spanID]);
       expect(spanInt, isNotNull);
-      expect(spanInt.bitLength, lessThanOrEqualTo(64));
+      expect(spanInt.bitLength, lessThanOrEqualTo(63));
     });
 
     test('sets trace headers for first party urls', () async {


### PR DESCRIPTION
### What and why?

For compatibility with systems that do not support unsigned 64-bit integers, some Datadog services only support 63-bit trace ids. Make sure we only send 63-bits.

### How?

Reduce the max value of the high bits to 31-bits, then shift into the high 32-bits.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue