### PR TITLE
Update to version 1.14.0-beta2

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -14,7 +14,7 @@ RUM supports monitoring for mobile Flutter Android and iOS applications.
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 1.12.0-beta2 | 1.14.0-beta1 | v4.11.2 |
+| 1.12.0-beta2 | 1.14.0-beta2 | v4.11.2 |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,7 +9,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_sdk_version = "1.14.0-beta1"
+    ext.datadog_sdk_version = "1.14.0-beta2"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 1.14.0-beta1 to version 1.14.0-beta2: [diff](https://github.com/DataDog/dd-sdk-android/compare/1.14.0-beta1...1.14.0-beta2)