### PR TITLE
✨ 🔥 Add the ability to report errors on logs.

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
@@ -18,4 +18,7 @@ class LogDecoder {
   String get loggerName => getNestedProperty('logger.name', log);
   String get loggerVersion => getNestedProperty('logger.version', log);
   String get threadName => getNestedProperty('logger.thread_name', log);
+  String get errorKind => getNestedProperty('error.kind', log);
+  String get errorMessage => getNestedProperty('error.message', log);
+  String get errorStack => getNestedProperty('error.stack', log);
 }

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* 🔥 BREAKING - Log functions (`debug`, `info`, `warn`) now use `attributes` as a named argument instead of a positional argument.
+* Allow errors to be sent on all log functions. See [#264][]
 * Disable tracing by default in iOS. Silences a benign warning from the SDK. See [#280][]
 
 ## 1.1.0
@@ -109,5 +111,6 @@
 [#159]: https://github.com/DataDog/dd-sdk-flutter/issues/159
 [#203]: https://github.com/DataDog/dd-sdk-flutter/issues/203
 [#254]: https://github.com/DataDog/dd-sdk-flutter/issues/254
+[#264]: https://github.com/DataDog/dd-sdk-flutter/issues/264
 [#271]: https://github.com/DataDog/dd-sdk-flutter/issues/271
 [#280]: https://github.com/DataDog/dd-sdk-flutter/issues/280

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
@@ -5,35 +5,35 @@
  */
 package com.datadoghq.flutter
 
+import android.util.Log
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import com.datadog.android.log.Logger
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.kotlin.mock
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
-import kotlin.reflect.typeOf
 
 @ExtendWith(ForgeExtension::class)
 @OptIn(kotlin.ExperimentalStdlibApi::class)
 class DatadogLogsPluginTest {
     private lateinit var plugin: DatadogLogsPlugin
+    private lateinit var mockLogger: Logger
 
     @BeforeEach
     fun beforeEach() {
         plugin = DatadogLogsPlugin()
+        mockLogger = mockk(relaxed = true)
 
-        plugin.addLogger("mock-logger", Logger.Builder().build())
+        plugin.addLogger("mock-logger", mockLogger)
     }
 
     @Test
@@ -45,35 +45,22 @@ class DatadogLogsPluginTest {
         val method = forge.anElementFrom( listOf("debug", "info", "warn", "error") )
         val call = MethodCall(method, mapOf(
             "message" to Int,
+            "logLevel" to "LogLevel.info",
             "context" to mapOf<String, Any>()
         ))
-        val mockResult = mock<MethodChannel.Result>()
+        val mockResult = mockk<MethodChannel.Result>(relaxed = true)
 
         // WHEN
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        verify(mockResult).error(eq(DatadogSdkPlugin.CONTRACT_VIOLATION), any(), anyOrNull())
+        verify { mockResult.error(eq(DatadogSdkPlugin.CONTRACT_VIOLATION), any(), any()) }
     }
 
     private val contracts = listOf(
-        Contract("debug", mapOf(
+        Contract("log", mapOf(
             "loggerHandle" to ContractParameter.Value("mock-logger"),
-            "message" to ContractParameter.Type(SupportedContractType.STRING),
-            "context" to ContractParameter.Type(SupportedContractType.MAP),
-        )),
-        Contract("info", mapOf(
-            "loggerHandle" to ContractParameter.Value("mock-logger"),
-            "message" to ContractParameter.Type(SupportedContractType.STRING),
-            "context" to ContractParameter.Type(SupportedContractType.MAP),
-        )),
-        Contract("warn", mapOf(
-            "loggerHandle" to ContractParameter.Value("mock-logger"),
-            "message" to ContractParameter.Type(SupportedContractType.STRING),
-            "context" to ContractParameter.Type(SupportedContractType.MAP),
-        )),
-        Contract("error", mapOf(
-            "loggerHandle" to ContractParameter.Value("mock-logger"),
+            "logLevel" to ContractParameter.Type(SupportedContractType.STRING),
             "message" to ContractParameter.Type(SupportedContractType.STRING),
             "context" to ContractParameter.Type(SupportedContractType.MAP),
         )),
@@ -119,6 +106,35 @@ class DatadogLogsPluginTest {
     }
 
     @Test
+    fun `M parse correct level W parseLogLevel`() {
+        // WHEN
+        var debug = parseLogLevel("LogLevel.debug")
+        var info = parseLogLevel("LogLevel.info")
+        var notice = parseLogLevel("LogLevel.notice")
+        var warning = parseLogLevel("LogLevel.warning")
+        var error = parseLogLevel("LogLevel.error")
+        var critical = parseLogLevel("LogLevel.critical")
+        var alert = parseLogLevel("LogLevel.alert")
+        var emergency = parseLogLevel("LogLevel.emergency")
+        var unknown = parseLogLevel("LogLevel.unknown")
+
+        // THEN
+        assertThat(debug).isEqualTo(Log.DEBUG)
+        assertThat(info).isEqualTo(Log.INFO)
+        // No matching level in Log
+        assertThat(notice).isEqualTo(Log.WARN)
+        assertThat(warning).isEqualTo(Log.WARN)
+        assertThat(error).isEqualTo(Log.ERROR)
+        // No matching level in Log
+        assertThat(critical).isEqualTo(Log.ASSERT)
+        // No matching level in Log
+        assertThat(alert).isEqualTo(Log.ASSERT)
+        // No matching level in Log
+        assertThat(emergency).isEqualTo(Log.ASSERT)
+        assertThat(unknown).isEqualTo(Log.INFO)
+    }
+
+    @Test
     fun `M create logger W createLogger`(
         @StringForgery loggerHandle: String
     ) {
@@ -127,15 +143,72 @@ class DatadogLogsPluginTest {
             "loggerHandle" to loggerHandle,
             "configuration" to defaultLoggingConfig()
         ))
-        val mockResult = mock<MethodChannel.Result>()
+        val mockResult = mockk<MethodChannel.Result>(relaxed = true)
 
         // WHEN
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        verify(mockResult).success(null)
+        verify { mockResult.success(null) }
 
         val logger = plugin.getLogger(loggerHandle)
         assertThat(logger).isNotNull()
+    }
+
+    @Test
+    fun `M call logger W log called through channel`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val message = forge.aString()
+        val context = forge.exhaustiveAttributes()
+        val call = MethodCall("log", mapOf(
+            "loggerHandle" to "mock-logger",
+            "logLevel" to "LogLevel.info",
+            "message" to message,
+            "errorMessage" to null,
+            "errorKind" to null,
+            "stackTrace" to null,
+            "context" to context
+        ))
+        val mockResult = mockk<MethodChannel.Result>(relaxed = true)
+
+        // WHEN
+        plugin.onMethodCall(call, mockResult)
+
+        // THEN
+        verify { mockResult.success(null) }
+
+        verify { mockLogger.log(Log.INFO, message, null, null, null, context) }
+    }
+
+    @Test
+    fun `M call logger W log called through channel { error info }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val message = forge.aString()
+        val context = forge.exhaustiveAttributes()
+        val errorMessage = forge.aString()
+        val errorKind = forge.anAlphaNumericalString()
+        val stackTrace = forge.anAlphaNumericalString()
+        val call = MethodCall("log", mapOf(
+            "loggerHandle" to "mock-logger",
+            "logLevel" to "LogLevel.verbose",
+            "message" to message,
+            "errorMessage" to errorMessage,
+            "errorKind" to errorKind,
+            "stackTrace" to stackTrace,
+            "context" to context
+        ))
+        val mockResult = mockk<MethodChannel.Result>(relaxed = true)
+
+        // WHEN
+        plugin.onMethodCall(call, mockResult)
+
+        // THEN
+        verify { mockResult.success(null) }
+
+        verify { mockLogger.log(Log.INFO, message, errorKind, errorMessage, stackTrace, context) }
     }
 }

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/logs/logger_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/logs/logger_test.dart
@@ -60,7 +60,7 @@ void main() {
   /// ```
   testWidgets('logger - debug logs', (tester) async {
     await measure('flutter_log_debug_logs', () {
-      datadog.logs?.debug('fake message', {
+      datadog.logs?.debug('fake message', attributes: {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem
       });
@@ -87,7 +87,7 @@ void main() {
   /// ```
   testWidgets('logger - info logs', (tester) async {
     await measure('flutter_log_info_logs', () async {
-      datadog.logs?.info('fake info message', {
+      datadog.logs?.info('fake info message', attributes: {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,
       });
@@ -114,7 +114,7 @@ void main() {
   /// ```
   testWidgets('logger - warn logs', (tester) async {
     await measure('flutter_log_warn_logs', () async {
-      datadog.logs?.warn('fake warn message', {
+      datadog.logs?.warn('fake warn message', attributes: {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,
       });
@@ -141,7 +141,7 @@ void main() {
   /// ```
   testWidgets('logger - error logs', (tester) async {
     await measure('flutter_log_error_logs', () async {
-      datadog.logs?.error('fake error message', {
+      datadog.logs?.error('fake error message', attributes: {
         'test_method_name': tester.testDescription,
         'operating_system': Platform.operatingSystem,
       });

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/test_utils.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/test_utils.dart
@@ -77,6 +77,6 @@ void sendRandomLog(WidgetTester tester) {
 
   method!(
     randomString(),
-    e2eAttributes(tester),
+    attributes: e2eAttributes(tester),
   );
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
@@ -54,13 +54,13 @@ class DatadogConfigurationTests: XCTestCase {
   }
 
   func testAllVerbosityLevels_AreParsedCorrectly() {
-    let verbose = LogLevel.parseFromFlutter("Verbosity.verbose")
-    let debug = LogLevel.parseFromFlutter("Verbosity.debug")
-    let info = LogLevel.parseFromFlutter("Verbosity.info")
-    let warn = LogLevel.parseFromFlutter("Verbosity.warn")
-    let error = LogLevel.parseFromFlutter("Verbosity.error")
-    let none = LogLevel.parseFromFlutter("Verbosity.none")
-    let unknown = LogLevel.parseFromFlutter("unknown")
+    let verbose = LogLevel.parseVerbosityFromFlutter("Verbosity.verbose")
+    let debug = LogLevel.parseVerbosityFromFlutter("Verbosity.debug")
+    let info = LogLevel.parseVerbosityFromFlutter("Verbosity.info")
+    let warn = LogLevel.parseVerbosityFromFlutter("Verbosity.warn")
+    let error = LogLevel.parseVerbosityFromFlutter("Verbosity.error")
+    let none = LogLevel.parseVerbosityFromFlutter("Verbosity.none")
+    let unknown = LogLevel.parseVerbosityFromFlutter("unknown")
 
     // iOS doesn't have .verbose so use .debug
     XCTAssertEqual(verbose, .debug)

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -32,17 +32,17 @@ class _LoggingScenarioState extends State<LoggingScenario> {
       logger.addAttribute('logger-attribute1', 'string value');
       logger.addAttribute('logger-attribute2', 1000);
 
-      logger.debug('debug message', {'stringAttribute': 'string'});
+      logger.debug('debug message', attributes: {'stringAttribute': 'string'});
 
       logger.removeTag('my-tag');
-      logger.info('info message', {
+      logger.info('info message', attributes: {
         'nestedAttribute': {'internal': 'test', 'isValid': true}
       });
-      logger.warn('warn message', {'doubleAttribute': 10.34});
+      logger.warn('warn message', attributes: {'doubleAttribute': 10.34});
 
       logger.removeAttribute('logger-attribute1');
       logger.removeTagWithKey('tag1');
-      logger.error('error message', {'attribute': 'value'});
+      logger.error('error message', attributes: {'attribute': 'value'});
     }
 
     final config = LoggingConfiguration(loggerName: 'second_logger');

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -50,6 +50,14 @@ class _LoggingScenarioState extends State<LoggingScenario> {
 
     secondLogger.addAttribute('second-logger-attribute', 'second-value');
     secondLogger.info('message on second logger');
+
+    final st = StackTrace.current;
+
+    secondLogger.warn(
+      'Warning: this error occurred',
+      errorMessage: 'Error Message',
+      errorStackTrace: st,
+    );
   }
 
   @override

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogFlutterModels.swift
@@ -290,7 +290,7 @@ public extension Datadog.Configuration.DatadogEndpoint {
 }
 
 public extension LogLevel {
-    static func parseFromFlutter(_ value: String) -> Self? {
+    static func parseVerbosityFromFlutter(_ value: String) -> Self? {
         switch value {
         case "Verbosity.verbose": return .debug
         case "Verbosity.debug": return .debug
@@ -299,6 +299,20 @@ public extension LogLevel {
         case "Verbosity.error": return .error
         case "Verbosity.none": return nil
         default: return nil
+        }
+    }
+
+    static func parseLogLevelFromFlutter(_ value: String) -> Self {
+        switch value {
+        case "LogLevel.debug": return .debug
+        case "LogLevel.info": return .info
+        case "LogLevel.notice": return .notice
+        case "LogLevel.warning": return .warn
+        case "LogLevel.error": return .error
+        case "LogLevel.critical": return .critical
+        case "LogLevel.alert": return .critical
+        case "LogLevel.emergency": return .critical
+        default: return .info
         }
     }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
@@ -81,46 +81,31 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let message = arguments["message"] as? String
         var attributes: [String: Encodable]?
         if let context = arguments["context"] as? [String: Any?] {
             attributes = castFlutterAttributesToSwift(context)
         }
 
         switch call.method {
-        case "debug":
-            if let message = message {
-                logger.debug(message, error: nil, attributes: attributes)
-                result(nil)
-            } else {
-                result(
-                    FlutterError.missingParameter(methodName: call.method)
-                )
-            }
+        case "log":
+            if let message = arguments["message"] as? String,
+                let levelString = arguments["logLevel"] as? String {
+                let level = LogLevel.parseLogLevelFromFlutter(levelString)
 
-        case "info":
-            if let message = message {
-                logger.info(message, error: nil, attributes: attributes)
-                result(nil)
-            } else {
-                result(
-                    FlutterError.missingParameter(methodName: call.method)
-                )
-            }
+                // Optional args
+                let errorKind = arguments["errorKind"] as? String
+                let errorMessage = arguments["errorMessage"] as? String
+                let stackTrace = arguments["stackTrace"] as? String
 
-        case "warn":
-            if let message = message {
-                logger.warn(message, error: nil, attributes: attributes)
-                result(nil)
-            } else {
-                result(
-                    FlutterError.missingParameter(methodName: call.method)
+                logger.log(
+                    level: level,
+                    message: message,
+                    errorKind: errorKind,
+                    errorMessage: errorMessage,
+                    stackTrace: stackTrace,
+                    attributes: attributes
                 )
-            }
 
-        case "error":
-            if let message = message {
-                logger.error(message, error: nil, attributes: attributes)
                 result(nil)
             } else {
                 result(

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -80,7 +80,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             }
         case "setSdkVerbosity":
             if let verbosityString = arguments["value"] as? String {
-                let verbosity = LogLevel.parseFromFlutter(verbosityString)
+                let verbosity = LogLevel.parseVerbosityFromFlutter(verbosityString)
                 Datadog.verbosityLevel = verbosity
                 result(nil)
             } else {

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2021 Datadog, Inc.
+
 import 'package:uuid/uuid.dart';
 
 import '../../datadog_flutter_plugin.dart';
@@ -33,53 +34,85 @@ class DdLogs {
 
   /// Sends a `debug` log message.
   ///
-  /// You can provide additional attributes for this log message using the
+  /// You can optionally send an [errorMessage], [errorKind], and an [errorStackTrace]
+  /// that will be connected to this log message.
+  ///
+  /// You can also provide additional attributes for this log message using the
   /// [attributes] parameter. Values passed into [attributes] must be supported by
   /// [StandardMessageCodec].
-  void debug(String message, [Map<String, Object?> attributes = const {}]) {
+  void debug(
+    String message, {
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? errorStackTrace,
+    Map<String, Object?> attributes = const {},
+  }) {
     if (_reportingThreshold.index <= Verbosity.debug.index) {
-      wrap('logs.debug', _internalLogger, attributes, () {
-        return _platform.debug(loggerHandle, message, attributes);
-      });
+      _internalLog(LogLevel.debug, message, errorMessage, errorKind,
+          errorStackTrace, attributes);
     }
   }
 
   /// Sends an `info` log message.
   ///
-  /// You can provide additional attributes for this log message using the
+  /// You can optionally send an [errorMessage], [errorKind], and an [errorStackTrace]
+  /// that will be connected to this log message.
+  ///
+  /// You can also provide additional attributes for this log message using the
   /// [attributes] parameter. Values passed into [attributes] must be supported by
   /// [StandardMessageCodec].
-  void info(String message, [Map<String, Object?> attributes = const {}]) {
+  void info(
+    String message, {
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? errorStackTrace,
+    Map<String, Object?> attributes = const {},
+  }) {
     if (_reportingThreshold.index <= Verbosity.info.index) {
-      wrap('logs.info', _internalLogger, attributes, () {
-        return _platform.info(loggerHandle, message, attributes);
-      });
+      _internalLog(LogLevel.info, message, errorMessage, errorKind,
+          errorStackTrace, attributes);
     }
   }
 
   /// Sends a `warn` log message.
   ///
-  /// You can provide additional attributes for this log message using the
+  /// You can optionally send an [errorMessage], [errorKind], and an [errorStackTrace]
+  /// that will be connected to this log message.
+  ///
+  /// You can also provide additional attributes for this log message using the
   /// [attributes] parameter. Values passed into [attributes] must be supported by
   /// [StandardMessageCodec].
-  void warn(String message, [Map<String, Object?> attributes = const {}]) {
+  void warn(
+    String message, {
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? errorStackTrace,
+    Map<String, Object?> attributes = const {},
+  }) {
     if (_reportingThreshold.index <= Verbosity.warn.index) {
-      wrap('logs.warn', _internalLogger, attributes, () {
-        return _platform.warn(loggerHandle, message, attributes);
-      });
+      _internalLog(LogLevel.warning, message, errorMessage, errorKind,
+          errorStackTrace, attributes);
     }
   }
 
   /// Sends an `error` log message.
   ///
+  /// You can optionally send an [errorMessage], [errorKind], and an [errorStackTrace]
+  /// that will be connected to this log message.
+  ///
   /// You can provide additional attributes for this log message using the
   /// [attributes] parameter. Values passed into [attributes] must be supported by
   /// [StandardMessageCodec].
-  void error(String message, [Map<String, Object?> attributes = const {}]) {
+  void error(
+    String message, {
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? errorStackTrace,
+    Map<String, Object?> attributes = const {},
+  }) {
     if (_reportingThreshold.index <= Verbosity.error.index) {
-      wrap('logs.error', _internalLogger, attributes, () {
-        return _platform.error(loggerHandle, message, attributes);
-      });
+      _internalLog(LogLevel.error, message, errorMessage, errorKind,
+          errorStackTrace, attributes);
     }
   }
 
@@ -138,6 +171,20 @@ class DdLogs {
   void removeTagWithKey(String key) {
     wrap('logs.removeTagWithKey', _internalLogger, null, () {
       return _platform.removeTagWithKey(loggerHandle, key);
+    });
+  }
+
+  void _internalLog(
+    LogLevel level,
+    String message,
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? stackTrace,
+    Map<String, Object?> attributes,
+  ) {
+    wrap('logs._internalLog', _internalLogger, attributes, () {
+      return _platform.log(loggerHandle, level, message, errorMessage,
+          errorKind, stackTrace, attributes);
     });
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -22,10 +22,20 @@ class DdLogsMethodChannel extends DdLogsPlatform {
   }
 
   @override
-  Future<void> debug(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]) {
-    return methodChannel.invokeMethod('debug', {
+  Future<void> log(
+      String loggerHandle,
+      LogLevel level,
+      String message,
+      String? errorMessage,
+      String? errorKind,
+      StackTrace? errorStackTrace,
+      Map<String, Object?> context) {
+    return methodChannel.invokeMethod('log', {
       'loggerHandle': loggerHandle,
+      'logLevel': level.toString(),
+      'errorMessage': errorMessage,
+      'errorKind': errorKind,
+      'stackTrace': errorStackTrace?.toString(),
       'message': message,
       'context': context,
     });

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
@@ -7,6 +7,22 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '../../datadog_flutter_plugin.dart';
 import 'ddlogs_method_channel.dart';
 
+// Private for now until we can ensure all SDKs support all levels
+enum LogLevel {
+  debug,
+  info,
+  // ignore: unused_field
+  notice,
+  warning,
+  error,
+  // ignore: unused_field
+  critical,
+  // ignore: unused_field
+  alert,
+  // ignore: unused_field
+  emergency
+}
+
 abstract class DdLogsPlatform extends PlatformInterface {
   DdLogsPlatform() : super(token: _token);
 
@@ -23,14 +39,15 @@ abstract class DdLogsPlatform extends PlatformInterface {
 
   Future<void> createLogger(String loggerHandle, LoggingConfiguration config);
 
-  Future<void> debug(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]);
-  Future<void> info(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]);
-  Future<void> warn(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]);
-  Future<void> error(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]);
+  Future<void> log(
+    String loggerHandle,
+    LogLevel level,
+    String message,
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? errorStackTrace,
+    Map<String, Object?> attributes,
+  );
 
   Future<void> addAttribute(String loggerHandle, String key, Object value);
   Future<void> removeAttribute(String loggerHandle, String key);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -62,33 +62,33 @@ class DdLogsWeb extends DdLogsPlatform {
   @override
   Future<void> addTag(String loggerHandle, String tag, [String? value]) async {}
 
-  @override
-  Future<void> debug(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]) async {
-    final logger = _activeLoggers[loggerHandle];
-    logger?.debug(message, valueToJs(context, 'context'));
-  }
+  // @override
+  // Future<void> debug(String loggerHandle, String message,
+  //     [Map<String, Object?> context = const {}]) async {
+  //   final logger = _activeLoggers[loggerHandle];
+  //   logger?.debug(message, valueToJs(context, 'context'));
+  // }
 
-  @override
-  Future<void> error(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]) async {
-    final logger = _activeLoggers[loggerHandle];
-    logger?.error(message, valueToJs(context, 'context'));
-  }
+  // @override
+  // Future<void> error(String loggerHandle, String message,
+  //     [Map<String, Object?> context = const {}]) async {
+  //   final logger = _activeLoggers[loggerHandle];
+  //   logger?.error(message, valueToJs(context, 'context'));
+  // }
 
-  @override
-  Future<void> info(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]) async {
-    final logger = _activeLoggers[loggerHandle];
-    logger?.info(message, valueToJs(context, 'context'));
-  }
+  // @override
+  // Future<void> info(String loggerHandle, String message,
+  //     [Map<String, Object?> context = const {}]) async {
+  //   final logger = _activeLoggers[loggerHandle];
+  //   logger?.info(message, valueToJs(context, 'context'));
+  // }
 
-  @override
-  Future<void> warn(String loggerHandle, String message,
-      [Map<String, Object?> context = const {}]) async {
-    final logger = _activeLoggers[loggerHandle];
-    logger?.warn(message, valueToJs(context, 'context'));
-  }
+  // @override
+  // Future<void> warn(String loggerHandle, String message,
+  //     [Map<String, Object?> context = const {}]) async {
+  //   final logger = _activeLoggers[loggerHandle];
+  //   logger?.warn(message, valueToJs(context, 'context'));
+  // }
 
   @override
   Future<void> removeAttribute(String loggerHandle, String key) async {
@@ -101,6 +101,42 @@ class DdLogsWeb extends DdLogsPlatform {
 
   @override
   Future<void> removeTagWithKey(String loggerHandle, String key) async {}
+
+  @override
+  Future<void> log(
+    String loggerHandle,
+    LogLevel level,
+    String message,
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? errorStackTrace,
+    Map<String, Object?> context,
+  ) async {
+    final logger = _activeLoggers[loggerHandle];
+    final webLogLevel = _toWebLogLevel(level);
+    logger?.log(message, valueToJs(context, 'context'), webLogLevel);
+  }
+}
+
+String _toWebLogLevel(LogLevel level) {
+  switch (level) {
+    case LogLevel.debug:
+      return 'debug';
+    case LogLevel.info:
+      return 'info';
+    case LogLevel.notice:
+      return 'notice';
+    case LogLevel.warning:
+      return 'warning';
+    case LogLevel.error:
+      return 'error';
+    case LogLevel.critical:
+      return 'critical';
+    case LogLevel.alert:
+      return 'alert';
+    case LogLevel.emergency:
+      return 'emergency';
+  }
 }
 
 @JS()
@@ -139,10 +175,7 @@ class _JsLoggerConfiguration {
 
 @JS('Logger')
 class Logger {
-  external void debug(String message, dynamic messageContext);
-  external void info(String message, dynamic messageContext);
-  external void warn(String message, dynamic messageContext);
-  external void error(String message, dynamic messageContext);
+  external void log(String message, dynamic messageContext, String status);
 
   external void addContext(String key, dynamic value);
   external void removeContext(String key);

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/src/logs/ddlogs_method_channel.dart';
+import 'package:datadog_flutter_plugin/src/logs/ddlogs_platform_interface.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -37,51 +38,48 @@ void main() {
     ]);
   });
 
-  test('debug logs passed to method channel', () async {
-    await ddLogsPlatform.debug('uuid', 'debug message', {'attribute': 'value'});
+  test('log messages passed to method channel', () async {
+    for (final logLevel in LogLevel.values) {
+      await ddLogsPlatform.log('uuid', logLevel, '$logLevel message', null,
+          null, null, {'attribute': 'value'});
+    }
 
     expect(log, <Matcher>[
-      isMethodCall('debug', arguments: {
-        'loggerHandle': 'uuid',
-        'message': 'debug message',
-        'context': {'attribute': 'value'}
-      })
+      for (final logLevel in LogLevel.values)
+        isMethodCall('log', arguments: {
+          'loggerHandle': 'uuid',
+          'logLevel': logLevel.toString(),
+          'message': '$logLevel message',
+          'errorMessage': null,
+          'errorKind': null,
+          'stackTrace': null,
+          'context': {
+            'attribute': 'value',
+          }
+        })
     ]);
   });
 
-  test('info logs passed to method channel', () async {
-    await ddLogsPlatform.info('uuid', 'info message', {'attribute': 'value'});
+  test('log messages passed with error passed to method channel', () async {
+    final st = StackTrace.current;
+    for (final logLevel in LogLevel.values) {
+      await ddLogsPlatform.log('uuid', logLevel, '$logLevel message',
+          '$logLevel error message', 'error_type', st, {'attribute': 'value'});
+    }
 
     expect(log, <Matcher>[
-      isMethodCall('info', arguments: {
-        'loggerHandle': 'uuid',
-        'message': 'info message',
-        'context': {'attribute': 'value'}
-      })
-    ]);
-  });
-
-  test('warn logs passed to method channel', () async {
-    await ddLogsPlatform.warn('uuid', 'warn message', {'attribute': 'value'});
-
-    expect(log, <Matcher>[
-      isMethodCall('warn', arguments: {
-        'loggerHandle': 'uuid',
-        'message': 'warn message',
-        'context': {'attribute': 'value'}
-      })
-    ]);
-  });
-
-  test('error logs passed to method channel', () async {
-    await ddLogsPlatform.error('uuid', 'error message', {'attribute': 'value'});
-
-    expect(log, <Matcher>[
-      isMethodCall('error', arguments: {
-        'loggerHandle': 'uuid',
-        'message': 'error message',
-        'context': {'attribute': 'value'}
-      })
+      for (final logLevel in LogLevel.values)
+        isMethodCall('log', arguments: {
+          'loggerHandle': 'uuid',
+          'logLevel': logLevel.toString(),
+          'message': '$logLevel message',
+          'errorMessage': '$logLevel error message',
+          'errorKind': 'error_type',
+          'stackTrace': st.toString(),
+          'context': {
+            'attribute': 'value',
+          }
+        })
     ]);
   });
 

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -31,44 +31,40 @@ void main() {
     setUp(() {
       logger = TestLogger();
       mockPlatform = MockDdLogsPlatform();
-      when(() => mockPlatform.debug(any(), any(), any()))
-          .thenAnswer((invocation) => Future<void>.value());
-      when(() => mockPlatform.info(any(), any(), any()))
-          .thenAnswer((invocation) => Future<void>.value());
-      when(() => mockPlatform.warn(any(), any(), any()))
-          .thenAnswer((invocation) => Future<void>.value());
-      when(() => mockPlatform.error(any(), any(), any()))
+      registerFallbackValue(LogLevel.info);
+      when(() =>
+              mockPlatform.log(any(), any(), any(), any(), any(), any(), any()))
           .thenAnswer((invocation) => Future<void>.value());
       DdLogsPlatform.instance = mockPlatform;
       ddLogs = DdLogs(logger, Verbosity.verbose);
     });
 
     test('debug logs pass to platform', () async {
-      ddLogs.debug('debug message', {'attribute': 'value'});
+      ddLogs.debug('debug message', attributes: {'attribute': 'value'});
 
-      verify(() => mockPlatform
-          .debug(ddLogs.loggerHandle, 'debug message', {'attribute': 'value'}));
+      verify(() => mockPlatform.log(ddLogs.loggerHandle, LogLevel.debug,
+          'debug message', null, null, null, {'attribute': 'value'}));
     });
 
-    test('info logs pass to platform', () async {
-      ddLogs.info('info message', {'attribute': 'value'});
+    test('debug info pass to platform', () async {
+      ddLogs.info('info message', attributes: {'attribute': 'value'});
 
-      verify(() => mockPlatform
-          .info(ddLogs.loggerHandle, 'info message', {'attribute': 'value'}));
+      verify(() => mockPlatform.log(ddLogs.loggerHandle, LogLevel.info,
+          'info message', null, null, null, {'attribute': 'value'}));
     });
 
-    test('warn logs pass to platform', () async {
-      ddLogs.warn('warn message', {'attribute': 'value'});
+    test('debug warn pass to platform', () async {
+      ddLogs.warn('warn message', attributes: {'attribute': 'value'});
 
-      verify(() => mockPlatform
-          .warn(ddLogs.loggerHandle, 'warn message', {'attribute': 'value'}));
+      verify(() => mockPlatform.log(ddLogs.loggerHandle, LogLevel.warning,
+          'warn message', null, null, null, {'attribute': 'value'}));
     });
 
     test('error logs pass to platform', () async {
-      ddLogs.error('error message', {'attribute': 'value'});
+      ddLogs.error('error message', attributes: {'attribute': 'value'});
 
-      verify(() => mockPlatform
-          .error(ddLogs.loggerHandle, 'error message', {'attribute': 'value'}));
+      verify(() => mockPlatform.log(ddLogs.loggerHandle, LogLevel.error,
+          'error message', null, null, null, {'attribute': 'value'}));
     });
 
     test('addAttribute argumentError sent to logger', () async {
@@ -84,13 +80,9 @@ void main() {
     setUp(() {
       logger = TestLogger();
       mockPlatform = MockDdLogsPlatform();
-      when(() => mockPlatform.debug(any(), any(), any()))
-          .thenAnswer((invocation) => Future<void>.value());
-      when(() => mockPlatform.info(any(), any(), any()))
-          .thenAnswer((invocation) => Future<void>.value());
-      when(() => mockPlatform.warn(any(), any(), any()))
-          .thenAnswer((invocation) => Future<void>.value());
-      when(() => mockPlatform.error(any(), any(), any()))
+      registerFallbackValue(LogLevel.info);
+      when(() =>
+              mockPlatform.log(any(), any(), any(), any(), any(), any(), any()))
           .thenAnswer((invocation) => Future<void>.value());
       DdLogsPlatform.instance = mockPlatform;
     });
@@ -103,10 +95,15 @@ void main() {
       ddLogs.warn('Warn message');
       ddLogs.error('Error message');
 
-      verify(() => mockPlatform.debug(any(), any()));
-      verify(() => mockPlatform.info(any(), any()));
-      verify(() => mockPlatform.warn(any(), any()));
-      verify(() => mockPlatform.error(any(), any()));
+      for (var level in [
+        LogLevel.debug,
+        LogLevel.info,
+        LogLevel.warning,
+        LogLevel.error
+      ]) {
+        verify(() =>
+            mockPlatform.log(any(), level, any(), null, null, null, any()));
+      }
     });
 
     test('threshold set to middle sends call proper platform methods',
@@ -118,10 +115,21 @@ void main() {
       ddLogs.warn('Warn message');
       ddLogs.error('Error message');
 
-      verifyNever(() => mockPlatform.debug(any(), any()));
-      verifyNever(() => mockPlatform.info(any(), any()));
-      verify(() => mockPlatform.warn(any(), any()));
-      verify(() => mockPlatform.error(any(), any()));
+      for (var level in [
+        LogLevel.debug,
+        LogLevel.info,
+      ]) {
+        verifyNever(() =>
+            mockPlatform.log(any(), level, any(), any(), any(), any(), any()));
+      }
+
+      for (var level in [
+        LogLevel.warning,
+        LogLevel.error,
+      ]) {
+        verify(() =>
+            mockPlatform.log(any(), level, any(), null, null, null, any()));
+      }
     });
 
     test('threshold set to none does not call platform', () async {
@@ -132,10 +140,15 @@ void main() {
       ddLogs.warn('Warn message');
       ddLogs.error('Error message');
 
-      verifyNever(() => mockPlatform.debug(any(), any()));
-      verifyNever(() => mockPlatform.info(any(), any()));
-      verifyNever(() => mockPlatform.warn(any(), any()));
-      verifyNever(() => mockPlatform.error(any(), any()));
+      for (var level in [
+        LogLevel.debug,
+        LogLevel.info,
+        LogLevel.warning,
+        LogLevel.error
+      ]) {
+        verifyNever(() =>
+            mockPlatform.log(any(), level, any(), any(), any(), any(), any()));
+      }
     });
   });
 }


### PR DESCRIPTION
### What and why?

Add parameters to add error information on Logs

This is a minor breaking change, as the `attributes` parameter is now a named arg, to make room for the error parameters (`errorKind`, `errorMessage`, and `errorStack`)

This fixes #264 

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests