### PR TITLE
👷 Support working from Android Snapshot builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -77,6 +77,8 @@ workflows:
             set -e
             ./generate_env.sh
 
+            pod repo update
+
             pushd packages/datadog_common_test
             flutter pub run build_runner build
             popd          

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,11 +9,10 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_sdk_version = "1.14.1"
+    ext.datadog_sdk_version = "1+"
     repositories {
         google()
         mavenCentral()
-
     }
 
     dependencies {
@@ -27,6 +26,9 @@ rootProject.allprojects {
         google()
         mavenCentral()
         maven { url("https://jitpack.io") }
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 }
 

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -77,6 +77,8 @@ flutter {
 }
 
 dependencies {
+    implementation "com.datadoghq:dd-sdk-android:$datadog_sdk_version"
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.work:work-runtime-ktx:2.7.0'
 }

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -77,8 +77,6 @@ flutter {
 }
 
 dependencies {
-    implementation "com.datadoghq:dd-sdk-android:1.12.0-alpha2"
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.work:work-runtime-ktx:2.7.0'
 }

--- a/packages/datadog_flutter_plugin/example/android/app/src/main/kotlin/com/datadoghq/example/flutter/MainActivity.kt
+++ b/packages/datadog_flutter_plugin/example/android/app/src/main/kotlin/com/datadoghq/example/flutter/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : FlutterActivity() {
             "performCallback" -> {
                 val callbackId = call.argument<Int>("callbackId")
 
-                val result = object : MethodChannel.Result {
+                val callbackResult = object : MethodChannel.Result {
                     override fun error(
                         errorCode: String,
                         errorMessage: String?,
@@ -71,7 +71,7 @@ class MainActivity : FlutterActivity() {
                         "callbackId" to callbackId,
                         "callbackValue" to "Value String"
                     ),
-                    result
+                    callbackResult
                 )
             }
         }

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -6,6 +6,8 @@
 
 buildscript {
     ext.kotlin_version = '1.5.31'
+    ext.datadog_sdk_version = '1+'
+
     repositories {
         google()
         mavenCentral()

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -26,6 +26,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -373,8 +373,8 @@ class DdSdkConfiguration {
     this.loggingConfiguration,
     this.rumConfiguration,
   }) {
-    // Transfer customEndpoint to other properties if they're not set ignore:
-    // deprecated_member_use_from_same_package
+    // Transfer customEndpoint to other properties if they're not set
+    // ignore: deprecated_member_use_from_same_package
     if (customEndpoint != null) {
       // ignore: deprecated_member_use_from_same_package
       customLogsEndpoint ??= customEndpoint;

--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as path;
 import 'package:releaser/cocoapod_util.dart';
 import 'package:releaser/command.dart';
 import 'package:releaser/git_actions.dart';
+import 'package:releaser/gradle_util.dart';
 import 'package:releaser/helpers.dart';
 import 'package:releaser/release_validator.dart';
 import 'package:releaser/version_updater.dart';
@@ -31,6 +32,10 @@ void main(List<String> arguments) async {
     ..addOption(
       'ios-version',
       help: 'Explicitly set the iOS release this release will target',
+    )
+    ..addOption(
+      'android-version',
+      help: 'Explicitly set the Android release this release will target',
     )
     ..addFlag(
       'dry-run',
@@ -102,14 +107,13 @@ void main(List<String> arguments) async {
     CreateReleaseBranchCommand(),
     RemoveDependencyOverridesCommand(),
     RemovePodOverridesCommand(),
+    UpdateGradleFilesCommand(),
     CommitChangesCommand(
       '🧹 Remove dependency overrides for release of ${commandArgs.packageName} ${commandArgs.version}.',
       noChangesOkay: true,
     ),
     ValidatePublishDryRun(),
     SwitchBranchCommand(choreBranch),
-    // Do pre-release always for now. Later use the branch name as
-    // the indicator.
     BumpVersionCommand(versionBumpType),
     CommitChangesCommand(
         '📝 Bump version of ${commandArgs.packageName} to next potential release.'),
@@ -145,6 +149,7 @@ Future<CommandArguments?> _validateArguments(ArgResults argResults) async {
     skipGitChecks: skipGitChecks,
     version: version,
     iOSRelease: argResults['ios-version'],
+    androidRelease: argResults['android-version'],
     dryRun: dryRun,
   );
 }

--- a/tools/releaser/lib/command.dart
+++ b/tools/releaser/lib/command.dart
@@ -24,6 +24,9 @@ class CommandArguments {
   // The release of the iOS SDK we want this release to refer to
   String? iOSRelease;
 
+  // The release of the iOS SDK we want this release to refer to
+  String? androidRelease;
+
   // Whether we're doing a dry run
   final bool dryRun;
 
@@ -34,6 +37,7 @@ class CommandArguments {
     required this.skipGitChecks,
     required this.version,
     required this.iOSRelease,
+    required this.androidRelease,
     required this.dryRun,
   });
 }

--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:logging/src/logger.dart';
+import 'package:path/path.dart' as path;
+
+import 'command.dart';
+import 'helpers.dart';
+
+class UpdateGradleFilesCommand extends Command {
+  static const versionPrefix = 'ext.datadog_sdk_version';
+
+  final versionRegex = RegExp('\\s+$versionPrefix = "(.*)"');
+  final gradleFileLocations = [
+    'packages/datadog_flutter_plugin/android/build.gradle',
+    'packages/datadog_flutter_plugin/example/android/build.gradle',
+  ];
+
+  @override
+  Future<bool> run(CommandArguments args, Logger logger) async {
+    for (var filePath in gradleFileLocations) {
+      final file = File(path.join(args.gitDir.path, filePath));
+      if (!file.existsSync()) {
+        logger.shout('❌ Could not find file $filePath');
+        return false;
+      }
+
+      // IF we see a maven block, hold onto it until we know if it's
+      // one we want to keep or remove
+      final mavenBlock = StringBuffer();
+      bool inMavenBlock = false;
+      bool writeMavenBlock = true;
+      await transformFile(file, logger, args.dryRun, (line) {
+        final versionMatch = versionRegex.firstMatch(line);
+        if (versionMatch != null) {
+          final oldVersion = versionMatch.group(1);
+          line = line.replaceFirst('$versionPrefix = "$oldVersion"',
+              '$versionPrefix = "${args.androidRelease}"');
+        }
+
+        if (line.contains('maven ')) {
+          inMavenBlock = true;
+        }
+
+        if (inMavenBlock) {
+          mavenBlock.writeln(line);
+          if (line.contains('url') && line.contains('/snapshots/')) {
+            // this is a request for a snapshots maven repo. Don't write it to the final file
+            writeMavenBlock = false;
+          }
+          if (line.contains('}')) {
+            inMavenBlock = false;
+            if (writeMavenBlock) {
+              line = mavenBlock.toString();
+            } else {
+              line = '';
+            }
+
+            // Reset to default values
+            mavenBlock.clear();
+            writeMavenBlock = true;
+
+            return line;
+          }
+          return null;
+        }
+
+        return line;
+      });
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
### What and why?

So that we can more quickly iterate on features in the Flutter SDK, we're going to start relying SNAPSHOT builds of the Android SDK instead of only released versions.

As part of the release process, we pin to the last released version of the Android SDK and remove the sonatype snapshot repository from the gradle files.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests