### PR TITLE
⬆️ Manually update Android SDK to 1.13.0

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -14,7 +14,7 @@ RUM supports monitoring for mobile Flutter Android and iOS applications.
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 1.11.1 | 1.13.0-rc1 | v4.11.2 |
+| 1.11.1 | 1.13.0 | v4.11.2 |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,7 +9,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_sdk_version = "1.13.0-rc1"
+    ext.datadog_sdk_version = "1.13.0"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
### What and why?

Automatic update of 1.13.0-rc1 to 1.13.0 didn't happen on CI, so update manually.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests