### PR TITLE
💚 Fix e2e tests on Android

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -170,9 +170,6 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
             rumRegisteredField.isAccessible = true
             val isRegistered: AtomicBoolean = rumRegisteredField.get(null) as AtomicBoolean
             isRegistered.set(false)
-
-            logsPlugin.detachFromEngine()
-            rumPlugin.detachFromEngine()
         }.get()
 
         result.success(null)

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/test_utils.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/test_utils.dart
@@ -30,7 +30,10 @@ Future<void> initializeDatadog([DatadogConfigCallback? configCallback]) async {
       site: DatadogSite.us1,
       trackingConsent: TrackingConsent.granted)
     ..loggingConfiguration = LoggingConfiguration()
-    ..rumConfiguration = RumConfiguration(applicationId: applicationId)
+    ..rumConfiguration = RumConfiguration(
+      applicationId: applicationId,
+      detectLongTasks: false,
+    )
     ..serviceName = 'com.datadog.flutter.nightly';
 
   if (configCallback != null) {


### PR DESCRIPTION
### What and why?

E2E tests on Android were broken because of changes made around initialization to support the Flutter engine detaching. Calling "flushAndDeinitialize" was also detaching the rum and logs plugin, which was incorrect.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests