### PR TITLE
🐛 Fix an issue where the example app was not reporting errors correctly

### DIFF
--- a/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
@@ -187,12 +187,13 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
 
   void _flutterException() {
     // Iterate a list to get a system symbol in the stack.
-    ['a', 'b', 'c'].map((element) {
+    var xes = ['a', 'b', 'c'].map((element) {
       if (element == 'a') {
         throw Exception("This wasn't supposed to happen!");
       }
       return 'x';
-    });
+    }).toList();
+    xes.length;
   }
 
   static int nativeCallback(int value) {


### PR DESCRIPTION
### What and why?

Flutter errors weren't being reported properly in the example app because of some lazy iterator evaluation. This fixes that.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests