### PR TITLE
Allow `datadog_tracking_http_client` to be used from flutter 2.10.3

### DIFF
--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://datadoghq.com
 
 
 environment:
-  sdk: ">=2.17.0-0 <3.0.0"
+  sdk: ">=2.16.1 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
### What and why?

Without this this package can only be used by flutter 3 users

It fixes: 
- https://github.com/DataDog/dd-sdk-flutter/issues/144

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests