### PR TITLE
👷 Set iOS podfiles to use git source directly

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
@@ -31,6 +31,12 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # Datadog Pod Overrides
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  # End Datadog Pod Overrides
+  
 end
 
 post_install do |installer|

--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -32,6 +32,11 @@ target 'Runner' do
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
+  # Datadog Pod Overrides
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  # End Datadog Pod Overrides
+
   target 'flutter_datadog_plugin_tests' do
     inherit! :search_paths
   end

--- a/packages/datadog_flutter_plugin/example/ios/Podfile.lock
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile.lock
@@ -12,19 +12,33 @@ PODS:
 
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
+  - DatadogSDK (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogSDKCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `Flutter`)
 
 SPEC REPOS:
   trunk:
-    - DatadogSDK
-    - DatadogSDKCrashReporting
     - PLCrashReporter
 
 EXTERNAL SOURCES:
   datadog_flutter_plugin:
     :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
+  DatadogSDK:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogSDKCrashReporting:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
   Flutter:
     :path: Flutter
+
+CHECKOUT OPTIONS:
+  DatadogSDK:
+    :commit: b52cf84f7b3dea8b93092f356fd3860ac0a4933e
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogSDKCrashReporting:
+    :commit: b52cf84f7b3dea8b93092f356fd3860ac0a4933e
+    :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: c9ec815b884e7e5b176ed697b05bf54d2bfa68b6
@@ -33,6 +47,6 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   PLCrashReporter: 2a08001f8e6a30abe405ee8f13d2753cfb5d682a
 
-PODFILE CHECKSUM: 60af4a72633bf3e7036827fe38cf2e8b94c2db28
+PODFILE CHECKSUM: a7c5531b308a33cd6677c17870954548143bea7c
 
 COCOAPODS: 1.11.3

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
@@ -31,6 +31,11 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # Datadog Pod Overrides
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  # End Datadog Pod Overrides
 end
 
 post_install do |installer|

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -94,7 +94,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             }
         case "telemetryDebug":
             if let message = arguments["message"] as? String {
-                Datadog._internal._telemtry.debug(id: "datadog_flutter:\(message)", message: message)
+                Datadog._internal._telemetry.debug(id: "datadog_flutter:\(message)", message: message)
                 result(nil)
             } else {
                 result(FlutterError.missingParameter(methodName: call.method))
@@ -103,7 +103,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             if let message = arguments["message"] as? String {
                 let stack = arguments["stack"] as? String
                 let kind = arguments["kind"] as? String
-                Datadog._internal._telemtry.error(id: "datadog_flutter:\(String(describing: kind)):\(message)",
+                Datadog._internal._telemetry.error(id: "datadog_flutter:\(String(describing: kind)):\(message)",
                                                   message: message, kind: kind, stack: stack)
                 result(nil)
             } else {

--- a/packages/datadog_tracking_http_client/example/ios/Podfile
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile
@@ -32,6 +32,11 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # Datadog Pod Overrides
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  # End Datadog Pod Overrides
 end
 
 post_install do |installer|

--- a/tools/releaser/lib/cocoapod_util.dart
+++ b/tools/releaser/lib/cocoapod_util.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:logging/src/logger.dart';
+import 'package:path/path.dart' as path;
+
+import 'command.dart';
+import 'helpers.dart';
+
+final overridesStartPattern = RegExp(r'\s+# Datadog Pod Overrides');
+final overridesEndPattern = RegExp(r'\s+# End Datadog Pod Overrides');
+final specDependencyPattern =
+    RegExp(r"\s+s\.dependency\s+'(?<dependency>Datadog.+)', '.+");
+
+class RemovePodOverridesCommand extends Command {
+  final podfileLocations = [
+    'packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile',
+    'packages/datadog_flutter_plugin/example/ios/Podfile',
+    'packages/datadog_flutter_plugin/integration_test_app/ios/Podfile',
+    'packages/datadog_tracking_http_client/example/ios/Podfile',
+  ];
+
+  final podspecLocation =
+      'packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec';
+
+  @override
+  Future<bool> run(CommandArguments args, Logger logger) async {
+    if (!await _removePodfileOverrides(args, logger)) {
+      return false;
+    }
+
+    if (!await _pinPodspecVersion(args, logger)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  Future<bool> _removePodfileOverrides(
+      CommandArguments args, Logger logger) async {
+    logger.info('ℹ️ Removing overrides from Podfiles.');
+    for (var filePath in podfileLocations) {
+      final file = File(path.join(args.gitDir.path, filePath));
+      if (!file.existsSync()) {
+        logger.shout('❌ Could not find file $filePath');
+        return false;
+      }
+
+      bool removingLines = false;
+      logger.fine('-- ℹ️ Removing overrides from $filePath');
+      await transformFile(file, logger, args.dryRun, (element) {
+        if (removingLines && element.startsWith(overridesEndPattern)) {
+          removingLines = false;
+          // Remove the end pattern line
+          return null;
+        } else if (element.startsWith(overridesStartPattern)) {
+          removingLines = true;
+        }
+
+        return removingLines ? null : element;
+      });
+    }
+
+    return true;
+  }
+
+  Future<bool> _pinPodspecVersion(CommandArguments args, Logger logger) async {
+    logger.info('ℹ️ Setting the iOS Pod Dependency to ${args.iOSRelease}');
+
+    final file = File(path.join(args.gitDir.path, podspecLocation));
+    if (!file.existsSync()) {
+      logger.shout('❌ Could not find file $podspecLocation');
+      return false;
+    }
+
+    await transformFile(file, logger, args.dryRun, (element) {
+      final match = specDependencyPattern.firstMatch(element);
+      if (match != null) {
+        element =
+            "  s.dependency '${match.namedGroup('dependency')}', '${args.iOSRelease}'";
+      }
+      return element;
+    });
+
+    return true;
+  }
+}

--- a/tools/releaser/lib/command.dart
+++ b/tools/releaser/lib/command.dart
@@ -21,6 +21,9 @@ class CommandArguments {
   // The version we're releasing
   final String version;
 
+  // The release of the iOS SDK we want this release to refer to
+  String? iOSRelease;
+
   // Whether we're doing a dry run
   final bool dryRun;
 
@@ -30,6 +33,7 @@ class CommandArguments {
     required this.gitDir,
     required this.skipGitChecks,
     required this.version,
+    required this.iOSRelease,
     required this.dryRun,
   });
 }

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -95,10 +95,12 @@ packages:
   github:
     dependency: "direct main"
     description:
-      name: github
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "9.0.1"
+      path: "."
+      ref: "feature/comparison-commits"
+      resolved-ref: b1319158e11481a56569705a78b8e5393cde7770
+      url: "git@github.com:fuzzybinary/github.dart.git"
+    source: git
+    version: "9.4.0"
   glob:
     dependency: transitive
     description:
@@ -112,7 +114,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -1,6 +1,7 @@
 name: releaser
 description: A simple command-line application.
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: '>=2.16.1 <3.0.0'
@@ -10,7 +11,10 @@ dependencies:
   logging: ^1.0.2
   path: ^1.8.0
   git: ^2.0.0
-  github: ^9.0.0
+  github:
+    git:
+         url: git@github.com:fuzzybinary/github.dart.git
+         ref: feature/comparison-commits
   version: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

So that we can more quickly iterate on features in the Flutter SDK, we're going to start relying on iOS source directly instead of pinned Pod versions. This is done in the Podfiles of the individual projects, similarly to the `dependency_overrides` in the Flutter pubspec.yaml

As part of the release process, we remove the overrides from all the Podfiles and pin the spec to the most recently released version.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests