### PR TITLE
✨Added `datadogReportingThreshold` to loggers

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update iOS SDK to 1.11-rc2
   * Allow manually tracked resources in RUM Sessions to detect first party hosts.
   * Better error message when encountering an invalid token (Fixes #117)
+* Added `datadogReportingThreshold` to `LoggingConfiguration` to support only sending logs above a certain threshold to Datadog.
 * Add support for setting a tracing sample rate for RUM.
 * Expose `DdLogs` through the main package import. Added documentation to DdLogs.
 

--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.11"
   async:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   file:
     dependency: transitive
     description:
@@ -135,7 +135,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -156,7 +156,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -170,7 +170,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   platform:
     dependency: transitive
     description:
@@ -203,7 +203,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -245,7 +245,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -266,14 +266,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.2"
   webdriver:
     dependency: transitive
     description:
@@ -282,5 +282,5 @@ packages:
     source: hosted
     version: "3.0.0"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -186,7 +186,8 @@ class DatadogSdk {
   ///
   /// This can be used in addition to or instead of the default logger at [logs]
   DdLogs createLogger(LoggingConfiguration configuration) {
-    final logger = DdLogs(internalLogger);
+    final logger =
+        DdLogs(internalLogger, configuration.datadogReportingThreshold);
     wrap('createLogger', internalLogger, () {
       return DdLogsPlatform.instance
           .createLogger(logger.loggerHandle, configuration);

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -93,10 +93,19 @@ class LoggingConfiguration {
   /// Defaults to `false`.
   bool printLogsToConsole;
 
-  // Enables or disables sending logs to Datadog.
+  /// Enables or disables sending logs to Datadog.
   ///
   /// Defaults to `true`.
   bool sendLogsToDatadog;
+
+  /// Sets the level of logs that get sent to Datadog
+  ///
+  /// Logs below the configured threshold are not sent to Datadog, while
+  /// logs at this threshold and above are, so long as [sendLogsToDatadog]
+  /// is also set.
+  ///
+  /// Defaults to [Verbosity.verbose]
+  Verbosity datadogReportingThreshold;
 
   /// Enables the logs integration with RUM.
   ///
@@ -125,6 +134,7 @@ class LoggingConfiguration {
     this.sendNetworkInfo = false,
     this.printLogsToConsole = false,
     this.sendLogsToDatadog = true,
+    this.datadogReportingThreshold = Verbosity.verbose,
     this.bundleWithRum = true,
     this.bundleWithTrace = true,
     this.loggerName,

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -3,6 +3,7 @@
 // Copyright 2019-2021 Datadog, Inc.
 import 'package:uuid/uuid.dart';
 
+import '../../datadog_flutter_plugin.dart';
 import '../helpers.dart';
 import '../internal_logger.dart';
 import 'ddlogs_platform_interface.dart';
@@ -19,9 +20,12 @@ const _uuid = Uuid();
 /// their own settings.
 class DdLogs {
   final InternalLogger _internalLogger;
+  final Verbosity _reportingThreshold;
+
   final String loggerHandle;
 
-  DdLogs(this._internalLogger) : loggerHandle = _uuid.v4();
+  DdLogs(this._internalLogger, this._reportingThreshold)
+      : loggerHandle = _uuid.v4();
 
   static DdLogsPlatform get _platform {
     return DdLogsPlatform.instance;
@@ -33,9 +37,11 @@ class DdLogs {
   /// [context] parameter. Values passed into [context] must be supported by
   /// [StandardMessageCodec].
   void debug(String message, [Map<String, Object?> context = const {}]) {
-    wrap('logs.debug', _internalLogger, () {
-      return _platform.debug(loggerHandle, message, context);
-    });
+    if (_reportingThreshold.index <= Verbosity.debug.index) {
+      wrap('logs.debug', _internalLogger, () {
+        return _platform.debug(loggerHandle, message, context);
+      });
+    }
   }
 
   /// Sends an `info` log message.
@@ -44,9 +50,11 @@ class DdLogs {
   /// [context] parameter. Values passed into [context] must be supported by
   /// [StandardMessageCodec].
   void info(String message, [Map<String, Object?> context = const {}]) {
-    wrap('logs.info', _internalLogger, () {
-      return _platform.info(loggerHandle, message, context);
-    });
+    if (_reportingThreshold.index <= Verbosity.info.index) {
+      wrap('logs.info', _internalLogger, () {
+        return _platform.info(loggerHandle, message, context);
+      });
+    }
   }
 
   /// Sends a `warn` log message.
@@ -55,9 +63,11 @@ class DdLogs {
   /// [context] parameter. Values passed into [context] must be supported by
   /// [StandardMessageCodec].
   void warn(String message, [Map<String, Object?> context = const {}]) {
-    wrap('logs.warn', _internalLogger, () {
-      return _platform.warn(loggerHandle, message, context);
-    });
+    if (_reportingThreshold.index <= Verbosity.warn.index) {
+      wrap('logs.warn', _internalLogger, () {
+        return _platform.warn(loggerHandle, message, context);
+      });
+    }
   }
 
   /// Sends an `error` log message.
@@ -66,9 +76,11 @@ class DdLogs {
   /// [context] parameter. Values passed into [context] must be supported by
   /// [StandardMessageCodec].
   void error(String message, [Map<String, Object?> context = const {}]) {
-    wrap('logs.error', _internalLogger, () {
-      return _platform.error(loggerHandle, message, context);
-    });
+    if (_reportingThreshold.index <= Verbosity.error.index) {
+      wrap('logs.error', _internalLogger, () {
+        return _platform.error(loggerHandle, message, context);
+      });
+    }
   }
 
   /// Add a custom attribute to all future logs sent by this logger.

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -27,54 +27,115 @@ void main() {
   late DdLogs ddLogs;
   late MockDdLogsPlatform mockPlatform;
 
-  setUp(() {
-    logger = TestLogger();
-    mockPlatform = MockDdLogsPlatform();
-    when(() => mockPlatform.debug(any(), any(), any()))
-        .thenAnswer((invocation) => Future.value());
-    when(() => mockPlatform.info(any(), any(), any()))
-        .thenAnswer((invocation) => Future.value());
-    when(() => mockPlatform.warn(any(), any(), any()))
-        .thenAnswer((invocation) => Future.value());
-    when(() => mockPlatform.error(any(), any(), any()))
-        .thenAnswer((invocation) => Future.value());
-    DdLogsPlatform.instance = mockPlatform;
-    ddLogs = DdLogs(logger);
+  group('basic logger tests', () {
+    setUp(() {
+      logger = TestLogger();
+      mockPlatform = MockDdLogsPlatform();
+      when(() => mockPlatform.debug(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      when(() => mockPlatform.info(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      when(() => mockPlatform.warn(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      when(() => mockPlatform.error(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      DdLogsPlatform.instance = mockPlatform;
+      ddLogs = DdLogs(logger, Verbosity.verbose);
+    });
+
+    test('debug logs pass to platform', () async {
+      ddLogs.debug('debug message', {'attribute': 'value'});
+
+      verify(() => mockPlatform
+          .debug(ddLogs.loggerHandle, 'debug message', {'attribute': 'value'}));
+    });
+
+    test('info logs pass to platform', () async {
+      ddLogs.info('info message', {'attribute': 'value'});
+
+      verify(() => mockPlatform
+          .info(ddLogs.loggerHandle, 'info message', {'attribute': 'value'}));
+    });
+
+    test('warn logs pass to platform', () async {
+      ddLogs.warn('warn message', {'attribute': 'value'});
+
+      verify(() => mockPlatform
+          .warn(ddLogs.loggerHandle, 'warn message', {'attribute': 'value'}));
+    });
+
+    test('error logs pass to platform', () async {
+      ddLogs.error('error message', {'attribute': 'value'});
+
+      verify(() => mockPlatform
+          .error(ddLogs.loggerHandle, 'error message', {'attribute': 'value'}));
+    });
+
+    test('addAttribute argumentError sent to logger', () async {
+      when(() => mockPlatform.addAttribute(any(), any(), any()))
+          .thenThrow(ArgumentError());
+      ddLogs.addAttribute('My key', 'Any Value');
+
+      assert(logger.logs.isNotEmpty);
+    });
   });
 
-  test('debug logs pass to platform', () async {
-    ddLogs.debug('debug message', {'attribute': 'value'});
+  group('threshold tests', () {
+    setUp(() {
+      logger = TestLogger();
+      mockPlatform = MockDdLogsPlatform();
+      when(() => mockPlatform.debug(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      when(() => mockPlatform.info(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      when(() => mockPlatform.warn(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      when(() => mockPlatform.error(any(), any(), any()))
+          .thenAnswer((invocation) => Future.value());
+      DdLogsPlatform.instance = mockPlatform;
+    });
 
-    verify(() => mockPlatform
-        .debug(ddLogs.loggerHandle, 'debug message', {'attribute': 'value'}));
-  });
+    test('threshold set to verbose always calls platform', () async {
+      ddLogs = DdLogs(logger, Verbosity.verbose);
 
-  test('info logs pass to platform', () async {
-    ddLogs.info('info message', {'attribute': 'value'});
+      ddLogs.debug('Debug message');
+      ddLogs.info('Info message');
+      ddLogs.warn('Warn message');
+      ddLogs.error('Error message');
 
-    verify(() => mockPlatform
-        .info(ddLogs.loggerHandle, 'info message', {'attribute': 'value'}));
-  });
+      verify(() => mockPlatform.debug(any(), any()));
+      verify(() => mockPlatform.info(any(), any()));
+      verify(() => mockPlatform.warn(any(), any()));
+      verify(() => mockPlatform.error(any(), any()));
+    });
 
-  test('warn logs pass to platform', () async {
-    ddLogs.warn('warn message', {'attribute': 'value'});
+    test('threshold set to middle sends call proper platform methods',
+        () async {
+      ddLogs = DdLogs(logger, Verbosity.warn);
 
-    verify(() => mockPlatform
-        .warn(ddLogs.loggerHandle, 'warn message', {'attribute': 'value'}));
-  });
+      ddLogs.debug('Debug message');
+      ddLogs.info('Info message');
+      ddLogs.warn('Warn message');
+      ddLogs.error('Error message');
 
-  test('error logs pass to platform', () async {
-    ddLogs.error('error message', {'attribute': 'value'});
+      verifyNever(() => mockPlatform.debug(any(), any()));
+      verifyNever(() => mockPlatform.info(any(), any()));
+      verify(() => mockPlatform.warn(any(), any()));
+      verify(() => mockPlatform.error(any(), any()));
+    });
 
-    verify(() => mockPlatform
-        .error(ddLogs.loggerHandle, 'error message', {'attribute': 'value'}));
-  });
+    test('threshold set to none does not call platform', () async {
+      ddLogs = DdLogs(logger, Verbosity.none);
 
-  test('addAttribute argumentError sent to logger', () async {
-    when(() => mockPlatform.addAttribute(any(), any(), any()))
-        .thenThrow(ArgumentError());
-    ddLogs.addAttribute('My key', 'Any Value');
+      ddLogs.debug('Debug message');
+      ddLogs.info('Info message');
+      ddLogs.warn('Warn message');
+      ddLogs.error('Error message');
 
-    assert(logger.logs.isNotEmpty);
+      verifyNever(() => mockPlatform.debug(any(), any()));
+      verifyNever(() => mockPlatform.info(any(), any()));
+      verifyNever(() => mockPlatform.warn(any(), any()));
+      verifyNever(() => mockPlatform.error(any(), any()));
+    });
   });
 }


### PR DESCRIPTION
### What and why?

Allow clients to specify what level of logging should be sent to Datadog. The `datadogReportingThreshold` parameter on logger configuration determines what level of logs should get sent to Datadog from that logger.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests