### PR TITLE
💥 Remove RumHttpMethod.unknown

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Remove deprecated tracing feature.
-
+* Removed `RumHttpMethod.unknown` as it is translated GET on the native side anyway.
 ## 1.0.0-beta.3
 
 * Update Android SDK to 1.13.0-rc1

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -14,7 +14,7 @@ import '../internal_logger.dart';
 import 'ddrum_platform_interface.dart';
 
 /// HTTP method of the resource
-enum RumHttpMethod { post, get, head, put, delete, patch, unknown }
+enum RumHttpMethod { post, get, head, put, delete, patch }
 
 RumHttpMethod rumMethodFromMethodString(String value) {
   var lowerValue = value.toLowerCase();


### PR DESCRIPTION
### What and why?

In both iOS and Android, RumHttpMethod.unknown was translated to GET anyway. So to avoid confusion I'm going to remove it entirely.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests