### PR TITLE
🔊 Adding logging messages to Mock Http server, add new example error

### DIFF
--- a/packages/datadog_common_test/lib/src/mock_http_sever.dart
+++ b/packages/datadog_common_test/lib/src/mock_http_sever.dart
@@ -23,8 +23,10 @@ String get _endpoint => 'http://localhost:$_bindingPort';
 class RecordingHttpServer {
   late HttpServer server;
   final Map<String, List<RequestLog>> _recordedRequests = {};
+
   // Used for debugging sessions
   bool serializeSessions = false;
+  bool printRequests = false;
 
   RecordingHttpServer();
 
@@ -60,6 +62,11 @@ class RecordingHttpServer {
         final sessionFile = File('$session.session');
         await sessionFile.writeAsString(parsed.data,
             mode: FileMode.append, flush: true);
+      }
+      if (printRequests) {
+        print('---- BEGIN REQUEST ----');
+        print(parsed.data);
+        print('---- END REQUEST ----');
       }
     } catch (e) {
       print('Failed parsing request: $e');

--- a/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
@@ -125,6 +125,13 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
             ),
             Wrap(
               children: [
+                Container(
+                  padding: const EdgeInsets.only(left: 5),
+                  child: ElevatedButton(
+                    onPressed: () => _crashNonAsync(),
+                    child: const Text('Non async crash'),
+                  ),
+                ),
                 for (final t in CrashType.values)
                   Container(
                     padding: const EdgeInsets.only(left: 5),
@@ -156,6 +163,13 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
     );
   }
 
+  void _crashNonAsync() {
+    final viewName = _viewName.isEmpty ? 'Rum Crash View' : _viewName;
+    DatadogSdk.instance.rum?.startView(viewName, viewName);
+
+    _flutterException();
+  }
+
   Future<void> _crashAfterRumSession(CrashType crashType) async {
     final viewName = _viewName.isEmpty ? 'Rum Crash View' : _viewName;
     DatadogSdk.instance.rum?.startView(viewName, viewName);
@@ -171,6 +185,17 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
     _crash(crashType).onError((error, stackTrace) => print(error));
   }
 
+  void _flutterException() {
+    // Iterate a list to get a system symbol in the stack.
+    var x = ['a', 'b', 'c'].map((element) {
+      if (element == 'a') {
+        throw Exception("This wasn't supposed to happen!");
+      }
+      return 'x';
+    });
+    print(x.first);
+  }
+
   static int nativeCallback(int value) {
     throw Exception(('FFI Callback Exception with value $value'));
   }
@@ -178,7 +203,8 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
   Future<void> _crash(CrashType crashType) async {
     switch (crashType) {
       case CrashType.flutterException:
-        throw Exception("This wasn't supposed to happen!");
+        _flutterException();
+        break;
       case CrashType.methodChannelCrash:
         await nativeCrashPlugin.crashNative();
         break;

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -245,6 +245,22 @@ void main() {
     expect(datadogSdk.isFirstPartyHost(uri), isFalse);
   });
 
+  test('isFirstPartyHost escapes special characters in hosts', () async {
+    var firstPartyHosts = ['test.datadoghq.com'];
+
+    final configuration = DdSdkConfiguration(
+      clientToken: 'clientToken',
+      env: 'env',
+      site: DatadogSite.us1,
+      trackingConsent: TrackingConsent.pending,
+      firstPartyHosts: firstPartyHosts,
+    );
+    await datadogSdk.initialize(configuration);
+
+    var uri = Uri.parse('https://testdatadoghq.com/path');
+    expect(datadogSdk.isFirstPartyHost(uri), isFalse);
+  });
+
   test('set user info calls into platform', () {
     datadogSdk.setUserInfo(
         id: 'fake_id', name: 'fake_name', email: 'fake_email');


### PR DESCRIPTION
### What and why?

When running in simulators, writing sessions puts the files in a weird location. Printing to console is easier in these situations.
Also added a new Flutter error that is non-async, which results in a larger stack that goes further into Flutter's built-in libraries.

Also, added an extra regex test for firstPartyHosts.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests