### PR TITLE
✨ Support long tasks and http tracking for attachToExisting

### DIFF
--- a/examples/native-hybrid-app/README.md
+++ b/examples/native-hybrid-app/README.md
@@ -4,7 +4,7 @@ This example covers how to use the Datadog Flutter SDK in conjunction with an al
 
 ## Native App is Primary and Datadog is Already Initialized -  `attachToExisting`
 
-If you are using an applicaiton that is already using the native Datadog iOS or Datadog Android SDKs, the Flutter SDK can attach to these using the same parameters. In your `main` function, after calling `WidgetsFlutterBinding.ensureInitialized`, call `DatadogSdk.instance.attachToExisting`. You can optionally add a `LoggingConfiguraiton` to this call, which automatically creates a global logger and attaches it to `DatadogSdk.logs`.
+If you are using an application that is already using the native Datadog iOS or Datadog Android SDKs, the Flutter SDK can attach to these using the same parameters. In your `main` function, after calling `WidgetsFlutterBinding.ensureInitialized`, call `DatadogSdk.instance.attachToExisting`. You can optionally add a `LoggingConfiguraiton` to this call, which automatically creates a global logger and attaches it to `DatadogSdk.logs`.
 
 ```dart
 void main() async {
@@ -19,6 +19,8 @@ void main() async {
   runApp(MyApp());
 }
 ```
+
+Additional options for `DdSdkExistingConfiguration` are documented in the [API reference](https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/datadog_flutter_plugin-library.html). Note that options in this class need to be re-specified even if they are already passed during Native SDK initialization.
 
 ### Prewarmed and Cached Flutter Engines
 The Flutter documentation on adding Flutter to an existing app for iOS uses a "prewarmed" Flutter engine by default (see [Create a FlutterEngine](https://docs.flutter.dev/development/add-to-app/ios/add-flutter-screen#create-a-flutterengine)) whereas the Android example does not (see [Launch a FlutterActivity](https://docs.flutter.dev/development/add-to-app/android/add-flutter-screen?tab=default-activity-launch-kotlin-tab#step-2-launch-flutteractivity)).

--- a/examples/native-hybrid-app/README.md
+++ b/examples/native-hybrid-app/README.md
@@ -10,7 +10,11 @@ If you are using an applicaiton that is already using the native Datadog iOS or 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await DatadogSdk.instance.attachToExisting();
+  final config = DdSdkExistingConfiguration(
+    loggingConfiguration: LoggingConfiguration()
+  );
+
+  await DatadogSdk.instance.attachToExisting(config);
 
   runApp(MyApp());
 }

--- a/examples/native-hybrid-app/flutter_module/lib/main.dart
+++ b/examples/native-hybrid-app/flutter_module/lib/main.dart
@@ -3,6 +3,7 @@
 // Copyright 2022-Present Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
 import 'package:flutter/material.dart';
 
 import 'my_app.dart';
@@ -10,7 +11,12 @@ import 'my_app.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await DatadogSdk.instance.attachToExisting();
+  final config = DdSdkExistingConfiguration(
+    loggingConfiguration: LoggingConfiguration(),
+    detectLongTasks: true,
+  )..enableHttpTracking();
+
+  await DatadogSdk.instance.attachToExisting(config);
 
   runApp(MyApp());
 }

--- a/examples/native-hybrid-app/flutter_module/pubspec.lock
+++ b/examples/native-hybrid-app/flutter_module/pubspec.lock
@@ -57,6 +57,13 @@ packages:
       relative: true
     source: path
     version: "1.1.0"
+  datadog_tracking_http_client:
+    dependency: "direct main"
+    description:
+      path: "../../../packages/datadog_tracking_http_client"
+      relative: true
+    source: path
+    version: "1.2.0"
   fake_async:
     dependency: transitive
     description:
@@ -93,6 +100,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.5"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.5"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.2"
   js:
     dependency: transitive
     description:

--- a/examples/native-hybrid-app/flutter_module/pubspec.yaml
+++ b/examples/native-hybrid-app/flutter_module/pubspec.yaml
@@ -15,12 +15,18 @@ dependencies:
   go_router:  ^5.0.5
   datadog_flutter_plugin:
     path: ../../../packages/datadog_flutter_plugin
+  datadog_tracking_http_client:
+    path: ../../../packages/datadog_tracking_http_client
+  http: ^0.13.5
+
+dependency_overrides:
+  datadog_flutter_plugin:
+    path: ../../../packages/datadog_flutter_plugin
   
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.0
-
 
 flutter:
   uses-material-design: true

--- a/examples/native-hybrid-app/ios/Podfile
+++ b/examples/native-hybrid-app/ios/Podfile
@@ -10,6 +10,11 @@ target 'iOS Flutter Hybrid Example' do
 
   install_all_flutter_pods(flutter_application_path)
   # Pods for iOS Flutter Hybrid Example  
+  
+  # Datadog Pod Overrides
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  # End Datadog Pod Overrides
 end
 
 post_install do |installer|

--- a/examples/native-hybrid-app/ios/Podfile.lock
+++ b/examples/native-hybrid-app/ios/Podfile.lock
@@ -1,45 +1,66 @@
 PODS:
   - datadog_flutter_plugin (0.0.1):
-    - DatadogSDK (= 1.12.0)
-    - DatadogSDKCrashReporting (= 1.12.0)
+    - DatadogSDK (~> 1)
+    - DatadogSDKCrashReporting (~> 1)
     - Flutter
-  - DatadogSDK (1.12.0)
-  - DatadogSDKCrashReporting (1.12.0):
-    - DatadogSDK (= 1.12.0)
-    - PLCrashReporter (~> 1.10.1)
+  - DatadogSDK (1.12.1)
+  - DatadogSDKCrashReporting (1.12.1):
+    - DatadogSDK (= 1.12.1)
+    - PLCrashReporter (~> 1.11.0)
   - Flutter (1.0.0)
   - FlutterPluginRegistrant (0.0.1):
     - datadog_flutter_plugin
     - Flutter
-  - PLCrashReporter (1.10.2)
+    - thaw
+  - PLCrashReporter (1.11.0)
+  - thaw (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - datadog_flutter_plugin (from `../flutter_module/.ios/.symlinks/plugins/datadog_flutter_plugin/ios`)
+  - DatadogSDK (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogSDKCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `../flutter_module/.ios/Flutter`)
   - FlutterPluginRegistrant (from `../flutter_module/.ios/Flutter/FlutterPluginRegistrant`)
+  - thaw (from `../flutter_module/.ios/.symlinks/plugins/thaw/ios`)
 
 SPEC REPOS:
   trunk:
-    - DatadogSDK
-    - DatadogSDKCrashReporting
     - PLCrashReporter
 
 EXTERNAL SOURCES:
   datadog_flutter_plugin:
     :path: "../flutter_module/.ios/.symlinks/plugins/datadog_flutter_plugin/ios"
+  DatadogSDK:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogSDKCrashReporting:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
   Flutter:
     :path: "../flutter_module/.ios/Flutter"
   FlutterPluginRegistrant:
     :path: "../flutter_module/.ios/Flutter/FlutterPluginRegistrant"
+  thaw:
+    :path: "../flutter_module/.ios/.symlinks/plugins/thaw/ios"
+
+CHECKOUT OPTIONS:
+  DatadogSDK:
+    :commit: b08780c61c807e8f09696a0b7b21e4ec3e898a4a
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogSDKCrashReporting:
+    :commit: b08780c61c807e8f09696a0b7b21e4ec3e898a4a
+    :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: c9ec815b884e7e5b176ed697b05bf54d2bfa68b6
-  DatadogSDK: 176291d7422a1f96c8e69793a88b5b72cb0959cb
-  DatadogSDKCrashReporting: 505df234595ec89966608363c0437294b4c42820
+  datadog_flutter_plugin: aca1a089d6704f87468365c91dd7273bbdc48acf
+  DatadogSDK: 7bf8d43caa4a8b2ec633c261eb71155e71ed97d6
+  DatadogSDKCrashReporting: b12615817e5dc5d0973334f02d6cf78b63bc8c20
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  FlutterPluginRegistrant: d73654fcefcfea6fa9400fb38046c4eb01f4955e
-  PLCrashReporter: 2a08001f8e6a30abe405ee8f13d2753cfb5d682a
+  FlutterPluginRegistrant: 47f83dd3ba8571af5b2f7ba71f42c4a868625fb8
+  PLCrashReporter: 7a9dff14a23ba5d2e28c6160f0bb6fada5e71a8d
+  thaw: 3b4ea6568cd30b9c81a5eacbcb52c59949a3e3ee
 
-PODFILE CHECKSUM: 865b9a543350785fd4f7ef467bf48746ff5e890d
+PODFILE CHECKSUM: ebf9772950d27696f084b7ee93c3ae111d9205bc
 
 COCOAPODS: 1.11.3

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Add methods for attaching to existing instances of the DatadogSdk for "add-to-app" scenarios.
+
+## 1.0.1
+
 * Update Android SDK to 1.14.1
   * Add CPU architecture to the collected device information.
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_plugin.dart
@@ -17,4 +17,5 @@ abstract class DatadogPlugin {
   DatadogPlugin(this.instance);
 
   void initialize();
+  void shutdown() {}
 }

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add methods for enabling the DatadogTrackingHttpClient in add-to-app scenarios.
+
 ## 1.1.0
 
 * Minor documentation update to clarify 1.1.x / 1.0.x changes

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -4,7 +4,8 @@
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 
-import 'src/tracking_http_client_plugin.dart';
+import 'src/tracking_http_client_plugin.dart'
+    show DdHttpTrackingPluginConfiguration;
 
 export 'src/tracking_http_client.dart';
 
@@ -27,6 +28,23 @@ extension TrackingExtension on DdSdkConfiguration {
   /// If both RUM and Tracing features are enabled, the SDK will be sending RUM
   /// Resources for 1st- and 3rd-party requests and tracing Spans for
   /// 1st-parties.
+  ///
+  /// See also [firstPartyHosts]
+  void enableHttpTracking() {
+    addPlugin(DdHttpTrackingPluginConfiguration());
+  }
+}
+
+extension TrackingExtensionExisting on DdSdkExistingConfiguration {
+  /// Configures network requests monitoring for Tracing and RUM features.
+  ///
+  /// If enabled, the SDK will override [HttpClient] creation (via
+  /// [HttpOverrides]) to provide its own implementation. For more information,
+  /// check the documentation on [DatadogTrackingHttpClient]
+  ///
+  /// If the RUM feature is enabled, the SDK will send RUM Resources for all
+  /// intercepted requests, along with generated spans for requests to first
+  /// part hosts.
   ///
   /// See also [firstPartyHosts]
   void enableHttpTracking() {


### PR DESCRIPTION
### What and why?

Additional configuration options are needed to support features that are implemented only in Dart / don't share information with Native code. This includes whether to perform longTask detection for Dart, and the long task threshold, as well as `firstPartyHosts` and http tracking.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests