### PR TITLE
💥 Update datadog_tracking_http_client 1.0.x line for rc1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tools/e2e_generator/terraform.tfstate
 **/.flutter-plugins*
 __pycache__
 venv/
+.fvm/

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,14 +210,20 @@ workflows:
     before_run:
     - _prepare_gradle_wrapper
     steps:
-    - flutter-test@1:
+    - script:
         run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin"
-    - flutter-test@1:
+        - content: |-
+            #!/usr/bin/env bash
+            flutter test
+        - working_dir: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin"
+    - script:
         run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client"
+        - content: |-
+            #!/usr/bin/env bash
+            flutter test
+        - working_dir: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client"
     - xcode-test@4.0.2:
         run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
@@ -244,35 +250,39 @@ workflows:
 
   integration_android:
     steps:
-    - flutter-test@1:
+    - script:
         run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin/integration_test_app"
-        - tests_path_pattern: "integration_test"
-        - additional_params: "-d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
-    - flutter-test@1:
+        - content: |-
+            #!/usr/bin/env bash
+            flutter test integration_test -d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID
+        - working_dir: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin/integration_test_app"
+    - script:
         run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/example"
-        - tests_path_pattern: "integration_test"
-        - additional_params: "-d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
+        - content: |-
+            #!/usr/bin/env bash
+            flutter test integration_test -d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID
+        - working_dir: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/example"
   
   integration_ios:
     before_run:
     - _launch_ios_simulator
     steps:
-    - flutter-test@1:
+    - script:
         run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin/integration_test_app"
-        - tests_path_pattern: "integration_test"
-        - additional_params: "-d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
-    - flutter-test@1:
+        - content: |-
+            #!/usr/bin/env bash
+            flutter test integration_test -d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID
+        - working_dir: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin/integration_test_app"
+    - script:
         run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/example"
-        - tests_path_pattern: "integration_test"
-        - additional_params: "-d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
+        - content: |-
+            #!/usr/bin/env bash
+            flutter test integration_test -d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID
+        - working_dir: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/example"
 
   integration_web:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -196,9 +196,6 @@ workflows:
     - flutter-analyze@0:
         inputs:
         - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/"
-    - flutter-analyze@0:
-        inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_grpc_interceptor/"
     - script:
         title: Android lint and static analysis
         inputs:
@@ -221,10 +218,6 @@ workflows:
         run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:
         - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client"
-    - flutter-test@1:
-        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
-        inputs:
-        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_grpc_interceptor"
     - xcode-test@4.0.2:
         run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         inputs:

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* 💥 BREAKING - Set the 1.0.x line to be Dart 2.15 (Flutter 2.8) and below. If you are using Dart 2.17 (Flutter 3) please use the 1.1.x line.
+* Updated to use `datadog_flutter_plugin` 1.0.0-rc.1
+
 ## 1.0.0-beta.2
 
 * Decrease the SDK constraint from Dart 2.16 (Flutter 2.10) to Dart 2.15 (Flutter 2.8)

--- a/packages/datadog_tracking_http_client/example/lib/main.dart
+++ b/packages/datadog_tracking_http_client/example/lib/main.dart
@@ -55,9 +55,6 @@ Future<void> main() async {
       sendNetworkInfo: true,
       printLogsToConsole: true,
     ),
-    tracingConfiguration: TracingConfiguration(
-      sendNetworkInfo: true,
-    ),
     rumConfiguration: applicationId != null
         ? RumConfiguration(applicationId: applicationId)
         : null,

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.11"
+    version: "3.1.6"
   async:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -72,26 +72,26 @@ packages:
     source: path
     version: "0.0.1"
   datadog_flutter_plugin:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../datadog_flutter_plugin"
-      relative: true
-    source: path
-    version: "1.0.0-alpha.2"
+      name: datadog_flutter_plugin
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-rc.1"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1-alpha.1"
+    version: "1.0.0-beta.2"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   file:
     dependency: transitive
     description:
@@ -163,7 +163,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   lints:
     dependency: transitive
     description:
@@ -178,13 +178,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -198,14 +191,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -231,7 +224,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -273,7 +266,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.3"
   transparent_image:
     dependency: "direct main"
     description:
@@ -301,14 +294,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.2"
+    version: "7.3.0"
   webdriver:
     dependency: transitive
     description:
@@ -317,5 +310,5 @@ packages:
     source: hosted
     version: "3.0.0"
 sdks:
-  dart: ">=2.16.1 <2.17.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.15.0 <2.17.0"
+  flutter: ">=1.20.0"

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -110,10 +110,13 @@ class DatadogTrackingHttpClient implements HttpClient {
         rum.startResourceLoading(
             rumKey, rumHttpMethod, url.toString(), attributes);
       }
-    } catch (e) {
+    } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error while attempting '
-          ' to track an _openUrl call: $e');
+        '$DatadogTrackingHttpClient encountered an error while attempting '
+        ' to track an _openUrl call: $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
 
     HttpClientRequest request;
@@ -130,10 +133,13 @@ class DatadogTrackingHttpClient implements HttpClient {
         try {
           rum?.stopResourceLoadingWithErrorInfo(
               rumKey, e.toString(), e.runtimeType.toString());
-        } catch (innerE) {
+        } catch (innerE, st) {
           datadogSdk.internalLogger.sendToDatadog(
-              '$DatadogTrackingHttpClient encountered an error while attempting '
-              ' to track an _openUrl error: $e');
+            '$DatadogTrackingHttpClient encountered an error while attempting '
+            ' to track an _openUrl error: $e',
+            st,
+            e.runtimeType.toString(),
+          );
         }
       }
       rethrow;
@@ -302,9 +308,12 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
         datadogSdk.rum?.stopResourceLoadingWithErrorInfo(
             rumKey!, e.toString(), e.runtimeType.toString());
       }
-    } catch (e) {
+    } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error attempting to report a stream error; $e');
+        '$DatadogTrackingHttpClient encountered an error attempting to report a stream error; $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
   }
 
@@ -448,10 +457,13 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
               ?.stopResourceLoading(rumKey!, statusCode, resourceType, size);
         }
       }
-    } catch (e) {
+    } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogTrackingHttpClient encountered an error while attempting '
-          ' to finish a resource: $e');
+        '$DatadogTrackingHttpClient encountered an error while attempting '
+        ' to finish a resource: $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
   }
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 1.0.0-beta.2
+version: 1.0.1-rc.1
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-beta.1
+  datadog_flutter_plugin: ^1.0.0-rc.1
   uuid: ^3.0.5
 
 dev_dependencies:

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-rc.1
+  datadog_flutter_plugin: ^1.0.0-rc.2
   uuid: ^3.0.5
 
 dev_dependencies:

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';


### PR DESCRIPTION
### What and why?

This sets up 1.0.1-rc.1 to be the Flutter 2.8 package, while 1.1.0-rc1 will be for Flutter 3+.
Also cherry pick telemetry changes into this package.

Note - CI for this package is likely to fail until the main plugin rc.1 is released.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests