### PR TITLE
📝 Minor adjustments to documentation

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -127,10 +127,11 @@ You can enable automatic tracking of resources and HTTP calls from your RUM view
 ```dart
 final configuration = DdSdkConfiguration(
   // configuration
+  firstPartyHosts: ['example.com'],
 )..enableHttpTracking()
 ```
 
-If you want to enable Datadog distributed tracing, you must also set the `DdSdkConfiguration.firstPartyHosts` configuration option.
+In order to enable Datadog Distributed Tracing, the `DdSdkConfiguration.firstPartyHosts` property in your configuration object must be set to a domain that supports distributed tracing.
 
 ## Data Storage
 

--- a/packages/datadog_tracking_http_client/README.md
+++ b/packages/datadog_tracking_http_client/README.md
@@ -5,7 +5,7 @@
 
 ## Getting started
 
-To use this plugin, enable it during configuration of your SDK. In order to enable Datadog Distributed Tracing, you will also need to set the `firstPartyHosts` property in your configuration object.
+To use this plugin, enable it during configuration of your SDK. In order to enable Datadog Distributed Tracing, you also need to set the `firstPartyHosts` property in your configuration object.
 
 ```dart
 import 'package:datadog_tracking_http_client/datadog_tracing_http_client.dart';

--- a/packages/datadog_tracking_http_client/README.md
+++ b/packages/datadog_tracking_http_client/README.md
@@ -3,19 +3,19 @@
 
 > A plugin for use with the Datadog SDK, used to track performance of HTTP calls and enable Datadog Distributed Tracing.
 
-> ⚠️ This plugin is still in Alpha / Developer Preview. 
-
 ## Getting started
 
-To utilize this plugin, enable it during configuration of your SDK:
+To use this plugin, enable it during configuration of your SDK. In order to enable Datadog Distributed Tracing, you will also need to set the `firstPartyHosts` property in your configuration object.
 
 ```dart
-import 'package:datadog_tracking_http_client/datadog_tracing_http_client.dart'
+import 'package:datadog_tracking_http_client/datadog_tracing_http_client.dart';
 
 final configuration = DdSdkConfiguration(
   // configuration
+  firstPartyHosts: ['example.com'],
 )..enableHttpTracking()
 ```
+
 
 # Contributing
 


### PR DESCRIPTION
### What and why?

Improve some of our documentation.

Add a missing semi-colon in the `datadog_tracking_http_client` README.
Add information about needing to set `firstPartyHosts` when using the tracking http client.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue