### PR TITLE
⬆️ Update github dependency for releaser tool

### DIFF
--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -95,12 +95,10 @@ packages:
   github:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "feature/comparison-commits"
-      resolved-ref: b1319158e11481a56569705a78b8e5393cde7770
-      url: "git@github.com:fuzzybinary/github.dart.git"
-    source: git
-    version: "9.4.0"
+      name: github
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.5.0"
   glob:
     dependency: transitive
     description:

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -11,10 +11,7 @@ dependencies:
   logging: ^1.0.2
   path: ^1.8.0
   git: ^2.0.0
-  github:
-    git:
-         url: git@github.com:fuzzybinary/github.dart.git
-         ref: feature/comparison-commits
+  github: ^9.5.0
   version: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

The Dart Github library added `commits` to their official release. Prior to this I had added it onto a fork. This upgrades us to an official release instead of using my fork.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests