### PR TITLE
💚 Lock Flutter version to last pre-3.0 version.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -28,7 +28,7 @@ workflows:
     steps:
     - flutter-installer@0:
         inputs:
-        - version: stable
+        - version: 2.10.5
     
   _prepare_gradle_wrapper:
     steps:


### PR DESCRIPTION
### What and why?

Packages aren't ready for 3.0 yet, so lock to the last stable 2.0 release for now.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue