### PR TITLE
✨ Long Task reporting

### DIFF
--- a/packages/datadog_common_test/lib/src/data_helpers.dart
+++ b/packages/datadog_common_test/lib/src/data_helpers.dart
@@ -22,3 +22,14 @@ extension RandomExtension<T> on List<T> {
     return this[_random.nextInt(length)];
   }
 }
+
+extension DurationHelpers on Duration {
+  /// The number of whole nanoseconds spanned by this [Duration].
+  ///
+  /// Note, Dart only has precision up to the microsecond level, so the last
+  /// digits of this value will always be zero.
+  /// ```
+  int get inNanoseconds {
+    return inMicroseconds * 1000;
+  }
+}

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
 
 class RumSessionDecoder {
   final List<RumViewVisit> visits;
@@ -57,6 +57,10 @@ class RumSessionDecoder {
           final errorEvent = RumErrorEventDecoder(e.rumEvent);
           visit.errorEvents.add(errorEvent);
           break;
+        case 'long_task':
+          final longTaskEvent = RumLongTaskEventDecoder(e.rumEvent);
+          visit.longTaskEvents.add(longTaskEvent);
+          break;
       }
     }
 
@@ -78,6 +82,7 @@ class RumViewVisit {
   final List<RumActionEventDecoder> actionEvents = [];
   final List<RumResourceEventDecoder> resourceEvents = [];
   final List<RumErrorEventDecoder> errorEvents = [];
+  final List<RumLongTaskEventDecoder> longTaskEvents = [];
 
   RumViewVisit(this.id, this.name, this.path);
 }
@@ -98,7 +103,7 @@ class RumEventDecoder {
 
   String get eventType => rumEvent['type'] as String;
   String get service {
-    if (!kIsWeb) {
+    if (!kManualIsWeb) {
       if (Platform.isIOS) return rumEvent['service'];
     }
     return rumEvent['service'];
@@ -161,6 +166,12 @@ class RumErrorEventDecoder extends RumEventDecoder {
   int? get resourceStatusCode => rumEvent['error']['resource']?['statusCode'];
 }
 
+class RumLongTaskEventDecoder extends RumEventDecoder {
+  RumLongTaskEventDecoder(Map<String, dynamic> rumEvent) : super(rumEvent);
+
+  int? get duration => rumEvent['long_task']['duration'];
+}
+
 class RumViewDecoder {
   final Map<String, dynamic> viewData;
 
@@ -171,6 +182,7 @@ class RumViewDecoder {
   int get actionCount => viewData['action']['count'] as int;
   int get resourceCount => viewData['resource']['count'] as int;
   int get errorCount => viewData['error']['count'] as int;
+  int get longTaskCount => viewData['long_task']['count'] as int;
 
   Map<String, int> get customTimings =>
       (viewData['custom_timings'] as Map<String, dynamic>)

--- a/packages/datadog_common_test/lib/src/decoders/span_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/span_decoder.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:datadog_common_test/datadog_common_test.dart';
+import '../../datadog_common_test.dart';
 
 class SpanDecoder {
   final Map<String, Object?> envelope;

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update Android SDK to 1.14.0-beta1
 * Remove deprecated tracing feature.
 * Removed `RumHttpMethod.unknown` as it is translated GET on the native side anyway.
-* Added Long Task reporting
+* Added Long Task reporting.
 
 ## 1.0.0-beta.3
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update Android SDK to 1.14.0-beta1
 * Remove deprecated tracing feature.
 * Removed `RumHttpMethod.unknown` as it is translated GET on the native side anyway.
+* Added Long Task reporting
 
 ## 1.0.0-beta.3
 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -77,7 +77,7 @@ final configuration = DdSdkConfiguration(
 );
 ```
 
-For more information on available configuration options, consult the documentation for the [DdSdkConfiguration][8] object.
+For more information on available configuration options, see the [DdSdkConfiguration object][8] documentation.
 
 ### Initialize the library
 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -77,6 +77,8 @@ final configuration = DdSdkConfiguration(
 );
 ```
 
+For more information on available configuration options, consult the documentation for the [DdSdkConfiguration][8] object.
+
 ### Initialize the library
 
 You can initialize RUM using one of two methods in the `main.dart` file.
@@ -203,4 +205,5 @@ For more information, see [Apache License, v2.0][5].
 [5]: https://github.com/DataDog/dd-sdk-flutter/blob/main/LICENSE
 [6]: https://source.android.com/security/app-sandbox
 [7]: https://pub.dev/packages/datadog_tracking_http_client
+[8]: https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/DdSdkConfiguration-class.html
 client

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -14,6 +14,7 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.lang.ClassCastException
+import java.util.concurrent.TimeUnit
 
 class DatadogRumPlugin(
     rumInstance: RumMonitor? = null
@@ -214,7 +215,7 @@ class DatadogRumPlugin(
                     val duration = call.argument<Int>(PARAM_DURATION)
                     if (at != null && duration != null) {
                         // Duration is in ms, convert to ns
-                        val durationNs = duration.toLong() * 1000
+                        val durationNs = TimeUnit.MILLISECONDS.toNanos(duration.toLong())
                         rum?._getInternal()?.addLongTask(durationNs, "")
                         result.success(null)
                     } else {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -19,6 +19,8 @@ class DatadogRumPlugin(
     rumInstance: RumMonitor? = null
 ) : MethodChannel.MethodCallHandler {
     companion object RumParameterNames {
+        const val PARAM_AT = "at"
+        const val PARAM_DURATION = "duration"
         const val PARAM_KEY = "key"
         const val PARAM_VALUE = "value"
         const val PARAM_NAME = "name"
@@ -202,6 +204,18 @@ class DatadogRumPlugin(
                     val key = call.argument<String>(PARAM_KEY)
                     if (key != null) {
                         GlobalRum.removeAttribute(key)
+                        result.success(null)
+                    } else {
+                        result.missingParameter(call.method)
+                    }
+                }
+                "reportLongTask" -> {
+                    val at = call.argument<Long>(PARAM_AT)
+                    val duration = call.argument<Int>(PARAM_DURATION)
+                    if (at != null && duration != null) {
+                        // Duration is in ms, convert to ns
+                        val durationNs = duration.toLong() * 1000
+                        rum?._getInternal()?.addLongTask(durationNs, "")
                         result.success(null)
                     } else {
                         result.missingParameter(call.method)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -26,6 +26,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.util.concurrent.TimeUnit
 
 @ExtendWith(ForgeExtension::class)
 @OptIn(kotlin.ExperimentalStdlibApi::class)
@@ -448,7 +449,7 @@ class DatadogRumPluginTest {
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        val durationNs = duration.toLong() * 1000
+        val durationNs = TimeUnit.MILLISECONDS.toNanos(duration.toLong())
         verify { mockRumProxy.addLongTask(durationNs, "") }
         verify { mockResult.success(null) }
     }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -11,513 +11,566 @@ import XCTest
 import datadog_flutter_plugin
 
 enum ResultStatus: EquatableInTests {
-  case notCalled
-  case called(value: Any?)
+    case notCalled
+    case called(value: Any?)
 }
 
 // MARK: - Tests
 
 // swiftlint:disable:next type_body_length
 class DatadogRumPluginTests: XCTestCase {
-  func testAllRumResourceTypes_AreParsedCorrectly() {
-    let document = RUMResourceType.parseFromFlutter("RumResourceType.document")
-    let image = RUMResourceType.parseFromFlutter("RumResourceType.image")
-    let xhr = RUMResourceType.parseFromFlutter("RumResourceType.xhr")
-    let beacon = RUMResourceType.parseFromFlutter("RumResourceType.beacon")
-    let css = RUMResourceType.parseFromFlutter("RumResourceType.css")
-    let fetch = RUMResourceType.parseFromFlutter("RumResourceType.fetch")
-    let font = RUMResourceType.parseFromFlutter("RumResourceType.font")
-    let jsx = RUMResourceType.parseFromFlutter("RumResourceType.js")
-    let media = RUMResourceType.parseFromFlutter("RumResourceType.media")
-    let other = RUMResourceType.parseFromFlutter("RumResourceType.other")
-    let native = RUMResourceType.parseFromFlutter("RumResourceType.native")
-    let unknown = RUMResourceType.parseFromFlutter("uknowntype")
+    func testAllRumResourceTypes_AreParsedCorrectly() {
+        let document = RUMResourceType.parseFromFlutter("RumResourceType.document")
+        let image = RUMResourceType.parseFromFlutter("RumResourceType.image")
+        let xhr = RUMResourceType.parseFromFlutter("RumResourceType.xhr")
+        let beacon = RUMResourceType.parseFromFlutter("RumResourceType.beacon")
+        let css = RUMResourceType.parseFromFlutter("RumResourceType.css")
+        let fetch = RUMResourceType.parseFromFlutter("RumResourceType.fetch")
+        let font = RUMResourceType.parseFromFlutter("RumResourceType.font")
+        let jsx = RUMResourceType.parseFromFlutter("RumResourceType.js")
+        let media = RUMResourceType.parseFromFlutter("RumResourceType.media")
+        let other = RUMResourceType.parseFromFlutter("RumResourceType.other")
+        let native = RUMResourceType.parseFromFlutter("RumResourceType.native")
+        let unknown = RUMResourceType.parseFromFlutter("uknowntype")
 
-    XCTAssertEqual(document, .document)
-    XCTAssertEqual(image, .image)
-    XCTAssertEqual(xhr, .xhr)
-    XCTAssertEqual(beacon, .beacon)
-    XCTAssertEqual(css, .css)
-    XCTAssertEqual(fetch, .fetch)
-    XCTAssertEqual(font, .font)
-    XCTAssertEqual(jsx, .js)
-    XCTAssertEqual(media, .media)
-    XCTAssertEqual(other, .other)
-    XCTAssertEqual(native, .native)
-    XCTAssertEqual(unknown, .other)
-  }
-
-  func testAllRumHttpMethods_AreParsedCorrectly() {
-    let post = RUMMethod.parseFromFlutter("RumHttpMethod.post")
-    let get = RUMMethod.parseFromFlutter("RumHttpMethod.get")
-    let head = RUMMethod.parseFromFlutter("RumHttpMethod.head")
-    let put = RUMMethod.parseFromFlutter("RumHttpMethod.put")
-    let delete = RUMMethod.parseFromFlutter("RumHttpMethod.delete")
-    let patch = RUMMethod.parseFromFlutter("RumHttpMethod.patch")
-
-    XCTAssertEqual(post, .post)
-    XCTAssertEqual(get, .get)
-    XCTAssertEqual(head, .head)
-    XCTAssertEqual(put, .put)
-    XCTAssertEqual(delete, .delete)
-    XCTAssertEqual(patch, .patch)
-  }
-
-  func testAllUserActions_AreParsedCorrectly() {
-    let tap = RUMUserActionType.parseFromFlutter("RumUserActionType.tap")
-    let scroll = RUMUserActionType.parseFromFlutter("RumUserActionType.scroll")
-    let swipe = RUMUserActionType.parseFromFlutter("RumUserActionType.swipe")
-    let custom = RUMUserActionType.parseFromFlutter("RumUserActionType.custom")
-    let unknown = RUMUserActionType.parseFromFlutter("unknowntype")
-
-    XCTAssertEqual(tap, .tap)
-    XCTAssertEqual(scroll, .scroll)
-    XCTAssertEqual(swipe, .swipe)
-    XCTAssertEqual(custom, .custom)
-    XCTAssertEqual(unknown, .custom)
-  }
-
-  func testAllRumErrorSource_AreParsedCorrectly() {
-    let source = RUMErrorSource.parseFromFlutter("RumErrorSource.source")
-    let network = RUMErrorSource.parseFromFlutter("RumErrorSource.network")
-    let webview = RUMErrorSource.parseFromFlutter("RumErrorSource.webview")
-    let console = RUMErrorSource.parseFromFlutter("RumErrorSource.console")
-    let custom = RUMErrorSource.parseFromFlutter("RumErrorSource.custom")
-    let unknown = RUMErrorSource.parseFromFlutter("unknown")
-
-    XCTAssertEqual(source, .source)
-    XCTAssertEqual(network, .network)
-    XCTAssertEqual(webview, .webview)
-    XCTAssertEqual(console, .console)
-    XCTAssertEqual(custom, .custom)
-    XCTAssertEqual(unknown, .custom)
-  }
-
-  var mock: MockRUMMonitor!
-  var plugin: DatadogRumPlugin!
-
-  override func setUp() {
-    mock = MockRUMMonitor()
-    plugin = DatadogRumPlugin.instance
-    plugin.initialize(withRum: mock)
-  }
-
-  let contracts = [
-    Contract(methodName: "startView", requiredParameters: [
-      "key": .string, "name": .string, "attributes": .map
-    ]),
-    Contract(methodName: "stopView", requiredParameters: [
-      "key": .string, "attributes": .map
-    ]),
-    Contract(methodName: "addTiming", requiredParameters: [
-      "name": .string
-    ]),
-    Contract(methodName: "startResourceLoading", requiredParameters: [
-      "key": .string, "url": .string, "httpMethod": .string, "attributes": .map
-    ]),
-    Contract(methodName: "stopResourceLoading", requiredParameters: [
-      "key": .string, "kind": .string, "attributes": .map
-    ]),
-    Contract(methodName: "stopResourceLoadingWithError", requiredParameters: [
-      "key": .string, "message": .string, "type": .string, "attributes": .map
-    ]),
-    Contract(methodName: "addError", requiredParameters: [
-      "message": .string, "source": .string, "attributes": .map
-    ]),
-    Contract(methodName: "addUserAction", requiredParameters: [
-      "type": .string, "name": .string, "attributes": .map
-    ]),
-    Contract(methodName: "startUserAction", requiredParameters: [
-      "type": .string, "name": .string, "attributes": .map
-    ]),
-    Contract(methodName: "stopUserAction", requiredParameters: [
-      "type": .string, "name": .string, "attributes": .map
-    ]),
-    Contract(methodName: "addAttribute", requiredParameters: [
-      "key": .string, "value": .string
-    ]),
-    Contract(methodName: "removeAttribute", requiredParameters: [
-      "key": .string
-    ])
-  ]
-
-  func testRumPlugin_ContractViolationsThrowErrors() {
-    testContracts(contracts: contracts, plugin: plugin)
-  }
-
-  func testStartViewCall_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "startView", arguments: [
-      "key": "view_key",
-      "name": "view_name",
-      "attributes": ["my_attribute": "my_value"]
-    ])
-
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+        XCTAssertEqual(document, .document)
+        XCTAssertEqual(image, .image)
+        XCTAssertEqual(xhr, .xhr)
+        XCTAssertEqual(beacon, .beacon)
+        XCTAssertEqual(css, .css)
+        XCTAssertEqual(fetch, .fetch)
+        XCTAssertEqual(font, .font)
+        XCTAssertEqual(jsx, .js)
+        XCTAssertEqual(media, .media)
+        XCTAssertEqual(other, .other)
+        XCTAssertEqual(native, .native)
+        XCTAssertEqual(unknown, .other)
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .startView(key: "view_key", name: "view_name", attributes: ["my_attribute": "my_value"])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testAllRumHttpMethods_AreParsedCorrectly() {
+        let post = RUMMethod.parseFromFlutter("RumHttpMethod.post")
+        let get = RUMMethod.parseFromFlutter("RumHttpMethod.get")
+        let head = RUMMethod.parseFromFlutter("RumHttpMethod.head")
+        let put = RUMMethod.parseFromFlutter("RumHttpMethod.put")
+        let delete = RUMMethod.parseFromFlutter("RumHttpMethod.delete")
+        let patch = RUMMethod.parseFromFlutter("RumHttpMethod.patch")
 
-  func testStopViewCall_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "stopView", arguments: [
-      "key": "view_key",
-      "attributes": ["my_attribute": "my_value"]
-    ])
-
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+        XCTAssertEqual(post, .post)
+        XCTAssertEqual(get, .get)
+        XCTAssertEqual(head, .head)
+        XCTAssertEqual(put, .put)
+        XCTAssertEqual(delete, .delete)
+        XCTAssertEqual(patch, .patch)
     }
 
-    XCTAssertEqual(mock.callLog, [.stopView(key: "view_key", attributes: ["my_attribute": "my_value"])])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testAllUserActions_AreParsedCorrectly() {
+        let tap = RUMUserActionType.parseFromFlutter("RumUserActionType.tap")
+        let scroll = RUMUserActionType.parseFromFlutter("RumUserActionType.scroll")
+        let swipe = RUMUserActionType.parseFromFlutter("RumUserActionType.swipe")
+        let custom = RUMUserActionType.parseFromFlutter("RumUserActionType.custom")
+        let unknown = RUMUserActionType.parseFromFlutter("unknowntype")
 
-  func testAddTimingCall_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "addTiming", arguments: [
-      "name": "timing name"
-    ])
-
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+        XCTAssertEqual(tap, .tap)
+        XCTAssertEqual(scroll, .scroll)
+        XCTAssertEqual(swipe, .swipe)
+        XCTAssertEqual(custom, .custom)
+        XCTAssertEqual(unknown, .custom)
     }
 
-    XCTAssertEqual(mock.callLog, [ .addTiming(name: "timing name") ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testAllRumErrorSource_AreParsedCorrectly() {
+        let source = RUMErrorSource.parseFromFlutter("RumErrorSource.source")
+        let network = RUMErrorSource.parseFromFlutter("RumErrorSource.network")
+        let webview = RUMErrorSource.parseFromFlutter("RumErrorSource.webview")
+        let console = RUMErrorSource.parseFromFlutter("RumErrorSource.console")
+        let custom = RUMErrorSource.parseFromFlutter("RumErrorSource.custom")
+        let unknown = RUMErrorSource.parseFromFlutter("unknown")
 
-  func testStartResourceLoading_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "startResourceLoading", arguments: [
-      "key": "resource_key",
-      "httpMethod": "RumHttpMethod.get",
-      "url": "https://fakeresource.com/url",
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
-
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+        XCTAssertEqual(source, .source)
+        XCTAssertEqual(network, .network)
+        XCTAssertEqual(webview, .webview)
+        XCTAssertEqual(console, .console)
+        XCTAssertEqual(custom, .custom)
+        XCTAssertEqual(unknown, .custom)
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .startResourceLoading(key: "resource_key",
-                            httpMethod: .get,
-                            urlString: "https://fakeresource.com/url",
-                            attributes: ["attribute_key": "attribute_value"])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    var mock: MockRUMMonitor!
+    var plugin: DatadogRumPlugin!
 
-  func testStopResourceLoading_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "stopResourceLoading", arguments: [
-      "key": "resource_key",
-      "statusCode": 200,
-      "kind": "RumResourceType.image",
-      "size": nil,
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
-
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+    override func setUp() {
+        mock = MockRUMMonitor()
+        plugin = DatadogRumPlugin.instance
+        plugin.initialize(withRum: mock)
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .stopResourceLoading(key: "resource_key", statusCode: 200, kind: .image, size: nil, attributes: [
-        "attribute_key": "attribute_value"
-      ])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    let contracts = [
+        Contract(methodName: "startView", requiredParameters: [
+            "key": .string, "name": .string, "attributes": .map
+        ]),
+        Contract(methodName: "stopView", requiredParameters: [
+            "key": .string, "attributes": .map
+        ]),
+        Contract(methodName: "addTiming", requiredParameters: [
+            "name": .string
+        ]),
+        Contract(methodName: "startResourceLoading", requiredParameters: [
+            "key": .string, "url": .string, "httpMethod": .string, "attributes": .map
+        ]),
+        Contract(methodName: "stopResourceLoading", requiredParameters: [
+            "key": .string, "kind": .string, "attributes": .map
+        ]),
+        Contract(methodName: "stopResourceLoadingWithError", requiredParameters: [
+            "key": .string, "message": .string, "type": .string, "attributes": .map
+        ]),
+        Contract(methodName: "addError", requiredParameters: [
+            "message": .string, "source": .string, "attributes": .map
+        ]),
+        Contract(methodName: "addUserAction", requiredParameters: [
+            "type": .string, "name": .string, "attributes": .map
+        ]),
+        Contract(methodName: "startUserAction", requiredParameters: [
+            "type": .string, "name": .string, "attributes": .map
+        ]),
+        Contract(methodName: "stopUserAction", requiredParameters: [
+            "type": .string, "name": .string, "attributes": .map
+        ]),
+        Contract(methodName: "addAttribute", requiredParameters: [
+            "key": .string, "value": .string
+        ]),
+        Contract(methodName: "removeAttribute", requiredParameters: [
+            "key": .string
+        ]),
+        Contract(methodName: "reportLongTask", requiredParameters: [
+            "at": .int64,
+            "duration": .int
+        ])
+    ]
 
-  func testStopResourceLoading_WithSize_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "stopResourceLoading", arguments: [
-      "key": "resource_key",
-      "statusCode": 200,
-      "kind": "RumResourceType.image",
-      "size": 12_408_812,
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
-
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+    func testRumPlugin_ContractViolationsThrowErrors() {
+        testContracts(contracts: contracts, plugin: plugin)
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .stopResourceLoading(key: "resource_key", statusCode: 200, kind: .image,
-                           size: 12_408_812, attributes: [
-        "attribute_key": "attribute_value"
-      ])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testStartViewCall_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "startView", arguments: [
+            "key": "view_key",
+            "name": "view_name",
+            "attributes": ["my_attribute": "my_value"]
+        ])
 
-  func testStopResourceLoadingWithError_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "stopResourceLoadingWithError", arguments: [
-      "key": "resource_key",
-      "message": "error message",
-      "type": "error kind",
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = .called(value: result)
+        XCTAssertEqual(mock.callLog, [
+            .startView(key: "view_key", name: "view_name", attributes: ["my_attribute": "my_value"])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .stopResourceLoadingWithErrorMessage(key: "resource_key",
-                                           errorMessage: "error message",
-                                           type: "error kind",
-                                           response: nil,
-                                           attributes: [
-        "attribute_key": "attribute_value"
-      ])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testStopViewCall_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "stopView", arguments: [
+            "key": "view_key",
+            "attributes": ["my_attribute": "my_value"]
+        ])
 
-  func testAddError_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "addError", arguments: [
-      "message": "Error message",
-      "source": "RumErrorSource.network",
-      "stackTrace": nil,
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = ResultStatus.called(value: result)
+        XCTAssertEqual(mock.callLog, [.stopView(key: "view_key", attributes: ["my_attribute": "my_value"])])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .addError(message: "Error message", type: nil, source: RUMErrorSource.network, stack: nil,
-                attributes: ["attribute_key": "attribute_value"], file: nil, line: nil)
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testAddTimingCall_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "addTiming", arguments: [
+            "name": "timing name"
+        ])
 
-  func testAddUserAction_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "addUserAction", arguments: [
-      "type": "RumUserActionType.tap",
-      "name": "Action Name",
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = ResultStatus.called(value: result)
+        XCTAssertEqual(mock.callLog, [ .addTiming(name: "timing name") ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .addUserAction(type: .tap, name: "Action Name", attributes: [
-        "attribute_key": "attribute_value"
-      ])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testStartResourceLoading_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "startResourceLoading", arguments: [
+            "key": "resource_key",
+            "httpMethod": "RumHttpMethod.get",
+            "url": "https://fakeresource.com/url",
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
 
-  func testStartUserAction_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "startUserAction", arguments: [
-      "type": "RumUserActionType.scroll",
-      "name": "Action Name",
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = ResultStatus.called(value: result)
+        XCTAssertEqual(mock.callLog, [
+            .startResourceLoading(key: "resource_key",
+                                  httpMethod: .get,
+                                  urlString: "https://fakeresource.com/url",
+                                  attributes: ["attribute_key": "attribute_value"])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .startUserAction(type: .scroll, name: "Action Name", attributes: [
-        "attribute_key": "attribute_value"
-      ])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testStopResourceLoading_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "stopResourceLoading", arguments: [
+            "key": "resource_key",
+            "statusCode": 200,
+            "kind": "RumResourceType.image",
+            "size": nil,
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
 
-  func testStopUserAction_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "stopUserAction", arguments: [
-      "type": "RumUserActionType.swipe",
-      "name": "Action Name",
-      "attributes": [
-        "attribute_key": "attribute_value"
-      ]
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = ResultStatus.called(value: result)
+        XCTAssertEqual(mock.callLog, [
+            .stopResourceLoading(key: "resource_key", statusCode: 200, kind: .image, size: nil, attributes: [
+                "attribute_key": "attribute_value"
+            ])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .stopUserAction(type: .swipe, name: "Action Name", attributes: [
-        "attribute_key": "attribute_value"
-      ])
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testStopResourceLoading_WithSize_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "stopResourceLoading", arguments: [
+            "key": "resource_key",
+            "statusCode": 200,
+            "kind": "RumResourceType.image",
+            "size": 12_408_812,
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
 
-  func testAddAttribute_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "addAttribute", arguments: [
-      "key": "My key",
-      "value": "My value"
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = ResultStatus.called(value: result)
+        XCTAssertEqual(mock.callLog, [
+            .stopResourceLoading(key: "resource_key", statusCode: 200, kind: .image,
+                                 size: 12_408_812, attributes: [
+                                    "attribute_key": "attribute_value"
+                                 ])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .addAttribute(forKey: "My key", value: "My value")
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testStopResourceLoadingWithError_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "stopResourceLoadingWithError", arguments: [
+            "key": "resource_key",
+            "message": "error message",
+            "type": "error kind",
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
 
-  func testRemoveAttribute_CallsRumMonitor() {
-    let call = FlutterMethodCall(methodName: "removeAttribute", arguments: [
-      "key": "remove_key"
-    ])
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
 
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle(call) { result in
-      resultStatus = ResultStatus.called(value: result)
+        XCTAssertEqual(mock.callLog, [
+            .stopResourceLoadingWithErrorMessage(key: "resource_key",
+                                                 errorMessage: "error message",
+                                                 type: "error kind",
+                                                 response: nil,
+                                                 attributes: [
+                                                    "attribute_key": "attribute_value"
+                                                 ])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    XCTAssertEqual(mock.callLog, [
-      .removeAttribute(forKey: "remove_key")
-    ])
-    XCTAssertEqual(resultStatus, .called(value: nil))
-  }
+    func testAddError_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "addError", arguments: [
+            "message": "Error message",
+            "source": "RumErrorSource.network",
+            "stackTrace": nil,
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [
+            .addError(message: "Error message", type: nil, source: RUMErrorSource.network, stack: nil,
+                      attributes: ["attribute_key": "attribute_value"], file: nil, line: nil)
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testAddUserAction_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "addUserAction", arguments: [
+            "type": "RumUserActionType.tap",
+            "name": "Action Name",
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [
+            .addUserAction(type: .tap, name: "Action Name", attributes: [
+                "attribute_key": "attribute_value"
+            ])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testStartUserAction_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "startUserAction", arguments: [
+            "type": "RumUserActionType.scroll",
+            "name": "Action Name",
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [
+            .startUserAction(type: .scroll, name: "Action Name", attributes: [
+                "attribute_key": "attribute_value"
+            ])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testStopUserAction_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "stopUserAction", arguments: [
+            "type": "RumUserActionType.swipe",
+            "name": "Action Name",
+            "attributes": [
+                "attribute_key": "attribute_value"
+            ]
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [
+            .stopUserAction(type: .swipe, name: "Action Name", attributes: [
+                "attribute_key": "attribute_value"
+            ])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testAddAttribute_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "addAttribute", arguments: [
+            "key": "My key",
+            "value": "My value"
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [
+            .addAttribute(forKey: "My key", value: "My value")
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testRemoveAttribute_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "removeAttribute", arguments: [
+            "key": "remove_key"
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [
+            .removeAttribute(forKey: "remove_key")
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testReportLongTask_CallsInternal() {
+        let startTime = Date.now
+        let duration = 340124
+
+        let call = FlutterMethodCall(methodName: "reportLongTask", arguments: [
+            "at": startTime.timeIntervalSince1970 * 1000.0,
+            "duration": duration
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = ResultStatus.called(value: result)
+        }
+
+        let mockInternal = mock._internal as! MockRumInternalProxy
+        XCTAssertEqual(mockInternal.callLog, [
+            .addLongTask(at: startTime, duration: TimeInterval(Double(duration) / 1000.0), attributes: [:])
+        ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
 }
 
 // MARK: - MockRUMMonitor
 
 class MockRUMMonitor: DDRUMMonitor {
-  enum MethodCall: EquatableInTests {
-    case startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue])
-    case stopView(key: String, attributes: [AttributeKey: AttributeValue])
-    case addTiming(name: String)
+    enum MethodCall: EquatableInTests {
+        case startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue])
+        case stopView(key: String, attributes: [AttributeKey: AttributeValue])
+        case addTiming(name: String)
 
-    case startResourceLoading(key: String, httpMethod: RUMMethod, urlString: String,
-                              attributes: [AttributeKey: AttributeValue])
-    case stopResourceLoading(key: String, statusCode: Int?, kind: RUMResourceType, size: Int64?,
-                             attributes: [AttributeKey: AttributeValue])
-    case stopResourceLoadingWithError(key: String, error: Error, response: URLResponse?,
-                                      attributes: [AttributeKey: AttributeValue])
-    case stopResourceLoadingWithErrorMessage(key: String, errorMessage: String, type: String?, response: URLResponse?,
-                                      attributes: [AttributeKey: AttributeValue])
-    case addError(message: String, type: String?, source: RUMErrorSource, stack: String?,
-                  attributes: [AttributeKey: AttributeValue], file: StaticString?, line: UInt?)
-    case addUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])
-    case startUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])
-    case stopUserAction(type: RUMUserActionType, name: String?, attributes: [AttributeKey: AttributeValue])
-    case addAttribute(forKey: AttributeKey, value: AttributeValue)
-    case removeAttribute(forKey: AttributeKey)
+        case startResourceLoading(key: String, httpMethod: RUMMethod, urlString: String,
+                                  attributes: [AttributeKey: AttributeValue])
+        case stopResourceLoading(key: String, statusCode: Int?, kind: RUMResourceType, size: Int64?,
+                                 attributes: [AttributeKey: AttributeValue])
+        case stopResourceLoadingWithError(key: String, error: Error, response: URLResponse?,
+                                          attributes: [AttributeKey: AttributeValue])
+        case stopResourceLoadingWithErrorMessage(key: String, errorMessage: String, type: String?,
+                                                 response: URLResponse?, attributes: [AttributeKey: AttributeValue])
+        case addError(message: String, type: String?, source: RUMErrorSource, stack: String?,
+                      attributes: [AttributeKey: AttributeValue], file: StaticString?, line: UInt?)
+        case addUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])
+        case startUserAction(type: RUMUserActionType, name: String, attributes: [AttributeKey: AttributeValue])
+        case stopUserAction(type: RUMUserActionType, name: String?, attributes: [AttributeKey: AttributeValue])
+        case addAttribute(forKey: AttributeKey, value: AttributeValue)
+        case removeAttribute(forKey: AttributeKey)
 
-  }
+    }
 
-  var callLog: [MethodCall] = []
+    var callLog: [MethodCall] = []
 
-  override func startView(key: String, name: String? = nil, attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(.startView(key: key, name: name, attributes: attributes))
-  }
+    override init() {
+        super.init()
 
-  override func stopView(key: String, attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(.stopView(key: key, attributes: attributes))
-  }
+        _internal = MockRumInternalProxy(subscriber: NOOPCommandSubscriber())
+    }
 
-  override func addTiming(name: String) {
-    callLog.append(.addTiming(name: name))
-  }
+    override func startView(key: String, name: String? = nil, attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(.startView(key: key, name: name, attributes: attributes))
+    }
 
-  override func startResourceLoading(resourceKey: String, httpMethod: RUMMethod,
-                                     urlString: String, attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(
-      .startResourceLoading(key: resourceKey, httpMethod: httpMethod, urlString: urlString, attributes: attributes)
-    )
-  }
+    override func stopView(key: String, attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(.stopView(key: key, attributes: attributes))
+    }
 
-  override func stopResourceLoading(resourceKey: String, statusCode: Int?, kind: RUMResourceType,
-                                    size: Int64? = nil, attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(
-      .stopResourceLoading(key: resourceKey, statusCode: statusCode, kind: kind, size: size, attributes: attributes)
-    )
-  }
+    override func addTiming(name: String) {
+        callLog.append(.addTiming(name: name))
+    }
 
-  override public func stopResourceLoadingWithError(
-      resourceKey: String,
-      error: Error,
-      response: URLResponse? = nil,
-      attributes: [AttributeKey: AttributeValue] = [:]
-  ) {
-    callLog.append(.stopResourceLoadingWithError(key: resourceKey, error: error,
-                                                 response: response, attributes: attributes))
-  }
+    override func startResourceLoading(resourceKey: String, httpMethod: RUMMethod,
+                                       urlString: String, attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(
+            .startResourceLoading(key: resourceKey, httpMethod: httpMethod, urlString: urlString,
+                                  attributes: attributes)
+        )
+    }
 
-  override func stopResourceLoadingWithError(resourceKey: String,
-                                             errorMessage: String,
-                                             type: String? = nil,
-                                             response: URLResponse? = nil,
-                                             attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(
-      .stopResourceLoadingWithErrorMessage(key: resourceKey, errorMessage: errorMessage, type: type, response: response,
-                                    attributes: attributes)
-    )
-  }
+    override func stopResourceLoading(resourceKey: String, statusCode: Int?, kind: RUMResourceType,
+                                      size: Int64? = nil, attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(
+            .stopResourceLoading(key: resourceKey, statusCode: statusCode, kind: kind, size: size,
+                                 attributes: attributes)
+        )
+    }
 
-  override func addError(message: String, type: String? = nil, source: RUMErrorSource = .custom, stack: String? = nil,
-                         attributes: [AttributeKey: AttributeValue] = [:],
-                         file: StaticString? = #file, line: UInt? = #line) {
-    callLog.append(
-      .addError(message: message, type: type, source: source, stack: stack,
-                attributes: attributes, file: file, line: line)
-    )
-  }
+    override public func stopResourceLoadingWithError(
+        resourceKey: String,
+        error: Error,
+        response: URLResponse? = nil,
+        attributes: [AttributeKey: AttributeValue] = [:]
+    ) {
+        callLog.append(.stopResourceLoadingWithError(key: resourceKey, error: error,
+                                                     response: response, attributes: attributes))
+    }
 
-  override func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
-    callLog.append(.addAttribute(forKey: key, value: value))
-  }
+    override func stopResourceLoadingWithError(resourceKey: String,
+                                               errorMessage: String,
+                                               type: String? = nil,
+                                               response: URLResponse? = nil,
+                                               attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(
+            .stopResourceLoadingWithErrorMessage(key: resourceKey, errorMessage: errorMessage, type: type,
+                                                 response: response, attributes: attributes)
+        )
+    }
 
-  override func removeAttribute(forKey key: AttributeKey) {
-    callLog.append(.removeAttribute(forKey: key))
-  }
+    override func addError(message: String, type: String? = nil, source: RUMErrorSource = .custom, stack: String? = nil,
+                           attributes: [AttributeKey: AttributeValue] = [:],
+                           file: StaticString? = #file, line: UInt? = #line) {
+        callLog.append(
+            .addError(message: message, type: type, source: source, stack: stack,
+                      attributes: attributes, file: file, line: line)
+        )
+    }
 
-  override func addUserAction(type: RUMUserActionType, name: String,
-                              attributes: [AttributeKey: AttributeValue] = [:]) {
-   callLog.append(.addUserAction(type: type, name: name, attributes: attributes))
-  }
+    override func addAttribute(forKey key: AttributeKey, value: AttributeValue) {
+        callLog.append(.addAttribute(forKey: key, value: value))
+    }
 
-  override func startUserAction(type: RUMUserActionType, name: String,
+    override func removeAttribute(forKey key: AttributeKey) {
+        callLog.append(.removeAttribute(forKey: key))
+    }
+
+    override func addUserAction(type: RUMUserActionType, name: String,
                                 attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(.startUserAction(type: type, name: name, attributes: attributes))
-  }
+        callLog.append(.addUserAction(type: type, name: name, attributes: attributes))
+    }
 
-  override func stopUserAction(type: RUMUserActionType, name: String? = nil,
-                               attributes: [AttributeKey: AttributeValue] = [:]) {
-    callLog.append(.stopUserAction(type: type, name: name, attributes: attributes))
-  }
+    override func startUserAction(type: RUMUserActionType, name: String,
+                                  attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(.startUserAction(type: type, name: name, attributes: attributes))
+    }
+
+    override func stopUserAction(type: RUMUserActionType, name: String? = nil,
+                                 attributes: [AttributeKey: AttributeValue] = [:]) {
+        callLog.append(.stopUserAction(type: type, name: name, attributes: attributes))
+    }
+}
+
+class NOOPCommandSubscriber: RUMCommandSubscriber {
+    func process(command: RUMCommand) {
+        // NOOP
+    }
+}
+
+class MockRumInternalProxy: _RUMInternalProxy {
+    enum MethodCall: EquatableInTests {
+        // swiftlint:disable:next identifier_name
+        case addLongTask(at: Date, duration: TimeInterval, attributes: [AttributeKey: AttributeValue])
+    }
+
+    var callLog: [MethodCall] = []
+
+    // swiftlint:disable:next identifier_name
+    override func addLongTask(at: Date, duration: TimeInterval, attributes: [AttributeKey: AttributeValue]) {
+        callLog.append(.addLongTask(at: at, duration: duration, attributes: attributes))
+    }
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -419,10 +419,11 @@ class DatadogRumPluginTests: XCTestCase {
 
     func testReportLongTask_CallsInternal() {
         let startTime = Date.now
+        let startTimeInterval = startTime.timeIntervalSince1970
         let duration = 340124
 
         let call = FlutterMethodCall(methodName: "reportLongTask", arguments: [
-            "at": startTime.timeIntervalSince1970 * 1000.0,
+            "at": startTimeInterval * 1000.0,
             "duration": duration
         ])
 
@@ -433,7 +434,8 @@ class DatadogRumPluginTests: XCTestCase {
 
         let mockInternal = mock._internal as! MockRumInternalProxy
         XCTAssertEqual(mockInternal.callLog, [
-            .addLongTask(at: startTime, duration: TimeInterval(Double(duration) / 1000.0), attributes: [:])
+            .addLongTask(at: Date(timeIntervalSince1970: startTimeInterval), duration: TimeInterval(Double(duration) / 1000.0),
+                         attributes: [:])
         ])
         XCTAssertEqual(resultStatus, .called(value: nil))
     }

--- a/packages/datadog_flutter_plugin/example/lib/main.dart
+++ b/packages/datadog_flutter_plugin/example/lib/main.dart
@@ -28,7 +28,10 @@ void main() async {
         printLogsToConsole: true,
       ),
       rumConfiguration: applicationId != null
-          ? RumConfiguration(applicationId: applicationId)
+          ? RumConfiguration(
+              applicationId: applicationId,
+              detectLongTasks: true,
+            )
           : null,
     );
 

--- a/packages/datadog_flutter_plugin/example/lib/rum_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_screen.dart
@@ -91,6 +91,13 @@ class _RumScreenState extends State<RumScreen> {
     });
   }
 
+  void _triggerLongTask() {
+    final done = DateTime.now().add(const Duration(milliseconds: 200));
+    while (DateTime.now().isBefore(done)) {
+      // noop
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     var theme = Theme.of(context);
@@ -170,6 +177,10 @@ class _RumScreenState extends State<RumScreen> {
                         IconButton(
                           onPressed: () {},
                           icon: const Icon(Icons.add),
+                        ),
+                        ElevatedButton(
+                          onPressed: () => _triggerLongTask(),
+                          child: const Text('Trigger Long Task'),
                         ),
                       ],
                     ),

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -178,8 +178,13 @@ void main() {
     // than 200 ms (triggered by the tapping of the button)
     var over200 = 0;
     for (var longTask in view2.longTaskEvents) {
-      expect(longTask.duration, greaterThan(100000));
-      if (longTask.duration! > 200000) {
+      expect(longTask.duration,
+          greaterThan(const Duration(milliseconds: 100).inNanoseconds));
+      // Nothing should have taken more than 2 seconds
+      expect(longTask.duration,
+          lessThan(const Duration(seconds: 2).inNanoseconds));
+      if (longTask.duration! >
+          const Duration(milliseconds: 200).inNanoseconds) {
         over200++;
       }
     }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -86,18 +86,23 @@ void main() {
     } else {
       expect(view1.path, 'RumManualInstrumentationScenario');
     }
-    expect(view1.viewEvents.last.view.actionCount, kIsWeb ? 2 : 3);
+
+    // In some cases, application_start doesn't get associated to the first view
+    var actionCount = 2;
+    var baseAction = 0;
+    if (view1.actionEvents[0].actionType == 'application_start') {
+      actionCount = 3;
+      baseAction = 1;
+    }
+    expect(view1.viewEvents.last.view.actionCount, actionCount);
+
     if (!kIsWeb) {
       // Manual resources on web don't work (the error is a resource loading error)
       expect(view1.viewEvents.last.view.resourceCount, 1);
       expect(view1.viewEvents.last.view.errorCount, 1);
     }
     expect(view1.viewEvents.last.context![contextKey], expectedContextValue);
-    const baseAction = kIsWeb ? 0 : 1;
-    if (!kIsWeb) {
-      // No application start event on web.
-      expect(view1.actionEvents[0].actionType, 'application_start');
-    }
+
     expect(view1.actionEvents[baseAction + 0].actionType,
         kIsWeb ? 'custom' : 'tap');
     expect(view1.actionEvents[baseAction + 0].actionName, 'Tapped Download');

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -142,6 +142,7 @@ class RumManualInstrumentation2 extends StatefulWidget {
 
 class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
     implements RouteAware {
+  bool _longTaskReady = false;
   bool _nextReady = false;
   late String _viewKey;
   final _viewName = 'SecondManualRumView';
@@ -193,9 +194,17 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
         title: const Text('Manual RUM 2'),
       ),
       body: Center(
-        child: ElevatedButton(
-          onPressed: _nextReady ? _onNextTapped : null,
-          child: const Text('Next Screen'),
+        child: Column(
+          children: [
+            ElevatedButton(
+              onPressed: _longTaskReady ? _triggerLongTask : null,
+              child: const Text('Trigger Long Task'),
+            ),
+            ElevatedButton(
+              onPressed: _nextReady ? _onNextTapped : null,
+              child: const Text('Next Screen'),
+            ),
+          ],
         ),
       ),
     );
@@ -216,6 +225,14 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
     DatadogSdk.instance.rum?.stopUserAction(
         RumUserActionType.scroll, 'User Scrolling', {'scroll_distance': 12.2});
 
+    setState(() {
+      _longTaskReady = true;
+    });
+  }
+
+  void _triggerLongTask() {
+    final doneTime = DateTime.now().add(const Duration(milliseconds: 200));
+    while (DateTime.now().compareTo(doneTime) < 0) {}
     setState(() {
       _nextReady = true;
     });

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -218,6 +218,17 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
           FlutterError.missingParameter(methodName: call.method)
         )
       }
+    case "reportLongTask":
+        if let atTime = arguments["at"] as? NSNumber,
+           let duration = arguments["duration"] as? NSNumber {
+            let atDate = Date(timeIntervalSince1970: TimeInterval(atTime.doubleValue / 1000.0))
+            rum._internal?.addLongTask(at: atDate, duration: TimeInterval(duration.doubleValue / 1000.0))
+            result(nil)
+        } else {
+            result(
+                FlutterError.missingParameter(methodName: call.method)
+            )
+        }
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -58,7 +58,8 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
                     let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
                     if !dict.isEqual(to: currentConfiguration!) {
                         consolePrint(
-                            "🔥 Reinitialziing the DatadogSDK with different options, even after a hot restart, is not supported. Cold restart your application to change your current configuation."
+                            "🔥 Reinitialziing the DatadogSDK with different options, even after a hot restart," +
+                            " is not supported. Cold restart your application to change your current configuation."
                         )
                     }
                 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -187,7 +187,7 @@ class RumConfiguration {
   /// much work on the main isolate, which could prevent your app from rendering
   /// at a smooth framerate.
   ///
-  /// Defaults to false.
+  /// Defaults to true.
   bool detectLongTasks;
 
   /// The amount of elapsed time that is considered to be a "long task", in
@@ -204,7 +204,7 @@ class RumConfiguration {
     required this.applicationId,
     double sessionSamplingRate = 100.0,
     double tracingSamplingRate = 20.0,
-    this.detectLongTasks = false,
+    this.detectLongTasks = true,
     double longTaskThreshold = 0.1,
   })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
         tracingSamplingRate = max(0, min(tracingSamplingRate, 100)),

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -181,12 +181,34 @@ class RumConfiguration {
   /// Defaults to `20.0`.
   double tracingSamplingRate;
 
+  /// Enable or disable detection of "long tasks"
+  ///
+  /// Long task detection attempts to detect when an application is doing too
+  /// much work on the main isolate, which could prevent your app from rendering
+  /// at a smooth framerate.
+  ///
+  /// Defaults to false.
+  bool detectLongTasks;
+
+  /// The amount of elapsed time that is considered to be a "long task", in
+  /// seconds.
+  ///
+  /// If the main isolate takes more than [longTaskThreshold] seconds to process
+  /// a microtask, it will appear as a Long Task in Datadog RUM Explorer. This
+  /// has a minimum of 0.02 seconds.
+  ///
+  /// Defaults to 0.1 seconds
+  double longTaskThreshold;
+
   RumConfiguration({
     required this.applicationId,
     double sessionSamplingRate = 100.0,
     double tracingSamplingRate = 20.0,
+    this.detectLongTasks = false,
+    double longTaskThreshold = 0.1,
   })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
-        tracingSamplingRate = max(0, min(tracingSamplingRate, 100));
+        tracingSamplingRate = max(0, min(tracingSamplingRate, 100)),
+        longTaskThreshold = max(0.02, longTaskThreshold);
 
   Map<String, Object?> encode() {
     return {

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -295,9 +295,9 @@ class DdRum {
   }
 
   @internal
-  void reportLongTask(int taskLength) {
+  void reportLongTask(int taskLengthMs) {
     wrap('rum.reportLongTask', logger, null, () {
-      return _platform.reportLongTask(DateTime.now(), taskLength);
+      return _platform.reportLongTask(DateTime.now(), taskLengthMs);
     });
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -12,6 +12,7 @@ import '../attributes.dart';
 import '../helpers.dart';
 import '../internal_logger.dart';
 import 'ddrum_platform_interface.dart';
+import 'rum_long_task_observer.dart';
 
 /// HTTP method of the resource
 enum RumHttpMethod { post, get, head, put, delete, patch }
@@ -91,7 +92,17 @@ class DdRum {
   final RumConfiguration configuration;
   final InternalLogger logger;
 
-  DdRum(this.configuration, this.logger);
+  RumLongTaskObserver? _longTaskObserver;
+
+  DdRum(this.configuration, this.logger) {
+    if (configuration.detectLongTasks) {
+      _longTaskObserver = RumLongTaskObserver(
+        longTaskThreshold: configuration.longTaskThreshold,
+        rumInstance: this,
+      );
+      _longTaskObserver!.init();
+    }
+  }
 
   /// Notifies that the View identified by [key] starts being presented to the
   /// user. This view will show as [name] in the RUM explorer, and defaults to

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -141,10 +141,10 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> reportLongTask(DateTime at, int duration) {
+  Future<void> reportLongTask(DateTime at, int durationMs) {
     return methodChannel.invokeMethod('reportLongTask', {
       'at': at.millisecondsSinceEpoch,
-      'duration': duration,
+      'duration': durationMs,
     });
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -139,4 +139,12 @@ class DdRumMethodChannel extends DdRumPlatform {
   Future<void> removeAttribute(String key) {
     return methodChannel.invokeMethod('removeAttribute', {'key': key});
   }
+
+  @override
+  Future<void> reportLongTask(DateTime at, int duration) {
+    return methodChannel.invokeMethod('reportLongTask', {
+      'at': at.millisecondsSinceEpoch,
+      'duration': duration,
+    });
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -50,5 +50,5 @@ abstract class DdRumPlatform extends PlatformInterface {
   Future<void> addAttribute(String key, dynamic value);
   Future<void> removeAttribute(String key);
 
-  Future<void> reportLongTask(DateTime at, int duration);
+  Future<void> reportLongTask(DateTime at, int durationMs);
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -49,4 +49,6 @@ abstract class DdRumPlatform extends PlatformInterface {
 
   Future<void> addAttribute(String key, dynamic value);
   Future<void> removeAttribute(String key);
+
+  Future<void> reportLongTask(DateTime at, int duration);
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -115,6 +115,11 @@ class DdRumWeb extends DdRumPlatform {
   Future<void> stopView(String key, Map<String, dynamic> attributes) async {
     // NOOP
   }
+
+  @override
+  Future<void> reportLongTask(DateTime at, int duration) async {
+    // NOOP - The browser SDK will report this automatically
+  }
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -117,7 +117,7 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> reportLongTask(DateTime at, int duration) async {
+  Future<void> reportLongTask(DateTime at, int durationMs) async {
     // NOOP - The browser SDK will report this automatically
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:flutter/material.dart';
+
+import '../../datadog_flutter_plugin.dart';
+
+class RumLongTaskObserver with WidgetsBindingObserver {
+  // The amount of elapsed time that is considered to be a "long task", in seconds.
+  final double longTaskThreshold;
+  final DdRum? rumInstance;
+
+  var _detectingLongTasks = false;
+  Future<void>? _longTaskDetectorFuture;
+
+  RumLongTaskObserver({
+    this.longTaskThreshold = 0.1,
+    this.rumInstance,
+  });
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _startLongTaskDetection();
+        break;
+      case AppLifecycleState.inactive:
+        _stopLongTaskDetection();
+        break;
+      case AppLifecycleState.paused:
+        _stopLongTaskDetection();
+        break;
+      case AppLifecycleState.detached:
+        _stopLongTaskDetection();
+        break;
+    }
+  }
+
+  void init() {
+    WidgetsBinding.instance.addObserver(this);
+    _startLongTaskDetection();
+  }
+
+  void _startLongTaskDetection() async {
+    if (!_detectingLongTasks) {
+      // We were in the process of stopping this, wait for
+      // it to finish before starting it up again
+      if (_longTaskDetectorFuture != null) {
+        await _longTaskDetectorFuture;
+      }
+      _detectingLongTasks = true;
+      _longTaskDetectorFuture = _longTaskDetector();
+    }
+  }
+
+  void _stopLongTaskDetection() async {
+    if (_detectingLongTasks) {
+      _detectingLongTasks = false;
+      await _longTaskDetectorFuture;
+      _longTaskDetectorFuture = null;
+    }
+  }
+
+  Future<void> _longTaskDetector() async {
+    final millisecondThreshold = longTaskThreshold * 1000;
+    var lastCheck = DateTime.now().millisecondsSinceEpoch;
+    while (_detectingLongTasks) {
+      await Future<void>.delayed(const Duration(milliseconds: 13));
+      final check = DateTime.now().millisecondsSinceEpoch;
+      final taskLength = check - lastCheck;
+      if (check - lastCheck > millisecondThreshold) {
+        print('LONG TASK DETECTED: $taskLength ms');
+      }
+      lastCheck = check;
+    }
+  }
+}

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -3,6 +3,7 @@
 // Copyright 2016-Present Datadog, Inc.
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_method_channel.dart';
@@ -256,6 +257,20 @@ void main() {
 
     expect(log, [
       isMethodCall('removeAttribute', arguments: {'key': 'attribute_key'})
+    ]);
+  });
+
+  test('reportLongTask calls to platform', () async {
+    final now = DateTime.now();
+    final duration = Random().nextInt(1000) + 100;
+
+    await ddRumPlatform.reportLongTask(now, duration);
+
+    expect(log, [
+      isMethodCall('reportLongTask', arguments: {
+        'at': now.millisecondsSinceEpoch,
+        'duration': duration,
+      }),
     ]);
   });
 }

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -71,6 +71,7 @@ void main() {
     final rumConfiguration = RumConfiguration(
       applicationId: 'applicationId',
       tracingSamplingRate: 100,
+      detectLongTasks: false,
     );
     final internalLogger = InternalLogger();
     final rum = DdRum(rumConfiguration, internalLogger);
@@ -84,6 +85,7 @@ void main() {
     final rumConfiguration = RumConfiguration(
       applicationId: 'applicationId',
       tracingSamplingRate: 0,
+      detectLongTasks: false,
     );
     final internalLogger = InternalLogger();
     final rum = DdRum(rumConfiguration, internalLogger);
@@ -97,6 +99,7 @@ void main() {
     final rumConfiguration = RumConfiguration(
       applicationId: 'applicationId',
       tracingSamplingRate: 23,
+      detectLongTasks: false,
     );
     final internalLogger = InternalLogger();
     final rum = DdRum(rumConfiguration, internalLogger);
@@ -119,6 +122,7 @@ void main() {
     final rumConfiguration = RumConfiguration(
       applicationId: 'applicationId',
       tracingSamplingRate: 85,
+      detectLongTasks: false,
     );
     final internalLogger = InternalLogger();
     final rum = DdRum(rumConfiguration, internalLogger);

--- a/packages/datadog_flutter_plugin/test/rum/rum_long_task_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_long_task_observer_test.dart
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:async';
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/src/rum/rum_long_task_observer.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockDdRum extends Mock implements DdRum {}
+
+// These tests need to use testWidgets because the RumLongTaskObserver
+// automatically registers itself to the WidgetsBindingInterface during init
+void main() {
+  Future<void> shutdownObserver(
+      WidgetTester tester, RumLongTaskObserver observer) async {
+    // Prevent timer pending exception
+    await tester.runAsync(() async {
+      unawaited(observer.stopLongTaskDetection());
+    });
+    await tester.pump(const Duration(milliseconds: 100));
+    observer.dispose();
+  }
+
+  testWidgets('long task observer reports stall to rum instance',
+      (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(rumInstance: mockRum);
+    observer.init();
+
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump(const Duration(milliseconds: 200));
+
+    verify(() => mockRum.reportLongTask(any()));
+
+    await shutdownObserver(tester, observer);
+  });
+
+  testWidgets('long task observer does not report short delays',
+      (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(rumInstance: mockRum);
+    observer.init();
+
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    });
+    await tester.pump(const Duration(milliseconds: 50));
+
+    verifyNever(() => mockRum.reportLongTask(any()));
+
+    await shutdownObserver(tester, observer);
+  });
+
+  testWidgets('long task observer reports length of long task', (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(rumInstance: mockRum);
+    observer.init();
+
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump(const Duration(milliseconds: 200));
+
+    var captured = verify(() => mockRum.reportLongTask(captureAny()));
+    expect(captured.captured[0], closeTo(100, 20));
+
+    await shutdownObserver(tester, observer);
+  });
+
+  testWidgets('long task observer reports tasks longer than configured time',
+      (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(
+      longTaskThreshold: 0.03,
+      rumInstance: mockRum,
+    );
+    observer.init();
+
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pump(const Duration(milliseconds: 100));
+
+    var captured = verify(() => mockRum.reportLongTask(captureAny()));
+    expect(captured.captured[0], closeTo(50, 10));
+
+    await shutdownObserver(tester, observer);
+  });
+
+  testWidgets(
+      'long task observer does not report tasks shorter than configured time',
+      (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(
+      longTaskThreshold: 0.2,
+      rumInstance: mockRum,
+    );
+    observer.init();
+
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump(const Duration(milliseconds: 250));
+
+    verifyNever(() => mockRum.reportLongTask(any()));
+
+    await shutdownObserver(tester, observer);
+  });
+
+  testWidgets('long task observer stops observing on app inactive',
+      (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(rumInstance: mockRum);
+    observer.init();
+
+    await tester.runAsync(() async {
+      observer.didChangeAppLifecycleState(AppLifecycleState.inactive);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump(const Duration(milliseconds: 200));
+
+    verifyNever(() => mockRum.reportLongTask(any()));
+
+    await shutdownObserver(tester, observer);
+  });
+
+  testWidgets('long task observer starts observing on app resumed',
+      (tester) async {
+    final mockRum = MockDdRum();
+    final observer = RumLongTaskObserver(rumInstance: mockRum);
+    observer.init();
+
+    observer.didChangeAppLifecycleState(AppLifecycleState.inactive);
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump(const Duration(milliseconds: 200));
+
+    observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump(const Duration(milliseconds: 200));
+
+    verify(() => mockRum.reportLongTask(any())).called(1);
+
+    await shutdownObserver(tester, observer);
+  });
+}


### PR DESCRIPTION
### What and why?

Report "long tasks," which are stalls of the main isolate than more a specific amount of time.

### How?

We create an observer that continuously adds a microtask to the end of the queue waiting for a short duration, then we check how much time has elapsed between each task. If more than `longTaskThreshold` seconds have elapsed, it will report a long task to the native code.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests