### PR TITLE
⬇️ Cherry pick changes for lower required Dart SDK

### DIFF
--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: '1.0.0'
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.16.1 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add methods for Dart 2.17, set minimum supported version to Dart 2.17
 
+## 1.0.0-beta.2
+
+* Decrease the SDK constraint from Dart 2.16 (Flutter 2.10) to Dart 2.15 (Flutter 2.8)
+
 ## 1.0.0-beta.1
 
 * Removed using platform traces / spans in DatadogTrackingHttpClient

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### What and why?

All pubspecs, other than datadog_tracking_http_client 1.0.1+ should allow versions of dart as low as 2.15 (Fluter 2.8). This was changed in the release for datadog_tracking_http_client 1.0.0-beta.2 and this brings those changes into mainline.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests