### PR TITLE
💚 Upgrade gradle version for e2e test app

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,12 +1,6 @@
-#
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2016-Present Datadog, Inc.
-#
-
-#Fri Jun 23 08:50:38 CEST 2017
+#Fri Nov 04 16:56:33 EDT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### What and why?

e2e test app is currently failing because it is using an old version of gradle that doesn't support version catalogs.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests