### PR TITLE
✨ Add flavor / variant to configuration

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Deprecation - `DdSdkConfiguration.customEndpoint` has been deprecated in favor of `DdSdkConfiguration.customLogsEndpoint` and `RumConfiguration.customEndpoint`.
 * Added `DdSdkConfiguration.version` configuration option for specifying a custom application version.
-* Fix `null` values in attributes not being correctly encoded on iOS
+* Fix `null` values in attributes not being correctly encoded on iOS.
+* Add `flavor` as a configuration parameter.
 
 ## 1.0.0-rc.3
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -104,11 +104,13 @@ data class DatadogFlutterConfiguration(
     }
 
     fun toCredentials(): Credentials {
+        val variant = additionalConfig["_dd.variant"] as? String
+
         return Credentials(
             clientToken = clientToken,
             envName = env,
             rumApplicationId = rumConfiguration?.applicationId,
-            variant = Credentials.NO_VARIANT,
+            variant = variant ?: Credentials.NO_VARIANT,
             serviceName = serviceName
         )
     }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -98,7 +98,8 @@ extension Waiter on WidgetTester {
   }
 }
 
-void verifyCommonTags(RequestLog request, String service, String version) {
+void verifyCommonTags(
+    RequestLog request, String service, String version, String? variant) {
   final sdkVersion = request.tags['sdk_version'];
   if (kIsWeb) {
     // Returning the browser version of the SDK.
@@ -115,5 +116,6 @@ void verifyCommonTags(RequestLog request, String service, String version) {
 
     // Not sent as a tag on web
     expect(request.tags['version'], version);
+    expect(request.tags['variant'], variant);
   }
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -76,7 +76,12 @@ void main() {
     const expectedContextValue = 1;
 
     for (var log in requestLog) {
-      verifyCommonTags(log, 'com.datadoghq.flutter.integration', '1.2.3-555');
+      verifyCommonTags(
+        log,
+        'com.datadoghq.flutter.integration',
+        '1.2.3-555',
+        'integration',
+      );
     }
 
     final session = RumSessionDecoder.fromEvents(rumLog);

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -37,6 +37,7 @@ Future<void> main() async {
     env: dotenv.get('DD_ENV', fallback: ''),
     serviceName: 'com.datadoghq.flutter.integration',
     version: '1.2.3+555',
+    flavor: 'integration',
     site: DatadogSite.us1,
     trackingConsent: TrackingConsent.granted,
     uploadFrequency: UploadFrequency.frequent,

--- a/packages/datadog_flutter_plugin/lib/src/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/attributes.dart
@@ -7,6 +7,7 @@ class DatadogConfigKey {
   static const sdkVersion = '_dd.sdk_version';
   static const nativeViewTracking = '_dd.native_view_tracking';
   static const version = '_dd.version';
+  static const variant = '_dd.variant';
 }
 
 class DatadogPlatformAttributeKey {

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -282,6 +282,13 @@ class DdSdkConfiguration {
   /// upload` command in order for symbolication to work.
   String? version;
 
+  /// Set the current flavor (variant) of the application
+  ///
+  /// This must match the flavor set during symbol upload in order for stack trace
+  /// deobfuscation to work. By default, the flavor parameter is null and will
+  /// not appear as a tag in RUM, but other tools will default to 'release'
+  String? flavor;
+
   /// Set a custom endpoint to send information to.
   ///
   /// This is deprecated in favor of [customLogsEndpoint] and
@@ -342,6 +349,7 @@ class DdSdkConfiguration {
     this.uploadFrequency,
     this.batchSize,
     this.version,
+    this.flavor,
     this.customEndpoint,
     this.telemetrySampleRate,
     this.firstPartyHosts = const [],
@@ -370,6 +378,10 @@ class DdSdkConfiguration {
     if (version != null) {
       final fixedVersion = version?.replaceAll('+', '-');
       encodedAdditionalConfig[DatadogConfigKey.version] = fixedVersion;
+    }
+
+    if (flavor != null) {
+      encodedAdditionalConfig[DatadogConfigKey.variant] = flavor;
     }
 
     return {

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -143,6 +143,21 @@ void main() {
     expect(additionalConfig[DatadogConfigKey.version], '1.9.8-123');
   });
 
+  test('flavor added to additionalConfiguration', () {
+    final configuration = DdSdkConfiguration(
+      clientToken: 'fakeClientToken',
+      env: 'fake-env',
+      site: DatadogSite.us1,
+      trackingConsent: TrackingConsent.notGranted,
+      flavor: 'strawberry',
+    );
+
+    final encoded = configuration.encode();
+    final additionalConfig =
+        encoded['additionalConfig'] as Map<String, Object?>;
+    expect(additionalConfig[DatadogConfigKey.variant], 'strawberry');
+  });
+
   test('configuration encodes default sub-configuration', () {
     final configuration = DdSdkConfiguration(
       clientToken: 'fakeClientToken',


### PR DESCRIPTION
### What and why?

When set, flavor get sent as the `variant` tag on both iOS and Android.

Fixes RUMM-2471

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests