### PR TITLE
✨ Forward long task parameters to native

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,8 @@
         "titleBar.activeBackground": "#7f757f",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#7f757f99",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "commandCenter.border": "#e7e7e799"
     },
     "peacock.color": "#7f757f",
     "rewrap.wrappingColumn": 80,

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * 🔥 MAJOR - Fixed an issue on Android where Datadog would not properly reinitialize after backing out of an application (pressing the back button on the home screen) and returning to it.
 * Fix Flutter 3 log spam regarding use of `?.` on WidgetBindings.instance. See [#203][]
+* Sync long task threshold between Flutter and Native long task reporting.
 
 ## 1.0.0-rc.2
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -53,11 +53,15 @@ data class DatadogFlutterConfiguration(
 ) {
     data class RumConfiguration(
         var applicationId: String,
-        var sampleRate: Float
+        var sampleRate: Float,
+        var detectLongTasks: Boolean,
+        var longTaskThreshold: Float
     ) {
         constructor(encoded: Map<String, Any?>) : this(
             (encoded["applicationId"] as? String) ?: "",
-            (encoded["sampleRate"] as? Number)?.toFloat() ?: 100.0f
+            (encoded["sampleRate"] as? Number)?.toFloat() ?: 100.0f,
+            (encoded["detectLongTasks"] as? Boolean) ?: true,
+            (encoded["longTaskThreshold"] as? Number?)?.toFloat() ?: 0.1f
         )
     }
 
@@ -131,6 +135,8 @@ data class DatadogFlutterConfiguration(
         rumConfiguration?.let {
             configBuilder.sampleRumSessions(it.sampleRate)
             configBuilder.useViewTrackingStrategy(NoOpViewTrackingStrategy)
+            // Native Android always has long task reporting - only sync the threshold
+            configBuilder.trackLongTasks((it.longTaskThreshold * 1000).toLong())
         }
         customEndpoint?.let {
             configBuilder.useCustomLogsEndpoint(it)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -232,7 +232,9 @@ class DatadogConfigurationTest {
             "firstPartyHosts" to listOf<String>(),
             "rumConfiguration" to mapOf(
                 "applicationId" to applicationId,
-                "sampleRate" to 35.0f
+                "sampleRate" to 35.0f,
+                "detectLongTasks" to false,
+                "longTaskThreshold" to 0.3f
             ),
             "additionalConfig" to mapOf<String, Any?>()
         )
@@ -244,6 +246,8 @@ class DatadogConfigurationTest {
         assertThat(config.rumConfiguration).isNotNull()
         assertThat(config.rumConfiguration?.applicationId).isEqualTo(applicationId)
         assertThat(config.rumConfiguration?.sampleRate).isEqualTo(35.0f)
+        assertThat(config.rumConfiguration?.detectLongTasks).isEqualTo(false)
+        assertThat(config.rumConfiguration?.longTaskThreshold).isEqualTo(0.3f)
     }
 
     @Test
@@ -284,7 +288,9 @@ class DatadogConfigurationTest {
             trackingConsent = TrackingConsent.PENDING,
             rumConfiguration = DatadogFlutterConfiguration.RumConfiguration(
                 applicationId = applicationId,
-                sampleRate = 100.0f
+                sampleRate = 100.0f,
+                detectLongTasks = true,
+                longTaskThreshold = 0.1f
             ),
         )
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -152,7 +152,9 @@ class DatadogSdkPluginTest {
             trackingConsent = TrackingConsent.GRANTED,
             rumConfiguration = DatadogFlutterConfiguration.RumConfiguration(
                 applicationId = applicationId,
-                sampleRate = 82.3f
+                sampleRate = 82.3f,
+                detectLongTasks = true,
+                longTaskThreshold = 0.1f
             )
         )
 

--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.2"
+    version: "1.0.0-rc.3"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
@@ -182,7 +182,9 @@ class DatadogConfigurationTests: XCTestCase {
         "printLogsToConsole": NSNumber(true)
       ],
       "rumConfiguration": [
-        "applicationId": "fakeApplicationId"
+        "applicationId": "fakeApplicationId",
+        "detectLongTasks": NSNumber(false),
+        "longTaskThreshold": NSNumber(0.3)
       ],
       "additionalConfig": [:]
     ]
@@ -191,5 +193,7 @@ class DatadogConfigurationTests: XCTestCase {
 
     XCTAssertNotNil(config.rumConfiguration)
     XCTAssertEqual(config.rumConfiguration?.applicationId, "fakeApplicationId")
+    XCTAssertEqual(config.rumConfiguration?.detectLongTasks, false)
+    XCTAssertEqual(config.rumConfiguration?.longTaskThreshold, 0.3)
   }
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -434,7 +434,8 @@ class DatadogRumPluginTests: XCTestCase {
 
         let mockInternal = mock._internal as! MockRumInternalProxy
         XCTAssertEqual(mockInternal.callLog, [
-            .addLongTask(at: Date(timeIntervalSince1970: startTimeInterval), duration: TimeInterval(Double(duration) / 1000.0),
+            .addLongTask(at: Date(timeIntervalSince1970: startTimeInterval),
+                         duration: TimeInterval(Double(duration) / 1000.0),
                          attributes: [:])
         ])
         XCTAssertEqual(resultStatus, .called(value: nil))

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -87,7 +87,9 @@ class FlutterSdkTests: XCTestCase {
             nativeCrashReportingEnabled: true,
             rumConfiguration: DatadogFlutterConfiguration.RumConfiguration(
                 applicationId: "fakeApplicationId",
-                sampleRate: 100.0
+                sampleRate: 100.0,
+                detectLongTasks: true,
+                longTaskThreshold: 0.3
             )
         )
 

--- a/packages/datadog_flutter_plugin/example/pubspec.lock
+++ b/packages/datadog_flutter_plugin/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.2"
+    version: "1.0.0-rc.3"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.2"
+    version: "1.0.0-rc.3"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
@@ -40,10 +40,14 @@ class DatadogFlutterConfiguration {
     class RumConfiguration {
         let applicationId: String
         let sampleRate: Float
+        let detectLongTasks: Bool
+        let longTaskThreshold: Float
 
-        init(applicationId: String, sampleRate: Float) {
+        init(applicationId: String, sampleRate: Float, detectLongTasks: Bool, longTaskThreshold: Float) {
             self.applicationId = applicationId
             self.sampleRate = sampleRate
+            self.detectLongTasks = detectLongTasks
+            self.longTaskThreshold = longTaskThreshold
         }
 
         init?(fromEncoded encoded: [String: Any?]) {
@@ -54,6 +58,8 @@ class DatadogFlutterConfiguration {
             }
 
             sampleRate = (encoded["sampleRate"] as? NSNumber)?.floatValue ?? 100.0
+            detectLongTasks = (encoded["detectLongTasks"] as? NSNumber)?.boolValue ?? true
+            longTaskThreshold = (encoded["longTaskThreshold"] as? NSNumber)?.floatValue ?? 0.1
         }
     }
 
@@ -134,16 +140,25 @@ class DatadogFlutterConfiguration {
         }
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     func toDdConfig() -> Datadog.Configuration {
         let ddConfigBuilder: Datadog.Configuration.Builder
-        if let rumConfiguration = rumConfiguration {
-            ddConfigBuilder = Datadog.Configuration.builderUsing(rumApplicationID: rumConfiguration.applicationId,
-                                                                 clientToken: clientToken,
-                                                                 environment: env)
-            .set(rumSessionsSamplingRate: rumConfiguration.sampleRate)
+        if let rumConfig = rumConfiguration {
+            ddConfigBuilder = Datadog.Configuration.builderUsing(
+                rumApplicationID: rumConfig.applicationId,
+                clientToken: clientToken,
+                environment: env
+            )
+            .set(rumSessionsSamplingRate: rumConfig.sampleRate)
+
+            if rumConfig.detectLongTasks {
+                _ = ddConfigBuilder.trackRUMLongTasks(threshold: TimeInterval(rumConfig.longTaskThreshold))
+            }
         } else {
-            ddConfigBuilder = Datadog.Configuration.builderUsing(clientToken: clientToken,
-                                                                 environment: env)
+            ddConfigBuilder = Datadog.Configuration.builderUsing(
+                clientToken: clientToken,
+                environment: env
+            )
         }
 
         if nativeCrashReportingEnabled {
@@ -157,34 +172,35 @@ class DatadogFlutterConfiguration {
         if let site = site {
             _ = ddConfigBuilder.set(endpoint: site)
         }
+
         if let batchSize = batchSize {
             _ = ddConfigBuilder.set(batchSize: batchSize)
         }
         if let uploadFrequency = uploadFrequency {
             _ = ddConfigBuilder.set(uploadFrequency: uploadFrequency)
         }
-        if let customEndpoint = customEndpoint {
-            if let customEndpointUrl = URL(string: customEndpoint) {
-                _ = ddConfigBuilder
-                    .set(customLogsEndpoint: customEndpointUrl)
-                    .set(customRUMEndpoint: customEndpointUrl)
-            }
+
+        if !firstPartyHosts.isEmpty {
+            _ = ddConfigBuilder.trackURLSession(firstPartyHosts: Set(firstPartyHosts))
         }
 
-        _ = ddConfigBuilder.set(additionalConfiguration: additionalConfig)
+        if let customEndpoint = customEndpoint,
+           let customEndpointUrl = URL(string: customEndpoint) {
+            _ = ddConfigBuilder
+                .set(customLogsEndpoint: customEndpointUrl)
+                .set(customRUMEndpoint: customEndpointUrl)
+        }
 
-        if let enableViewTracking = additionalConfig["_dd.native_view_tracking"] as? Bool, enableViewTracking {
+        if let enableViewTracking = additionalConfig["_dd.native_view_tracking"] as? Bool,
+           enableViewTracking {
             _ = ddConfigBuilder.trackUIKitRUMViews()
         }
 
-        if let serviceName = additionalConfig["_dd.service_name"] as? String {
+        if let serviceName = serviceName {
             _ = ddConfigBuilder.set(serviceName: serviceName)
         }
 
-        if let threshold = additionalConfig["_dd.long_task.threshold"] as? TimeInterval {
-            // `_dd.long_task.threshold` attribute is in milliseconds
-            _ = ddConfigBuilder.trackRUMLongTasks(threshold: threshold / 1_000)
-        }
+        _ = ddConfigBuilder.set(additionalConfiguration: additionalConfig)
 
         return ddConfigBuilder.build()
     }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -184,8 +184,8 @@ class RumConfiguration {
   /// Enable or disable detection of "long tasks"
   ///
   /// Long task detection attempts to detect when an application is doing too
-  /// much work on the main isolate, which could prevent your app from rendering
-  /// at a smooth framerate.
+  /// much work on the main isolate, or on the main native thread, which could
+  /// prevent your app from rendering at a smooth framerate.
   ///
   /// Defaults to true.
   bool detectLongTasks;
@@ -196,6 +196,10 @@ class RumConfiguration {
   /// If the main isolate takes more than [longTaskThreshold] seconds to process
   /// a microtask, it will appear as a Long Task in Datadog RUM Explorer. This
   /// has a minimum of 0.02 seconds.
+  ///
+  /// The Datadog iOS and Android SDKs will also report if their main threads
+  /// are stalled for longer than this threshold, and will also appear as a
+  /// Long Task in the Datadog RUM Explorer
   ///
   /// Defaults to 0.1 seconds
   double longTaskThreshold;
@@ -214,6 +218,8 @@ class RumConfiguration {
     return {
       'applicationId': applicationId,
       'sampleRate': sessionSamplingRate,
+      'detectLongTasks': detectLongTasks,
+      'longTaskThreshold': longTaskThreshold,
     };
   }
 }

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: "../../datadog_flutter_plugin"
       relative: true
     source: path
-    version: "1.0.0-rc.2"
+    version: "1.0.0-rc.3"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:


### PR DESCRIPTION
### What and why?

This makes the behavior of the native long task reporter mostly consistent with the parameters passed to Flutter.

The one exception is that it appears Android always has long task reporting enabled, so regardless of the `detectLongTask` parameter, Android will detect long tasks at the provided threshold.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests