### PR TITLE
👷 Modify in dev podspec to be looser with version numbers

### DIFF
--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
@@ -16,8 +16,8 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'DatadogSDK', '1.12.0'
-  s.dependency 'DatadogSDKCrashReporting', '1.12.0'
+  s.dependency 'DatadogSDK', '~> 1'
+  s.dependency 'DatadogSDKCrashReporting', '~> 1'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
### What and why?

For the dependency resolution to work properly, we need the podspec to be very permissive with what versions it supports. For now, allow any 1.x version.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests