### PR TITLE
[datadog_grpc_interceptor Adds support for grpc hosts that don't have a URL scheme

### DIFF
--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -64,7 +64,7 @@ class DatadogGrpcInterceptor extends ClientInterceptor {
       fullPath,
       {
         "grpc.method": method.path.split('/').lastWhere(
-              (e) => e == '/',
+              (e) => e.isNotEmpty,
               orElse: () => method.path,
             ),
         "grpc.path": method.path,

--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -60,10 +60,14 @@ class DatadogGrpcInterceptor extends ClientInterceptor {
     final rumKey = uuid.v1();
     _datadog.rum?.startResourceLoading(
       rumKey,
-      RumHttpMethod.get,
+      RumHttpMethod.unknown,
       fullPath,
       {
-        "grpc.method": method.path,
+        "grpc.method": method.path.split('/').lastWhere(
+              (e) => e == '/',
+              orElse: () => method.path,
+            ),
+        "grpc.path": method.path,
         if (shouldAppendTraces) ...{
           DatadogRumPlatformAttributeKey.traceID: traceId,
           DatadogRumPlatformAttributeKey.spanID: parentId

--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -33,7 +33,17 @@ class DatadogGrpcInterceptor extends ClientInterceptor {
     if (host is InternetAddress) {
       fullPath = '${host.host}:${_channel.port}$path';
     } else {
-      fullPath = '$host:${_channel.port}$path';
+      /// Account for host not containing a scheme in it
+      if (Uri.parse(_channel.host.toString()).scheme == '') {
+        if (_channel.options.credentials.isSecure) {
+          fullPath = 'https://$host:${_channel.port}$path';
+        } else {
+          fullPath = 'http://$host:${_channel.port}$path';
+        }
+      } else {
+        /// Url has a scheme in it
+        fullPath = '$host:${_channel.port}$path';
+      }
     }
 
     bool shouldSample = _datadog.rum?.shouldSampleTrace() ?? false;


### PR DESCRIPTION
Add support for grpc channels that don't have a URL scheme.