### PR TITLE
📝 Documentation changes for DatadogRouteAwareMixin

### DIFF
--- a/packages/datadog_common_test/analysis_options.yaml
+++ b/packages/datadog_common_test/analysis_options.yaml
@@ -6,9 +6,11 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   strong-mode:
     implicit-dynamic: false
+  exclude:
+    - lib/**.g.dart
 
 linter:
   rules:
     prefer_single_quotes: true
     prefer_relative_imports: true
-    unawaited_futures: true
+    unawaited_futures: true 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -151,6 +151,16 @@ This works if you are using named routes or if you have supplied a name to the `
 
 Alternately, you can use the `DatadogRouteAwareMixin` property in conjunction with the `DatadogNavigationObserverProvider` property to start and stop your RUM views automatically. With `DatadogRouteAwareMixin`, move any logic from `initState` to `didPush`. 
 
+Note that, by default, `DatadogRouteAwareMixin` uses the name of the widget as the name of the View. However, this **does not work with obfuscated code** as the name of the Widget class is lost during obfuscation. To keep the correct view name, you should override `rumViewInfo`:
+```dart
+class _MyHomeScreenState extends State<MyHomeScreen>
+    with RouteAware, DatadogRouteAwareMixin {
+
+  @override
+  RumViewInfo get rumViewInfo => RumViewInfo(name: 'MyHomeScreen');
+}
+```
+
 ### Automatic Resource Tracking
 
 You can enable automatic tracking of resources and HTTP calls from your RUM views using the [Datadog Tracking HTTP Client][7] package. Add the package to your `pubspec.yaml`, and add the following to your initialization:

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -151,7 +151,7 @@ This works if you are using named routes or if you have supplied a name to the `
 
 Alternately, you can use the `DatadogRouteAwareMixin` property in conjunction with the `DatadogNavigationObserverProvider` property to start and stop your RUM views automatically. With `DatadogRouteAwareMixin`, move any logic from `initState` to `didPush`. 
 
-Note that, by default, `DatadogRouteAwareMixin` uses the name of the widget as the name of the View. However, this **does not work with obfuscated code** as the name of the Widget class is lost during obfuscation. To keep the correct view name, you should override `rumViewInfo`:
+Note that, by default, `DatadogRouteAwareMixin` uses the name of the widget as the name of the View. However, this **does not work with obfuscated code** as the name of the Widget class is lost during obfuscation. To keep the correct view name, override `rumViewInfo`:
 ```dart
 class _MyHomeScreenState extends State<MyHomeScreen>
     with RouteAware, DatadogRouteAwareMixin {

--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc.4"
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -122,8 +122,11 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>> {
 /// ```
 ///
 /// By default, DatadogRouteAwareMixin will use the name of its parent Widget as
-/// the name of the route. You can override this by overriding the [rumViewInfo]
-/// getter, as well as supply additional properties about the view.
+/// the name of the route, **but only when the code is not obfuscated**.
+///
+/// If you are obfuscating your final code, or if you want to provide a
+/// different name or additional view attributes, you should override the
+/// [rumViewInfo] getter.
 ///
 /// [DatadogNavigationObserver] uses the [didChangeDependencies] lifecycle
 /// method to start the RUM view. For this reason, you should avoid calling RUM

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0-rc.2"
+    version: "1.2.0"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
### What and why?

RouteAwareMixin is not able to get the class name of the Widget post deobfuscation, so I've added documentation to call that out.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests