### PR TITLE
fix simple typo in line 169

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -166,7 +166,7 @@ final configuration = DdSdkConfiguration(
 )..enableHttpTracking()
 ```
 
-In order to enable Datadog Distributed Tracing, the `DdSdkConfiguration.firstPartyHosts` property in your configutation object must be set to a domain that supports distributed tracing. You can also modify the sampling rate for Datadog distributed tracing by setting the `tracingSamplingRate` on your `RumConfiguration`.
+In order to enable Datadog Distributed Tracing, the `DdSdkConfiguration.firstPartyHosts` property in your configuration object must be set to a domain that supports distributed tracing. You can also modify the sampling rate for Datadog distributed tracing by setting the `tracingSamplingRate` on your `RumConfiguration`.
 
 ## Data Storage
 


### PR DESCRIPTION
corrected "configutation" to configuration

### What and why?

What changes does this pull request introduce and why is it necessary?
This change corrects the spelling of the word "configuration" in line 169.

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests