### PR TITLE
✨ Add performance metric tracking

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -129,8 +129,45 @@ class RumEventDecoder {
   }
 }
 
+class Vital {
+  final double minTime;
+  final double maxTime;
+  final double avgTime;
+
+  Vital({
+    required this.minTime,
+    required this.maxTime,
+    required this.avgTime,
+  });
+}
+
 class RumViewEventDecoder extends RumEventDecoder {
   int get timeSpent => rumEvent['view']['time_spent'] as int;
+  Vital? get flutterRasterTime {
+    final rasterTime =
+        rumEvent['view']['flutter_raster_time'] as Map<String, Object?>?;
+    if (rasterTime != null) {
+      return Vital(
+        minTime: rasterTime['min'] as double,
+        maxTime: rasterTime['max'] as double,
+        avgTime: rasterTime['average'] as double,
+      );
+    }
+    return null;
+  }
+
+  Vital? get flutterBuildTime {
+    final buildTime =
+        rumEvent['view']['flutter_build_time'] as Map<String, Object?>?;
+    if (buildTime != null) {
+      return Vital(
+        minTime: buildTime['min'] as double,
+        maxTime: buildTime['max'] as double,
+        avgTime: buildTime['average'] as double,
+      );
+    }
+    return null;
+  }
 
   RumViewEventDecoder(Map<String, dynamic> rumEvent) : super(rumEvent);
 }

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -238,18 +238,7 @@ class DatadogRumPlugin(
                     val buildTimes = call.argument<List<Double>>(PARAM_BUILD_TIMES)
                     val rasterTimes = call.argument<List<Double>>(PARAM_RASTER_TIMES)
                     if(buildTimes != null && rasterTimes != null) {
-                        buildTimes.forEach {
-                            rum?._getInternal()?.updatePerformanceMetric(
-                                RumPerformanceMetric.FLUTTER_BUILD_TIME,
-                                it
-                            )
-                        }
-                        rasterTimes.forEach {
-                            rum?._getInternal()?.updatePerformanceMetric(
-                                RumPerformanceMetric.FLUTTER_RASTER_TIME,
-                                it
-                            )
-                        }
+                        updatePerformanceMetrics(buildTimes, rasterTimes)
                         result.success(null)
                     } else {
                         result.missingParameter(call.method)
@@ -265,6 +254,24 @@ class DatadogRumPlugin(
                 mapOf(
                     "methodName" to call.method
                 )
+            )
+        }
+    }
+
+    private fun updatePerformanceMetrics(
+        buildTimes: List<Double>,
+        rasterTimes: List<Double>
+    ) {
+        buildTimes.forEach {
+            rum?._getInternal()?.updatePerformanceMetric(
+                RumPerformanceMetric.FLUTTER_BUILD_TIME,
+                it
+            )
+        }
+        rasterTimes.forEach {
+            rum?._getInternal()?.updatePerformanceMetric(
+                RumPerformanceMetric.FLUTTER_RASTER_TIME,
+                it
             )
         }
     }

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -9,6 +9,7 @@ import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -35,6 +36,8 @@ class DatadogRumPlugin(
         const val PARAM_SOURCE = "source"
         const val PARAM_STACK_TRACE = "stackTrace"
         const val PARAM_TYPE = "type"
+        const val PARAM_BUILD_TIMES = "buildTimes"
+        const val PARAM_RASTER_TIMES = "rasterTimes"
     }
 
     private lateinit var channel: MethodChannel
@@ -226,6 +229,27 @@ class DatadogRumPlugin(
                         // Duration is in ms, convert to ns
                         val durationNs = TimeUnit.MILLISECONDS.toNanos(duration.toLong())
                         rum?._getInternal()?.addLongTask(durationNs, "")
+                        result.success(null)
+                    } else {
+                        result.missingParameter(call.method)
+                    }
+                }
+                "updatePerformanceMetrics" -> {
+                    val buildTimes = call.argument<List<Double>>(PARAM_BUILD_TIMES)
+                    val rasterTimes = call.argument<List<Double>>(PARAM_RASTER_TIMES)
+                    if(buildTimes != null && rasterTimes != null) {
+                        buildTimes.forEach {
+                            rum?._getInternal()?.updatePerformanceMetric(
+                                RumPerformanceMetric.FLUTTER_BUILD_TIME,
+                                it
+                            )
+                        }
+                        rasterTimes.forEach {
+                            rum?._getInternal()?.updatePerformanceMetric(
+                                RumPerformanceMetric.FLUTTER_RASTER_TIME,
+                                it
+                            )
+                        }
                         result.success(null)
                     } else {
                         result.missingParameter(call.method)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ContractHelpers.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ContractHelpers.kt
@@ -58,7 +58,7 @@ data class Contract(
         return when(type) {
             SupportedContractType.STRING -> forge.anExtendedAsciiString()
             SupportedContractType.MAP -> forge.exhaustiveAttributes()
-            SupportedContractType.LIST -> forge.aList(0) {}
+            SupportedContractType.LIST -> emptyList<Any>()
             SupportedContractType.INT -> forge.anInt()
             SupportedContractType.LONG -> forge.aLong()
         }

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ContractHelpers.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ContractHelpers.kt
@@ -16,6 +16,7 @@ import kotlin.reflect.KType
 enum class SupportedContractType {
     STRING,
     MAP,
+    LIST,
     INT,
     LONG
 }
@@ -57,6 +58,7 @@ data class Contract(
         return when(type) {
             SupportedContractType.STRING -> forge.anExtendedAsciiString()
             SupportedContractType.MAP -> forge.exhaustiveAttributes()
+            SupportedContractType.LIST -> forge.aList(0) {}
             SupportedContractType.INT -> forge.anInt()
             SupportedContractType.LONG -> forge.aLong()
         }

--- a/packages/datadog_flutter_plugin/example/ios/Podfile.lock
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - datadog_flutter_plugin (0.0.1):
-    - DatadogSDK (= 1.12.0)
-    - DatadogSDKCrashReporting (= 1.12.0)
+    - DatadogSDK (~> 1)
+    - DatadogSDKCrashReporting (~> 1)
     - Flutter
   - DatadogSDK (1.12.0)
   - DatadogSDKCrashReporting (1.12.0):
@@ -41,7 +41,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: c9ec815b884e7e5b176ed697b05bf54d2bfa68b6
+  datadog_flutter_plugin: aca1a089d6704f87468365c91dd7273bbdc48acf
   DatadogSDK: 176291d7422a1f96c8e69793a88b5b72cb0959cb
   DatadogSDKCrashReporting: 505df234595ec89966608363c0437294b4c42820
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854

--- a/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
@@ -11,6 +11,7 @@ enum SupportedContractType {
     case int
     case int64
     case map
+    case list
 
     func createOfType() -> Any {
         switch self {
@@ -18,6 +19,7 @@ enum SupportedContractType {
         case .int: return 1_234
         case .int64: return 1_223_455_123
         case .map: return ["key to": "value"]
+        case .list: return []
         }
     }
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_auto_instrumentation_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_auto_instrumentation_test.dart
@@ -79,23 +79,31 @@ void main() {
 
     final view1 = session.visits[0];
     expect(view1.name, '/');
-    // Path is the actual browser path in web
     if (!kIsWeb) {
+      // Path is the actual browser path in web
       expect(view1.path, '/');
+
+      // Web doesn't support performance metrics
+      expect(view1.viewEvents.last.flutterBuildTime, isNotNull);
+      expect(view1.viewEvents.last.flutterRasterTime, isNotNull);
     }
 
     final view2 = session.visits[1];
     expect(view2.name, 'rum_second_screen');
-    // Path is the actual browser path in web
     if (!kIsWeb) {
+      // Path is the actual browser path in web
       expect(view2.path, 'rum_second_screen');
+
+      // Web doesn't support performance metrics
+      expect(view2.viewEvents.last.flutterBuildTime, isNotNull);
+      expect(view2.viewEvents.last.flutterRasterTime, isNotNull);
     }
 
     // Check last view name
     final view3 = session.visits[2];
     expect(view3.name, 'RumAutoInstrumentationThirdScreen');
-    // Path is the actual browser path in web
     if (!kIsWeb) {
+      // Path is the actual browser path in web
       expect(view3.path, 'RumAutoInstrumentationThirdScreen');
     }
   });

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/main.dart
@@ -59,6 +59,7 @@ Future<void> main() async {
     rumConfiguration: applicationId != null
         ? RumConfiguration(
             applicationId: applicationId,
+            reportFlutterPerformance: true,
             customEndpoint: customEndpoint,
           )
         : null,

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -234,6 +234,21 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                     FlutterError.missingParameter(methodName: call.method)
                 )
             }
+        case "updatePerformanceMetrics":
+            if let buildTimes = arguments["buildTimes"] as? Array<Double>,
+               let rasterTimes = arguments["rasterTimes"] as? Array<Double> {
+                buildTimes.forEach { val in
+                    rum.updatePerformanceMetric(metric: .flutterBuildTime, value: val)
+                }
+                rasterTimes.forEach { val in
+                    rum.updatePerformanceMetric(metric: .flutterRasterTime, value: val)
+                }
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -209,6 +209,16 @@ class RumConfiguration {
   /// Defaults to 0.1 seconds
   double longTaskThreshold;
 
+  /// Whether to report Flutter specific performance metrics (build and raster
+  /// times)
+  ///
+  /// This uses the [SchedulerBinding.addTimingsCallback] method to report build
+  /// and raster times for views, and has a documented negligible impact on
+  /// performance.
+  ///
+  /// Defaults to false
+  bool reportFlutterPerformance = false;
+
   /// Use a custom endpoint for sending RUM data.
   String? customEndpoint;
 
@@ -218,6 +228,7 @@ class RumConfiguration {
     double tracingSamplingRate = 20.0,
     this.detectLongTasks = true,
     double longTaskThreshold = 0.1,
+    this.reportFlutterPerformance = false,
     this.customEndpoint,
   })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
         tracingSamplingRate = max(0, min(tracingSamplingRate, 100)),
@@ -232,6 +243,7 @@ class RumConfiguration {
     this.detectLongTasks = true,
     this.longTaskThreshold = 0.1,
     this.tracingSamplingRate = 20.0,
+    this.reportFlutterPerformance = false,
   })  : applicationId = '<unknown>',
         sessionSamplingRate = 100.0;
 
@@ -241,6 +253,7 @@ class RumConfiguration {
       'sampleRate': sessionSamplingRate,
       'detectLongTasks': detectLongTasks,
       'longTaskThreshold': longTaskThreshold,
+      'reportFlutterPerformance': reportFlutterPerformance,
       'customEndpoint': customEndpoint,
     };
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -147,4 +147,13 @@ class DdRumMethodChannel extends DdRumPlatform {
       'duration': durationMs,
     });
   }
+
+  @override
+  Future<void> updatePerformanceMetrics(
+      List<double> buildTimes, List<double> rasterTimes) {
+    return methodChannel.invokeMethod('updatePerformanceMetrics', {
+      'buildTimes': buildTimes,
+      'rasterTimes': rasterTimes,
+    });
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -51,4 +51,6 @@ abstract class DdRumPlatform extends PlatformInterface {
   Future<void> removeAttribute(String key);
 
   Future<void> reportLongTask(DateTime at, int durationMs);
+  Future<void> updatePerformanceMetrics(
+      List<double> buildTimes, List<double> rasterTimes);
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -125,6 +125,12 @@ class DdRumWeb extends DdRumPlatform {
   Future<void> reportLongTask(DateTime at, int durationMs) async {
     // NOOP - The browser SDK will report this automatically
   }
+
+  @override
+  Future<void> updatePerformanceMetrics(
+      List<double> buildTimes, List<double> rasterTimes) async {
+    // NOOP - Not supported by the Browser SDK
+  }
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -273,4 +273,15 @@ void main() {
       }),
     ]);
   });
+
+  test('updatePerformanceMetrics calls to platform', () async {
+    await ddRumPlatform.updatePerformanceMetrics([0.2, 0.3], [0.11, 0.25]);
+
+    expect(log, [
+      isMethodCall('updatePerformanceMetrics', arguments: {
+        'buildTimes': [0.2, 0.3],
+        'rasterTimes': [0.11, 0.25],
+      }),
+    ]);
+  });
 }


### PR DESCRIPTION
### What and why?

Add a configuration option, `reportFlutterPerformance` that uses `SchedulerBinding.addTimingsCallback` to report build and raster times for views. These are sent to Datadog as "performance metrics" for each view.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests