### PR TITLE
🐛 Fix iOS not encoding null attributes properly

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Deprecation - `DdSdkConfiguration.customEndpoint` has been deprecated in favor of `DdSdkConfiguration.customLogsEndpoint` and `RumConfiguration.customEndpoint`.
 * Added `DdSdkConfiguration.version` configuration option for specifying a custom application version.
+* Fix `null` values in attributes not being correctly encoded on iOS
 
 ## 1.0.0-rc.3
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -233,6 +233,15 @@ void main() {
     expect(view3.viewEvents.last.view.actionCount, 0);
     expect(view3.viewEvents.last.view.errorCount, 0);
 
+    const expectedNestedAttribute = {
+      'testing_attribute': {
+        'nested_1': 123,
+        'nested_null': null,
+      },
+    };
+    expect(view3.viewEvents.last.context!['nesting_attribute'],
+        expectedNestedAttribute);
+
     // Verify service name in RUM events
     for (final event in rumLog) {
       if (!kIsWeb && Platform.isIOS) {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -290,6 +290,13 @@ class _RumManualInstrumentation3State extends State<RumManualInstrumentation3>
     DatadogSdk.instance.rum?.removeAttribute('onboarding_stage');
     DatadogSdk.instance.rum?.startView(_viewKey, _viewName);
 
+    DatadogSdk.instance.rum?.addAttribute('nesting_attribute', {
+      'testing_attribute': {
+        'nested_1': 123,
+        'nested_null': null,
+      },
+    });
+
     _simulateActions();
   }
 

--- a/packages/datadog_flutter_plugin/ios/Classes/DdFlutterEncodable.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DdFlutterEncodable.swift
@@ -72,6 +72,8 @@ internal class DdFlutterEncodable: Encodable {
         switch value {
         case let number as NSNumber:
             try encodeNSNumber(number, into: &container)
+        case is NSNull, is Void:
+            try container.encodeNil()
         case let string as String:
             try container.encode(string)
         case let array as [Any]:


### PR DESCRIPTION
### What and why?

We didn't properly handle the case of NSNull / Void in the AnyEncodable conversion.  Also added integration checks for nested nulls.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests