### PR TITLE
🐛 Add a schema to the gRPC interceptor

### DIFF
--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -12,29 +12,41 @@ import 'package:uuid/uuid.dart';
 /// A client GrpcInterceptor which enables automatic resource tracking and
 /// distributed tracing
 ///
-/// Note: This only supports intercepting unary calls. It does not intercepting
+/// Note: This only supports intercepting unary calls. It does not intercept
 /// streaming calls.
 class DatadogGrpcInterceptor extends ClientInterceptor {
   final Uuid uuid = const Uuid();
   final DatadogSdk _datadog;
   final ClientChannel _channel;
 
+  late String _hostPath;
+
   DatadogGrpcInterceptor(
     this._datadog,
     this._channel,
-  );
+  ) {
+    final host = _channel.host;
+    final scheme = _channel.options.credentials.isSecure ? 'https' : 'http';
+    // Add http / https scheme. This scheme is a lie but needed to connect
+    // resources to distributed tracing.
+    if (host is InternetAddress) {
+      _hostPath = '$scheme://${host.host}:${_channel.port}';
+    } else {
+      if (Uri.parse(host.toString()).scheme.isEmpty) {
+        // Add missing scheme
+        _hostPath = '$scheme://$host:${_channel.port}';
+      } else {
+        // Already has scheme
+        _hostPath = '$host:${_channel.port}';
+      }
+    }
+  }
 
   @override
   ResponseFuture<R> interceptUnary<Q, R>(ClientMethod<Q, R> method, Q request,
       CallOptions options, ClientUnaryInvoker<Q, R> invoker) {
-    final host = _channel.host;
     final path = method.path;
-    final String fullPath;
-    if (host is InternetAddress) {
-      fullPath = '${host.host}:${_channel.port}$path';
-    } else {
-      fullPath = '$host:${_channel.port}$path';
-    }
+    final String fullPath = '$_hostPath$path';
 
     bool shouldSample = _datadog.rum?.shouldSampleTrace() ?? false;
     bool isFirstPartyHost = _datadog.isFirstPartyHost(Uri.parse(fullPath));

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-// ignore_for_file: deprecated_member_use
+import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_grpc_interceptor/datadog_grpc_interceptor.dart';
@@ -28,8 +28,6 @@ class LoggingGreeterService extends GreeterServiceBase {
 
 void main() {
   const int port = 50192;
-  late ClientChannel channel;
-  late Server server;
   late LoggingGreeterService loggingService;
 
   late DatadogSdkMock mockDatadog;
@@ -39,30 +37,245 @@ void main() {
     registerFallbackValue(Uri(host: 'localhost'));
   });
 
-  setUp(() async {
-    channel = ClientChannel(
+  group("all tests with insecure channel", () {
+    late ClientChannel channel;
+    late Server server;
+
+    setUp(() async {
+      channel = ClientChannel(
+        'localhost',
+        port: port,
+        options: const ChannelOptions(
+          credentials: ChannelCredentials.insecure(),
+        ),
+      );
+      loggingService = LoggingGreeterService();
+      server = Server([loggingService]);
+      await server.serve(port: port);
+
+      mockDatadog = DatadogSdkMock();
+      mockRum = RumMock();
+      when(() => mockDatadog.rum).thenReturn(mockRum);
+      when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+    });
+
+    tearDown(() async {
+      await channel.shutdown();
+      await server.shutdown();
+    });
+
+    test('Interceptor calls proper rum functions', () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      final captures = verify(() => mockRum.startResourceLoading(
+          captureAny(),
+          RumHttpMethod.get,
+          'http://localhost:$port/helloworld.Greeter/SayHello',
+          captureAny())).captured;
+      final key = captures[0];
+      final attributes = captures[1];
+
+      expect(attributes['grpc.method'], '/helloworld.Greeter/SayHello');
+
+      verify(
+          () => mockRum.stopResourceLoading(key, 200, RumResourceType.native));
+    });
+
+    test('Interceptor calls send tracing attributes', () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      final captures = verify(() => mockRum.startResourceLoading(
+          captureAny(),
+          RumHttpMethod.get,
+          'http://localhost:$port/helloworld.Greeter/SayHello',
+          captureAny())).captured;
+      final attributes = captures[1];
+      expect(attributes['_dd.trace_id'], isNotNull);
+      expect(BigInt.tryParse(attributes['_dd.trace_id'] as String), isNotNull);
+      expect(attributes['_dd.span_id'], isNotNull);
+      expect(BigInt.tryParse(attributes['_dd.span_id'] as String), isNotNull);
+    });
+
+    test(
+        'Interceptor calls do not send tracing attributes when shouldSample returns false',
+        () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+      when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      final captures = verify(() => mockRum.startResourceLoading(
+          captureAny(),
+          RumHttpMethod.get,
+          'http://localhost:$port/helloworld.Greeter/SayHello',
+          captureAny())).captured;
+      final attributes = captures[1];
+      expect(attributes['_dd.trace_id'], isNull);
+      expect(attributes['_dd.span_id'], isNull);
+    });
+
+    test('Interceptor passes on proper metadata', () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      expect(loggingService.calls.length, 1);
+      final call = loggingService.calls[0];
+      expect(call.clientMetadata!['x-datadog-trace-id'], isNotNull);
+      expect(
+          BigInt.tryParse(call.clientMetadata!['x-datadog-trace-id'] as String),
+          isNotNull);
+      expect(call.clientMetadata!['x-datadog-parent-id'], isNotNull);
+      expect(
+          BigInt.tryParse(
+              call.clientMetadata!['x-datadog-parent-id'] as String),
+          isNotNull);
+      expect(call.clientMetadata!['x-datadog-origin'], 'rum');
+      expect(call.clientMetadata!['x-datadog-sampling-priority'], '1');
+    });
+
+    test('Interceptor does not send traces metadata when shouldSample returns false',
+        () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+      when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      expect(loggingService.calls.length, 1);
+      final call = loggingService.calls[0];
+      expect(call.clientMetadata!['x-datadog-trace-id'], isNull);
+      expect(call.clientMetadata!['x-datadog-parent-id'], isNull);
+      expect(call.clientMetadata!['x-datadog-origin'], isNull);
+      expect(call.clientMetadata!['x-datadog-sampling-priority'], '0');
+    });
+
+    test('Interceptor does not send traces for non-first-party hosts',
+        () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(false);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      expect(loggingService.calls.length, 1);
+      final call = loggingService.calls[0];
+      expect(call.clientMetadata!['x-datadog-trace-id'], isNull);
+      expect(call.clientMetadata!['x-datadog-parent-id'], isNull);
+      expect(call.clientMetadata!['x-datadog-origin'], isNull);
+      expect(call.clientMetadata!['x-datadog-sampling-priority'], isNull);
+    });
+
+    test(
+        'Interceptor calls do not send tracing attributes for non-first-party hosts',
+        () async {
+      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(false);
+
+      final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+      final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+      await stub.sayHello(HelloRequest(name: 'test'));
+
+      final captures = verify(() => mockRum.startResourceLoading(
+          captureAny(),
+          RumHttpMethod.get,
+          'http://localhost:$port/helloworld.Greeter/SayHello',
+          captureAny())).captured;
+      final attributes = captures[1];
+      expect(attributes['_dd.trace_id'], isNull);
+      expect(attributes['_dd.span_id'], isNull);
+    });
+  });
+
+  test("secure channel adds https scheme", () async {
+    final channel = ClientChannel(
       'localhost',
       port: port,
       options: const ChannelOptions(
-        credentials: ChannelCredentials.insecure(),
+        credentials: ChannelCredentials.secure(),
       ),
     );
     loggingService = LoggingGreeterService();
-    server = Server([loggingService]);
+    final server = Server([loggingService]);
     await server.serve(port: port);
 
     mockDatadog = DatadogSdkMock();
     mockRum = RumMock();
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+
+    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+
+    final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+
+    final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+    try {
+      await stub.sayHello(HelloRequest(name: 'test'));
+    } catch (_) {
+      // this is fine, we can't actually connect to a secure channel
+    }
+
+    final captures = verify(() => mockRum.startResourceLoading(
+        captureAny(),
+        RumHttpMethod.get,
+        'https://localhost:$port/helloworld.Greeter/SayHello',
+        captureAny())).captured;
+    final key = captures[0];
+    final attributes = captures[1];
+
+    expect(attributes['grpc.method'], '/helloworld.Greeter/SayHello');
+
+    verify(() =>
+        mockRum.stopResourceLoadingWithErrorInfo(key, any(), "GrpcError", {}));
+
+    channel.shutdown();
+    server.shutdown();
   });
 
-  tearDown(() async {
-    await channel.shutdown();
-    await server.shutdown();
-  });
+  test("internet address channel adds scheme", () async {
+    final channel = ClientChannel(
+      InternetAddress.loopbackIPv4,
+      port: port,
+      options: const ChannelOptions(
+        credentials: ChannelCredentials.insecure(),
+      ),
+    );
+    loggingService = LoggingGreeterService();
+    final server = Server([loggingService]);
+    await server.serve(port: port);
 
-  test('Interceptor calls proper rum functions', () async {
+    mockDatadog = DatadogSdkMock();
+    mockRum = RumMock();
+    when(() => mockDatadog.rum).thenReturn(mockRum);
+    when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+
     when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
 
     final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
@@ -74,7 +287,7 @@ void main() {
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),
         RumHttpMethod.get,
-        'localhost:$port/helloworld.Greeter/SayHello',
+        'http://127.0.0.1:$port/helloworld.Greeter/SayHello',
         captureAny())).captured;
     final key = captures[0];
     final attributes = captures[1];
@@ -82,128 +295,54 @@ void main() {
     expect(attributes['grpc.method'], '/helloworld.Greeter/SayHello');
 
     verify(() => mockRum.stopResourceLoading(key, 200, RumResourceType.native));
+
+    channel.shutdown();
+    server.shutdown();
   });
 
-  test('Interceptor calls send tracing attributes', () async {
+  test("secure internet address channel adds scheme", () async {
+    final channel = ClientChannel(
+      InternetAddress.loopbackIPv4,
+      port: port,
+      options: const ChannelOptions(
+        credentials: ChannelCredentials.secure(),
+      ),
+    );
+    loggingService = LoggingGreeterService();
+    final server = Server([loggingService]);
+    await server.serve(port: port);
+
+    mockDatadog = DatadogSdkMock();
+    mockRum = RumMock();
+    when(() => mockDatadog.rum).thenReturn(mockRum);
+    when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+
     when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
 
     final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
 
     final stub = GreeterClient(channel, interceptors: [interceptor]);
 
-    await stub.sayHello(HelloRequest(name: 'test'));
+    try {
+      await stub.sayHello(HelloRequest(name: 'test'));
+    } catch (_) {
+      // This is okay, we can't actually connect securely
+    }
 
     final captures = verify(() => mockRum.startResourceLoading(
         captureAny(),
         RumHttpMethod.get,
-        'localhost:$port/helloworld.Greeter/SayHello',
+        'https://127.0.0.1:$port/helloworld.Greeter/SayHello',
         captureAny())).captured;
+    final key = captures[0];
     final attributes = captures[1];
-    expect(attributes['_dd.trace_id'], isNotNull);
-    expect(BigInt.tryParse(attributes['_dd.trace_id'] as String), isNotNull);
-    expect(attributes['_dd.span_id'], isNotNull);
-    expect(BigInt.tryParse(attributes['_dd.span_id'] as String), isNotNull);
-  });
 
-  test(
-      'Interceptor calls do not send tracing attributes when shouldSample returns false',
-      () async {
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
-    when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+    expect(attributes['grpc.method'], '/helloworld.Greeter/SayHello');
 
-    final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
+    verify(() =>
+        mockRum.stopResourceLoadingWithErrorInfo(key, any(), "GrpcError", {}));
 
-    final stub = GreeterClient(channel, interceptors: [interceptor]);
-
-    await stub.sayHello(HelloRequest(name: 'test'));
-
-    final captures = verify(() => mockRum.startResourceLoading(
-        captureAny(),
-        RumHttpMethod.get,
-        'localhost:$port/helloworld.Greeter/SayHello',
-        captureAny())).captured;
-    final attributes = captures[1];
-    expect(attributes['_dd.trace_id'], isNull);
-    expect(attributes['_dd.span_id'], isNull);
-  });
-
-  test('Interceptor passes on proper metadata', () async {
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
-
-    final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
-
-    final stub = GreeterClient(channel, interceptors: [interceptor]);
-
-    await stub.sayHello(HelloRequest(name: 'test'));
-
-    expect(loggingService.calls.length, 1);
-    final call = loggingService.calls[0];
-    expect(call.clientMetadata!['x-datadog-trace-id'], isNotNull);
-    expect(
-        BigInt.tryParse(call.clientMetadata!['x-datadog-trace-id'] as String),
-        isNotNull);
-    expect(call.clientMetadata!['x-datadog-parent-id'], isNotNull);
-    expect(
-        BigInt.tryParse(call.clientMetadata!['x-datadog-parent-id'] as String),
-        isNotNull);
-    expect(call.clientMetadata!['x-datadog-origin'], 'rum');
-    expect(call.clientMetadata!['x-datadog-sampling-priority'], '1');
-  });
-
-  test('Interceptor does not send traces for when shouldSample returns false',
-      () async {
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
-    when(() => mockRum.shouldSampleTrace()).thenReturn(false);
-
-    final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
-
-    final stub = GreeterClient(channel, interceptors: [interceptor]);
-
-    await stub.sayHello(HelloRequest(name: 'test'));
-
-    expect(loggingService.calls.length, 1);
-    final call = loggingService.calls[0];
-    expect(call.clientMetadata!['x-datadog-trace-id'], isNull);
-    expect(call.clientMetadata!['x-datadog-parent-id'], isNull);
-    expect(call.clientMetadata!['x-datadog-origin'], isNull);
-    expect(call.clientMetadata!['x-datadog-sampling-priority'], '0');
-  });
-
-  test('Interceptor does not send traces for non-first-party hosts', () async {
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(false);
-
-    final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
-
-    final stub = GreeterClient(channel, interceptors: [interceptor]);
-
-    await stub.sayHello(HelloRequest(name: 'test'));
-
-    expect(loggingService.calls.length, 1);
-    final call = loggingService.calls[0];
-    expect(call.clientMetadata!['x-datadog-trace-id'], isNull);
-    expect(call.clientMetadata!['x-datadog-parent-id'], isNull);
-    expect(call.clientMetadata!['x-datadog-origin'], isNull);
-    expect(call.clientMetadata!['x-datadog-sampling-priority'], isNull);
-  });
-
-  test(
-      'Interceptor calls do not send tracing attributes for non-first-party hosts',
-      () async {
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(false);
-
-    final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
-
-    final stub = GreeterClient(channel, interceptors: [interceptor]);
-
-    await stub.sayHello(HelloRequest(name: 'test'));
-
-    final captures = verify(() => mockRum.startResourceLoading(
-        captureAny(),
-        RumHttpMethod.get,
-        'localhost:$port/helloworld.Greeter/SayHello',
-        captureAny())).captured;
-    final attributes = captures[1];
-    expect(attributes['_dd.trace_id'], isNull);
-    expect(attributes['_dd.span_id'], isNull);
+    channel.shutdown();
+    server.shutdown();
   });
 }


### PR DESCRIPTION
### What and why?

Apparently to connect RUM resources properly to distributed tracing, we need to include a URL schema. For now, we're adding http / https to all calls that do not include a schema.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [x] Run integration tests