### PR TITLE
🚀 Prep versions for RC

### DIFF
--- a/packages/datadog_flutter_plugin/example/pubspec.lock
+++ b/packages/datadog_flutter_plugin/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-beta.4"
+    version: "1.0.0-rc.1"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_flutter_plugin
 description: Flutter bindings and tools for utilizing Datadog Mobile SDks
-version: 1.0.0-beta.4
+version: 1.0.0-rc.1
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-beta.1
+  datadog_flutter_plugin: ^1.0.0-rc.1
   grpc: ^3.0.2
   uuid: ^3.0.5
 

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -77,14 +77,14 @@ packages:
       path: "../../datadog_flutter_plugin"
       relative: true
     source: path
-    version: "1.0.0-beta.4"
+    version: "1.0.0-rc.1"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1-beta.2"
+    version: "1.1.0-rc.1"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 1.0.1-beta.2
+version: 1.1.0-rc.1
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-beta.3
+  datadog_flutter_plugin: ^1.0.0-rc.1
   uuid: ^3.0.5
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

Update versions in pubspecs to be rc.1 over beta.

This also updates datadog_tracking_http_client to use 1.1 over 1.0.1 for Dart 2.17

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests