### PR TITLE
💚 Fix flakey test in long task reporting

### DIFF
--- a/packages/datadog_flutter_plugin/test/rum/rum_long_task_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_long_task_observer_test.dart
@@ -68,7 +68,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     var captured = verify(() => mockRum.reportLongTask(captureAny()));
-    expect(captured.captured[0], closeTo(100, 20));
+    expect(captured.captured[0], closeTo(100, 50));
 
     await shutdownObserver(tester, observer);
   });


### PR DESCRIPTION
### What and why?

The long task reporting in this test appears to vary slightly more than 20ms. Upping it to 50ms of leeway to hopefully make the test less flakey.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests