### PR TITLE
⬆️ Update dependencies to depend on 1.0.0 of datadog_flutter_plugin

### DIFF
--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-rc.1
+  datadog_flutter_plugin: ^1.0.0
   grpc: ^3.0.2
   uuid: ^3.0.5
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0-rc.1
+  datadog_flutter_plugin: ^1.0.0
   uuid: ^3.0.5
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

`datadog_grpc_interceptor` and `datadog_tracking_http_client` now depend on the stable releases of `datadog_flutter_plugin`

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests