### PR TITLE
🐛 Disable user action tracking in Android

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -137,6 +137,8 @@ data class DatadogFlutterConfiguration(
         telemetrySampleRate?.let { configBuilder.sampleTelemetry(it) }
         rumConfiguration?.let {
             configBuilder.sampleRumSessions(it.sampleRate)
+            // Always disable user action tracking and view tracking for Flutter
+            configBuilder.disableInteractionTracking()
             configBuilder.useViewTrackingStrategy(NoOpViewTrackingStrategy)
             // Native Android always has long task reporting - only sync the threshold
             configBuilder.trackLongTasks((it.longTaskThreshold * 1000).toLong())
@@ -144,6 +146,7 @@ data class DatadogFlutterConfiguration(
                 configBuilder.useCustomRumEndpoint(ce)
             }
         }
+
         customLogsEndpoint?.let {
             configBuilder.useCustomLogsEndpoint(it)
         }


### PR DESCRIPTION
### What and why?

User action tracking was enabled by default in Android and could cause issues when backgrounding and foregrounding the app.

### How?

Take advantage of a new method in Android to disable interaction tracking.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests