### PR TITLE
🐛 Fix an issue backing out of an Android application

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* 🔥 MAJOR - Fixed an issue on Android where Datadog would not properly reinitialize after backing out of an application (pressing the back button on the home screen) and returning to it.
+
 ## 1.0.0-rc.2
 
 * Fix an issue with using `WidgetBindings.instance` as a non-optional (Property is optional pre-Flutter 3.0)

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -28,13 +28,15 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
 
     private val loggerRegistry: MutableMap<String, Logger> = mutableMapOf()
 
-    fun setup(
-        flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
-    ) {
+    fun attachToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "datadog_sdk_flutter.logs")
         channel.setMethodCallHandler(this)
 
         binding = flutterPluginBinding
+    }
+
+    fun detachFromEngine() {
+        channel.setMethodCallHandler(null)
     }
 
     internal fun addLogger(loggerHandle: String, logger: Logger) {
@@ -169,11 +171,6 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
         }
         val logger = logBuilder.build()
         loggerRegistry[loggerHandle] = logger
-    }
-
-    @Suppress("UNUSED_PARAMETER")
-    fun teardown(binding: FlutterPlugin.FlutterPluginBinding) {
-        channel.setMethodCallHandler(null)
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -43,15 +43,20 @@ class DatadogRumPlugin(
     var rum: RumMonitor? = rumInstance
         private set
 
-    fun setup(
-        flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
-        configuration: DatadogFlutterConfiguration.RumConfiguration
-    ) {
+    fun attachToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "datadog_sdk_flutter.rum")
         channel.setMethodCallHandler(this)
 
         binding = flutterPluginBinding
+    }
 
+    fun detachFromEngine() {
+        channel.setMethodCallHandler(null)
+    }
+
+    fun setup(
+        configuration: DatadogFlutterConfiguration.RumConfiguration
+    ) {
         rum = RumMonitor.Builder()
             .sampleRumSessions(configuration.sampleRate)
             .build()
@@ -234,11 +239,6 @@ class DatadogRumPlugin(
                 )
             )
         }
-    }
-
-    @Suppress("UNUSED_PARAMETER")
-    fun teardown(binding: FlutterPlugin.FlutterPluginBinding) {
-        channel.setMethodCallHandler(null)
     }
 }
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -44,7 +44,6 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
     val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin()
     val rumPlugin: DatadogRumPlugin = DatadogRumPlugin()
 
-
     override fun onAttachedToEngine(
         @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding
     ) {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -21,14 +21,19 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
-    companion object ErrorCodes {
+    companion object {
         const val CONTRACT_VIOLATION = "DatadogSdk:ContractViolation"
         const val INVALID_OPERATION = "DatadogSdk:InvalidOperation"
+
+        // Flutter can destroy / recreate the plugin object if the engine detaches. If you use the
+        // back button on the first screen, for example, this will detach the Flutter engine
+        // but the application will still be running. We keep the configuration separate
+        // from the plugin to warn about reinitialization.
+        var previousConfiguration: DatadogFlutterConfiguration? = null
     }
 
     private lateinit var channel: MethodChannel
     private lateinit var binding: FlutterPlugin.FlutterPluginBinding
-    private var previousConfiguration: DatadogFlutterConfiguration? = null
 
     // Only used to shutdown Datadog in debug builds
     private val executor: ExecutorService = ThreadPoolExecutor(
@@ -36,10 +41,9 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         TimeUnit.SECONDS, SynchronousQueue<Runnable>()
     )
 
-    var logsPlugin: DatadogLogsPlugin? = null
-        private set
-    var rumPlugin: DatadogRumPlugin? = null
-        private set
+    val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin()
+    val rumPlugin: DatadogRumPlugin = DatadogRumPlugin()
+
 
     override fun onAttachedToEngine(
         @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding
@@ -48,6 +52,9 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         channel.setMethodCallHandler(this)
 
         binding = flutterPluginBinding
+
+        logsPlugin.attachToEngine(flutterPluginBinding)
+        rumPlugin.attachToEngine(flutterPluginBinding)
     }
 
     @Suppress("LongMethod")
@@ -139,11 +146,8 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
             config.trackingConsent
         )
 
-        // Always setup logging as a user can create a log after initialization
-        logsPlugin = DatadogLogsPlugin().apply { setup(binding) }
-
         if (config.rumConfiguration != null) {
-            rumPlugin = DatadogRumPlugin().apply { setup(binding, config.rumConfiguration!!) }
+            rumPlugin.setup(config.rumConfiguration!!)
         }
     }
 
@@ -168,11 +172,8 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
             val isRegistered: AtomicBoolean = rumRegisteredField.get(null) as AtomicBoolean
             isRegistered.set(false)
 
-            logsPlugin?.teardown(binding)
-            logsPlugin = null
-
-            rumPlugin?.teardown(binding)
-            rumPlugin = null
+            logsPlugin.detachFromEngine()
+            rumPlugin.detachFromEngine()
         }.get()
 
         result.success(null)
@@ -181,11 +182,8 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
 
-        logsPlugin?.teardown(binding)
-        logsPlugin = null
-
-        rumPlugin?.teardown(binding)
-        rumPlugin = null
+        logsPlugin.detachFromEngine()
+        rumPlugin.detachFromEngine()
     }
 }
 
@@ -193,4 +191,4 @@ internal const val DATADOG_FLUTTER_TAG = "DatadogFlutter"
 
 internal const val MESSAGE_INVALID_REINITIALIZATION =
     "🔥 Reinitialziing the DatadogSDK with different options, even after a hot restart, is not" +
-        " supported. Cold restart your application to change your current configuation."
+        " supported. Cold restart your application to change your current configuration."

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -129,10 +129,10 @@ class DatadogSdkPluginTest {
 
         // THEN
         assertThat(Datadog.isInitialized()).isTrue()
-        assertThat(plugin.rumPlugin).isNull()
 
         // Because we have no way to reset these, we can't test
         // that they're registered properly.
+        //assertThat(plugin.rumPlugin).isNull()
         //assertThat(GlobalRum.isRegistered()).isFalse()
     }
 


### PR DESCRIPTION
### What and why?

On Android, if you press the back button on the top of the view stack, the app backgrounds and detaches the Flutter engine. We would then clean up a lot of the Flutter -> Datadog glue. However, if the application was then reopened, Datadog would be in a weird state where native code was initialized and thus not re-setup any of the glue.

This changes it so the glue is always set up for all Datadog modules properly, and still cleaned up on a Flutter engine detach.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests