### PR TITLE
Update to version 1.14.0-beta1

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+* Update Android SDK to 1.14.0-beta1
 * Remove deprecated tracing feature.
 * Removed `RumHttpMethod.unknown` as it is translated GET on the native side anyway.
+
 ## 1.0.0-beta.3
 
 * Update Android SDK to 1.13.0-rc1

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -14,7 +14,7 @@ RUM supports monitoring for mobile Flutter Android and iOS applications.
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 1.11.1 | 1.13.0 | v4.11.2 |
+| 1.11.1 | 1.14.0-beta1 | v4.11.2 |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,7 +9,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_sdk_version = "1.13.0"
+    ext.datadog_sdk_version = "1.14.0-beta1"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 1.13.0 to version 1.14.0-beta1: [diff](https://github.com/DataDog/dd-sdk-android/compare/1.13.0...1.14.0-beta1)