### PR TITLE
✅ Fix nightly e2e by changing internal method signature

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -120,7 +120,7 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
     fun simpleInvokeOn(methodName: String, target: Any) {
         val klass = target.javaClass
         val method = klass.declaredMethods.firstOrNull {
-            it.name == methodName
+            it.name == methodName || it.name == "$methodName\$dd_sdk_android_release"
         }
         method?.let {
             it.isAccessible = true


### PR DESCRIPTION
### What and why?

e2e tests were failing because "stop" wasn't being called during reinitialization between tests, which made it so that we couldn't reinitialize.

### How?

Apparently, internal methods are mangled with the package name. Adding that to the method name fixed stop not being called.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests