### PR TITLE
Update to version 1.14.1

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Update Android SDK to 1.14.1
+  * Add CPU architecture to the collected device information.
+
 ## 1.0.0
 
 * Deprecation - `DdSdkConfiguration.customEndpoint` has been deprecated in favor of `DdSdkConfiguration.customLogsEndpoint` and `RumConfiguration.customEndpoint`.

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -11,7 +11,7 @@ RUM supports monitoring for Flutter Android and iOS applications for Flutter 2.8
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 1.12.0 | 1.14.0 | v4.11.2 |
+| 1.12.0 | 1.14.1 | v4.11.2 |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,7 +9,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_sdk_version = "1.14.0"
+    ext.datadog_sdk_version = "1.14.1"
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
This PR has been created automatically by the CI
Updating from version 1.14.0 to version 1.14.1: [diff](https://github.com/DataDog/dd-sdk-android/compare/1.14.0...1.14.1)