### PR TITLE
💚 Fix an underspecified unit test.

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -235,7 +235,9 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCallB, mockResultB)
 
         // THEN
-        io.mockk.verify(exactly = 0) { Log.println(any(), any(), any()) }
+        io.mockk.verify(exactly = 0) {
+            Log.println(any(), eq(DATADOG_FLUTTER_TAG), any())
+        }
     }
 
     @Test


### PR DESCRIPTION
### What and why?

The configuration check unit test looked for any log message, which broke when we added a deprecation warning. Now it just checks for warnings from the Flutter plugin.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests