### PR TITLE
⬆️ Upgrade lints to 2.0. Fix associated warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,6 +21,7 @@
     "peacock.color": "#7f757f",
     "rewrap.wrappingColumn": 80,
     "cSpell.words": [
+        "jsutil",
         "mocktail",
         "Pubspec",
         "rethrown",

--- a/packages/datadog_common_test/lib/src/mock_http_sever.dart
+++ b/packages/datadog_common_test/lib/src/mock_http_sever.dart
@@ -102,11 +102,7 @@ class RecordingHttpServer {
 }
 
 abstract class RecordingServerClient {
-  var _currentSession = '';
-  String get currentSession => _currentSession;
-  set currentSession(String value) {
-    _currentSession = value;
-  }
+  var currentSession = '';
 
   String get sessionEndpoint => '$_endpoint/$currentSession/';
 

--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  collection: ^1.16.0
   flutter:
     sdk: flutter
   http: ^0.13.4
@@ -17,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   json_serializable: ^6.1.0
   build_runner: ^2.1.10
 

--- a/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
@@ -96,7 +96,7 @@ class CrashReportingScreen extends StatefulWidget {
   const CrashReportingScreen({Key? key}) : super(key: key);
 
   @override
-  _CrashReportingScreenState createState() => _CrashReportingScreenState();
+  State<CrashReportingScreen> createState() => _CrashReportingScreenState();
 }
 
 class _CrashReportingScreenState extends State<CrashReportingScreen> {

--- a/packages/datadog_flutter_plugin/example/lib/rum_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_screen.dart
@@ -9,7 +9,7 @@ class RumScreen extends StatefulWidget {
   const RumScreen({Key? key}) : super(key: key);
 
   @override
-  _RumScreenState createState() => _RumScreenState();
+  State<RumScreen> createState() => _RumScreenState();
 }
 
 class _RumScreenState extends State<RumScreen> {

--- a/packages/datadog_flutter_plugin/example/pubspec.lock
+++ b/packages/datadog_flutter_plugin/example/pubspec.lock
@@ -96,7 +96,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
@@ -225,5 +225,5 @@ packages:
     source: hosted
     version: "2.1.2"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/datadog_flutter_plugin/example/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 flutter:
   uses-material-design: true

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_scenario.dart
@@ -11,7 +11,7 @@ class RumAutoInstrumentationScenario extends StatefulWidget {
   const RumAutoInstrumentationScenario({Key? key}) : super(key: key);
 
   @override
-  _RumAutoInstrumentationScenarioState createState() =>
+  State<RumAutoInstrumentationScenario> createState() =>
       _RumAutoInstrumentationScenarioState();
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_second_screen.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_second_screen.dart
@@ -12,7 +12,7 @@ class RumAutoInstrumentationSecondScreen extends StatefulWidget {
   const RumAutoInstrumentationSecondScreen({Key? key}) : super(key: key);
 
   @override
-  _RumAutoInstrumentationSecondScreenState createState() =>
+  State<RumAutoInstrumentationSecondScreen> createState() =>
       _RumAutoInstrumentationSecondScreenState();
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_third_screen.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_third_screen.dart
@@ -8,7 +8,7 @@ class RumAutoInstrumentationThirdScreen extends StatefulWidget {
   const RumAutoInstrumentationThirdScreen({Key? key}) : super(key: key);
 
   @override
-  _RumAutoInstrumentationThirdScreenState createState() =>
+  State<RumAutoInstrumentationThirdScreen> createState() =>
       _RumAutoInstrumentationThirdScreenState();
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
@@ -14,7 +14,7 @@ class IntegrationScenariosScreen extends StatefulWidget {
   const IntegrationScenariosScreen({Key? key}) : super(key: key);
 
   @override
-  _IntegrationScenariosScreenState createState() =>
+  State<IntegrationScenariosScreen> createState() =>
       _IntegrationScenariosScreenState();
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -9,7 +9,7 @@ class LoggingScenario extends StatefulWidget {
   const LoggingScenario({Key? key}) : super(key: key);
 
   @override
-  _LoggingScenarioState createState() => _LoggingScenarioState();
+  State<LoggingScenario> createState() => _LoggingScenarioState();
 }
 
 class _LoggingScenarioState extends State<LoggingScenario> {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -11,7 +11,7 @@ class RumManualErrorReportingScenario extends StatefulWidget {
   const RumManualErrorReportingScenario({Key? key}) : super(key: key);
 
   @override
-  _RumManualErrorReportingScenarioState createState() =>
+  State<RumManualErrorReportingScenario> createState() =>
       _RumManualErrorReportingScenarioState();
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -16,7 +16,7 @@ class RumManualInstrumentationScenario extends StatefulWidget {
   const RumManualInstrumentationScenario({Key? key}) : super(key: key);
 
   @override
-  _RumManualInstrumentationScenarioState createState() =>
+  State<RumManualInstrumentationScenario> createState() =>
       _RumManualInstrumentationScenarioState();
 }
 
@@ -136,7 +136,7 @@ class RumManualInstrumentation2 extends StatefulWidget {
   const RumManualInstrumentation2({Key? key}) : super(key: key);
 
   @override
-  _RumManualInstrumentation2State createState() =>
+  State<RumManualInstrumentation2> createState() =>
       _RumManualInstrumentation2State();
 }
 
@@ -237,7 +237,7 @@ class RumManualInstrumentation3 extends StatefulWidget {
   const RumManualInstrumentation3({Key? key}) : super(key: key);
 
   @override
-  _RumManualInstrumentation3State createState() =>
+  State<RumManualInstrumentation3> createState() =>
       _RumManualInstrumentation3State();
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/traces_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/traces_scenario.dart
@@ -14,7 +14,7 @@ class TracesScenario extends StatefulWidget {
   const TracesScenario({Key? key}) : super(key: key);
 
   @override
-  _TracesScenarioState createState() => _TracesScenarioState();
+  State<TracesScenario> createState() => _TracesScenarioState();
 }
 
 class _TracesScenarioState extends State<TracesScenario> {

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -115,7 +115,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -132,7 +132,7 @@ packages:
     source: sdk
     version: "0.0.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
@@ -170,7 +170,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     path: ../
   datadog_common_test:
     path: ../../datadog_common_test
+  http: ^0.13.4
     
 dev_dependencies:
   flutter_test:
@@ -25,7 +26,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   collection: ^1.15.0
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 flutter:
   uses-material-design: true

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -86,7 +86,7 @@ class DatadogSdk {
     _firstPartyHosts = value;
     if (value.isNotEmpty) {
       // pattern = "^(.*\\.)*tracedHost1$|tracedHost2$|...$"
-      var hosts = value.map((e) => RegExp.escape(e) + '\$').join('|');
+      var hosts = value.map((e) => '${RegExp.escape(e)}\$').join('|');
       _firstPartyRegex = RegExp('^(.*\\.)*$hosts');
     } else {
       _firstPartyRegex = null;

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
-// ignore_for_file: unused_element
+// ignore_for_file: unused_element, library_private_types_in_public_api
 
 @JS('DD_LOGS')
 library ddlogs_flutter_web;

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
-// ignore_for_file: unused_element
+// ignore_for_file: unused_element, library_private_types_in_public_api
 
 @JS('DD_RUM')
 library ddrum_flutter_web;
@@ -25,7 +25,7 @@ class DdRumWeb extends DdRumPlatform {
       applicationId: rumConfiguration.applicationId,
       clientToken: configuration.clientToken,
       site: siteStringForSite(configuration.site),
-      sampleRate: rumConfiguration.sampleRate,
+      sampleRate: rumConfiguration.sessionSamplingRate,
       service: configuration.serviceName,
       env: configuration.env,
       proxyUrl: configuration.customEndpoint,

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -2,7 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import 'package:collection/collection.dart';
 import 'package:js/js_util.dart' as jsutil;
 
 import '../datadog_flutter_plugin.dart';
@@ -43,8 +42,10 @@ dynamic valueToJs(Object? value, String parameterName) {
   }
 
   if (value is List) {
-    final jsList =
-        value.mapIndexed((e, i) => valueToJs(e, '$parameterName[i]')).toList();
+    final jsList = [];
+    for (int i = 0; i < value.length; ++i) {
+      jsList.add(valueToJs(value[i], '$parameterName[$i]'));
+    }
     return jsList;
   }
 

--- a/packages/datadog_flutter_plugin/pubspec.lock
+++ b/packages/datadog_flutter_plugin/pubspec.lock
@@ -110,7 +110,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -169,7 +169,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
@@ -414,5 +414,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   mocktail: ^0.2.0
 
 flutter:

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/src/internal_logger.dart';
-import 'package:datadog_flutter_plugin/src/logs/ddlogs.dart';
 import 'package:datadog_flutter_plugin/src/logs/ddlogs_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/src/internal_logger.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -3,7 +3,6 @@
 // Copyright 2019-2022 Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -410,7 +409,7 @@ class MixedDestination extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _MixedDestinationState createState() => _MixedDestinationState();
+  State<MixedDestination> createState() => _MixedDestinationState();
 }
 
 class _MixedDestinationState extends State<MixedDestination>
@@ -426,7 +425,7 @@ class _MixedDestinationState extends State<MixedDestination>
       child: Column(
         children: [
           if (widget.nextPageBuilder != null)
-            ElevatedButton(child: const Text('Push'), onPressed: _onPush),
+            ElevatedButton(onPressed: _onPush, child: const Text('Push')),
           ElevatedButton(
             child: const Text('Pop'),
             onPressed: () {

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   mocktail: ^0.3.0
 
 flutter:

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -2,8 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+// ignore_for_file: deprecated_member_use
+
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/traces/ddtraces.dart';
 import 'package:datadog_grpc_interceptor/datadog_grpc_interceptor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,7 +72,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),
@@ -95,7 +96,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),
@@ -117,7 +118,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),
@@ -143,7 +144,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),
@@ -165,7 +166,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     expect(loggingService.calls.length, 1);
     final call = loggingService.calls[0];
@@ -188,7 +189,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     expect(loggingService.calls.length, 1);
     final call = loggingService.calls[0];
@@ -209,7 +210,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     expect(loggingService.calls.length, 1);
     final call = loggingService.calls[0];
@@ -228,7 +229,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     expect(loggingService.calls.length, 1);
     final call = loggingService.calls[0];
@@ -249,7 +250,7 @@ void main() {
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    final _ = await stub.sayHello(HelloRequest(name: 'test'));
+    await stub.sayHello(HelloRequest(name: 'test'));
 
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),

--- a/packages/datadog_tracking_http_client/example/lib/rum_auto_instrumentation_scenario.dart
+++ b/packages/datadog_tracking_http_client/example/lib/rum_auto_instrumentation_scenario.dart
@@ -15,7 +15,7 @@ class RumAutoInstrumentationScenario extends StatefulWidget {
   const RumAutoInstrumentationScenario({Key? key}) : super(key: key);
 
   @override
-  _RumAutoInstrumentationScenarioState createState() =>
+  State<RumAutoInstrumentationScenario> createState() =>
       _RumAutoInstrumentationScenarioState();
 }
 

--- a/packages/datadog_tracking_http_client/example/lib/rum_auto_instrumentation_second_screen.dart
+++ b/packages/datadog_tracking_http_client/example/lib/rum_auto_instrumentation_second_screen.dart
@@ -12,7 +12,7 @@ class RumAutoInstrumentationSecondScreen extends StatefulWidget {
   const RumAutoInstrumentationSecondScreen({Key? key}) : super(key: key);
 
   @override
-  _RumAutoInstrumentationSecondScreenState createState() =>
+  State<RumAutoInstrumentationSecondScreen> createState() =>
       _RumAutoInstrumentationSecondScreenState();
 }
 

--- a/packages/datadog_tracking_http_client/example/lib/rum_auto_instrumentation_third_screen.dart
+++ b/packages/datadog_tracking_http_client/example/lib/rum_auto_instrumentation_third_screen.dart
@@ -8,7 +8,7 @@ class RumAutoInstrumentationThirdScreen extends StatefulWidget {
   const RumAutoInstrumentationThirdScreen({Key? key}) : super(key: key);
 
   @override
-  _RumAutoInstrumentationThirdScreenState createState() =>
+  State<RumAutoInstrumentationThirdScreen> createState() =>
       _RumAutoInstrumentationThirdScreenState();
 }
 

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -72,7 +72,7 @@ packages:
     source: path
     version: "0.0.1"
   datadog_flutter_plugin:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: "../../datadog_flutter_plugin"
       relative: true
@@ -122,7 +122,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -177,7 +177,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
@@ -324,5 +324,5 @@ packages:
     source: hosted
     version: "3.0.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0-206.0.dev <3.0.0"
   flutter: ">=1.17.0"

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   http: ^0.13.4
   transparent_image: ^2.0.0
 
+  datadog_flutter_plugin:
+    path: ../../datadog_flutter_plugin
   datadog_tracking_http_client:
     path: ../
   datadog_common_test:
@@ -25,7 +27,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   
 flutter:
   uses-material-design: true
@@ -36,3 +38,4 @@ flutter:
 dependency_overrides:
   datadog_flutter_plugin:
     path: ../../datadog_flutter_plugin
+    

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
   mocktail: ^0.2.0
 
 flutter:

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -139,7 +138,7 @@ void main() {
       final client = DatadogTrackingHttpClient(mockDatadog, mockClient);
 
       var url = Uri.parse('https://test_url/path');
-      var _ = await client.openUrl('get', url);
+      await client.openUrl('get', url);
 
       verify(() => mockClient.openUrl('get', url));
     });


### PR DESCRIPTION
### What and why?

With Flutter 3.0, the Flutter / Dart team also updated their linting rules. I've updated and fixed all warnings associated with this update.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests