### PR TITLE
👷 Fix releaser to work on non-prerelease versions

### DIFF
--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -68,6 +68,17 @@ void main(List<String> arguments) async {
   final choreBranch =
       'chore/${commandArgs.packageName}/prep-v${commandArgs.version}';
 
+  // By default (develop) increment the version by a minor version
+  var versionBumpType = VersionBumpType.minor;
+  // If we're on a release branch, bump by a revision
+  if (currentBranch.branchName.contains('release')) {
+    versionBumpType = VersionBumpType.rev;
+  }
+  // If we're releasing a pre-release, bump by pre-release
+  if (commandArgs.version.contains('-')) {
+    versionBumpType = VersionBumpType.prerelease;
+  }
+
   final commands = <Command>[
     ValidateReleaseCommand(),
     CreateBranchCommand(choreBranch),
@@ -84,7 +95,7 @@ void main(List<String> arguments) async {
     SwitchBranchCommand(choreBranch),
     // Do pre-release always for now. Later use the branch name as
     // the indicator.
-    BumpVersionCommand(VersionBumpType.prerelease),
+    BumpVersionCommand(versionBumpType),
     CommitChangesCommand(
         '📝 Bump version of ${commandArgs.packageName} to next potential release.'),
   ];


### PR DESCRIPTION
### What and why?

Current version of the releaser script assumes it only has to update pre-release versions. Now it needs to be able to update released versions.

### How?

This checks the branch we're releasing from. The default case (usually develop) is to update the minor version. On release branches, update the revision number. In all cases, if it's a pre-release version, update it as a pre-release.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests