### PR TITLE
🐛 Fix WidgetsBinding.instance log spam

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix Flutter 3 log spam regarding use of `?.` on WidgetBindings.instance. See [#203][]
+
 ## 1.0.0-rc.2
 
 * Fix an issue with using `WidgetBindings.instance` as a non-optional (Property is optional pre-Flutter 3.0)
@@ -76,3 +78,4 @@
 [#143]: https://github.com/DataDog/dd-sdk-flutter/issues/143
 [#148]: https://github.com/DataDog/dd-sdk-flutter/issues/148
 [#159]: https://github.com/DataDog/dd-sdk-flutter/issues/159
+[#203]: https://github.com/DataDog/dd-sdk-flutter/issues/203

--- a/packages/datadog_flutter_plugin/lib/src/helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/helpers.dart
@@ -142,3 +142,9 @@ InvalidAttributeInfo? findInvalidAttribute(Map<String, Object?> attributes,
     [String parentPropertyName = '']) {
   return _checkInvalidValue(attributes, parentPropertyName);
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` to support older versions of FLutter.
+T? ambiguate<T>(T? value) => value;

--- a/packages/datadog_flutter_plugin/lib/src/helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/helpers.dart
@@ -146,5 +146,5 @@ InvalidAttributeInfo? findInvalidAttribute(Map<String, Object?> attributes,
 /// This allows a value of type T or T? to be treated as a value of type T?.
 ///
 /// We use this so that APIs that have become non-nullable can still be used
-/// with `!` and `?` to support older versions of FLutter.
+/// with `!` and `?` to support older versions of Flutter.
 T? ambiguate<T>(T? value) => value;

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../datadog_flutter_plugin.dart';
+import '../helpers.dart';
 
 class RumLongTaskObserver with WidgetsBindingObserver {
   // The amount of elapsed time that is considered to be a "long task", in seconds.
@@ -40,14 +41,12 @@ class RumLongTaskObserver with WidgetsBindingObserver {
   }
 
   void init() {
-    // ignore: invalid_null_aware_operator
-    WidgetsBinding.instance?.addObserver(this);
+    ambiguate(WidgetsBinding.instance)?.addObserver(this);
     _startLongTaskDetection();
   }
 
   void dispose() {
-    // ignore: invalid_null_aware_operator
-    WidgetsBinding.instance?.removeObserver(this);
+    ambiguate(WidgetsBinding.instance)?.removeObserver(this);
   }
 
   void _startLongTaskDetection() async {


### PR DESCRIPTION
### What and why?

Because WidgetsBinding.instance is optional in Flutter 2.x, we have to use `?.` to access it. However, in Flutter 3,  WidgetsBinding is now non-optional, and Flutter will give you a warning that your use of ?. is unnecessary, even when you put an `// ignore:` comment above it.

### How?

I added a method `ambiguate` that makes WidgetsBinding.instance back into to optional, which can then be used safely with `?.`. This is actually the recommend method from Flutter's release note on Flutter 3.0: https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#your-code

Fixes #203

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests