### PR TITLE
🐛 Fix datadog_tracking_http_client Dart dependency

### DIFF
--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://datadoghq.com
 
 
 environment:
-  sdk: ">=2.17.0-0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
### What and why?

The package was incorrectly dependent on a prerelease version of Dart. Remove the "prerelease" portion of the dart dependency.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests