### PR TITLE
📝 Add additional documentation for ViewInfoExtractor.

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -36,7 +36,8 @@ export 'src/rum/navigation_observer.dart'
         DatadogNavigationObserver,
         DatadogNavigationObserverProvider,
         RumViewInfo,
-        DatadogRouteAwareMixin;
+        DatadogRouteAwareMixin,
+        ViewInfoExtractor;
 export 'src/traces/ddtraces.dart'
     show DdSpan, OTTags, OTLogFields, generateTraceId;
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -6,20 +6,31 @@ import 'package:flutter/material.dart';
 
 import '../../datadog_flutter_plugin.dart';
 
+/// Information about a View that will be passed to [DdRum.startView]
 class RumViewInfo {
+  /// The name of the view
   final String name;
+
+  /// A path to the view
   final String? path;
-  final String? service;
+
+  /// Any attributes to be associated with this view
   final Map<String, dynamic> attributes;
 
   RumViewInfo({
     required this.name,
     this.path,
-    this.service,
     this.attributes = const {},
   });
 }
 
+/// A function that can be used to supply custom information to
+/// [DdRum.startView].
+///
+/// Returning `null` from this function will prevent the call
+/// to [DdRum.startView].
+///
+/// See [DatadogNavigationObserver.viewInfoExtractor].
 typedef ViewInfoExtractor = RumViewInfo? Function(Route route);
 
 RumViewInfo? defaultViewInfoExtractor(Route route) {


### PR DESCRIPTION
### What and why?

ViewInfoExtractor can be used over an event mapper to potentially remove or rename routes, so we want it to be more public with additional documentation.

Also, remove 'service' from RumViewInfo as it currently has no affect.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue