### PR TITLE
🧹 Cleanup public interfaces

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -16,33 +16,15 @@ import 'src/helpers.dart';
 import 'src/internal_logger.dart';
 import 'src/logs/ddlogs.dart';
 import 'src/logs/ddlogs_platform_interface.dart';
-import 'src/rum/ddrum.dart';
+import 'src/rum/rum.dart';
 import 'src/traces/ddtraces.dart';
 import 'src/version.dart' show ddPackageVersion;
 
-export 'src/attributes.dart' show DatadogConfigKey;
 export 'src/datadog_configuration.dart';
 export 'src/datadog_plugin.dart';
 export 'src/logs/ddlogs.dart';
-export 'src/rum/ddrum.dart'
-    show
-        DdRum,
-        RumHttpMethod,
-        RumUserActionType,
-        RumErrorSource,
-        RumResourceType,
-        rumMethodFromMethodString,
-        resourceTypeFromContentType;
-export 'src/rum/navigation_observer.dart'
-    show
-        DatadogNavigationObserver,
-        DatadogNavigationObserverProvider,
-        RumViewInfo,
-        DatadogRouteAwareMixin,
-        ViewInfoExtractor;
-export 'src/rum/rum_gesture_detector.dart';
-export 'src/traces/ddtraces.dart'
-    show DdSpan, OTTags, OTLogFields, generateTraceId;
+export 'src/rum/rum.dart';
+export 'src/traces/ddtraces.dart';
 
 typedef AppRunner = void Function();
 

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -6,4 +6,5 @@
 // extension packages, and is not meant for public use. Anything exposed by this
 // file has the potential to change without notice.
 
+export 'src/attributes.dart';
 export 'src/rum/attributes.dart';

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -9,6 +9,7 @@ library ddlogs_flutter_web;
 import 'package:js/js.dart';
 
 import '../../datadog_flutter_plugin.dart';
+import '../attributes.dart';
 import '../web_helpers.dart';
 import 'ddlogs_platform_interface.dart';
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+export 'ddrum.dart';
+export 'navigation_observer.dart';
+export 'rum_gesture_detector.dart';

--- a/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
+++ b/packages/datadog_flutter_plugin/lib/src/traces/ddtraces.dart
@@ -4,11 +4,15 @@
 
 import 'dart:math';
 
+import 'package:meta/meta.dart';
+
 import '../helpers.dart';
 import '../internal_logger.dart';
 import 'ddtraces_platform_interface.dart';
 
 typedef TimeProvider = DateTime Function();
+
+@visibleForTesting
 DateTime systemTimeProvider() => DateTime.now();
 
 /// A collection of standard `Span` tag keys defined by Open Tracing.

--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -5,28 +5,9 @@
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:grpc/grpc.dart';
 import 'package:uuid/uuid.dart';
-
-class DatadogTracingHeaders {
-  static const traceId = 'x-datadog-trace-id';
-  static const parentId = 'x-datadog-parent-id';
-
-  static const samplingPriority = 'x-datadog-sampling-priority';
-  static const origin = 'x-datadog-origin';
-}
-
-// TODO: These are defined in the main datadog_flutter_plugin package but aren't
-// public. Probably want to fix that.
-class DatadogPlatformAttributeKey {
-  /// Trace ID. Used in RUM resources created by automatic resource tracking.
-  /// Expects `String` value.
-  static const traceID = '_dd.trace_id';
-
-  /// Span ID. Used in RUM resources created by automatic resource tracking.
-  /// Expects `String` value.
-  static const spanID = '_dd.span_id';
-}
 
 /// A client GrpcInterceptor which enables automatic resource tracking and
 /// distributed tracing
@@ -75,8 +56,8 @@ class DatadogGrpcInterceptor extends ClientInterceptor {
       {
         "grpc.method": method.path,
         if (shouldAppendTraces) ...{
-          DatadogPlatformAttributeKey.traceID: traceId,
-          DatadogPlatformAttributeKey.spanID: parentId
+          DatadogRumPlatformAttributeKey.traceID: traceId,
+          DatadogRumPlatformAttributeKey.spanID: parentId
         }
       },
     );

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: deprecated_member_use
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
-import 'package:datadog_flutter_plugin/src/traces/ddtraces.dart';
 import 'package:datadog_grpc_interceptor/datadog_grpc_interceptor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
@@ -81,7 +80,7 @@ void main() {
         captureAny())).captured;
     final key = captures[0];
     final attributes = captures[1];
-    // TODO: Double check that this is a proper value for the grpc.method
+
     expect(attributes['grpc.method'], '/helloworld.Greeter/SayHello');
 
     verify(() => mockRum.stopResourceLoading(key, 200, RumResourceType.native));


### PR DESCRIPTION
### What and why?

Have a single import file for each module (rum.dart, ddlogs.dart, ddtraces.dart). These are inconsistent for now, mostly because rum is more complicated than logs and traces and a separate export file wasn't needed for the simpler cases.

Putting internal attributes in datadog_internal.dart allowed cleanup of some TODOs

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests