### PR TITLE
🧹 Reindent all swift files to XCode defaults

### DIFF
--- a/packages/datadog_flutter_plugin/example/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Runner/AppDelegate.swift
@@ -7,67 +7,67 @@ import Flutter
 import Datadog
 
 enum InternalError: Error {
-  case pluginError
+    case pluginError
 }
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-  var methodChannel: FlutterMethodChannel!
+    var methodChannel: FlutterMethodChannel!
 
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    let crashPluginRegistry = registrar(forPlugin: "ExampleCrashPlugin")!
-    registerCrashPlugin(with: crashPluginRegistry)
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        GeneratedPluginRegistrant.register(with: self)
+        let crashPluginRegistry = registrar(forPlugin: "ExampleCrashPlugin")!
+        registerCrashPlugin(with: crashPluginRegistry)
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  @objc func registerCrashPlugin(with registrar: FlutterPluginRegistrar) {
-    methodChannel = FlutterMethodChannel(name: "datadog_sdk_flutter.example.crash",
-                                       binaryMessenger: registrar.messenger())
-    methodChannel.setMethodCallHandler { call, result in
-      // swiftlint:disable:next force_try
-      try! self.handle(methodCall: call, result: result)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
-  }
 
-  func handle(methodCall: FlutterMethodCall, result: FlutterResult) throws {
-    switch methodCall.method {
-    case "crashNative":
-      let crashValue: Int? = nil
-      _ = crashValue! + 5
-
-    case "throwException":
-      throw InternalError.pluginError
-
-    case "performCallback":
-      let arguments = methodCall.arguments as! [String: Any?]
-      let callbackId = arguments["callbackId"] as! Int
-
-      methodChannel.invokeMethod("nativeCallback", arguments: [
-        "callbackId": callbackId,
-        "callbackValue": "Value String"
-      ]) { callbackResult in
-        switch callbackResult {
-        case let error as FlutterError:
-          Global.rum.addError(message: error.message ?? "Unknown Dart Error",
-                              source: RUMErrorSource.source,
-                              stack: nil,
-                              attributes: [
-                                "errorCode": error.code
-                              ])
-        default:
-          break
+    @objc func registerCrashPlugin(with registrar: FlutterPluginRegistrar) {
+        methodChannel = FlutterMethodChannel(name: "datadog_sdk_flutter.example.crash",
+                                             binaryMessenger: registrar.messenger())
+        methodChannel.setMethodCallHandler { call, result in
+            // swiftlint:disable:next force_try
+            try! self.handle(methodCall: call, result: result)
         }
-      }
-
-    default:
-      break
     }
 
-    result(nil)
-  }
+    func handle(methodCall: FlutterMethodCall, result: FlutterResult) throws {
+        switch methodCall.method {
+        case "crashNative":
+            let crashValue: Int? = nil
+            _ = crashValue! + 5
+
+        case "throwException":
+            throw InternalError.pluginError
+
+        case "performCallback":
+            let arguments = methodCall.arguments as! [String: Any?]
+            let callbackId = arguments["callbackId"] as! Int
+
+            methodChannel.invokeMethod("nativeCallback", arguments: [
+                "callbackId": callbackId,
+                "callbackValue": "Value String"
+            ]) { callbackResult in
+                switch callbackResult {
+                case let error as FlutterError:
+                    Global.rum.addError(message: error.message ?? "Unknown Dart Error",
+                                        source: RUMErrorSource.source,
+                                        stack: nil,
+                                        attributes: [
+                                            "errorCode": error.code
+                                        ])
+                default:
+                    break
+                }
+            }
+
+        default:
+            break
+        }
+
+        result(nil)
+    }
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/FlutterSdkAttibutesTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/FlutterSdkAttibutesTests.swift
@@ -9,41 +9,41 @@ import Datadog
 @testable import datadog_flutter_plugin
 
 class FlutterSdkAttributesTests: XCTestCase {
-  func testAttributes_SimpleValues_AreEncodedProperly() {
-    let flutterTypes: [String: Any?] = [
-      "intValue": NSNumber(value: 8),
-      "doubleValue": NSNumber(value: 3.1415),
-      "booleanValue": NSNumber(value: false),
-      "stringValue": "String value",
-      "nullValue": nil
-    ]
-    let encoded = castFlutterAttributesToSwift(flutterTypes)
+    func testAttributes_SimpleValues_AreEncodedProperly() {
+        let flutterTypes: [String: Any?] = [
+            "intValue": NSNumber(value: 8),
+            "doubleValue": NSNumber(value: 3.1415),
+            "booleanValue": NSNumber(value: false),
+            "stringValue": "String value",
+            "nullValue": nil
+        ]
+        let encoded = castFlutterAttributesToSwift(flutterTypes)
 
-    XCTAssertEqual(encoded["intValue"] as? Int64, 8)
-    XCTAssertEqual(encoded["doubleValue"] as? Double, 3.1415)
-    XCTAssertEqual(encoded["booleanValue"] as? Bool, false)
-    XCTAssertEqual(encoded["stringValue"] as? String, "String value")
-  }
+        XCTAssertEqual(encoded["intValue"] as? Int64, 8)
+        XCTAssertEqual(encoded["doubleValue"] as? Double, 3.1415)
+        XCTAssertEqual(encoded["booleanValue"] as? Bool, false)
+        XCTAssertEqual(encoded["stringValue"] as? String, "String value")
+    }
 
-  func testAttributes_NestedTypes_AreEncodedProperly() {
-    let flutterTypes: [String: Any?] = [
-      "arrayType": [ "My String Value", NSNumber(value: 32) ],
-      "objectType": [
-        "doubleValue": NSNumber(value: 3.1415),
-        "booleanValue": NSNumber(value: true)
-      ]
-    ]
-    let encoded = castFlutterAttributesToSwift(flutterTypes)
+    func testAttributes_NestedTypes_AreEncodedProperly() {
+        let flutterTypes: [String: Any?] = [
+            "arrayType": [ "My String Value", NSNumber(value: 32) ],
+            "objectType": [
+                "doubleValue": NSNumber(value: 3.1415),
+                "booleanValue": NSNumber(value: true)
+            ]
+        ]
+        let encoded = castFlutterAttributesToSwift(flutterTypes)
 
-    // One level deep, values aren't encoded
-    let array = (encoded["arrayType"] as? DdFlutterEncodable)?.value as? [Any]
-    XCTAssertNotNil(array)
-    XCTAssertEqual(array?[0] as? String, "My String Value")
-    XCTAssertEqual(array?[1] as? Int64, 32)
+        // One level deep, values aren't encoded
+        let array = (encoded["arrayType"] as? DdFlutterEncodable)?.value as? [Any]
+        XCTAssertNotNil(array)
+        XCTAssertEqual(array?[0] as? String, "My String Value")
+        XCTAssertEqual(array?[1] as? Int64, 32)
 
-    let object = (encoded["objectType"] as? DdFlutterEncodable)?.value as? [String: Any?]
-    XCTAssertNotNil(object)
-    XCTAssertEqual(object?["doubleValue"] as? Double, 3.1415)
-    XCTAssertEqual(object?["booleanValue"] as? Bool, true)
-  }
+        let object = (encoded["objectType"] as? DdFlutterEncodable)?.value as? [String: Any?]
+        XCTAssertNotNil(object)
+        XCTAssertEqual(object?["doubleValue"] as? Double, 3.1415)
+        XCTAssertEqual(object?["booleanValue"] as? Bool, true)
+    }
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
@@ -7,82 +7,84 @@ import XCTest
 @testable import datadog_flutter_plugin
 
 enum SupportedContractType {
-  case string
-  case int
-  case int64
-  case map
+    case string
+    case int
+    case int64
+    case map
 
-  func createOfType() -> Any {
-    switch self {
-    case .string: return "fake string"
-    case .int: return 1_234
-    case .int64: return 1_223_455_123
-    case .map: return ["key to": "value"]
+    func createOfType() -> Any {
+        switch self {
+        case .string: return "fake string"
+        case .int: return 1_234
+        case .int64: return 1_223_455_123
+        case .map: return ["key to": "value"]
+        }
     }
-  }
 }
 
 struct Contract {
-  let methodName: String
-  let requiredParameters: [String: SupportedContractType]
+    let methodName: String
+    let requiredParameters: [String: SupportedContractType]
 
-  init(methodName: String, requiredParameters: [String: SupportedContractType]) {
-    self.methodName = methodName
-    self.requiredParameters = requiredParameters
-  }
-
-  func createContractArguments(excluding: String?, additionalArguments: [String: Any]? = nil) -> [String: Any] {
-    var arguments: [String: Any] = [:]
-    for param in requiredParameters where param.key != excluding {
-      arguments[param.key] = param.value.createOfType()
-    }
-    if let additionalArguments = additionalArguments {
-      for addedArg in additionalArguments {
-        arguments[addedArg.key] = addedArg.value
-      }
+    init(methodName: String, requiredParameters: [String: SupportedContractType]) {
+        self.methodName = methodName
+        self.requiredParameters = requiredParameters
     }
 
-    return arguments
-  }
+    func createContractArguments(excluding: String?, additionalArguments: [String: Any]? = nil) -> [String: Any] {
+        var arguments: [String: Any] = [:]
+        for param in requiredParameters where param.key != excluding {
+            arguments[param.key] = param.value.createOfType()
+        }
+        if let additionalArguments = additionalArguments {
+            for addedArg in additionalArguments {
+                arguments[addedArg.key] = addedArg.value
+            }
+        }
+
+        return arguments
+    }
 }
 
 func testContracts(contracts: [Contract], plugin: FlutterPlugin, additionalArguments: [String: Any]? = nil) {
-  func callContract(contract: Contract, arguments: [String: Any], plugin: FlutterPlugin) -> ResultStatus {
-    let call = FlutterMethodCall(methodName: contract.methodName, arguments: arguments)
-    var resultStatus = ResultStatus.notCalled
-    plugin.handle!(call) { result in
-      resultStatus = .called(value: result)
+    func callContract(contract: Contract, arguments: [String: Any], plugin: FlutterPlugin) -> ResultStatus {
+        let call = FlutterMethodCall(methodName: contract.methodName, arguments: arguments)
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle!(call) { result in
+            resultStatus = .called(value: result)
+        }
+
+        return resultStatus
     }
 
-    return resultStatus
-  }
+    for contract in contracts {
+        let arguments = contract.createContractArguments(excluding: nil, additionalArguments: additionalArguments)
+        let result = callContract(contract: contract, arguments: arguments, plugin: plugin)
+        switch result {
+        case .called(let value):
+            let error = value as? FlutterError
+            XCTAssertNil(error, "\(contract.methodName) returned result \(String(describing: error)) on valid call")
 
-  for contract in contracts {
-    let arguments = contract.createContractArguments(excluding: nil, additionalArguments: additionalArguments)
-    let result = callContract(contract: contract, arguments: arguments, plugin: plugin)
-    switch result {
-    case .called(let value):
-      let error = value as? FlutterError
-      XCTAssertNil(error, "\(contract.methodName) returned result \(String(describing: error)) on valid call")
+        case .notCalled:
+            XCTFail("\(contract.methodName) did call result in valid call")
+        }
 
-    case .notCalled:
-      XCTFail("\(contract.methodName) did call result in valid call")
+        for param in contract.requiredParameters {
+            let arguments = contract.createContractArguments(excluding: param.key,
+                                                             additionalArguments: additionalArguments)
+            let result = callContract(contract: contract, arguments: arguments, plugin: plugin)
+            switch result {
+            case .called(let value):
+                let error = value as? FlutterError
+                XCTAssertNotNil(error)
+                XCTAssertEqual(error?.code, FlutterError.DdErrorCodes.contractViolation,
+                               // swiftlint:disable:next line_length
+                               "\(contract.methodName) did not throw a contact violation when missing parameter \(param)")
+                XCTAssertNotNil(error?.message)
+
+            case .notCalled:
+                XCTFail("\(contract.methodName) did not throw a contact violation when missing parameter \(param)")
+            }
+        }
     }
-
-    for param in contract.requiredParameters {
-      let arguments = contract.createContractArguments(excluding: param.key, additionalArguments: additionalArguments)
-      let result = callContract(contract: contract, arguments: arguments, plugin: plugin)
-      switch result {
-      case .called(let value):
-        let error = value as? FlutterError
-        XCTAssertNotNil(error)
-        XCTAssertEqual(error?.code, FlutterError.DdErrorCodes.contractViolation,
-                       "\(contract.methodName) did not throw a contact violation when missing parameter \(param)")
-        XCTAssertNotNil(error?.message)
-
-      case .notCalled:
-        XCTFail("\(contract.methodName) did not throw a contact violation when missing parameter \(param)")
-      }
-    }
-  }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
@@ -7,265 +7,265 @@ import Datadog
 import DatadogCrashReporting
 
 class DatadogLoggingConfiguration {
-  let sendNetworkInfo: Bool
-  let printLogsToConsole: Bool
-  let sendLogsToDatadog: Bool
-  let bundleWithRum: Bool
-  let loggerName: String?
+    let sendNetworkInfo: Bool
+    let printLogsToConsole: Bool
+    let sendLogsToDatadog: Bool
+    let bundleWithRum: Bool
+    let loggerName: String?
 
-  init(
-    sendNetworkInfo: Bool = false,
-    printLogsToConsole: Bool = false,
-    sendLogsToDatadog: Bool = true,
-    bundleWithRum: Bool = true,
-    loggerName: String? = nil
-  ) {
-    self.sendNetworkInfo = sendNetworkInfo
-    self.printLogsToConsole = printLogsToConsole
-    self.sendLogsToDatadog = sendLogsToDatadog
-    self.bundleWithRum = bundleWithRum
-    self.loggerName = loggerName
-  }
-
-  init?(fromEncoded encoded: [String: Any?]) {
-    sendNetworkInfo = (encoded["sendNetworkInfo"] as? NSNumber)?.boolValue ?? false
-    printLogsToConsole = (encoded["printLogsToConsole"] as? NSNumber)?.boolValue ?? false
-    sendLogsToDatadog = (encoded["sendLogsToDatadog"] as? NSNumber)?.boolValue ?? true
-    bundleWithRum = (encoded["bundleWithRum"] as? NSNumber)?.boolValue ?? true
-    loggerName = encoded["loggerName"] as? String
-  }
-}
-
-class DatadogFlutterConfiguration {
-  class RumConfiguration {
-    let applicationId: String
-    let sampleRate: Float
-
-    init(applicationId: String, sampleRate: Float) {
-      self.applicationId = applicationId
-      self.sampleRate = sampleRate
+    init(
+        sendNetworkInfo: Bool = false,
+        printLogsToConsole: Bool = false,
+        sendLogsToDatadog: Bool = true,
+        bundleWithRum: Bool = true,
+        loggerName: String? = nil
+    ) {
+        self.sendNetworkInfo = sendNetworkInfo
+        self.printLogsToConsole = printLogsToConsole
+        self.sendLogsToDatadog = sendLogsToDatadog
+        self.bundleWithRum = bundleWithRum
+        self.loggerName = loggerName
     }
 
     init?(fromEncoded encoded: [String: Any?]) {
-      do {
-        applicationId = try castUnwrap(encoded["applicationId"])
-      } catch {
-        return nil
-      }
-
-      sampleRate = (encoded["sampleRate"] as? NSNumber)?.floatValue ?? 100.0
+        sendNetworkInfo = (encoded["sendNetworkInfo"] as? NSNumber)?.boolValue ?? false
+        printLogsToConsole = (encoded["printLogsToConsole"] as? NSNumber)?.boolValue ?? false
+        sendLogsToDatadog = (encoded["sendLogsToDatadog"] as? NSNumber)?.boolValue ?? true
+        bundleWithRum = (encoded["bundleWithRum"] as? NSNumber)?.boolValue ?? true
+        loggerName = encoded["loggerName"] as? String
     }
-  }
+}
 
-  let clientToken: String
-  let env: String
-  let serviceName: String?
-  let nativeCrashReportingEnabled: Bool
-  let trackingConsent: TrackingConsent
-  let telemetrySampleRate: Float?
+class DatadogFlutterConfiguration {
+    class RumConfiguration {
+        let applicationId: String
+        let sampleRate: Float
 
-  let site: Datadog.Configuration.DatadogEndpoint?
-  let batchSize: Datadog.Configuration.BatchSize?
-  let uploadFrequency: Datadog.Configuration.UploadFrequency?
-  let firstPartyHosts: [String]
-  let customEndpoint: String?
-  let additionalConfig: [String: Any]
+        init(applicationId: String, sampleRate: Float) {
+            self.applicationId = applicationId
+            self.sampleRate = sampleRate
+        }
 
-  let rumConfiguration: RumConfiguration?
+        init?(fromEncoded encoded: [String: Any?]) {
+            do {
+                applicationId = try castUnwrap(encoded["applicationId"])
+            } catch {
+                return nil
+            }
 
-  init(
-    clientToken: String,
-    env: String,
-    serviceName: String?,
-    trackingConsent: TrackingConsent,
-    telemetrySampleRate: Float? = nil,
-    nativeCrashReportingEnabled: Bool,
-    site: Datadog.Configuration.DatadogEndpoint? = nil,
-    batchSize: Datadog.Configuration.BatchSize? = nil,
-    uploadFrequency: Datadog.Configuration.UploadFrequency? = nil,
-    firstPartyHosts: [String] = [],
-    customEndpoint: String? = nil,
-    additionalConfig: [String: Any] = [:],
-    rumConfiguration: RumConfiguration? = nil
-  ) {
-    self.clientToken = clientToken
-    self.env = env
-    self.serviceName = serviceName
-    self.trackingConsent = trackingConsent
-    self.telemetrySampleRate = telemetrySampleRate
-    self.nativeCrashReportingEnabled = nativeCrashReportingEnabled
-    self.site = site
-    self.batchSize = batchSize
-    self.uploadFrequency = uploadFrequency
-    self.firstPartyHosts = firstPartyHosts
-    self.customEndpoint = customEndpoint
-    self.additionalConfig = additionalConfig
-    self.rumConfiguration = rumConfiguration
-  }
-
-  init?(fromEncoded encoded: [String: Any?]) {
-    // Check for required values first
-    do {
-      clientToken = try castUnwrap(encoded["clientToken"])
-      env = try castUnwrap(encoded["env"])
-      serviceName = try? castUnwrap(encoded["serviceName"])
-      nativeCrashReportingEnabled = try castUnwrap(encoded["nativeCrashReportEnabled"])
-      trackingConsent = try TrackingConsent.parseFromFlutter(castUnwrap(encoded["trackingConsent"]))
-      telemetrySampleRate = (encoded["telemetrySampleRate"] as? NSNumber)?.floatValue
-    } catch {
-      return nil
+            sampleRate = (encoded["sampleRate"] as? NSNumber)?.floatValue ?? 100.0
+        }
     }
 
-    site = convertOptional(encoded["site"]) {
-      .parseFromFlutter($0)
-    }
-    batchSize = convertOptional(encoded["batchSize"]) {
-      .parseFromFlutter($0)
-    }
-    uploadFrequency = convertOptional(encoded["uploadFrequency"], {
-      .parseFromFlutter($0)
-    })
-    customEndpoint = encoded["customEndpoint"] as? String
-    firstPartyHosts = encoded["firstPartyHosts"] as? [String] ?? []
-    additionalConfig = encoded["additionalConfig"] as? [String: Any] ?? [:]
+    let clientToken: String
+    let env: String
+    let serviceName: String?
+    let nativeCrashReportingEnabled: Bool
+    let trackingConsent: TrackingConsent
+    let telemetrySampleRate: Float?
 
-    rumConfiguration = convertOptional(encoded["rumConfiguration"]) {
-      .init(fromEncoded: $0)
-    }
-  }
+    let site: Datadog.Configuration.DatadogEndpoint?
+    let batchSize: Datadog.Configuration.BatchSize?
+    let uploadFrequency: Datadog.Configuration.UploadFrequency?
+    let firstPartyHosts: [String]
+    let customEndpoint: String?
+    let additionalConfig: [String: Any]
 
-  func toDdConfig() -> Datadog.Configuration {
-    let ddConfigBuilder: Datadog.Configuration.Builder
-    if let rumConfiguration = rumConfiguration {
-      ddConfigBuilder = Datadog.Configuration.builderUsing(rumApplicationID: rumConfiguration.applicationId,
-                                                           clientToken: clientToken,
-                                                           environment: env)
-        .set(rumSessionsSamplingRate: rumConfiguration.sampleRate)
-    } else {
-      ddConfigBuilder = Datadog.Configuration.builderUsing(clientToken: clientToken,
-                                                           environment: env)
-    }
+    let rumConfiguration: RumConfiguration?
 
-    if nativeCrashReportingEnabled {
-      _ = ddConfigBuilder.enableCrashReporting(using: DDCrashReportingPlugin())
-    }
-
-    if let telemetrySampleRate = telemetrySampleRate {
-      _ = ddConfigBuilder.set(sampleTelemetry: telemetrySampleRate)
-    }
-
-    if let site = site {
-      _ = ddConfigBuilder.set(endpoint: site)
-    }
-    if let batchSize = batchSize {
-      _ = ddConfigBuilder.set(batchSize: batchSize)
-    }
-    if let uploadFrequency = uploadFrequency {
-      _ = ddConfigBuilder.set(uploadFrequency: uploadFrequency)
-    }
-    if let customEndpoint = customEndpoint {
-      if let customEndpointUrl = URL(string: customEndpoint) {
-        _ = ddConfigBuilder
-          .set(customLogsEndpoint: customEndpointUrl)
-          .set(customRUMEndpoint: customEndpointUrl)
-      }
+    init(
+        clientToken: String,
+        env: String,
+        serviceName: String?,
+        trackingConsent: TrackingConsent,
+        telemetrySampleRate: Float? = nil,
+        nativeCrashReportingEnabled: Bool,
+        site: Datadog.Configuration.DatadogEndpoint? = nil,
+        batchSize: Datadog.Configuration.BatchSize? = nil,
+        uploadFrequency: Datadog.Configuration.UploadFrequency? = nil,
+        firstPartyHosts: [String] = [],
+        customEndpoint: String? = nil,
+        additionalConfig: [String: Any] = [:],
+        rumConfiguration: RumConfiguration? = nil
+    ) {
+        self.clientToken = clientToken
+        self.env = env
+        self.serviceName = serviceName
+        self.trackingConsent = trackingConsent
+        self.telemetrySampleRate = telemetrySampleRate
+        self.nativeCrashReportingEnabled = nativeCrashReportingEnabled
+        self.site = site
+        self.batchSize = batchSize
+        self.uploadFrequency = uploadFrequency
+        self.firstPartyHosts = firstPartyHosts
+        self.customEndpoint = customEndpoint
+        self.additionalConfig = additionalConfig
+        self.rumConfiguration = rumConfiguration
     }
 
-    _ = ddConfigBuilder.set(additionalConfiguration: additionalConfig)
+    init?(fromEncoded encoded: [String: Any?]) {
+        // Check for required values first
+        do {
+            clientToken = try castUnwrap(encoded["clientToken"])
+            env = try castUnwrap(encoded["env"])
+            serviceName = try? castUnwrap(encoded["serviceName"])
+            nativeCrashReportingEnabled = try castUnwrap(encoded["nativeCrashReportEnabled"])
+            trackingConsent = try TrackingConsent.parseFromFlutter(castUnwrap(encoded["trackingConsent"]))
+            telemetrySampleRate = (encoded["telemetrySampleRate"] as? NSNumber)?.floatValue
+        } catch {
+            return nil
+        }
 
-    if let enableViewTracking = additionalConfig["_dd.native_view_tracking"] as? Bool, enableViewTracking {
-      _ = ddConfigBuilder.trackUIKitRUMViews()
+        site = convertOptional(encoded["site"]) {
+            .parseFromFlutter($0)
+        }
+        batchSize = convertOptional(encoded["batchSize"]) {
+            .parseFromFlutter($0)
+        }
+        uploadFrequency = convertOptional(encoded["uploadFrequency"], {
+            .parseFromFlutter($0)
+        })
+        customEndpoint = encoded["customEndpoint"] as? String
+        firstPartyHosts = encoded["firstPartyHosts"] as? [String] ?? []
+        additionalConfig = encoded["additionalConfig"] as? [String: Any] ?? [:]
+
+        rumConfiguration = convertOptional(encoded["rumConfiguration"]) {
+            .init(fromEncoded: $0)
+        }
     }
 
-    if let serviceName = additionalConfig["_dd.service_name"] as? String {
-      _ = ddConfigBuilder.set(serviceName: serviceName)
-    }
+    func toDdConfig() -> Datadog.Configuration {
+        let ddConfigBuilder: Datadog.Configuration.Builder
+        if let rumConfiguration = rumConfiguration {
+            ddConfigBuilder = Datadog.Configuration.builderUsing(rumApplicationID: rumConfiguration.applicationId,
+                                                                 clientToken: clientToken,
+                                                                 environment: env)
+            .set(rumSessionsSamplingRate: rumConfiguration.sampleRate)
+        } else {
+            ddConfigBuilder = Datadog.Configuration.builderUsing(clientToken: clientToken,
+                                                                 environment: env)
+        }
 
-    if let threshold = additionalConfig["_dd.long_task.threshold"] as? TimeInterval {
-      // `_dd.long_task.threshold` attribute is in milliseconds
-      _ = ddConfigBuilder.trackRUMLongTasks(threshold: threshold / 1_000)
-    }
+        if nativeCrashReportingEnabled {
+            _ = ddConfigBuilder.enableCrashReporting(using: DDCrashReportingPlugin())
+        }
 
-    return ddConfigBuilder.build()
-  }
+        if let telemetrySampleRate = telemetrySampleRate {
+            _ = ddConfigBuilder.set(sampleTelemetry: telemetrySampleRate)
+        }
+
+        if let site = site {
+            _ = ddConfigBuilder.set(endpoint: site)
+        }
+        if let batchSize = batchSize {
+            _ = ddConfigBuilder.set(batchSize: batchSize)
+        }
+        if let uploadFrequency = uploadFrequency {
+            _ = ddConfigBuilder.set(uploadFrequency: uploadFrequency)
+        }
+        if let customEndpoint = customEndpoint {
+            if let customEndpointUrl = URL(string: customEndpoint) {
+                _ = ddConfigBuilder
+                    .set(customLogsEndpoint: customEndpointUrl)
+                    .set(customRUMEndpoint: customEndpointUrl)
+            }
+        }
+
+        _ = ddConfigBuilder.set(additionalConfiguration: additionalConfig)
+
+        if let enableViewTracking = additionalConfig["_dd.native_view_tracking"] as? Bool, enableViewTracking {
+            _ = ddConfigBuilder.trackUIKitRUMViews()
+        }
+
+        if let serviceName = additionalConfig["_dd.service_name"] as? String {
+            _ = ddConfigBuilder.set(serviceName: serviceName)
+        }
+
+        if let threshold = additionalConfig["_dd.long_task.threshold"] as? TimeInterval {
+            // `_dd.long_task.threshold` attribute is in milliseconds
+            _ = ddConfigBuilder.trackRUMLongTasks(threshold: threshold / 1_000)
+        }
+
+        return ddConfigBuilder.build()
+    }
 }
 
 private enum ConfigError: Error {
-  case castError
+    case castError
 }
 
 func castUnwrap<T>(_ value: Any??) throws -> T {
-  guard let testValue = value as? T else {
-    throw ConfigError.castError
-  }
-  return testValue
+    guard let testValue = value as? T else {
+        throw ConfigError.castError
+    }
+    return testValue
 }
 
 func convertOptional<T, R>(_ value: Any??, _ converter: (T) -> R?) -> R? {
-  if let encoded = value as? T {
-    return converter(encoded)
-  }
-  return nil
+    if let encoded = value as? T {
+        return converter(encoded)
+    }
+    return nil
 }
 
 // MARK: - Flutter enum parsing extensions
 
 public extension TrackingConsent {
-  static func parseFromFlutter(_ value: String) -> Self {
-    switch value {
-    case "TrackingConsent.granted": return .granted
-    case "TrackingConsent.notGranted": return .notGranted
-    case "TrackingConsent.pending": return .pending
-    default: return .pending
+    static func parseFromFlutter(_ value: String) -> Self {
+        switch value {
+        case "TrackingConsent.granted": return .granted
+        case "TrackingConsent.notGranted": return .notGranted
+        case "TrackingConsent.pending": return .pending
+        default: return .pending
+        }
     }
-  }
 }
 
 public extension Datadog.Configuration.BatchSize {
-  static func parseFromFlutter(_ value: String) -> Self {
-    switch value {
-    case "BatchSize.small": return .small
-    case "BatchSize.medium": return .medium
-    case "BatchSize.large": return .large
-    default: return .medium
+    static func parseFromFlutter(_ value: String) -> Self {
+        switch value {
+        case "BatchSize.small": return .small
+        case "BatchSize.medium": return .medium
+        case "BatchSize.large": return .large
+        default: return .medium
+        }
     }
-  }
 }
 
 public extension Datadog.Configuration.UploadFrequency {
-  static func parseFromFlutter(_ value: String) -> Self {
-    switch value {
-    case "UploadFrequency.frequent": return .frequent
-    case "UploadFrequency.average": return .average
-    case "UploadFrequency.rare": return .rare
-    default: return .average
+    static func parseFromFlutter(_ value: String) -> Self {
+        switch value {
+        case "UploadFrequency.frequent": return .frequent
+        case "UploadFrequency.average": return .average
+        case "UploadFrequency.rare": return .rare
+        default: return .average
+        }
     }
-  }
 }
 
 public extension Datadog.Configuration.DatadogEndpoint {
-  static func parseFromFlutter(_ value: String) -> Self {
-    switch value {
-    case "DatadogSite.us1": return .us1
-    case "DatadogSite.us3": return .us3
-    case "DatadogSite.us5": return .us5
-    case "DatadogSite.eu1": return .eu1
-    case "DatadogSite.us1Fed": return .us1_fed
-    default: return .us1
+    static func parseFromFlutter(_ value: String) -> Self {
+        switch value {
+        case "DatadogSite.us1": return .us1
+        case "DatadogSite.us3": return .us3
+        case "DatadogSite.us5": return .us5
+        case "DatadogSite.eu1": return .eu1
+        case "DatadogSite.us1Fed": return .us1_fed
+        default: return .us1
+        }
     }
-  }
 }
 
 public extension LogLevel {
-  static func parseFromFlutter(_ value: String) -> Self? {
-    switch value {
-    case "Verbosity.verbose": return .debug
-    case "Verbosity.debug": return .debug
-    case "Verbosity.info": return .info
-    case "Verbosity.warn": return .warn
-    case "Verbosity.error": return .error
-    case "Verbosity.none": return nil
-    default: return nil
+    static func parseFromFlutter(_ value: String) -> Self? {
+        switch value {
+        case "Verbosity.verbose": return .debug
+        case "Verbosity.debug": return .debug
+        case "Verbosity.info": return .info
+        case "Verbosity.warn": return .warn
+        case "Verbosity.error": return .error
+        case "Verbosity.none": return nil
+        default: return nil
+        }
     }
-  }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
@@ -6,180 +6,180 @@ import Foundation
 import Datadog
 
 public class DatadogLogsPlugin: NSObject, FlutterPlugin {
-  public static let instance = DatadogLogsPlugin()
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.logs", binaryMessenger: registrar.messenger())
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
-
-  private var loggerRegistry: [String: Logger] = [:]
-
-  override private init() {
-    super.init()
-  }
-
-  func addLogger(logger: Logger, withHandle handle: String) {
-    loggerRegistry[handle] = logger
-  }
-
-  func createLogger(loggerHandle: String, configuration: DatadogLoggingConfiguration) {
-    let builder = Logger.builder
-      .sendLogsToDatadog(configuration.sendLogsToDatadog)
-      .sendNetworkInfo(configuration.sendNetworkInfo)
-      .printLogsToConsole(configuration.printLogsToConsole)
-      .bundleWithRUM(configuration.bundleWithRum)
-    if let loggerName = configuration.loggerName {
-      _ = builder.set(loggerName: loggerName)
-    }
-    let logger = builder.build()
-    loggerRegistry[loggerHandle] = logger
-  }
-
-  internal func logger(withHandle handle: String) -> Logger? {
-    return loggerRegistry[handle]
-  }
-
-  // swiftlint:disable:next cyclomatic_complexity function_body_length
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let arguments = call.arguments as? [String: Any] else {
-      result(
-        FlutterError.invalidOperation(message: "No arguments in call to \(call.method).")
-      )
-      return
+    public static let instance = DatadogLogsPlugin()
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.logs", binaryMessenger: registrar.messenger())
+        registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
-    guard let loggerHandle = arguments["loggerHandle"] as? String else {
-      result(
-        FlutterError.missingParameter(methodName: call.method)
-      )
-      return
+    private var loggerRegistry: [String: Logger] = [:]
+
+    override private init() {
+        super.init()
     }
 
-    // Before other functions, see if we want to create a logger. All other functions
-    // require a logger already exist.
-    if call.method == "createLogger" {
-      guard let encodedConfiguration = arguments["configuration"] as? [String: Any?],
-            let configuration = DatadogLoggingConfiguration.init(fromEncoded: encodedConfiguration) else {
-        result(FlutterError.invalidOperation(message: "Bad logging configuration sent to createLogger"))
-        return
-      }
-      createLogger(loggerHandle: loggerHandle, configuration: configuration)
-      result(nil)
-      return
+    func addLogger(logger: Logger, withHandle handle: String) {
+        loggerRegistry[handle] = logger
     }
 
-    guard let logger = loggerRegistry[loggerHandle] else {
-      result(
-        FlutterError.invalidOperation(
-          message: "No logger available with handle \(loggerHandle) in call to \(call.method).")
-      )
-      return
-    }
-
-    let message = arguments["message"] as? String
-    var attributes: [String: Encodable]?
-    if let context = arguments["context"] as? [String: Any?] {
-      attributes = castFlutterAttributesToSwift(context)
-    }
-
-    switch call.method {
-    case "debug":
-      if let message = message {
-        logger.debug(message, error: nil, attributes: attributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "info":
-      if let message = message {
-        logger.info(message, error: nil, attributes: attributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "warn":
-      if let message = message {
-        logger.warn(message, error: nil, attributes: attributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "error":
-      if let message = message {
-        logger.error(message, error: nil, attributes: attributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "addAttribute":
-      if let key = arguments["key"] as? String,
-         let value = arguments["value"] {
-        logger.addAttribute(forKey: key, value: DdFlutterEncodable(value))
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "removeAttribute":
-      if let key = arguments["key"] as? String {
-        logger.removeAttribute(forKey: key)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "addTag":
-      if let tag = arguments["tag"] as? String {
-        if let keyValue = arguments["value"] as? String {
-          logger.addTag(withKey: tag, value: keyValue)
-        } else {
-          logger.add(tag: tag)
+    func createLogger(loggerHandle: String, configuration: DatadogLoggingConfiguration) {
+        let builder = Logger.builder
+            .sendLogsToDatadog(configuration.sendLogsToDatadog)
+            .sendNetworkInfo(configuration.sendNetworkInfo)
+            .printLogsToConsole(configuration.printLogsToConsole)
+            .bundleWithRUM(configuration.bundleWithRum)
+        if let loggerName = configuration.loggerName {
+            _ = builder.set(loggerName: loggerName)
         }
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "removeTag":
-      if let tag = arguments["tag"] as? String {
-        logger.remove(tag: tag)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    case "removeTagWithKey":
-      if let key = arguments["key"] as? String {
-        logger.removeTag(withKey: key)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-
-    default:
-      result(FlutterMethodNotImplemented)
+        let logger = builder.build()
+        loggerRegistry[loggerHandle] = logger
     }
-  }
+
+    internal func logger(withHandle handle: String) -> Logger? {
+        return loggerRegistry[handle]
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let arguments = call.arguments as? [String: Any] else {
+            result(
+                FlutterError.invalidOperation(message: "No arguments in call to \(call.method).")
+            )
+            return
+        }
+
+        guard let loggerHandle = arguments["loggerHandle"] as? String else {
+            result(
+                FlutterError.missingParameter(methodName: call.method)
+            )
+            return
+        }
+
+        // Before other functions, see if we want to create a logger. All other functions
+        // require a logger already exist.
+        if call.method == "createLogger" {
+            guard let encodedConfiguration = arguments["configuration"] as? [String: Any?],
+                  let configuration = DatadogLoggingConfiguration.init(fromEncoded: encodedConfiguration) else {
+                result(FlutterError.invalidOperation(message: "Bad logging configuration sent to createLogger"))
+                return
+            }
+            createLogger(loggerHandle: loggerHandle, configuration: configuration)
+            result(nil)
+            return
+        }
+
+        guard let logger = loggerRegistry[loggerHandle] else {
+            result(
+                FlutterError.invalidOperation(
+                    message: "No logger available with handle \(loggerHandle) in call to \(call.method).")
+            )
+            return
+        }
+
+        let message = arguments["message"] as? String
+        var attributes: [String: Encodable]?
+        if let context = arguments["context"] as? [String: Any?] {
+            attributes = castFlutterAttributesToSwift(context)
+        }
+
+        switch call.method {
+        case "debug":
+            if let message = message {
+                logger.debug(message, error: nil, attributes: attributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "info":
+            if let message = message {
+                logger.info(message, error: nil, attributes: attributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "warn":
+            if let message = message {
+                logger.warn(message, error: nil, attributes: attributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "error":
+            if let message = message {
+                logger.error(message, error: nil, attributes: attributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "addAttribute":
+            if let key = arguments["key"] as? String,
+               let value = arguments["value"] {
+                logger.addAttribute(forKey: key, value: DdFlutterEncodable(value))
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "removeAttribute":
+            if let key = arguments["key"] as? String {
+                logger.removeAttribute(forKey: key)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "addTag":
+            if let tag = arguments["tag"] as? String {
+                if let keyValue = arguments["value"] as? String {
+                    logger.addTag(withKey: tag, value: keyValue)
+                } else {
+                    logger.add(tag: tag)
+                }
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "removeTag":
+            if let tag = arguments["tag"] as? String {
+                logger.remove(tag: tag)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "removeTagWithKey":
+            if let key = arguments["key"] as? String {
+                logger.removeTag(withKey: key)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -6,288 +6,289 @@ import Foundation
 import Datadog
 
 extension FlutterError {
-  public enum DdErrorCodes {
-    static let contractViolation = "DatadogSdk:ContractViolation"
-    static let invalidOperation = "DatadogSdk:InvalidOperation"
-  }
+    public enum DdErrorCodes {
+        static let contractViolation = "DatadogSdk:ContractViolation"
+        static let invalidOperation = "DatadogSdk:InvalidOperation"
+    }
 
-  static func missingParameter(methodName: String) -> FlutterError {
-    return FlutterError(code: DdErrorCodes.contractViolation,
-                        message: "Missing parameter in call to \(methodName)",
-                        details: nil)
-  }
+    static func missingParameter(methodName: String) -> FlutterError {
+        return FlutterError(code: DdErrorCodes.contractViolation,
+                            message: "Missing parameter in call to \(methodName)",
+                            details: nil)
+    }
 
-  static func invalidOperation(message: String) -> FlutterError {
-    return FlutterError(code: DdErrorCodes.invalidOperation,
-                        message: message,
-                        details: nil)
-  }
+    static func invalidOperation(message: String) -> FlutterError {
+        return FlutterError(code: DdErrorCodes.invalidOperation,
+                            message: message,
+                            details: nil)
+    }
 }
 
 public class DatadogRumPlugin: NSObject, FlutterPlugin {
-  public static let instance =  DatadogRumPlugin()
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.rum", binaryMessenger: registrar.messenger())
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
-
-  private var rumInstance: DDRUMMonitor?
-  public var isInitialized: Bool { return rumInstance != nil }
-
-  private override init() {
-    super.init()
-  }
-
-  func initialize(configuration: DatadogFlutterConfiguration.RumConfiguration) {
-    rumInstance = RUMMonitor.initialize()
-    Global.rum = rumInstance!
-  }
-
-  public func initialize(withRum rum: DDRUMMonitor) {
-    rumInstance = rum
-  }
-
-  // swiftlint:disable:next cyclomatic_complexity function_body_length
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let arguments = call.arguments as? [String: Any] else {
-      result(
-        FlutterError.invalidOperation(message: "No arguments in call to \(call.method).")
-      )
-      return
-    }
-    guard let rum = rumInstance else {
-      result(
-        FlutterError.invalidOperation(message: "RUM has not been initialized when calling \(call.method).")
-      )
-      return
+    public static let instance =  DatadogRumPlugin()
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.rum", binaryMessenger: registrar.messenger())
+        registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
-    switch call.method {
-    case "startView":
-      if let key = arguments["key"] as? String,
-         let name = arguments["name"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.startView(key: key, name: name, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
+    private var rumInstance: DDRUMMonitor?
+    public var isInitialized: Bool { return rumInstance != nil }
 
-    case "stopView":
-      if let key = arguments["key"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.stopView(key: key, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "addTiming":
-      if let name = arguments["name"] as? String {
-        rum.addTiming(name: name)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "startResourceLoading":
-      if let key = arguments["key"] as? String,
-         let methodString = arguments["httpMethod"] as? String,
-         let url = arguments["url"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        let method = RUMMethod.parseFromFlutter(methodString)
-        rum.startResourceLoading(resourceKey: key, httpMethod: method, urlString: url, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "stopResourceLoading":
-      if let key = arguments["key"] as? String,
-         let kindString = arguments["kind"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        let kind = RUMResourceType.parseFromFlutter(kindString)
+    private override init() {
+        super.init()
+    }
 
-        let statusCode = arguments["statusCode"] as? NSNumber
-        let size = arguments["size"] as? NSNumber
+    func initialize(configuration: DatadogFlutterConfiguration.RumConfiguration) {
+        rumInstance = RUMMonitor.initialize()
+        Global.rum = rumInstance!
+    }
 
-        rum.stopResourceLoading(resourceKey: key, statusCode: statusCode?.intValue,
-                                kind: kind, size: size?.int64Value, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
+    public func initialize(withRum rum: DDRUMMonitor) {
+        rumInstance = rum
+    }
 
-    case "stopResourceLoadingWithError":
-      if let key = arguments["key"] as? String,
-         let message = arguments["message"] as? String,
-         let errorType = arguments["type"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.stopResourceLoadingWithError(resourceKey: key, errorMessage: message, type: errorType, response: nil,
-                                         attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "addError":
-      if let message = arguments["message"] as? String,
-         let sourceString = arguments["source"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        let source = RUMErrorSource.parseFromFlutter(sourceString)
-        let stackTrace = arguments["stackTrace"] as? String
-
-        rum.addError(message: message, source: source, stack: stackTrace, attributes: encodedAttributes,
-                     file: nil, line: nil)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "addUserAction":
-      if let typeString = arguments["type"] as? String,
-         let name = arguments["name"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let type = RUMUserActionType.parseFromFlutter(typeString)
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.addUserAction(type: type, name: name, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "startUserAction":
-      if let typeString = arguments["type"] as? String,
-         let name = arguments["name"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let type = RUMUserActionType.parseFromFlutter(typeString)
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.startUserAction(type: type, name: name, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "stopUserAction":
-      if let typeString = arguments["type"] as? String,
-         let name = arguments["name"] as? String,
-         let attributes = arguments["attributes"] as? [String: Any?] {
-        let type = RUMUserActionType.parseFromFlutter(typeString)
-        let encodedAttributes = castFlutterAttributesToSwift(attributes)
-        rum.stopUserAction(type: type, name: name, attributes: encodedAttributes)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "addAttribute":
-      if let key = arguments["key"] as? String,
-         let value = arguments["value"] {
-        let encodedValue = castAnyToEncodable(value)
-        rum.addAttribute(forKey: key, value: encodedValue)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "removeAttribute":
-      if let key = arguments["key"] as? String {
-        rum.removeAttribute(forKey: key)
-        result(nil)
-      } else {
-        result(
-          FlutterError.missingParameter(methodName: call.method)
-        )
-      }
-    case "reportLongTask":
-        if let atTime = arguments["at"] as? NSNumber,
-           let duration = arguments["duration"] as? NSNumber {
-            let atDate = Date(timeIntervalSince1970: TimeInterval(atTime.doubleValue / 1000.0))
-            rum._internal?.addLongTask(at: atDate, duration: TimeInterval(duration.doubleValue / 1000.0))
-            result(nil)
-        } else {
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let arguments = call.arguments as? [String: Any] else {
             result(
-                FlutterError.missingParameter(methodName: call.method)
+                FlutterError.invalidOperation(message: "No arguments in call to \(call.method).")
             )
+            return
         }
-    default:
-      result(FlutterMethodNotImplemented)
+        guard let rum = rumInstance else {
+            result(
+                FlutterError.invalidOperation(message: "RUM has not been initialized when calling \(call.method).")
+            )
+            return
+        }
+
+        switch call.method {
+        case "startView":
+            if let key = arguments["key"] as? String,
+               let name = arguments["name"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                rum.startView(key: key, name: name, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "stopView":
+            if let key = arguments["key"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                rum.stopView(key: key, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "addTiming":
+            if let name = arguments["name"] as? String {
+                rum.addTiming(name: name)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "startResourceLoading":
+            if let key = arguments["key"] as? String,
+               let methodString = arguments["httpMethod"] as? String,
+               let url = arguments["url"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                let method = RUMMethod.parseFromFlutter(methodString)
+                rum.startResourceLoading(resourceKey: key, httpMethod: method, urlString: url,
+                                         attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "stopResourceLoading":
+            if let key = arguments["key"] as? String,
+               let kindString = arguments["kind"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                let kind = RUMResourceType.parseFromFlutter(kindString)
+
+                let statusCode = arguments["statusCode"] as? NSNumber
+                let size = arguments["size"] as? NSNumber
+
+                rum.stopResourceLoading(resourceKey: key, statusCode: statusCode?.intValue,
+                                        kind: kind, size: size?.int64Value, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+
+        case "stopResourceLoadingWithError":
+            if let key = arguments["key"] as? String,
+               let message = arguments["message"] as? String,
+               let errorType = arguments["type"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                rum.stopResourceLoadingWithError(resourceKey: key, errorMessage: message, type: errorType,
+                                                 response: nil, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "addError":
+            if let message = arguments["message"] as? String,
+               let sourceString = arguments["source"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                let source = RUMErrorSource.parseFromFlutter(sourceString)
+                let stackTrace = arguments["stackTrace"] as? String
+
+                rum.addError(message: message, source: source, stack: stackTrace, attributes: encodedAttributes,
+                             file: nil, line: nil)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "addUserAction":
+            if let typeString = arguments["type"] as? String,
+               let name = arguments["name"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let type = RUMUserActionType.parseFromFlutter(typeString)
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                rum.addUserAction(type: type, name: name, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "startUserAction":
+            if let typeString = arguments["type"] as? String,
+               let name = arguments["name"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let type = RUMUserActionType.parseFromFlutter(typeString)
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                rum.startUserAction(type: type, name: name, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "stopUserAction":
+            if let typeString = arguments["type"] as? String,
+               let name = arguments["name"] as? String,
+               let attributes = arguments["attributes"] as? [String: Any?] {
+                let type = RUMUserActionType.parseFromFlutter(typeString)
+                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                rum.stopUserAction(type: type, name: name, attributes: encodedAttributes)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "addAttribute":
+            if let key = arguments["key"] as? String,
+               let value = arguments["value"] {
+                let encodedValue = castAnyToEncodable(value)
+                rum.addAttribute(forKey: key, value: encodedValue)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "removeAttribute":
+            if let key = arguments["key"] as? String {
+                rum.removeAttribute(forKey: key)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "reportLongTask":
+            if let atTime = arguments["at"] as? NSNumber,
+               let duration = arguments["duration"] as? NSNumber {
+                let atDate = Date(timeIntervalSince1970: TimeInterval(atTime.doubleValue / 1000.0))
+                rum._internal?.addLongTask(at: atDate, duration: TimeInterval(duration.doubleValue / 1000.0))
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        default:
+            result(FlutterMethodNotImplemented)
+        }
     }
-  }
 }
 
 public extension RUMResourceType {
-  // swiftlint:disable:next cyclomatic_complexity
-  static func parseFromFlutter(_ value: String) -> RUMResourceType {
-    switch value {
-    case "RumResourceType.document": return .document
-    case "RumResourceType.image": return .image
-    case "RumResourceType.xhr": return .xhr
-    case "RumResourceType.beacon": return .beacon
-    case "RumResourceType.css": return .css
-    case "RumResourceType.fetch": return .fetch
-    case "RumResourceType.font": return .font
-    case "RumResourceType.js": return .js
-    case "RumResourceType.media": return .media
-    case "RumResourceType.native": return .native
-    default: return .other
+    // swiftlint:disable:next cyclomatic_complexity
+    static func parseFromFlutter(_ value: String) -> RUMResourceType {
+        switch value {
+        case "RumResourceType.document": return .document
+        case "RumResourceType.image": return .image
+        case "RumResourceType.xhr": return .xhr
+        case "RumResourceType.beacon": return .beacon
+        case "RumResourceType.css": return .css
+        case "RumResourceType.fetch": return .fetch
+        case "RumResourceType.font": return .font
+        case "RumResourceType.js": return .js
+        case "RumResourceType.media": return .media
+        case "RumResourceType.native": return .native
+        default: return .other
+        }
     }
-  }
 }
 
 public extension RUMMethod {
-  static func parseFromFlutter(_ value: String) -> RUMMethod {
-    switch value {
-    case "RumHttpMethod.get": return .get
-    case "RumHttpMethod.post": return .post
-    case "RumHttpMethod.head": return .head
-    case "RumHttpMethod.put": return .put
-    case "RumHttpMethod.delete": return .delete
-    case "RumHttpMethod.patch": return .patch
-    default: return .get
+    static func parseFromFlutter(_ value: String) -> RUMMethod {
+        switch value {
+        case "RumHttpMethod.get": return .get
+        case "RumHttpMethod.post": return .post
+        case "RumHttpMethod.head": return .head
+        case "RumHttpMethod.put": return .put
+        case "RumHttpMethod.delete": return .delete
+        case "RumHttpMethod.patch": return .patch
+        default: return .get
+        }
     }
-  }
 }
 
 public extension RUMUserActionType {
-  static func parseFromFlutter(_ value: String) -> RUMUserActionType {
-    switch value {
-    case "RumUserActionType.tap": return .tap
-    case "RumUserActionType.scroll": return .scroll
-    case "RumUserActionType.swipe": return .swipe
-    default: return .custom
+    static func parseFromFlutter(_ value: String) -> RUMUserActionType {
+        switch value {
+        case "RumUserActionType.tap": return .tap
+        case "RumUserActionType.scroll": return .scroll
+        case "RumUserActionType.swipe": return .swipe
+        default: return .custom
+        }
     }
-  }
 }
 
 public extension RUMErrorSource {
-  static func parseFromFlutter(_ value: String) -> RUMErrorSource {
-    switch value {
-    case "RumErrorSource.source": return .source
-    case "RumErrorSource.network": return .network
-    case "RumErrorSource.webview": return .webview
-    case "RumErrorSource.console": return .console
-    case "RumErrorSource.custom": return .custom
-    default: return .custom
+    static func parseFromFlutter(_ value: String) -> RUMErrorSource {
+        switch value {
+        case "RumErrorSource.source": return .source
+        case "RumErrorSource.network": return .network
+        case "RumErrorSource.webview": return .webview
+        case "RumErrorSource.console": return .console
+        case "RumErrorSource.custom": return .custom
+        default: return .custom
+        }
     }
-  }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.m
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.m
@@ -14,6 +14,6 @@
 
 @implementation DatadogSdkPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  [SwiftDatadogSdkPlugin registerWithRegistrar:registrar];
+    [SwiftDatadogSdkPlugin registerWithRegistrar:registrar];
 }
 @end

--- a/packages/datadog_flutter_plugin/ios/Classes/DdFlutterEncodable.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DdFlutterEncodable.swift
@@ -5,120 +5,120 @@
 import Foundation
 
 internal func castFlutterAttributesToSwift(_ flutterAttributes: [String: Any?]) -> [String: Encodable] {
-  var casted: [String: Encodable] = [:]
+    var casted: [String: Encodable] = [:]
 
-  flutterAttributes.forEach { key, value in
-    if let value = value {
-      casted[key] = castAnyToEncodable(value)
+    flutterAttributes.forEach { key, value in
+        if let value = value {
+            casted[key] = castAnyToEncodable(value)
+        }
     }
-  }
 
-  return casted
+    return casted
 }
 
 // swiftlint:disable:next cyclomatic_complexity
 internal func castAnyToEncodable(_ flutterAny: Any) -> Encodable {
-  switch flutterAny {
-  case let number as NSNumber:
-    if CFGetTypeID(number) == CFBooleanGetTypeID() {
-      return CFBooleanGetValue(number)
-    } else {
-      switch CFNumberGetType(number) {
-      case .charType:
-        return number.uint8Value
-      case .sInt8Type:
-        return number.int8Value
-      case .sInt16Type:
-        return number.int16Value
-      case .sInt32Type:
-        return number.int32Value
-      case .sInt64Type:
-        return number.int64Value
-      case .shortType:
-        return number.uint16Value
-      case .longType:
-        return number.uint32Value
-      case .longLongType:
-        return number.uint64Value
-      case .intType, .nsIntegerType, .cfIndexType:
-        return number.intValue
-      case .floatType, .float32Type:
-        return number.floatValue
-      case .doubleType, .float64Type, .cgFloatType:
-        return number.doubleValue
-      @unknown default:
+    switch flutterAny {
+    case let number as NSNumber:
+        if CFGetTypeID(number) == CFBooleanGetTypeID() {
+            return CFBooleanGetValue(number)
+        } else {
+            switch CFNumberGetType(number) {
+            case .charType:
+                return number.uint8Value
+            case .sInt8Type:
+                return number.int8Value
+            case .sInt16Type:
+                return number.int16Value
+            case .sInt32Type:
+                return number.int32Value
+            case .sInt64Type:
+                return number.int64Value
+            case .shortType:
+                return number.uint16Value
+            case .longType:
+                return number.uint32Value
+            case .longLongType:
+                return number.uint64Value
+            case .intType, .nsIntegerType, .cfIndexType:
+                return number.intValue
+            case .floatType, .float32Type:
+                return number.floatValue
+            case .doubleType, .float64Type, .cgFloatType:
+                return number.doubleValue
+            @unknown default:
+                return DdFlutterEncodable(flutterAny)
+            }
+        }
+    case let string as String:
+        return string
+    default:
         return DdFlutterEncodable(flutterAny)
-      }
     }
-  case let string as String:
-    return string
-  default:
-    return DdFlutterEncodable(flutterAny)
-  }
 }
 
 // This is similar to AnyEncodable, but for simplicity, it only looks for types
 // that Flutter will send from MethodChannels
 internal class DdFlutterEncodable: Encodable {
-  public let value: Any
+    public let value: Any
 
-  init(_ value: Any) {
-    self.value = value
-  }
-
-  public func encode(to encoder: Encoder) throws {
-    var container = encoder.singleValueContainer()
-
-    switch value {
-    case let number as NSNumber:
-      try encodeNSNumber(number, into: &container)
-    case let string as String:
-      try container.encode(string)
-    case let array as [Any]:
-      try container.encode(array.map { DdFlutterEncodable($0) })
-    case let dictionary as [String: Any]:
-      try container.encode(dictionary.mapValues { DdFlutterEncodable($0) })
-    default:
-      let context = EncodingError.Context(
-        codingPath: container.codingPath,
-        // swiftlint:disable:next line_length
-        debugDescription: "Value \(value) cannot be encoded - \(type(of: value)) is not supported by `DdFlutterEncodable`."
-      )
-      throw EncodingError.invalidValue(value, context)
+    init(_ value: Any) {
+        self.value = value
     }
-  }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch value {
+        case let number as NSNumber:
+            try encodeNSNumber(number, into: &container)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            try container.encode(array.map { DdFlutterEncodable($0) })
+        case let dictionary as [String: Any]:
+            try container.encode(dictionary.mapValues { DdFlutterEncodable($0) })
+        default:
+            let context = EncodingError.Context(
+                codingPath: container.codingPath,
+                // swiftlint:disable:next line_length
+                debugDescription: "Value \(value) cannot be encoded - \(type(of: value)) is not supported by `DdFlutterEncodable`."
+            )
+            throw EncodingError.invalidValue(value, context)
+        }
+    }
 }
 
 // swiftlint:disable:next cyclomatic_complexity
 private func encodeNSNumber(_ number: NSNumber, into container: inout SingleValueEncodingContainer) throws {
-  if CFGetTypeID(number) == CFBooleanGetTypeID() {
-    try container.encode(CFBooleanGetValue(number))
-  } else {
-    switch CFNumberGetType(number) {
-    case .charType:
-      try container.encode(number.uint8Value)
-    case .sInt8Type:
-      try container.encode(number.int8Value)
-    case .sInt16Type:
-      try container.encode(number.int16Value)
-    case .sInt32Type:
-      try container.encode(number.int32Value)
-    case .sInt64Type:
-      try container.encode(number.int64Value)
-    case .shortType:
-      try container.encode(number.uint16Value)
-    case .longType:
-      try container.encode(number.uint32Value)
-    case .longLongType:
-      try container.encode(number.uint64Value)
-    case .intType, .nsIntegerType, .cfIndexType:
-      try container.encode(number.intValue)
-    case .floatType, .float32Type:
-      try container.encode(number.floatValue)
-    case .doubleType, .float64Type, .cgFloatType:
-      try container.encode(number.doubleValue)
-    @unknown default:
-      return
+    if CFGetTypeID(number) == CFBooleanGetTypeID() {
+        try container.encode(CFBooleanGetValue(number))
+    } else {
+        switch CFNumberGetType(number) {
+        case .charType:
+            try container.encode(number.uint8Value)
+        case .sInt8Type:
+            try container.encode(number.int8Value)
+        case .sInt16Type:
+            try container.encode(number.int16Value)
+        case .sInt32Type:
+            try container.encode(number.int32Value)
+        case .sInt64Type:
+            try container.encode(number.int64Value)
+        case .shortType:
+            try container.encode(number.uint16Value)
+        case .longType:
+            try container.encode(number.uint32Value)
+        case .longLongType:
+            try container.encode(number.uint64Value)
+        case .intType, .nsIntegerType, .cfIndexType:
+            try container.encode(number.intValue)
+        case .floatType, .float32Type:
+            try container.encode(number.floatValue)
+        case .doubleType, .float64Type, .cgFloatType:
+            try container.encode(number.doubleValue)
+        @unknown default:
+            return
+        }
     }
-  }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -143,7 +143,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
                 clientToken: flutterConfig.clientToken,
                 environment: flutterConfig.env
             )
-                .set(rumSessionsSamplingRate: rumConfig.sampleRate)
+            .set(rumSessionsSamplingRate: rumConfig.sampleRate)
         } else {
             ddConfigBuilder = Datadog.Configuration.builderUsing(
                 clientToken: flutterConfig.clientToken,


### PR DESCRIPTION
### What and why?

Originally I had my Xcode settings to 2 space indents, but that was conflicting trying to work on both the Flutter swift files and the iOS SDK, so I've switched it back to the 4 space default. This brings all swift files back in line with proper indentation.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests