### PR TITLE
👷Change releaser to reflect new release process

### DIFF
--- a/tools/releaser/lib/command.dart
+++ b/tools/releaser/lib/command.dart
@@ -18,9 +18,6 @@ class CommandArguments {
   // Skip git and branch checks during the validate step
   final bool skipGitChecks;
 
-  // Whether to commit changes and push them to github
-  final bool commitChanges;
-
   // The version we're releasing
   final String version;
 
@@ -32,7 +29,6 @@ class CommandArguments {
     required this.packageRoot,
     required this.gitDir,
     required this.skipGitChecks,
-    required this.commitChanges,
     required this.version,
     required this.dryRun,
   });

--- a/tools/releaser/lib/release_validator.dart
+++ b/tools/releaser/lib/release_validator.dart
@@ -62,7 +62,7 @@ class ValidateReleaseCommand extends Command {
     if (!(currentBranch.branchName == 'develop' ||
         currentBranch.branchName.startsWith('release'))) {
       logger.shout(
-          '❌ We really should only prep releases from `develop` or another `release` branch.');
+          '❌ We really should only release from `develop` or another `release` branch.');
       return false;
     }
 

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -7,110 +7,153 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:version/version.dart';
 
 import 'command.dart';
 
+enum VersionBumpType { major, minor, rev, prerelease }
+
 class UpdateVersionsCommand extends Command {
-  final versionCapture = RegExp(r'^version\: (?<version>.*)');
+  @override
+  Future<bool> run(CommandArguments args, Logger logger) async {
+    if (!await updateVersions(
+        args.packageRoot, args.version, logger, args.dryRun)) {
+      return false;
+    }
+
+    return _updateChangelog(
+        args.packageRoot, args.version, logger, args.dryRun);
+  }
+}
+
+class BumpVersionCommand extends Command {
+  final VersionBumpType bumpType;
+
+  BumpVersionCommand(this.bumpType);
 
   @override
   Future<bool> run(CommandArguments args, Logger logger) async {
-    if (!await _updatePackagePubspec(
-        args.packageRoot, args.version, logger, args.dryRun)) {
-      return false;
+    final version = Version.parse(args.version);
+    Version newVersion;
+    switch (bumpType) {
+      case VersionBumpType.major:
+        newVersion = version.incrementMajor();
+        break;
+      case VersionBumpType.minor:
+        newVersion = version.incrementMinor();
+        break;
+      case VersionBumpType.rev:
+        newVersion = version.incrementPatch();
+        break;
+      case VersionBumpType.prerelease:
+        try {
+          newVersion = version.incrementPreRelease();
+        } catch (e) {
+          logger.shout(
+              '❌ Failed to increment the pre-release version of $version. Is it not a pre-release?');
+          return false;
+        }
+        break;
     }
+    logger.info('🔀 Bumping version to $newVersion');
+    return updateVersions(
+        args.packageRoot, newVersion.toString(), logger, args.dryRun);
+  }
+}
 
-    await _updateVersionDartFile(
-        args.packageRoot, args.version, logger, args.dryRun);
+final _versionCapture = RegExp(r'^version\: (?<version>.*)');
 
-    if (!await _updateChangelog(
-        args.packageRoot, args.version, logger, args.dryRun)) {
-      return false;
-    }
-    return true;
+Future<bool> updateVersions(
+    String packageRoot, String version, Logger logger, bool dryRun) async {
+  if (!await _updatePackagePubspec(packageRoot, version, logger, dryRun)) {
+    return false;
   }
 
-  Future<void> _transformFile(
-    File file,
-    Logger logger,
-    bool dryRun,
-    String Function(String e) transformer,
-  ) async {
-    final newFileBuffer = StringBuffer();
-    await file
-        .openRead()
-        .transform(utf8.decoder)
-        .transform(LineSplitter())
-        .forEach((element) {
-      final newValue = transformer(element);
-      newFileBuffer.writeln(newValue);
-    });
+  await _updateVersionDartFile(packageRoot, version, logger, dryRun);
 
-    final filename = path.basename(file.path);
-    logger.finest(' ------- NEW  $filename CONTENTS ------');
-    logger.finest(newFileBuffer.toString());
-    if (!dryRun) {
-      file.openWrite().write(newFileBuffer);
-      logger.info(' ✏️ Wrote ${file.path}');
-    }
+  return true;
+}
+
+Future<void> _transformFile(
+  File file,
+  Logger logger,
+  bool dryRun,
+  String Function(String e) transformer,
+) async {
+  final newFileBuffer = StringBuffer();
+  await file
+      .openRead()
+      .transform(utf8.decoder)
+      .transform(LineSplitter())
+      .forEach((element) {
+    final newValue = transformer(element);
+    newFileBuffer.writeln(newValue);
+  });
+
+  final filename = path.basename(file.path);
+  logger.finest(' ------- NEW  $filename CONTENTS ------');
+  logger.finest(newFileBuffer.toString());
+  if (!dryRun) {
+    file.openWrite().write(newFileBuffer);
+    logger.info(' ✏️ Wrote ${file.path}');
+  }
+}
+
+Future<bool> _updatePackagePubspec(
+    String packageRoot, String version, Logger logger, bool dryRun) async {
+  final pubspecFile = File(path.join(packageRoot, 'pubspec.yaml'));
+  if (!pubspecFile.existsSync()) {
+    logger.shout('⁉️ Could not find pubspec.yaml at ${pubspecFile.path}');
+    return false;
   }
 
-  Future<bool> _updatePackagePubspec(
-      String packageRoot, String version, Logger logger, bool dryRun) async {
-    final pubspecFile = File(path.join(packageRoot, 'pubspec.yaml'));
-    if (!pubspecFile.existsSync()) {
-      logger.shout('⁉️ Could not find pubspec.yaml at ${pubspecFile.path}');
-      return false;
+  await _transformFile(pubspecFile, logger, dryRun, (element) {
+    final match = _versionCapture.firstMatch(element);
+    if (match != null) {
+      final oldVersion = match.namedGroup('version');
+      logger
+          .info(' - 🔀 Replacing version $oldVersion with $version in pubspec');
+      element = 'version: $version';
     }
+    return element;
+  });
 
-    await _transformFile(pubspecFile, logger, dryRun, (element) {
-      final match = versionCapture.firstMatch(element);
-      if (match != null) {
-        final oldVersion = match.namedGroup('version');
-        logger.info(
-            ' - 🔀 Replacing version $oldVersion with $version in pubspec');
-        element = 'version: $version';
-      }
-      return element;
-    });
+  return true;
+}
 
-    return true;
+Future<bool> _updateVersionDartFile(
+    String packageRoot, String version, Logger logger, bool dryRun) async {
+  final versionFile = File(path.join(packageRoot, 'lib/src/version.dart'));
+  if (!versionFile.existsSync()) {
+    logger.shout('⁉️ Could not find version.dart at ${versionFile.path}');
+    logger.shout('This is ignored as it is expected for non-core packages.');
+    return false;
   }
 
-  Future<bool> _updateVersionDartFile(
-      String packageRoot, String version, Logger logger, bool dryRun) async {
-    final versionFile = File(path.join(packageRoot, 'lib/src/version.dart'));
-    if (!versionFile.existsSync()) {
-      logger.shout('⁉️ Could not find version.dart at ${versionFile.path}');
-      logger.shout('This is ignored as it is expected for non-core packages.');
-      return false;
+  await _transformFile(versionFile, logger, dryRun, (element) {
+    if (element.startsWith('const ddPackageVersion')) {
+      element = "const ddPackageVersion = '$version';";
     }
+    return element;
+  });
 
-    await _transformFile(versionFile, logger, dryRun, (element) {
-      if (element.startsWith('const ddPackageVersion')) {
-        element = "const ddPackageVersion = '$version';";
-      }
-      return element;
-    });
+  return true;
+}
 
-    return true;
+Future<bool> _updateChangelog(
+    String packageRoot, String version, Logger logger, bool dryRun) async {
+  final changelogFile = File(path.join(packageRoot, 'CHANGELOG.md'));
+  if (!changelogFile.existsSync()) {
+    logger.shout('⁉️ Could not find CHANGELOG.md at ${changelogFile.path}');
+    return false;
   }
 
-  Future<bool> _updateChangelog(
-      String packageRoot, String version, Logger logger, bool dryRun) async {
-    final changelogFile = File(path.join(packageRoot, 'CHANGELOG.md'));
-    if (!changelogFile.existsSync()) {
-      logger.shout('⁉️ Could not find CHANGELOG.md at ${changelogFile.path}');
-      return false;
+  await _transformFile(changelogFile, logger, dryRun, (element) {
+    if (element.startsWith('## Unreleased')) {
+      element = '## Unreleased\n\n## $version';
     }
+    return element;
+  });
 
-    await _transformFile(changelogFile, logger, dryRun, (element) {
-      if (element.startsWith('## Unreleased')) {
-        element = '## Unreleased\n\n## $version';
-      }
-      return element;
-    });
-
-    return true;
-  }
+  return true;
 }


### PR DESCRIPTION
### What and why?

I'm looking to make the flutter release process a little bit simpler and more trunk based. To that end, I'm re-organizing some of the release process (this change is documented in the wiki).

The releaser script now updates the versions and creates a release branch from that commit. This becomes the starting point for all releases in that line. A second commit bumps the version, and that will be the pull request back into `develop.`

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests