### PR TITLE
🐛 Fix Pre-Flutter 3.0 analysis error

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix an issue with using `WidgetBindings.instance` as a non-optional (Property is optional pre-Flutter 3.0)
+
 ## 1.0.0-rc.1
 
 * Update Android SDK to 1.14.0-beta1

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
@@ -40,12 +40,14 @@ class RumLongTaskObserver with WidgetsBindingObserver {
   }
 
   void init() {
-    WidgetsBinding.instance.addObserver(this);
+    // ignore: invalid_null_aware_operator
+    WidgetsBinding.instance?.addObserver(this);
     _startLongTaskDetection();
   }
 
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    // ignore: invalid_null_aware_operator
+    WidgetsBinding.instance?.removeObserver(this);
   }
 
   void _startLongTaskDetection() async {


### PR DESCRIPTION
### What and why?

Pre-Flutter 3.0, WidgetsBinding.instance is optional, but in Flutter 3.0 it is not. Using it as a non-optional breaks users that are still working with Flutter 2

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests