### PR TITLE
Fix typed data encoding

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 * 🔥 MAJOR - Fixed an issue on Android where Datadog would not properly reinitialize after backing out of an application (pressing the back button on the home screen) and returning to it.
 * Fix Flutter 3 log spam regarding use of `?.` on WidgetBindings.instance. See [#203][]
 * Sync long task threshold between Flutter and Native long task reporting.
+* Fix an issue where events that contained lists from `dart:typed_data` (`Float32List`, `Uint8List`, etc) were not being encoded / sent on iOS.
 
 ## 1.0.0-rc.2
 

--- a/packages/datadog_flutter_plugin/ios/Classes/DdFlutterEncodable.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DdFlutterEncodable.swift
@@ -78,6 +78,8 @@ internal class DdFlutterEncodable: Encodable {
             try container.encode(array.map { DdFlutterEncodable($0) })
         case let dictionary as [String: Any]:
             try container.encode(dictionary.mapValues { DdFlutterEncodable($0) })
+        case let typedData as FlutterStandardTypedData:
+            try encodeTypedData(typedData, into: &container)
         default:
             let context = EncodingError.Context(
                 codingPath: container.codingPath,
@@ -86,6 +88,43 @@ internal class DdFlutterEncodable: Encodable {
             )
             throw EncodingError.invalidValue(value, context)
         }
+    }
+}
+
+private func encodeTypedData(_ data: FlutterStandardTypedData,
+                             into container: inout SingleValueEncodingContainer) throws {
+    switch data.type {
+    case .uInt8:
+        let array: [UInt8] = data.data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            return Array(bytes.bindMemory(to: UInt8.self))
+        }
+        try container.encode(array)
+    case .int32:
+        let array: [Int32] = data.data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            return Array(bytes.bindMemory(to: Int32.self))
+        }
+        try container.encode(array)
+    case .int64:
+        let array: [Int64] = data.data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            return Array(bytes.bindMemory(to: Int64.self))
+        }
+        try container.encode(array)
+    case .float32:
+        let array: [Float32] = data.data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            return Array(bytes.bindMemory(to: Float32.self))
+        }
+        try container.encode(array)
+    case .float64:
+        let array: [Float64] = data.data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            return Array(bytes.bindMemory(to: Float64.self))
+        }
+        try container.encode(array)
+    @unknown default:
+        let context = EncodingError.Context(
+            codingPath: container.codingPath,
+            debugDescription: "FlutterStandardTypedData has unknown type \(data.type)  and cannot be encoded."
+        )
+        throw EncodingError.invalidValue(data, context)
     }
 }
 


### PR DESCRIPTION
### What and why?

Flutter native lists from `dart:typed_data` were not being encoded properly, even though they are supported by the StandardMessageCodec, and therefore are interpreted as valid values by the Datadog plugin, until we go to encode them.

This fixes DdFlutterEncodable so that it recognizes FlutterStandardTypedData and encodes it properly.

### How?

In all cases, FlutterStandardTypedData is just a buffer (`Data`) with all of the values written to it using all platform conventions. Since we know the size and type, we can just use the unsafe pointer to create a types array, then immediately encode the resulting array.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests