### PR TITLE
📝 Minor documentation fix for datadog_tracking_http_client

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Minor documentation update to clarify 1.1.x / 1.0.x changes
+
 ## 1.1.0-rc.1
 
 * Updated to use `datadog_flutter_plugin` 1.0.0-rc.1

--- a/packages/datadog_tracking_http_client/README.md
+++ b/packages/datadog_tracking_http_client/README.md
@@ -16,13 +16,11 @@ final configuration = DdSdkConfiguration(
 )..enableHttpTracking()
 ```
 
-## Flutter 2.10 Support
+## Flutter 2.8 Support
 
 Flutter 3.0 updated to Dart 2.17, which added two methods to HttpClient. 
 
-Currently, `version 1.0.1-beta.1` sets a version constraint to Dart >= 2.17. If you need to support Flutter 2.10, use `version 1.0.0-beta.1` instead. There is no difference between these versions other than support for Dart 2.16 instead of Dart 2.17.
-
-Moving forward, Flutter Pre-3.0 is supported on the 1.0.x line, and Flutter Post-3.0 will be moved to 1.1.x.
+Currently, `version 1.1.x` sets a version constraint to Dart >= 2.17. If you need to support versions of Flutter prior to 3.0, back to flutter 2.8, use `version 1.0.x` instead. There is no difference between these versions other than support for lower versions of Dart.
   
 # Contributing
 


### PR DESCRIPTION
### What and why?

Change the documentation to reflect that datadog_tracking_http_client 1.1.x is now the correct Flutter 3 version, and 1.0.x is for Flutter 2.8

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests