### PR TITLE
⬆️ Update protobuf dependency in grpc_interceptor

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -33,3 +33,4 @@ import,json_annotation,BSD-3-Clause,"Copyright 2017, the Dart project authors."
 build,json_serializable,BSD-3-Clause,"Copyright 2017, the Dart project authors."
 import,js,BSD-3-Clause,"Copyright 2012, the Dart project authors."
 import,fluro,MIT,Copyright 2021 Luke Pighetti
+build,protobuf,BSD-3-Clause,"Copyright 2013, the Dart project authors."

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -20,6 +20,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.1
   mocktail: ^0.3.0
+  protobuf: ^2.1.0
 
 flutter:
 


### PR DESCRIPTION
### What and why?

Protobuf is used in tests, so it needs to be listed as a dev dependency in order to publish to pub.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests