### PR TITLE
💚 Add extra cleanup to unit tests to eliminate flakeyness

### DIFF
--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -12,202 +12,209 @@ extension UserInfo: EquatableInTests { }
 // way to to include tests in the Podspec.
 class FlutterSdkTests: XCTestCase {
 
-  override func tearDown() {
-    Datadog.flushAndDeinitialize()
-  }
-
-  func testInitialziation_MissingConfiguration_DoesNotInitFeatures() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: false
-    )
-
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-
-    XCTAssertTrue(Datadog.isInitialized)
-
-    XCTAssertNotNil(Global.rum as? DDNoopRUMMonitor)
-    XCTAssertNotNil(Global.sharedTracer as? DDNoopTracer)
-
-    XCTAssertNil(plugin.logs)
-    XCTAssertNil(plugin.tracer)
-    XCTAssertNil(plugin.rum)
-  }
-
-  func testInitialization_TracingConfiguration_InitializesTracing() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: true,
-      tracingConfiguration: DatadogFlutterConfiguration.TracingConfiguration(
-        sendNetworkInfo: true,
-        bundleWithRum: true
-      )
-    )
-
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-
-    XCTAssertNotNil(plugin.tracer)
-    XCTAssertEqual(plugin.tracer?.isInitialized, true)
-    XCTAssertNotNil(Global.sharedTracer)
-    XCTAssertNil(Global.sharedTracer as? DDNoopTracer)
-  }
-
-  func testInitialization_RumConfiguration_InitializesRum() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: true,
-      rumConfiguration: DatadogFlutterConfiguration.RumConfiguration(
-        applicationId: "fakeApplicationId",
-        sampleRate: 100.0
-      )
-    )
-
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-
-    XCTAssertNotNil(plugin.rum)
-    XCTAssertEqual(plugin.rum?.isInitialized, true)
-    XCTAssertNotNil(Global.rum)
-    XCTAssertNil(Global.rum as? DDNoopRUMMonitor)
-  }
-
-  func testInitialization_FromMethodChannel_InitializesDatadog() {
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    let methodCall = FlutterMethodCall(
-      methodName: "initialize",
-      arguments: [
-        "configuration": [
-          "clientToken": "fakeClientToken",
-          "env": "prod",
-          "trackingConsent": "TrackingConsent.granted",
-          "nativeCrashReportEnabled": false
-        ]
-      ]
-    )
-    plugin.handle(methodCall) { _ in }
-
-    XCTAssertTrue(Datadog.isInitialized)
-
-    XCTAssertNotNil(Global.rum as? DDNoopRUMMonitor)
-    XCTAssertNotNil(Global.sharedTracer as? DDNoopTracer)
-  }
-
-  func testSetVerbosity_FromMethodChannel_SetsVerbosity() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: false
-    )
-
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-    let methodCall = FlutterMethodCall(
-      methodName: "setSdkVerbosity", arguments: [
-        "value": "Verbosity.info"
-      ])
-
-    var callResult = ResultStatus.notCalled
-    plugin.handle(methodCall) { result in
-      callResult = ResultStatus.called(value: result)
+    override func setUp() {
+        if Datadog.instance != nil {
+            // Somehow we ended up with an extra instance of Datadog?
+            Datadog.flushAndDeinitialize()
+        }
     }
 
-    XCTAssertEqual(Datadog.verbosityLevel, .info)
-    XCTAssertEqual(callResult, .called(value: nil))
-  }
-
-  func testSetTrackingConsent_FromMethodChannel_SetsTrackingConsent() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: false
-    )
-
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-    let methodCall = FlutterMethodCall(
-      methodName: "setTrackingConsent", arguments: [
-        "value": "TrackingConsent.notGranted"
-      ])
-
-    var callResult = ResultStatus.notCalled
-    plugin.handle(methodCall) { result in
-      callResult = ResultStatus.called(value: result)
+    override func tearDown() {
+        Datadog.flushAndDeinitialize()
     }
 
-    XCTAssertEqual(Datadog.instance?.consentProvider.currentValue, .notGranted)
-    XCTAssertEqual(callResult, .called(value: nil))
-  }
+    func testInitialziation_MissingConfiguration_DoesNotInitFeatures() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: false
+        )
 
-  func testSetUserInfo_FromMethodChannel_SetsUserInfo() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: false
-    )
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
 
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-    let methodCall = FlutterMethodCall(
-      methodName: "setUserInfo", arguments: [
-        "id": "fakeUserId",
-        "name": "fake user name",
-        "email": "fake email",
-        "extraInfo": [:]
-      ])
+        XCTAssertTrue(Datadog.isInitialized)
 
-    var callResult = ResultStatus.notCalled
-    plugin.handle(methodCall) { result in
-      callResult = ResultStatus.called(value: result)
+        XCTAssertNotNil(Global.rum as? DDNoopRUMMonitor)
+        XCTAssertNotNil(Global.sharedTracer as? DDNoopTracer)
+
+        XCTAssertNil(plugin.logs)
+        XCTAssertNil(plugin.tracer)
+        XCTAssertNil(plugin.rum)
     }
 
-    let expectedUserInfo = UserInfo(id: "fakeUserId", name: "fake user name", email: "fake email", extraInfo: [:])
-    XCTAssertEqual(Datadog.instance?.userInfoProvider.value, expectedUserInfo)
-    XCTAssertEqual(callResult, .called(value: nil))
-  }
+    func testInitialization_TracingConfiguration_InitializesTracing() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: true,
+            tracingConfiguration: DatadogFlutterConfiguration.TracingConfiguration(
+                sendNetworkInfo: true,
+                bundleWithRum: true
+            )
+        )
 
-  func testSetUserInfo_FromMethodChannelWithNils_SetsUserInfo() {
-    let flutterConfig = DatadogFlutterConfiguration(
-      clientToken: "fakeClientToken",
-      env: "prod",
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportingEnabled: false
-    )
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
 
-    let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
-    plugin.initialize(configuration: flutterConfig)
-    let methodCall = FlutterMethodCall(
-      methodName: "setUserInfo", arguments: [
-        "id": "fakeUserId",
-        "name": nil,
-        "email": nil,
-        "extraInfo": [
-          "attribute": NSNumber(23.3)
-        ]
-      ])
-
-    var callResult = ResultStatus.notCalled
-    plugin.handle(methodCall) { result in
-      callResult = ResultStatus.called(value: result)
+        XCTAssertNotNil(plugin.tracer)
+        XCTAssertEqual(plugin.tracer?.isInitialized, true)
+        XCTAssertNotNil(Global.sharedTracer)
+        XCTAssertNil(Global.sharedTracer as? DDNoopTracer)
     }
 
-    let expectedUserInfo = UserInfo(id: "fakeUserId",
-                                    name: nil,
-                                    email: nil,
-                                    extraInfo: [
-                                      "attribute": 23.3
-                                    ])
-    XCTAssertEqual(Datadog.instance?.userInfoProvider.value, expectedUserInfo)
-    XCTAssertEqual(callResult, .called(value: nil))
-  }
+    func testInitialization_RumConfiguration_InitializesRum() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: true,
+            rumConfiguration: DatadogFlutterConfiguration.RumConfiguration(
+                applicationId: "fakeApplicationId",
+                sampleRate: 100.0
+            )
+        )
+
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
+
+        XCTAssertNotNil(plugin.rum)
+        XCTAssertEqual(plugin.rum?.isInitialized, true)
+        XCTAssertNotNil(Global.rum)
+        XCTAssertNil(Global.rum as? DDNoopRUMMonitor)
+    }
+
+    func testInitialization_FromMethodChannel_InitializesDatadog() {
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        let methodCall = FlutterMethodCall(
+            methodName: "initialize",
+            arguments: [
+                "configuration": [
+                    "clientToken": "fakeClientToken",
+                    "env": "prod",
+                    "trackingConsent": "TrackingConsent.granted",
+                    "nativeCrashReportEnabled": false
+                ]
+            ]
+        )
+        plugin.handle(methodCall) { _ in }
+
+        XCTAssertTrue(Datadog.isInitialized)
+
+        XCTAssertNotNil(Global.rum as? DDNoopRUMMonitor)
+        XCTAssertNotNil(Global.sharedTracer as? DDNoopTracer)
+    }
+
+    func testSetVerbosity_FromMethodChannel_SetsVerbosity() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: false
+        )
+
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
+        let methodCall = FlutterMethodCall(
+            methodName: "setSdkVerbosity", arguments: [
+                "value": "Verbosity.info"
+            ])
+
+        var callResult = ResultStatus.notCalled
+        plugin.handle(methodCall) { result in
+            callResult = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(Datadog.verbosityLevel, .info)
+        XCTAssertEqual(callResult, .called(value: nil))
+    }
+
+    func testSetTrackingConsent_FromMethodChannel_SetsTrackingConsent() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: false
+        )
+
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
+        let methodCall = FlutterMethodCall(
+            methodName: "setTrackingConsent", arguments: [
+                "value": "TrackingConsent.notGranted"
+            ])
+
+        var callResult = ResultStatus.notCalled
+        plugin.handle(methodCall) { result in
+            callResult = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(Datadog.instance?.consentProvider.currentValue, .notGranted)
+        XCTAssertEqual(callResult, .called(value: nil))
+    }
+
+    func testSetUserInfo_FromMethodChannel_SetsUserInfo() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: false
+        )
+
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
+        let methodCall = FlutterMethodCall(
+            methodName: "setUserInfo", arguments: [
+                "id": "fakeUserId",
+                "name": "fake user name",
+                "email": "fake email",
+                "extraInfo": [:]
+            ])
+
+        var callResult = ResultStatus.notCalled
+        plugin.handle(methodCall) { result in
+            callResult = ResultStatus.called(value: result)
+        }
+
+        let expectedUserInfo = UserInfo(id: "fakeUserId", name: "fake user name", email: "fake email", extraInfo: [:])
+        XCTAssertEqual(Datadog.instance?.userInfoProvider.value, expectedUserInfo)
+        XCTAssertEqual(callResult, .called(value: nil))
+    }
+
+    func testSetUserInfo_FromMethodChannelWithNils_SetsUserInfo() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: false
+        )
+
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
+        let methodCall = FlutterMethodCall(
+            methodName: "setUserInfo", arguments: [
+                "id": "fakeUserId",
+                "name": nil,
+                "email": nil,
+                "extraInfo": [
+                    "attribute": NSNumber(23.3)
+                ]
+            ])
+
+        var callResult = ResultStatus.notCalled
+        plugin.handle(methodCall) { result in
+            callResult = ResultStatus.called(value: result)
+        }
+
+        let expectedUserInfo = UserInfo(id: "fakeUserId",
+                                        name: nil,
+                                        email: nil,
+                                        extraInfo: [
+                                            "attribute": 23.3
+                                        ])
+        XCTAssertEqual(Datadog.instance?.userInfoProvider.value, expectedUserInfo)
+        XCTAssertEqual(callResult, .called(value: nil))
+    }
 }


### PR DESCRIPTION
It looks like either test ordering or some other issue causes an instance of the DatadogSDK to stick around, causing tests to fail.

I haven not been able to reproduce locally so hopefully this is the fix.

### What and why?

What changes does this pull request introduce and why is it necessary?

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests