### PR TITLE
🐛 Fix serviceName being passed to native libraries

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -2,6 +2,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
 
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
 class RumSessionDecoder {
   final List<RumViewVisit> visits;
 
@@ -93,6 +97,13 @@ class RumEventDecoder {
   final Dd dd;
 
   String get eventType => rumEvent['type'] as String;
+  String get service {
+    if (!kIsWeb) {
+      if (Platform.isIOS) return rumEvent['service'];
+    }
+    return rumEvent['service'];
+  }
+
   int get date => rumEvent['date'] as int;
 
   Map<String, dynamic>? get context => rumEvent['context'];

--- a/packages/datadog_common_test/lib/src/request_log.dart
+++ b/packages/datadog_common_test/lib/src/request_log.dart
@@ -12,13 +12,28 @@ part 'request_log.g.dart';
 @JsonSerializable()
 class RequestLog {
   final String requestedUrl;
+  final Map<String, String> queryParameters;
   final String requestMethod;
   final Map<String, List<String>> requestHeaders;
   final String data;
   Object? get jsonData => json.decode(data);
 
+  Map<String, String> get tags {
+    var tagMap = <String, String>{};
+    for (var tag in queryParameters['ddtags']!.split(',')) {
+      var colon = tag.indexOf(':');
+      if (colon == -1) {
+        tagMap[tag] = '';
+      } else {
+        tagMap[tag.substring(0, colon)] = tag.substring(colon + 1);
+      }
+    }
+    return tagMap;
+  }
+
   RequestLog({
     required this.requestedUrl,
+    required this.queryParameters,
     required this.requestMethod,
     required this.requestHeaders,
     required this.data,
@@ -48,6 +63,7 @@ class RequestLog {
 
     return RequestLog(
       requestedUrl: url,
+      queryParameters: request.requestedUri.queryParameters,
       requestMethod: request.method,
       requestHeaders: headers,
       data: decoded,

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Update iOS SDK to 1.11.0
   * For a full list of changes see the [iOS Changelog](https://github.com/DataDog/dd-sdk-ios/blob/develop/CHANGELOG.md#1110--13-06-2022)
 * Made analysis rules stricter and switched several attribute map parameters from `Map<String, dynamic>` to `Map<String, Object?>` for better compatibility with `implicit-dynamic: false` See [#143][] and [#148][]
+* Fix `serviceName` configuration parameter [#159][]
 
 ## 1.0.0-beta.2
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -43,6 +43,7 @@ data class DatadogFlutterConfiguration(
     var nativeCrashReportEnabled: Boolean,
     var trackingConsent: TrackingConsent,
     var site: DatadogSite? = null,
+    var serviceName: String? = null,
     var batchSize: BatchSize? = null,
     var uploadFrequency: UploadFrequency? = null,
     var customEndpoint: String? = null,
@@ -84,6 +85,9 @@ data class DatadogFlutterConfiguration(
         (encoded["site"] as? String)?.let {
             site = parseSite(it)
         }
+        (encoded["serviceName"] as? String)?.let {
+            serviceName = it
+        }
         (encoded["batchSize"] as? String)?.let {
             batchSize = parseBatchSize(it)
         }
@@ -109,7 +113,6 @@ data class DatadogFlutterConfiguration(
     }
 
     fun toCredentials(): Credentials {
-        val serviceName = additionalConfig["_dd.service_name"] as? String
         return Credentials(
             clientToken = clientToken,
             envName = env,

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -146,6 +146,7 @@ class DatadogConfigurationTest {
             "clientToken" to clientToken,
             "env" to environment,
             "nativeCrashReportEnabled" to true,
+            "serviceName" to null,
             "site" to "DatadogSite.us3",
             "batchSize" to "BatchSize.small",
             "uploadFrequency" to "UploadFrequency.frequent",
@@ -171,6 +172,42 @@ class DatadogConfigurationTest {
             additionalKey to additionalValue
         ))
         assertThat(config.firstPartyHosts).isEqualTo(listOf(firstPartyHost))
+    }
+
+    @Test
+    @Suppress("LongParameterList")
+    fun `M decode serviceName W fromEncoded`(
+        @StringForgery clientToken: String,
+        @StringForgery environment: String,
+        @StringForgery additionalKey: String,
+        @StringForgery additionalValue: String,
+        @StringForgery firstPartyHost: String,
+        @StringForgery serviceName: String,
+    ) {
+        // GIVEN
+        val encoded = mapOf<String, Any?>(
+            "clientToken" to clientToken,
+            "env" to environment,
+            "nativeCrashReportEnabled" to true,
+            "serviceName" to serviceName,
+            "site" to "DatadogSite.us3",
+            "batchSize" to "BatchSize.small",
+            "uploadFrequency" to "UploadFrequency.frequent",
+            "trackingConsent" to "TrackingConsent.granted",
+            "customEndpoint" to "customEndpoint",
+            "firstPartyHosts" to listOf(firstPartyHost),
+            "tracingConfiguration" to null,
+            "rumConfiguration" to null,
+            "additionalConfig" to mapOf<String, Any?>(
+                additionalKey to additionalValue
+            )
+        )
+
+        // WHEN
+        val config = DatadogFlutterConfiguration(encoded)
+
+        // THEN
+        assertThat(config.serviceName).isEqualTo(serviceName)
     }
 
     @Test
@@ -250,15 +287,13 @@ class DatadogConfigurationTest {
         val config = DatadogFlutterConfiguration(
             clientToken = clientToken,
             env = env,
+            serviceName = serviceName,
             nativeCrashReportEnabled = true,
             trackingConsent = TrackingConsent.PENDING,
             rumConfiguration = DatadogFlutterConfiguration.RumConfiguration(
                 applicationId = applicationId,
                 sampleRate = 100.0f
             ),
-            additionalConfig = mapOf<String, Any?>(
-                "_dd.service_name" to serviceName
-            )
         )
 
         // WHEN

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
@@ -134,6 +134,7 @@ class DatadogConfigurationTests: XCTestCase {
 
     XCTAssertNotNil(config)
     XCTAssertEqual(config.site, .eu1)
+    XCTAssertNil(config.serviceName)
     XCTAssertEqual(config.batchSize, .small)
     XCTAssertEqual(config.uploadFrequency, .frequent)
     XCTAssertEqual(config.firstPartyHosts, ["first_party.com"])
@@ -142,6 +143,30 @@ class DatadogConfigurationTests: XCTestCase {
     XCTAssertNil(config.tracingConfiguration)
     XCTAssertNil(config.rumConfiguration)
   }
+
+    func testConfiguration_ServiceName_IsDecoded() {
+      let encoded: [String: Any?]  = [
+        "clientToken": "fakeClientToken",
+        "env": "fakeEnvironment",
+        "serviceName": "com.servicename",
+        "nativeCrashReportEnabled": NSNumber(false),
+        "site": "DatadogSite.eu1",
+        "batchSize": "BatchSize.small",
+        "uploadFrequency": "UploadFrequency.frequent",
+        "trackingConsent": "TrackingConsent.pending",
+        "customEndpoint": nil,
+        "firstPartyHosts": [ "first_party.com" ],
+        "loggingConfiguration": nil,
+        "tracingConfiguration": nil,
+        "rumConfiguration": nil,
+        "additionalConfig": [:]
+      ]
+
+      let config = DatadogFlutterConfiguration(fromEncoded: encoded)!
+
+      XCTAssertNotNil(config)
+      XCTAssertEqual(config.serviceName, "com.servicename")
+    }
 
   func testConfiguration_NestedConfigurations_AreDecoded() {
     let encoded: [String: Any?]  = [

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -27,6 +27,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: false
         )
@@ -48,6 +49,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: true,
             tracingConfiguration: DatadogFlutterConfiguration.TracingConfiguration(
@@ -69,6 +71,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: true,
             rumConfiguration: DatadogFlutterConfiguration.RumConfiguration(
@@ -111,6 +114,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: false
         )
@@ -135,6 +139,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: false
         )
@@ -159,6 +164,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: false
         )
@@ -187,6 +193,7 @@ class FlutterSdkTests: XCTestCase {
         let flutterConfig = DatadogFlutterConfiguration(
             clientToken: "fakeClientToken",
             env: "prod",
+            serviceName: "serviceName",
             trackingConsent: TrackingConsent.granted,
             nativeCrashReportingEnabled: false
         )

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -98,7 +98,7 @@ void main() {
 
     for (final log in logs) {
       expect(log.serviceName,
-          equalsIgnoringCase('com.datadoghq.flutter.integrationtestapp'));
+          equalsIgnoringCase('com.datadoghq.flutter.integration'));
       if (!kIsWeb) {
         expect(log.threadName, 'main');
       }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -3,6 +3,7 @@
 // Copyright 2019-2022 Datadog, Inc.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:flutter/foundation.dart';
@@ -162,6 +163,7 @@ void main() {
     if (!kIsWeb) {
       expect(view2.actionEvents[0].actionType, 'scroll');
       expect(view2.actionEvents[0].actionName, 'User Scrolling');
+
       expect(view2.actionEvents[0].loadingTime,
           greaterThan(1800 * 1000 * 1000)); // 1.8s
       // TODO: Figure out why occasionally these have really high values
@@ -194,6 +196,21 @@ void main() {
     }
     expect(view3.viewEvents.last.view.actionCount, 0);
     expect(view3.viewEvents.last.view.errorCount, 0);
+
+    // Verify service name
+    for (var event in rumLog) {
+      if (!kIsWeb) {
+        if (Platform.isIOS) {
+          for (final event in rumLog) {
+            expect(event.service, 'com.datadoghq.flutter.integration');
+          }
+        }
+
+        for (final request in requestLog) {
+          expect(request.tags['service'], 'com.datadoghq.flutter.integration');
+        }
+      }
+    }
   });
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -35,7 +35,7 @@ Future<void> main() async {
   final configuration = DdSdkConfiguration(
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
-    serviceName: 'com.datadoghq.flutter.integrationtestapp',
+    serviceName: 'com.datadoghq.flutter.integration',
     site: DatadogSite.us1,
     trackingConsent: TrackingConsent.granted,
     uploadFrequency: UploadFrequency.frequent,

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
@@ -78,6 +78,7 @@ class DatadogFlutterConfiguration {
 
   let clientToken: String
   let env: String
+  let serviceName: String?
   let nativeCrashReportingEnabled: Bool
   let trackingConsent: TrackingConsent
 
@@ -94,6 +95,7 @@ class DatadogFlutterConfiguration {
   init(
     clientToken: String,
     env: String,
+    serviceName: String?,
     trackingConsent: TrackingConsent,
     nativeCrashReportingEnabled: Bool,
     site: Datadog.Configuration.DatadogEndpoint? = nil,
@@ -107,6 +109,7 @@ class DatadogFlutterConfiguration {
   ) {
     self.clientToken = clientToken
     self.env = env
+    self.serviceName = serviceName
     self.trackingConsent = trackingConsent
     self.nativeCrashReportingEnabled = nativeCrashReportingEnabled
     self.site = site
@@ -124,6 +127,7 @@ class DatadogFlutterConfiguration {
     do {
       clientToken = try castUnwrap(encoded["clientToken"])
       env = try castUnwrap(encoded["env"])
+      serviceName = try? castUnwrap(encoded["serviceName"])
       nativeCrashReportingEnabled = try castUnwrap(encoded["nativeCrashReportEnabled"])
       trackingConsent = try TrackingConsent.parseFromFlutter(castUnwrap(encoded["trackingConsent"]))
     } catch {

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -31,7 +31,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         DatadogRumPlugin.register(with: registrar)
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let arguments = call.arguments as? [String: Any] else {
             result(
@@ -154,7 +154,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             _ = ddConfigBuilder.trackUIKitRUMViews()
         }
 
-        if let serviceName = flutterConfig.additionalConfig["_dd.service_name"] as? String {
+        if let serviceName = flutterConfig.serviceName {
             _ = ddConfigBuilder.set(serviceName: serviceName)
         }
 

--- a/packages/datadog_flutter_plugin/lib/src/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/attributes.dart
@@ -5,8 +5,6 @@
 class DatadogConfigKey {
   static const source = '_dd.source';
   static const version = '_dd.sdk_version';
-  static const serviceName = '_dd.service_name';
-  static const verbosity = '_dd.sdk_verbosity';
   static const nativeViewTracking = '_dd.native_view_tracking';
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -321,6 +321,7 @@ class DdSdkConfiguration {
       'env': env,
       'nativeCrashReportEnabled': nativeCrashReportEnabled,
       'site': site.toString(),
+      'serviceName': serviceName,
       'batchSize': batchSize?.toString(),
       'uploadFrequency': uploadFrequency?.toString(),
       'trackingConsent': trackingConsent.toString(),

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -71,6 +71,7 @@ void main() {
       'clientToken': 'fake-client-token',
       'env': 'prod',
       'site': 'DatadogSite.us1',
+      'serviceName': null,
       'nativeCrashReportEnabled': false,
       'trackingConsent': 'TrackingConsent.pending',
       'customEndpoint': null,
@@ -98,6 +99,20 @@ void main() {
     expect(encoded['batchSize'], 'BatchSize.small');
     expect(encoded['uploadFrequency'], 'UploadFrequency.frequent');
     expect(encoded['site'], 'DatadogSite.eu1');
+  });
+
+  test('configuration encodes serviceName', () {
+    final configuration = DdSdkConfiguration(
+      clientToken: 'fakeClientToken',
+      env: 'fake-env',
+      serviceName: 'com.servicename',
+      site: DatadogSite.us1,
+      trackingConsent: TrackingConsent.notGranted,
+    );
+
+    final encoded = configuration.encode();
+    // Logging configuration is purposefully not encoded
+    expect(encoded['serviceName'], 'com.servicename');
   });
 
   test('configuration encodes default sub-configuration', () {


### PR DESCRIPTION
### What and why?

The refactor that made the service name a global parameter of the configuration for Web broke passing that parameter to the native libraries. This fixes that issue and adds additional integration tests.

Fixes #159 

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests