### PR TITLE
💥 Deprecate DdFlutterConfiguration.customEndpoint

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Deprecation - `DdSdkConfiguration.customEndpoint` has been deprecated in favor of `DdSdkConfiguration.customLogsEndpoint` and `RumConfiguration.customEndpoint`.
+
 ## 1.0.0-rc.3
 
 * 🔥 MAJOR - Fixed an issue on Android where Datadog would not properly reinitialize after backing out of an application (pressing the back button on the home screen) and returning to it.

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -45,7 +45,7 @@ data class DatadogFlutterConfiguration(
     var serviceName: String? = null,
     var batchSize: BatchSize? = null,
     var uploadFrequency: UploadFrequency? = null,
-    var customEndpoint: String? = null,
+    var customLogsEndpoint: String? = null,
     var firstPartyHosts: List<String> = listOf(),
     var additionalConfig: Map<String, Any?> = mapOf(),
 
@@ -55,13 +55,15 @@ data class DatadogFlutterConfiguration(
         var applicationId: String,
         var sampleRate: Float,
         var detectLongTasks: Boolean,
-        var longTaskThreshold: Float
+        var longTaskThreshold: Float,
+        var customEndpoint: String?
     ) {
         constructor(encoded: Map<String, Any?>) : this(
             (encoded["applicationId"] as? String) ?: "",
             (encoded["sampleRate"] as? Number)?.toFloat() ?: 100.0f,
             (encoded["detectLongTasks"] as? Boolean) ?: true,
-            (encoded["longTaskThreshold"] as? Number?)?.toFloat() ?: 0.1f
+            (encoded["longTaskThreshold"] as? Number?)?.toFloat() ?: 0.1f,
+            encoded["customEndpoint"] as? String
         )
     }
 
@@ -87,7 +89,7 @@ data class DatadogFlutterConfiguration(
         (encoded["uploadFrequency"] as? String)?.let {
             uploadFrequency = parseUploadFrequency(it)
         }
-        customEndpoint = encoded["customEndpoint"] as? String
+        customLogsEndpoint = encoded["customLogsEndpoint"] as? String
         (encoded["firstPartyHosts"] as? List<String>)?.let {
             firstPartyHosts = it
         }
@@ -111,6 +113,7 @@ data class DatadogFlutterConfiguration(
         )
     }
 
+    @Suppress("ComplexMethod")
     fun toSdkConfiguration(): Configuration {
         val configBuilder = Configuration.Builder(
             // Always enable logging as users can create logs post initialization
@@ -137,10 +140,12 @@ data class DatadogFlutterConfiguration(
             configBuilder.useViewTrackingStrategy(NoOpViewTrackingStrategy)
             // Native Android always has long task reporting - only sync the threshold
             configBuilder.trackLongTasks((it.longTaskThreshold * 1000).toLong())
+            it.customEndpoint?.let { ce ->
+                configBuilder.useCustomRumEndpoint(ce)
+            }
         }
-        customEndpoint?.let {
+        customLogsEndpoint?.let {
             configBuilder.useCustomLogsEndpoint(it)
-            configBuilder.useCustomRumEndpoint(it)
         }
         configBuilder.setFirstPartyHosts(firstPartyHosts)
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -154,7 +154,7 @@ class DatadogConfigurationTest {
             "uploadFrequency" to "UploadFrequency.frequent",
             "trackingConsent" to "TrackingConsent.granted",
             "telemetrySampleRate" to telemetrySampleRate,
-            "customEndpoint" to "customEndpoint",
+            "customLogsEndpoint" to "customEndpoint",
             "firstPartyHosts" to listOf(firstPartyHost),
             "rumConfiguration" to null,
             "additionalConfig" to mapOf<String, Any?>(
@@ -169,7 +169,7 @@ class DatadogConfigurationTest {
         assertThat(config.nativeCrashReportEnabled).isEqualTo(true)
         assertThat(config.site).isEqualTo(DatadogSite.US3)
         assertThat(config.batchSize).isEqualTo(BatchSize.SMALL)
-        assertThat(config.customEndpoint).isEqualTo("customEndpoint")
+        assertThat(config.customLogsEndpoint).isEqualTo("customEndpoint")
         assertThat(config.telemetrySampleRate).isEqualTo(telemetrySampleRate)
         assertThat(config.additionalConfig).isEqualTo(mapOf(
             additionalKey to additionalValue
@@ -197,7 +197,7 @@ class DatadogConfigurationTest {
             "batchSize" to "BatchSize.small",
             "uploadFrequency" to "UploadFrequency.frequent",
             "trackingConsent" to "TrackingConsent.granted",
-            "customEndpoint" to "customEndpoint",
+            "customLogsEndpoint" to "customEndpoint",
             "firstPartyHosts" to listOf(firstPartyHost),
             "rumConfiguration" to null,
             "additionalConfig" to mapOf<String, Any?>(
@@ -228,13 +228,14 @@ class DatadogConfigurationTest {
             "batchSize" to null,
             "uploadFrequency" to null,
             "trackingConsent" to "TrackingConsent.pending",
-            "customEndpoint" to null,
+            "customLogsEndpoint" to null,
             "firstPartyHosts" to listOf<String>(),
             "rumConfiguration" to mapOf(
                 "applicationId" to applicationId,
                 "sampleRate" to 35.0f,
                 "detectLongTasks" to false,
-                "longTaskThreshold" to 0.3f
+                "longTaskThreshold" to 0.3f,
+                "customEndpoint" to "customEndpoint",
             ),
             "additionalConfig" to mapOf<String, Any?>()
         )
@@ -248,6 +249,7 @@ class DatadogConfigurationTest {
         assertThat(config.rumConfiguration?.sampleRate).isEqualTo(35.0f)
         assertThat(config.rumConfiguration?.detectLongTasks).isEqualTo(false)
         assertThat(config.rumConfiguration?.longTaskThreshold).isEqualTo(0.3f)
+        assertThat(config.rumConfiguration?.customEndpoint).isEqualTo("customEndpoint")
     }
 
     @Test
@@ -290,7 +292,8 @@ class DatadogConfigurationTest {
                 applicationId = applicationId,
                 sampleRate = 100.0f,
                 detectLongTasks = true,
-                longTaskThreshold = 0.1f
+                longTaskThreshold = 0.1f,
+                customEndpoint = null
             ),
         )
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -154,7 +154,8 @@ class DatadogSdkPluginTest {
                 applicationId = applicationId,
                 sampleRate = 82.3f,
                 detectLongTasks = true,
-                longTaskThreshold = 0.1f
+                longTaskThreshold = 0.1f,
+                customEndpoint = null
             )
         )
 

--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.3"
+    version: "1.0.0-rc.4"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -89,7 +89,8 @@ class FlutterSdkTests: XCTestCase {
                 applicationId: "fakeApplicationId",
                 sampleRate: 100.0,
                 detectLongTasks: true,
-                longTaskThreshold: 0.3
+                longTaskThreshold: 0.3,
+                customEndpoint: nil
             )
         )
 

--- a/packages/datadog_flutter_plugin/example/pubspec.lock
+++ b/packages/datadog_flutter_plugin/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.3"
+    version: "1.0.0-rc.4"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/main.dart
@@ -51,13 +51,16 @@ Future<void> main() async {
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,
     firstPartyHosts: firstPartyHosts,
-    customEndpoint: customEndpoint,
+    customLogsEndpoint: customEndpoint,
     loggingConfiguration: LoggingConfiguration(
       sendNetworkInfo: true,
       printLogsToConsole: true,
     ),
     rumConfiguration: applicationId != null
-        ? RumConfiguration(applicationId: applicationId)
+        ? RumConfiguration(
+            applicationId: applicationId,
+            customEndpoint: customEndpoint,
+          )
         : null,
   );
 

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.3"
+    version: "1.0.0-rc.4"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -24,7 +24,7 @@ class DdLogsWeb extends DdLogsPlatform {
       clientToken: configuration.clientToken,
       env: configuration.env,
       site: siteStringForSite(configuration.site),
-      proxyUrl: configuration.customEndpoint,
+      proxyUrl: configuration.customLogsEndpoint,
       service: configuration.serviceName,
       version: version,
     ));

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -28,7 +28,7 @@ class DdRumWeb extends DdRumPlatform {
       sampleRate: rumConfiguration.sessionSamplingRate,
       service: configuration.serviceName,
       env: configuration.env,
-      proxyUrl: configuration.customEndpoint,
+      proxyUrl: configuration.rumConfiguration?.customEndpoint,
       allowedTracingOrigins: configuration.firstPartyHosts,
       trackViewsManually: true,
     ));

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -75,7 +75,7 @@ void main() {
       'nativeCrashReportEnabled': false,
       'trackingConsent': 'TrackingConsent.pending',
       'telemetrySampleRate': null,
-      'customEndpoint': null,
+      'customLogsEndpoint': null,
       'batchSize': null,
       'uploadFrequency': null,
       'firstPartyHosts': <String>[],

--- a/packages/datadog_tracking_http_client/example/lib/main.dart
+++ b/packages/datadog_tracking_http_client/example/lib/main.dart
@@ -50,7 +50,7 @@ Future<void> main() async {
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,
     firstPartyHosts: firstPartyHosts,
-    customEndpoint: customEndpoint,
+    customLogsEndpoint: customEndpoint,
     loggingConfiguration: LoggingConfiguration(
       sendNetworkInfo: true,
       printLogsToConsole: true,
@@ -59,6 +59,7 @@ Future<void> main() async {
         ? RumConfiguration(
             applicationId: applicationId,
             tracingSamplingRate: 100,
+            customEndpoint: customEndpoint,
           )
         : null,
   )..enableHttpTracking();

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: "../../datadog_flutter_plugin"
       relative: true
     source: path
-    version: "1.0.0-rc.3"
+    version: "1.0.0-rc.4"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:


### PR DESCRIPTION
### What and why?

Custom endpoint was being used to set the logs and rum endpoint to the same endpoint, but we need capabilities to set each feature's endpoint separately.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests