### PR TITLE
✨ Send telemetry to Datadog on errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tools/e2e_generator/terraform.tfstate
 __pycache__
 tools/ci/venv
 ndk_crash_reports_v2/
+ndk_crash_reports_intermediary_v2/

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -40,6 +40,7 @@ data class DatadogFlutterConfiguration(
     var env: String,
     var nativeCrashReportEnabled: Boolean,
     var trackingConsent: TrackingConsent,
+    var telemetrySampleRate: Float? = null,
     var site: DatadogSite? = null,
     var serviceName: String? = null,
     var batchSize: BatchSize? = null,
@@ -66,6 +67,7 @@ data class DatadogFlutterConfiguration(
         (encoded["nativeCrashReportEnabled"] as? Boolean) ?: false,
         TrackingConsent.PENDING
     ) {
+        telemetrySampleRate = (encoded["telemetrySampleRate"] as? Number)?.toFloat()
         (encoded["trackingConsent"] as? String)?.let {
             trackingConsent = parseTrackingConsent(it)
         }
@@ -125,6 +127,7 @@ data class DatadogFlutterConfiguration(
         site?.let { configBuilder.useSite(it) }
         batchSize?.let { configBuilder.setBatchSize(it) }
         uploadFrequency?.let { configBuilder.setUploadFrequency(it) }
+        telemetrySampleRate?.let { configBuilder.sampleTelemetry(it) }
         rumConfiguration?.let {
             configBuilder.sampleRumSessions(it.sampleRate)
             configBuilder.useViewTrackingStrategy(NoOpViewTrackingStrategy)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.privacy.TrackingConsent
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.Test
@@ -114,6 +115,7 @@ class DatadogConfigurationTest {
             "batchSize" to null,
             "uploadFrequency" to null,
             "trackingConsent" to "TrackingConsent.granted",
+            "telemetrySampleRate" to null,
             "customEndpoint" to null,
             "firstPartyHosts" to listOf<String>(),
             "rumConfiguration" to null,
@@ -132,12 +134,14 @@ class DatadogConfigurationTest {
     }
 
     @Test
+    @Suppress("LongParameterList")
     fun `M decode all properties W fromEncoded`(
         @StringForgery clientToken: String,
         @StringForgery environment: String,
         @StringForgery additionalKey: String,
         @StringForgery additionalValue: String,
         @StringForgery firstPartyHost: String,
+        @FloatForgery telemetrySampleRate: Float
     ) {
         // GIVEN
         val encoded = mapOf<String, Any?>(
@@ -149,6 +153,7 @@ class DatadogConfigurationTest {
             "batchSize" to "BatchSize.small",
             "uploadFrequency" to "UploadFrequency.frequent",
             "trackingConsent" to "TrackingConsent.granted",
+            "telemetrySampleRate" to telemetrySampleRate,
             "customEndpoint" to "customEndpoint",
             "firstPartyHosts" to listOf(firstPartyHost),
             "rumConfiguration" to null,
@@ -165,6 +170,7 @@ class DatadogConfigurationTest {
         assertThat(config.site).isEqualTo(DatadogSite.US3)
         assertThat(config.batchSize).isEqualTo(BatchSize.SMALL)
         assertThat(config.customEndpoint).isEqualTo("customEndpoint")
+        assertThat(config.telemetrySampleRate).isEqualTo(telemetrySampleRate)
         assertThat(config.additionalConfig).isEqualTo(mapOf(
             additionalKey to additionalValue
         ))

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
@@ -92,6 +92,7 @@ class DatadogConfigurationTests: XCTestCase {
       "site": nil,
       "batchSize": nil,
       "uploadFrequency": nil,
+      "telemetrySampleRate": nil,
       "trackingConsent": "TrackingConsent.pending",
       "customEndpoint": nil,
       "firstPartyHosts": [],
@@ -106,6 +107,7 @@ class DatadogConfigurationTests: XCTestCase {
     XCTAssertEqual(config.clientToken, "fakeClientToken")
     XCTAssertEqual(config.env, "fakeEnvironment")
     XCTAssertEqual(config.nativeCrashReportingEnabled, false)
+    XCTAssertNil(config.telemetrySampleRate)
     XCTAssertEqual(config.trackingConsent, TrackingConsent.pending)
 
     XCTAssertNil(config.rumConfiguration)
@@ -120,6 +122,7 @@ class DatadogConfigurationTests: XCTestCase {
       "batchSize": "BatchSize.small",
       "uploadFrequency": "UploadFrequency.frequent",
       "trackingConsent": "TrackingConsent.pending",
+      "telemetrySampleRate": 44,
       "customEndpoint": nil,
       "firstPartyHosts": [ "first_party.com" ],
       "loggingConfiguration": nil,
@@ -136,6 +139,7 @@ class DatadogConfigurationTests: XCTestCase {
     XCTAssertEqual(config.uploadFrequency, .frequent)
     XCTAssertEqual(config.firstPartyHosts, ["first_party.com"])
     XCTAssertEqual(config.trackingConsent, TrackingConsent.pending)
+    XCTAssertEqual(config.telemetrySampleRate, 44)
 
     XCTAssertNil(config.rumConfiguration)
   }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -10,6 +10,7 @@ extension UserInfo: EquatableInTests { }
 
 // Note: These tests are in the example app because Flutter does not provide a simple
 // way to to include tests in the Podspec.
+// swiftlint:disable:next type_body_length
 class FlutterSdkTests: XCTestCase {
 
     override func setUp() {
@@ -21,6 +22,39 @@ class FlutterSdkTests: XCTestCase {
 
     override func tearDown() {
         Datadog.flushAndDeinitialize()
+    }
+
+    let contracts = [
+        Contract(methodName: "setSdkVerbosity", requiredParameters: [
+            "value": .string
+        ]),
+        Contract(methodName: "setUserInfo", requiredParameters: [
+            "extraInfo": .map
+        ]),
+        Contract(methodName: "setTrackingConsent", requiredParameters: [
+            "value": .string
+        ]),
+        Contract(methodName: "telemetryDebug", requiredParameters: [
+            "message": .string
+        ]),
+        Contract(methodName: "telemetryError", requiredParameters: [
+            "message": .string
+        ])
+    ]
+
+    func testDatadogSdkCalls_FollowContracts() {
+        let flutterConfig = DatadogFlutterConfiguration(
+            clientToken: "fakeClientToken",
+            env: "prod",
+            serviceName: "serviceName",
+            trackingConsent: TrackingConsent.granted,
+            nativeCrashReportingEnabled: false
+        )
+
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+        plugin.initialize(configuration: flutterConfig)
+
+        testContracts(contracts: contracts, plugin: plugin)
     }
 
     func testInitialziation_MissingConfiguration_DoesNotInitFeatures() {

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
@@ -62,6 +62,7 @@ class DatadogFlutterConfiguration {
   let serviceName: String?
   let nativeCrashReportingEnabled: Bool
   let trackingConsent: TrackingConsent
+  let telemetrySampleRate: Float?
 
   let site: Datadog.Configuration.DatadogEndpoint?
   let batchSize: Datadog.Configuration.BatchSize?
@@ -77,6 +78,7 @@ class DatadogFlutterConfiguration {
     env: String,
     serviceName: String?,
     trackingConsent: TrackingConsent,
+    telemetrySampleRate: Float? = nil,
     nativeCrashReportingEnabled: Bool,
     site: Datadog.Configuration.DatadogEndpoint? = nil,
     batchSize: Datadog.Configuration.BatchSize? = nil,
@@ -90,6 +92,7 @@ class DatadogFlutterConfiguration {
     self.env = env
     self.serviceName = serviceName
     self.trackingConsent = trackingConsent
+    self.telemetrySampleRate = telemetrySampleRate
     self.nativeCrashReportingEnabled = nativeCrashReportingEnabled
     self.site = site
     self.batchSize = batchSize
@@ -108,6 +111,7 @@ class DatadogFlutterConfiguration {
       serviceName = try? castUnwrap(encoded["serviceName"])
       nativeCrashReportingEnabled = try castUnwrap(encoded["nativeCrashReportEnabled"])
       trackingConsent = try TrackingConsent.parseFromFlutter(castUnwrap(encoded["trackingConsent"]))
+      telemetrySampleRate = (encoded["telemetrySampleRate"] as? NSNumber)?.floatValue
     } catch {
       return nil
     }
@@ -144,6 +148,10 @@ class DatadogFlutterConfiguration {
 
     if nativeCrashReportingEnabled {
       _ = ddConfigBuilder.enableCrashReporting(using: DDCrashReportingPlugin())
+    }
+
+    if let telemetrySampleRate = telemetrySampleRate {
+      _ = ddConfigBuilder.set(sampleTelemetry: telemetrySampleRate)
     }
 
     if let site = site {

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -68,8 +68,10 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             if let verbosityString = arguments["value"] as? String {
                 let verbosity = LogLevel.parseFromFlutter(verbosityString)
                 Datadog.verbosityLevel = verbosity
+                result(nil)
+            } else {
+                result(FlutterError.missingParameter(methodName: call.method))
             }
-            result(nil)
         case "setUserInfo":
             if let extraInfo = arguments["extraInfo"] as? [String: Any?] {
                 let id = arguments["id"] as? String
@@ -77,14 +79,35 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
                 let email = arguments["email"] as? String
                 let encodedAttributes = castFlutterAttributesToSwift(extraInfo)
                 Datadog.setUserInfo(id: id, name: name, email: email, extraInfo: encodedAttributes)
+                result(nil)
+            } else {
+                result(FlutterError.missingParameter(methodName: call.method))
             }
-            result(nil)
         case "setTrackingConsent":
             if let trackingConsentString = arguments["value"] as? String {
                 let trackingConsent = TrackingConsent.parseFromFlutter(trackingConsentString)
                 Datadog.set(trackingConsent: trackingConsent)
+                result(nil)
+            } else {
+                result(FlutterError.missingParameter(methodName: call.method))
             }
-            result(nil)
+        case "telemetryDebug":
+            if let message = arguments["message"] as? String {
+                Datadog._internal._telemtry.debug(id: "datadog_flutter:\(message)", message: message)
+                result(nil)
+            } else {
+                result(FlutterError.missingParameter(methodName: call.method))
+            }
+        case "telemetryError":
+            if let message = arguments["message"] as? String {
+                let stack = arguments["stack"] as? String
+                let kind = arguments["kind"] as? String
+                Datadog._internal._telemtry.error(id: "datadog_flutter:\(String(describing: kind)):\(message)",
+                                                  message: message, kind: kind, stack: stack)
+                result(nil)
+            } else {
+                result(FlutterError.missingParameter(methodName: call.method))
+            }
 #if DD_SDK_COMPILED_FOR_TESTING
         case "flushAndDeinitialize":
             Datadog.flushAndDeinitialize()

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -48,4 +48,15 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
 
   @override
   Future<void> flushAndDeinitialize() async {}
+
+  @override
+  Future<void> sendTelemetryDebug(String message) async {
+    // Not currently supported
+  }
+
+  @override
+  Future<void> sendTelemetryError(
+      String message, String? stack, String? kind) async {
+    // Not currently supported
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -229,6 +229,15 @@ class DdSdkConfiguration {
   /// Set a custom endpoint to send information to.
   String? customEndpoint;
 
+  /// The sampling rate for Internal Telemetry (info related to the work of the
+  /// SDK internals).
+  ///
+  /// The sampling rate must be a value between 0 and 100. A value of 0 means no
+  /// telemetry will be sent, 100 means all telemetry will be sent. When
+  /// [telemetrySampleRate] is set to null, the default value from the iOS and
+  /// Android SDK is used, which is 20.
+  double? telemetrySampleRate;
+
   /// A list of first party hosts, used in conjunction with [trackHttpClient]
   ///
   /// Each request will be classified as 1st- or 3rd-party based on the host
@@ -271,6 +280,7 @@ class DdSdkConfiguration {
     this.uploadFrequency,
     this.batchSize,
     this.customEndpoint,
+    this.telemetrySampleRate,
     this.firstPartyHosts = const [],
     this.loggingConfiguration,
     this.rumConfiguration,
@@ -287,6 +297,7 @@ class DdSdkConfiguration {
       'site': site.toString(),
       'serviceName': serviceName,
       'batchSize': batchSize?.toString(),
+      'telemetrySampleRate': telemetrySampleRate,
       'uploadFrequency': uploadFrequency?.toString(),
       'trackingConsent': trackingConsent.toString(),
       'firstPartyHosts': firstPartyHosts,

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -56,4 +56,18 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
     return methodChannel
         .invokeMethod('flushAndDeinitialize', <String, Object?>{});
   }
+
+  @override
+  Future<void> sendTelemetryDebug(String message) {
+    return methodChannel.invokeMethod('telemetryDebug', {'message': message});
+  }
+
+  @override
+  Future<void> sendTelemetryError(String message, String? stack, String? kind) {
+    return methodChannel.invokeMethod('telemetryError', {
+      'message': message,
+      'stack': stack,
+      'kind': kind,
+    });
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -28,6 +28,9 @@ abstract class DatadogSdkPlatform extends PlatformInterface {
   Future<void> setUserInfo(
       String? id, String? name, String? email, Map<String, Object?> extraInfo);
 
+  Future<void> sendTelemetryDebug(String message);
+  Future<void> sendTelemetryError(String message, String? stack, String? kind);
+
   Future<void> initialize(DdSdkConfiguration configuration,
       {LogCallback? logCallback});
   Future<void> flushAndDeinitialize();

--- a/packages/datadog_flutter_plugin/lib/src/helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/helpers.dart
@@ -21,7 +21,10 @@ void _handleError(Object error, StackTrace stackTrace, String methodName,
     logger.error(
         'This may be a bug in the Datadog SDK. Please report it to Datadog.');
     logger.sendToDatadog(
-        'Platform exception caught by wrap(): ${error.toString()}');
+      'Platform exception caught by wrap(): ${error.toString()}',
+      stackTrace,
+      'PlatformException',
+    );
   } else {
     throw error;
   }

--- a/packages/datadog_flutter_plugin/lib/src/internal_logger.dart
+++ b/packages/datadog_flutter_plugin/lib/src/internal_logger.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'datadog_configuration.dart';
+import 'datadog_sdk_platform_interface.dart';
 import 'helpers.dart';
 
 /// This class is used internally by the SDK to log issues to the client
@@ -37,11 +38,11 @@ class InternalLogger {
   }
 
   /// Send a log to the Datadog org, not to the customer's org. This feature is
-  /// used mostly to track potential issues in the Datadog SDK. It is opt-in,
-  /// and requires specific configuration to be enabled. It is never enabled by
-  /// default.
-  void sendToDatadog(String message) {
-    // TODO: Internal telemetry
+  /// used mostly to track potential issues in the Datadog SDK. The rate at which
+  /// data is sent to Datadog is set by [DdSdkConfiguration.telemetrySampleRate]
+  void sendToDatadog(String message, StackTrace? stack, String? kind) {
+    DatadogSdkPlatform.instance
+        .sendTelemetryError(message, stack.toString(), kind);
   }
 
   // Standard error strings

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_gesture_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_gesture_detector.dart
@@ -81,7 +81,12 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
       RumUserActionDetector.elementMap.remove(oldWidget);
       RumUserActionDetector.elementMap[widget] = element;
     } else {
-      // Telemetry -- this shouldn't happen
+      final st = StackTrace.current;
+      widget.rum?.logger.sendToDatadog(
+        'Error locating old widget in element map during didUpdateWidget',
+        st,
+        null,
+      );
     }
   }
 

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
@@ -105,4 +105,28 @@ void main() {
       })
     ]);
   });
+
+  test('sendTelemetryDebug calls to method channel', () {
+    unawaited(ddSdkPlatform.sendTelemetryDebug('debug telemetry method'));
+
+    expect(log, [
+      isMethodCall('telemetryDebug', arguments: {
+        'message': 'debug telemetry method',
+      })
+    ]);
+  });
+
+  test('sendTelemetryError calls to method channel', () {
+    final st = StackTrace.current;
+    unawaited(ddSdkPlatform.sendTelemetryError(
+        'error telemetry method', st.toString(), 'fake error'));
+
+    expect(log, [
+      isMethodCall('telemetryError', arguments: {
+        'message': 'error telemetry method',
+        'stack': st.toString(),
+        'kind': 'fake error',
+      })
+    ]);
+  });
 }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -74,6 +74,7 @@ void main() {
       'serviceName': null,
       'nativeCrashReportEnabled': false,
       'trackingConsent': 'TrackingConsent.pending',
+      'telemetrySampleRate': null,
       'customEndpoint': null,
       'batchSize': null,
       'uploadFrequency': null,
@@ -98,6 +99,18 @@ void main() {
     expect(encoded['batchSize'], 'BatchSize.small');
     expect(encoded['uploadFrequency'], 'UploadFrequency.frequent');
     expect(encoded['site'], 'DatadogSite.eu1');
+  });
+
+  test('configuration encodes telemetrySampleRate', () {
+    final configuration = DdSdkConfiguration(
+      clientToken: 'fake-client-token',
+      env: 'prod',
+      site: DatadogSite.us1,
+      trackingConsent: TrackingConsent.pending,
+      telemetrySampleRate: 21.0,
+    );
+    final encoded = configuration.encode();
+    expect(encoded['telemetrySampleRate'], 21.0);
   });
 
   test('configuration encodes serviceName', () {

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -113,10 +113,13 @@ class DatadogTrackingHttpClient implements HttpClient {
         rum.startResourceLoading(
             rumKey, rumHttpMethod, url.toString(), attributes);
       }
-    } catch (e) {
+    } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error while attempting '
-          ' to track an _openUrl call: $e');
+        '$DatadogTrackingHttpClient encountered an error while attempting '
+        ' to track an _openUrl call: $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
 
     HttpClientRequest request;
@@ -135,10 +138,13 @@ class DatadogTrackingHttpClient implements HttpClient {
         try {
           rum?.stopResourceLoadingWithErrorInfo(
               rumKey, e.toString(), e.runtimeType.toString());
-        } catch (innerE) {
+        } catch (innerE, st) {
           datadogSdk.internalLogger.sendToDatadog(
-              '$DatadogTrackingHttpClient encountered an error while attempting '
-              ' to track an _openUrl error: $e');
+            '$DatadogTrackingHttpClient encountered an error while attempting '
+            ' to track an _openUrl error: $e',
+            st,
+            e.runtimeType.toString(),
+          );
         }
       }
       rethrow;
@@ -317,9 +323,12 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
         datadogSdk.rum?.stopResourceLoadingWithErrorInfo(
             rumKey!, e.toString(), e.runtimeType.toString());
       }
-    } catch (e) {
+    } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error attempting to report a stream error; $e');
+        '$DatadogTrackingHttpClient encountered an error attempting to report a stream error; $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
   }
 
@@ -463,10 +472,13 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
               ?.stopResourceLoading(rumKey!, statusCode, resourceType, size);
         }
       }
-    } catch (e) {
+    } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error while attempting '
-          ' to finish a resource: $e');
+        '$DatadogTrackingHttpClient encountered an error while attempting '
+        ' to finish a resource: $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
   }
 


### PR DESCRIPTION
### What and why?

If there's an issue in the Datadog SDK, we want to make sure we capture the error and fix it in the future. This attempts to capture as many errors as possible and send them to Datadog for analysis.

Also add a configuration option for the `telemetrySampleRate`.

Note, changes to the http_client will need to be brought into 1.0 branch.

### How?

The `wrap` function does most of the heavy lifting, sending errors to Datadog if any exception occurs other than those that are caused by serialization (which should be reported to the user).

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests