### PR TITLE
👷 Switch to Gradle Version Catalogs for Android builds

### DIFF
--- a/examples/native-hybrid-app/android/app/build.gradle
+++ b/examples/native-hybrid-app/android/app/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
     implementation 'androidx.navigation:navigation-ui-ktx:2.4.1'
-    implementation 'com.datadoghq:dd-sdk-android:1.14.1'
+    implementation libs.datadog.sdk.android
     implementation project(':flutter')
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/examples/native-hybrid-app/android/settings.gradle
+++ b/examples/native-hybrid-app/android/settings.gradle
@@ -13,7 +13,14 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url "https://storage.googleapis.com/download.flutter.io" }
     }
+
+    versionCatalogs {
+        libs {
+            from(files('../../../packages/datadog_flutter_plugin/android/datadog_version.toml'))
+        }
+    }
 }
+
 rootProject.name = "Datadog Flutter Hybrid Example"
 include ':app'
 setBinding(new Binding([gradle: this]))

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,7 +9,6 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_sdk_version = "1+"
     repositories {
         google()
         mavenCentral()
@@ -62,8 +61,8 @@ android {
 }
 
 dependencies {
-    implementation "com.datadoghq:dd-sdk-android:$datadog_sdk_version"
-    implementation "com.datadoghq:dd-sdk-android-ndk:$datadog_sdk_version"
+    implementation libs.datadog.sdk.android
+    implementation libs.datadog.sdk.android.ndk
     
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 

--- a/packages/datadog_flutter_plugin/android/datadog_version.toml
+++ b/packages/datadog_flutter_plugin/android/datadog_version.toml
@@ -1,0 +1,6 @@
+[versions]
+datadog-android = "1+"
+
+[libraries]
+datadog-sdk-android = { module = "com.datadoghq:dd-sdk-android", version.ref = "datadog-android" }
+datadog-sdk-android-ndk = { module = "com.datadoghq:dd-sdk-android-ndk", version.ref = "datadog.android" }

--- a/packages/datadog_flutter_plugin/android/settings.gradle
+++ b/packages/datadog_flutter_plugin/android/settings.gradle
@@ -5,3 +5,12 @@
  */
 
 rootProject.name = 'datadog_flutter_plugin'
+enableFeaturePreview("VERSION_CATALOGS")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files('datadog_version.toml'))
+        }
+    }
+}

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -77,7 +77,7 @@ flutter {
 }
 
 dependencies {
-    implementation "com.datadoghq:dd-sdk-android:$datadog_sdk_version"
+    implementation libs.datadog.sdk.android
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.work:work-runtime-ktx:2.7.0'

--- a/packages/datadog_flutter_plugin/example/android/settings.gradle
+++ b/packages/datadog_flutter_plugin/example/android/settings.gradle
@@ -1,4 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 include ':app'
+enableFeaturePreview("VERSION_CATALOGS")
 
 def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
 def properties = new Properties()
@@ -10,15 +17,10 @@ def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
 apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
 
-/*
- * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
- * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2016-Present Datadog, Inc.
- */
-
-//includeBuild('../../../dd-sdk-android') {
-//    dependencySubstitution {
-//        substitute module('com.datadoghq:dd-sdk-android') using project(':dd-sdk-android')
-//        substitute module('com.datadoghq:dd-sdk-android-ndk') using project(':dd-sdk-android-ndk')
-//    }
-//}
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files('../../android/datadog_version.toml'))
+        }
+    }
+}


### PR DESCRIPTION
### What and why?

This should make it easier to update versions and add libraries in the future, and ensure that all example applications are using the same version of the library.

### How?

Added `packages/datadog_flutter_plugin/android/datadog_version.toml` as an importable version catalog, and had all gradle.settings files import that.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests