### PR TITLE
Don't attempt to reinitialize Datadog on hot-reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tools/e2e_generator/terraform.tfstate
 **/.flutter-plugins*
 __pycache__
 tools/ci/venv
+ndk_crash_reports_v2/

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     testImplementation "com.github.xgouchet.Elmyr:core:1.3.1"
     testImplementation "com.github.xgouchet.Elmyr:junit5:1.3.1"
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:0.25"
 }
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -162,4 +162,4 @@ internal const val DATADOG_FLUTTER_TAG = "DatadogFlutter"
 
 internal const val MESSAGE_INVALID_REINITIALIZATION =
     "🔥 Reinitialziing the DatadogSDK with different options, even after a hot restart, is not" +
-        "supported. Cold restart your application to change your current configuation."
+        " supported. Cold restart your application to change your current configuation."

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -7,14 +7,12 @@ package com.datadoghq.flutter
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.util.Log
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
@@ -23,22 +21,16 @@ import com.datadog.android.core.model.UserInfo
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.mockk.mockkStatic
-import io.opentracing.util.GlobalTracer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.MockedStatic
-import org.mockito.Mockito
-import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -240,7 +232,7 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCallB, mockResultB)
 
         // THEN
-        io.mockk.verify(exactly = 1) { Log.e(any(), match { it.contains("🔥") }) }
+        io.mockk.verify(exactly = 1) { Log.e(DATADOG_FLUTTER_TAG, MESSAGE_INVALID_REINITIALIZATION) }
     }
 
     @Test

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ReflectUtils.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ReflectUtils.kt
@@ -58,7 +58,6 @@ private fun <T : Any> T.getDeclaredMethodRecursively(
         val lookingInClass = classesToSearch.removeAt(0)
         classesSearched.add(lookingInClass)
         method = try {
-            var methods = lookingInClass.declaredMethods
             if (matchingParams) {
                 lookingInClass.getDeclaredMethod(methodName, *declarationParams)
             } else {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ReflectUtils.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ReflectUtils.kt
@@ -58,6 +58,7 @@ private fun <T : Any> T.getDeclaredMethodRecursively(
         val lookingInClass = classesToSearch.removeAt(0)
         classesSearched.add(lookingInClass)
         method = try {
+            var methods = lookingInClass.declaredMethods
             if (matchingParams) {
                 lookingInClass.getDeclaredMethod(methodName, *declarationParams)
             } else {


### PR DESCRIPTION
### What and why?

Because hot reload / hot restart can recall `main`, you can get multiple requests to initialize Datadog, and the warning we spit to the console can get annoying. This removes that warning if your initialization hasn't changed.

If your initialization has changed, this shows a warning.

This fixes #141 

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests