### PR TITLE
📈 Add configuration telemetry with Flutter specific properties.

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -111,6 +111,8 @@ class RumEventDecoder {
 
   int get date => rumEvent['date'] as int;
   String get version => rumEvent['version'] as String;
+  Map<String, dynamic>? get telemetryConfiguration =>
+      rumEvent['telemetry']?['configuration'];
 
   Map<String, dynamic>? get context => rumEvent['context'];
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogFlutterConfiguration.kt
@@ -122,7 +122,7 @@ data class DatadogFlutterConfiguration(
     }
 
     @Suppress("ComplexMethod")
-    fun toSdkConfiguration(): Configuration {
+    fun toSdkConfiguration(): Configuration.Builder {
         val configBuilder = Configuration.Builder(
             // Always enable logging as users can create logs post initialization
             logsEnabled = true,
@@ -163,7 +163,7 @@ data class DatadogFlutterConfiguration(
         }
         configBuilder.setFirstPartyHosts(firstPartyHosts)
 
-        return configBuilder.build()
+        return configBuilder
     }
 }
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -571,4 +571,62 @@ class DatadogSdkPluginTest {
         assertThat(userInfo?.additionalProperties).isEqualTo(extraInfo)
         verify(mockResult).success(null)
     }
+
+    @Test
+    fun `M set correct telemetry overrides W updateTelemetryConfiguration`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val configuration = DatadogFlutterConfiguration(
+            clientToken = forge.aString(),
+            env = forge.anAlphabeticalString(),
+            nativeCrashReportEnabled = false,
+            trackingConsent = TrackingConsent.GRANTED
+        )
+        plugin.initialize(configuration)
+
+        val trackViewsManually = forge.aBool()
+        val trackInteractions = forge.aBool()
+        val trackErrors = forge.aBool()
+        val trackNetworkRequests = forge.aBool()
+        val trackNativeViews = forge.aBool()
+        val trackCrossPlatformLongTasks = forge.aBool()
+        val trackFlutterPerformance = forge.aBool()
+
+        fun callAndCheck(property: String, value: Boolean, check: () -> Unit) {
+            var methodCall = MethodCall(
+                "updateTelemetryConfiguration",
+                mapOf(
+                    "option" to property,
+                    "value" to value
+                )
+            )
+            val mockResult = mock<MethodChannel.Result>()
+            plugin.onMethodCall(methodCall, mockResult)
+            verify(mockResult).success(null)
+            check()
+        }
+
+        callAndCheck("trackViewsManually", trackViewsManually) {
+            assertThat(plugin.telemetryOverrides.trackViewsManually).isEqualTo(trackViewsManually)
+        }
+        callAndCheck("trackInteractions", trackInteractions) {
+            assertThat(plugin.telemetryOverrides.trackInteractions).isEqualTo(trackInteractions)
+        }
+        callAndCheck("trackErrors", trackErrors) {
+            assertThat(plugin.telemetryOverrides.trackErrors).isEqualTo(trackErrors)
+        }
+        callAndCheck("trackNetworkRequests", trackNetworkRequests) {
+            assertThat(plugin.telemetryOverrides.trackNetworkRequests).isEqualTo(trackNetworkRequests)
+        }
+        callAndCheck("trackNativeViews", trackNativeViews) {
+            assertThat(plugin.telemetryOverrides.trackNativeViews).isEqualTo(trackNativeViews)
+        }
+        callAndCheck("trackCrossPlatformLongTasks", trackCrossPlatformLongTasks) {
+            assertThat(plugin.telemetryOverrides.trackCrossPlatformLongTasks).isEqualTo(trackCrossPlatformLongTasks)
+        }
+        callAndCheck("trackFlutterPerformance", trackFlutterPerformance) {
+            assertThat(plugin.telemetryOverrides.trackFlutterPerformance).isEqualTo(trackFlutterPerformance)
+        }
+    }
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -429,4 +429,52 @@ class FlutterSdkTests: XCTestCase {
         XCTAssertEqual(core?.userInfoProvider.value, expectedUserInfo)
         XCTAssertEqual(callResult, .called(value: nil))
     }
+
+    func testConfigurationOverrides_FromMethodChannel_AreOverridden() {
+        let plugin = SwiftDatadogSdkPlugin(channel: FlutterMethodChannel())
+
+        let trackViewsManually: Bool = .random()
+        let trackInteractions: Bool = .random()
+        let trackErrors: Bool = .random()
+        let trackNetworkRequests: Bool = .random()
+        let trackNativeViews: Bool = .random()
+        let trackCrossPlatformLongTasks: Bool = .random()
+        let trackFlutterPerformance: Bool = .random()
+
+        func callAndCheck(property: String, value: Bool, check: () -> Void) {
+            var callResult = ResultStatus.notCalled
+            let call = FlutterMethodCall(methodName: "updateTelemetryConfiguration", arguments: [
+                "option": property,
+                "value": value
+            ])
+            plugin.handle(call) { result in
+                callResult = .called(value: result)
+            }
+
+            XCTAssertEqual(callResult, .called(value: nil))
+            check()
+        }
+
+        callAndCheck(property: "trackViewsManually", value: trackViewsManually) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackViewsManually, trackViewsManually)
+        }
+        callAndCheck(property: "trackInteractions", value: trackInteractions) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackInteractions, trackInteractions)
+        }
+        callAndCheck(property: "trackErrors", value: trackErrors) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackErrors, trackErrors)
+        }
+        callAndCheck(property: "trackNetworkRequests", value: trackNetworkRequests) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackNetworkRequests, trackNetworkRequests)
+        }
+        callAndCheck(property: "trackNativeViews", value: trackNativeViews) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackNativeViews, trackNativeViews)
+        }
+        callAndCheck(property: "trackCrossPlatformLongTasks", value: trackCrossPlatformLongTasks) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackCrossPlatformLongTasks, trackCrossPlatformLongTasks)
+        }
+        callAndCheck(property: "trackFlutterPerformance", value: trackFlutterPerformance) {
+            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackFlutterPerformance, trackFlutterPerformance)
+        }
+    }
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -50,7 +50,7 @@ Future<RecordingServerClient> startMockServer() async {
 }
 
 Future<RecordingServerClient> openTestScenario(
-    WidgetTester tester, String scenarioName) async {
+    WidgetTester tester, String? scenarioName) async {
   var client = await startMockServer();
 
   // These need to be set as const in order to work, so we
@@ -70,10 +70,12 @@ Future<RecordingServerClient> openTestScenario(
   await app.main();
   await tester.pumpAndSettle();
 
-  var integrationItem = find.byWidgetPredicate((widget) =>
-      widget is Text && (widget.data?.startsWith(scenarioName) ?? false));
-  await tester.tap(integrationItem);
-  await tester.pumpAndSettle();
+  if (scenarioName != null) {
+    var integrationItem = find.byWidgetPredicate((widget) =>
+        widget is Text && (widget.data?.startsWith(scenarioName) ?? false));
+    await tester.tap(integrationItem);
+    await tester.pumpAndSettle();
+  }
 
   return client;
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/configuration_telemetry_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/configuration_telemetry_test.dart
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-2021 Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_integration_test_app/auto_integration_scenarios/main.dart'
+    as auto_app;
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+import 'rum_auto_instrumentation_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  kManualIsWeb = kIsWeb;
+
+  testWidgets('test logging scenario', (WidgetTester tester) async {
+    var serverRecorder = await startMockServer();
+
+    const clientToken = bool.hasEnvironment('DD_CLIENT_TOKEN')
+        ? String.fromEnvironment('DD_CLIENT_TOKEN')
+        : null;
+    const applicationId = bool.hasEnvironment('DD_APPLICATION_ID')
+        ? String.fromEnvironment('DD_APPLICATION_ID')
+        : null;
+
+    auto_app.testingConfiguration = TestingConfiguration(
+        customEndpoint: serverRecorder.sessionEndpoint,
+        clientToken: clientToken,
+        applicationId: applicationId,
+        firstPartyHosts: ['localhost']);
+    await auto_app.main();
+    await tester.pumpAndSettle();
+
+    await performRumUserFlow(tester);
+    var endTime = DateTime.now().add(const Duration(seconds: 6));
+    // Wait for telemetry
+    while (DateTime.now().isBefore(endTime)) {
+      await tester.pumpAndSettle();
+    }
+
+    final requestLog = <RequestLog>[];
+    final telemetryLog = <RumEventDecoder>[];
+    await serverRecorder.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        requestLog.addAll(requests);
+        for (var request in requests) {
+          request.data.split('\n').forEach((e) {
+            dynamic jsonValue = json.decode(e);
+            if (jsonValue is Map<String, dynamic>) {
+              var rumEvent = RumEventDecoder(jsonValue);
+              if (rumEvent.eventType == 'telemetry') {
+                telemetryLog.add(rumEvent);
+              }
+            }
+          });
+        }
+        return telemetryLog
+            .where((element) => element.telemetryConfiguration != null)
+            .isNotEmpty;
+      },
+    );
+
+    var telemetryEvent = telemetryLog
+        .where((element) => element.telemetryConfiguration != null)
+        .firstOrNull;
+    expect(telemetryEvent, isNotNull);
+    if (telemetryEvent != null) {
+      final config = telemetryEvent.telemetryConfiguration!;
+      expect(config['track_views_manually'], false);
+      expect(config['track_interactions'], false);
+      expect(config['track_errors'], true);
+      expect(config['track_network_requests'], false);
+      expect(config['track_native_views'], false);
+      expect(config['track_cross_platform_long_tasks'], true);
+      expect(config['track_flutter_performance'], true);
+    }
+  });
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -257,7 +257,7 @@ void main() {
 
     // Verify service name in RUM events
     for (final event in rumLog) {
-      if (!kIsWeb && Platform.isIOS) {
+      if (!kIsWeb && Platform.isIOS && event.eventType != 'telemetry') {
         expect(event.service, 'com.datadoghq.flutter.integration');
         expect(event.version, '1.2.3-555');
       }

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/main.dart
@@ -52,6 +52,7 @@ Future<void> main() async {
     nativeCrashReportEnabled: true,
     firstPartyHosts: firstPartyHosts,
     customLogsEndpoint: customEndpoint,
+    telemetrySampleRate: 100,
     loggingConfiguration: LoggingConfiguration(
       sendNetworkInfo: true,
       printLogsToConsole: true,

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -8,6 +8,16 @@ import Datadog
 import DatadogCrashReporting
 
 public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
+    struct ConfigurationTelemetryOverrides {
+        var trackViewsManually: Bool = true
+        var trackInteractions: Bool = false
+        var trackErrors: Bool = false
+        var trackNetworkRequests: Bool = false
+        var trackNativeViews: Bool = false
+        var trackCrossPlatformLongTasks: Bool = false
+        var trackFlutterPerformance: Bool = false
+    }
+
     let channel: FlutterMethodChannel
 
     // NOTE: Although these are instances, they are still registered globally to
@@ -16,6 +26,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
     public private(set) var rum: DatadogRumPlugin?
 
     var currentConfiguration: [AnyHashable: Any]?
+    var configurationTelemetryOverrides: ConfigurationTelemetryOverrides = .init()
     var oldConsolePrint: ((String) -> Void)?
 
     public init(channel: FlutterMethodChannel) {
@@ -130,6 +141,9 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             } else {
                 result(FlutterError.missingParameter(methodName: call.method))
             }
+        case "updateTelemetryConfiguration":
+            updateTelemetryConfiguration(arguments: arguments)
+            result(nil)
 #if DD_SDK_COMPILED_FOR_TESTING
         case "flushAndDeinitialize":
             Datadog.flushAndDeinitialize()
@@ -153,6 +167,63 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         if let rumConfiguration = configuration.rumConfiguration {
             rum = DatadogRumPlugin.instance
             rum?.initialize(configuration: rumConfiguration)
+        }
+
+        Datadog._internal._telemetry.setTelemetryConfigurationMapper { [weak self] event in
+            guard let self = self else {
+                return event
+            }
+
+            // Supply configuration overrides
+            var event = event
+            var configuration = event.telemetry.configuration
+            configuration.trackViewsManually = self.configurationTelemetryOverrides.trackViewsManually
+            configuration.trackInteractions = self.configurationTelemetryOverrides.trackInteractions
+            configuration.trackErrors = self.configurationTelemetryOverrides.trackErrors
+            configuration.trackNetworkRequests = self.configurationTelemetryOverrides.trackNetworkRequests
+            configuration.trackNativeViews = self.configurationTelemetryOverrides.trackNativeViews
+            configuration.trackCrossPlatformLongTasks = self.configurationTelemetryOverrides.trackCrossPlatformLongTasks
+            configuration.trackFlutterPerformance = self.configurationTelemetryOverrides.trackFlutterPerformance
+            event.telemetry.configuration = configuration
+
+            return event
+        }
+    }
+
+    private func updateTelemetryConfiguration(arguments: [String: Any]) {
+        var wasValid = true
+        let option = arguments["option"]
+        let value = arguments["value"]
+
+        if let option = option as? String,
+           let value = value as? Bool {
+            switch(option) {
+            case "trackViewsManually":
+                configurationTelemetryOverrides.trackViewsManually = value
+            case "trackInteractions":
+                configurationTelemetryOverrides.trackInteractions = value
+            case "trackErrors":
+                configurationTelemetryOverrides.trackErrors = value
+            case "trackNetworkRequests":
+                configurationTelemetryOverrides.trackNetworkRequests = value
+            case "trackNativeViews":
+                configurationTelemetryOverrides.trackNativeViews = value
+            case "trackCrossPlatformLongTasks":
+                configurationTelemetryOverrides.trackCrossPlatformLongTasks = value
+            case "trackFlutterPerformance":
+                configurationTelemetryOverrides.trackFlutterPerformance = value
+            default:
+                wasValid = false
+            }
+        } else {
+            wasValid = false
+        }
+
+        if (!wasValid) {
+            Datadog._internal._telemetry.debug(
+                id: "datadog_flutter:configuration_error",
+                message: "Attempting to set telemetry configuration option '\(String(describing: option))'" +
+                    " to '\(String(describing: value))', which is invalid.")
         }
     }
 

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -197,7 +197,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
 
         if let option = option as? String,
            let value = value as? Bool {
-            switch(option) {
+            switch option {
             case "trackViewsManually":
                 configurationTelemetryOverrides.trackViewsManually = value
             case "trackInteractions":
@@ -219,7 +219,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             wasValid = false
         }
 
-        if (!wasValid) {
+        if !wasValid {
             Datadog._internal._telemetry.debug(
                 id: "datadog_flutter:configuration_error",
                 message: "Attempting to set telemetry configuration option '\(String(describing: option))'" +

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -169,7 +169,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             rum?.initialize(configuration: rumConfiguration)
         }
 
-        Datadog._internal._telemetry.setTelemetryConfigurationMapper { [weak self] event in
+        Datadog._internal.telemetry.setConfigurationMapper { [weak self] event in
             guard let self = self else {
                 return event
             }
@@ -220,7 +220,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         }
 
         if !wasValid {
-            Datadog._internal._telemetry.debug(
+            Datadog._internal.telemetry.debug(
                 id: "datadog_flutter:configuration_error",
                 message: "Attempting to set telemetry configuration option '\(String(describing: option))'" +
                     " to '\(String(describing: value))', which is invalid.")

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 
-import 'src/attributes.dart';
+import 'datadog_internal.dart';
 import 'src/datadog_configuration.dart';
 import 'src/datadog_plugin.dart';
 import 'src/datadog_sdk_platform_interface.dart';
@@ -117,6 +117,8 @@ class DatadogSdk {
       };
 
       await DatadogSdk.instance.initialize(configuration);
+      DatadogSdk.instance
+          .updateConfigurationInfo(LateConfigurationProperty.trackErrors, true);
 
       runner();
     }, (e, s) {
@@ -142,6 +144,13 @@ class DatadogSdk {
     }
     if (configuration.rumConfiguration != null) {
       _rum = DdRum(configuration.rumConfiguration!, internalLogger);
+
+      // Update 'late' configuration
+      updateConfigurationInfo(LateConfigurationProperty.trackFlutterPerformance,
+          configuration.rumConfiguration!.reportFlutterPerformance);
+      updateConfigurationInfo(
+          LateConfigurationProperty.trackCrossPlatformLongTasks,
+          configuration.rumConfiguration!.detectLongTasks);
     }
 
     _initializePlugins(configuration.additionalPlugins);

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -75,6 +75,9 @@ class DatadogSdk {
   @internal
   final InternalLogger internalLogger = InternalLogger();
 
+  /// Internal extension access to the configured platform
+  DatadogSdkPlatform get platform => _platform;
+
   /// Set the verbosity of the Datadog SDK. Set to [Verbosity.info] by
   /// default. All internal logging is enabled only when [kDebugMode] is
   /// set.

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -80,6 +80,11 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
       String message, String? stack, String? kind) async {
     // Not currently supported
   }
+
+  @override
+  Future<void> updateTelemetryConfiguration(String property, bool value) async {
+    // Not currently supported
+  }
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -52,7 +52,7 @@ enum LateConfigurationProperty {
   /// always the same as trackLongTasks
   trackCrossPlatformLongTasks,
 
-  /// Whether native views are being tracked. Currently Unused.
+  /// Whether native views are being tracked. Currently unused.
   trackNativeViews,
 
   /// Whether [DdSdkConfiguration.reportFlutterPerformance] was set to true

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -8,6 +8,9 @@
 
 import 'dart:math';
 
+import 'datadog_flutter_plugin.dart';
+import 'src/datadog_sdk_platform_interface.dart';
+
 export 'src/attributes.dart';
 export 'src/rum/attributes.dart';
 
@@ -24,4 +27,42 @@ String generateTraceId() {
   traceId += lowBits;
 
   return traceId.toString();
+}
+
+/// A set of properties that Flutter can configure "late", meaning after the
+/// first call to [DatadogSdk.initialize].
+enum LateConfigurationProperty {
+  /// Whether the user is tracking views manually. This is set to false if a
+  /// DatadogNavigationObserver is constructed.
+  trackViewsManually,
+
+  /// Whether the user is using [RumUserActionDetector]. Set when the first
+  /// [RumUserActionDetector] is constructed.
+  trackInteractions,
+
+  /// Whether Datadog is automatically tracking errors, set if
+  /// [DatadogSdk.runApp] is used.
+  trackErrors,
+
+  /// Whether or not network requests are being tracked. Set during initialization
+  /// of the datadog_tracking_http_client HttpClient or http.Client classes.
+  trackNetworkRequests,
+
+  /// Whether we are tracking cross platform long tasks. This is currently
+  /// always the same as trackLongTasks
+  trackCrossPlatformLongTasks,
+
+  /// Whether native views are being tracked. Currently Unused.
+  trackNativeViews,
+
+  /// Whether [DdSdkConfiguration.reportFlutterPerformance] was set to true
+  trackFlutterPerformance,
+}
+
+extension DatadogInternal on DatadogSdk {
+  /// Update a late configuration property
+  void updateConfigurationInfo(LateConfigurationProperty property, bool value) {
+    DatadogSdkPlatform.instance
+        .updateTelemetryConfiguration(property.name, value);
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -9,9 +9,9 @@
 import 'dart:math';
 
 import 'datadog_flutter_plugin.dart';
-import 'src/datadog_sdk_platform_interface.dart';
 
 export 'src/attributes.dart';
+export 'src/datadog_sdk_platform_interface.dart';
 export 'src/rum/attributes.dart';
 
 final Random _traceRandom = Random();
@@ -62,7 +62,6 @@ enum LateConfigurationProperty {
 extension DatadogInternal on DatadogSdk {
   /// Update a late configuration property
   void updateConfigurationInfo(LateConfigurationProperty property, bool value) {
-    DatadogSdkPlatform.instance
-        .updateTelemetryConfiguration(property.name, value);
+    platform.updateTelemetryConfiguration(property.name, value);
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -90,4 +90,12 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       'kind': kind,
     });
   }
+
+  @override
+  Future<void> updateTelemetryConfiguration(String property, bool value) {
+    return methodChannel.invokeMethod('updateTelemetryConfiguration', {
+      'option': property,
+      'value': value,
+    });
+  }
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -57,4 +57,6 @@ abstract class DatadogSdkPlatform extends PlatformInterface {
       {LogCallback? logCallback});
   Future<AttachResponse?> attachToExisting();
   Future<void> flushAndDeinitialize();
+
+  Future<void> updateTelemetryConfiguration(String property, bool value);
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../datadog_flutter_plugin.dart';
+import '../../datadog_internal.dart';
 import '../helpers.dart';
 
 /// Information about a View that will be passed to [DdRum.startView]
@@ -71,6 +72,8 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>>
     this.viewInfoExtractor = defaultViewInfoExtractor,
   }) {
     ambiguate(WidgetsBinding.instance)?.addObserver(this);
+    datadogSdk.updateConfigurationInfo(
+        LateConfigurationProperty.trackViewsManually, false);
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_gesture_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_gesture_detector.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
 
 import '../../datadog_flutter_plugin.dart';
+import '../../datadog_internal.dart';
 
 // The distance a 'pointer' can move and still be considered a tap, in logical
 // pixels.
@@ -69,10 +70,22 @@ class RumUserActionDetector extends StatefulWidget {
 }
 
 class _RumUserActionDetectorState extends State<RumUserActionDetector> {
+  static var _didUpdateTelemetry = false;
+
   final _listenerKey = GlobalKey();
 
   int? _lastPointerId;
   Offset? _lastPointerDownLocation;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!_didUpdateTelemetry) {
+      DatadogSdk.instance.updateConfigurationInfo(
+          LateConfigurationProperty.trackInteractions, true);
+      _didUpdateTelemetry = true;
+    }
+  }
 
   @override
   void didUpdateWidget(covariant RumUserActionDetector oldWidget) {

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
@@ -194,4 +194,23 @@ void main() {
       })
     ]);
   });
+
+  test('updateTelemetryConfiguration calls to method channel', () {
+    final st = StackTrace.current;
+    unawaited(
+        ddSdkPlatform.updateTelemetryConfiguration('telemetryProperty', true));
+    unawaited(ddSdkPlatform.updateTelemetryConfiguration(
+        'secondTelemetryProperty', false));
+
+    expect(log, [
+      isMethodCall('updateTelemetryConfiguration', arguments: {
+        'option': 'telemetryProperty',
+        'value': true,
+      }),
+      isMethodCall('updateTelemetryConfiguration', arguments: {
+        'option': 'secondTelemetryProperty',
+        'value': false,
+      })
+    ]);
+  });
 }

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -3,9 +3,12 @@
 // Copyright 2019-2022 Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+class MockDatadogSdkPlatform extends Mock implements DatadogSdkPlatform {}
 
 class MockDatadogSdk extends Mock implements DatadogSdk {}
 
@@ -13,13 +16,19 @@ class MockDdRum extends Mock implements DdRum {}
 
 void main() {
   late MockDdRum mockRum;
+  late MockDatadogSdkPlatform mockPlatform;
   late MockDatadogSdk mockDatadog;
 
   setUp(() {
     mockRum = MockDdRum();
+    mockPlatform = MockDatadogSdkPlatform();
     mockDatadog = MockDatadogSdk();
 
+    when(() => mockPlatform.updateTelemetryConfiguration(any(), any()))
+        .thenAnswer((_) => Future<void>.value());
+
     when(() => mockDatadog.rum).thenReturn(mockRum);
+    when(() => mockDatadog.platform).thenReturn(mockPlatform);
     when(() => mockRum.startView(any(), any(), any()))
         .thenAnswer((_) => Future<void>.value());
     when(() => mockRum.stopView(any(), any()))

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -44,7 +44,10 @@ class DatadogClient extends http.BaseClient {
   DatadogClient({
     required this.datadogSdk,
     http.Client? innerClient,
-  }) : _innerClient = innerClient ?? http.Client();
+  }) : _innerClient = innerClient ?? http.Client() {
+    datadogSdk.updateConfigurationInfo(
+        LateConfigurationProperty.trackNetworkRequests, true);
+  }
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 
 import '../datadog_tracking_http_client.dart';
 
@@ -21,5 +22,7 @@ class _DdHttpTrackingPlugin extends DatadogPlugin {
   @override
   void initialize() {
     HttpOverrides.global = DatadogTrackingHttpOverrides(instance);
+    instance.updateConfigurationInfo(
+        LateConfigurationProperty.trackNetworkRequests, true);
   }
 }

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^1.0.0
+  datadog_flutter_plugin: ^1.2.0
   uuid: ^3.0.5
   http: ^0.13.5
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -14,6 +15,8 @@ import 'package:mocktail/mocktail.dart';
 import 'test_utils.dart';
 
 class MockDatadogSdk extends Mock implements DatadogSdk {}
+
+class MockDatadogSdkPlatform extends Mock implements DatadogSdkPlatform {}
 
 class MockDdRum extends Mock implements DdRum {}
 
@@ -25,6 +28,7 @@ class FakeBaseRequest extends Fake implements http.BaseRequest {}
 
 void main() {
   late MockDatadogSdk mockDatadog;
+  late MockDatadogSdkPlatform mockPlatform;
   late MockClient mockClient;
   late MockStreamedResponse mockResponse;
 
@@ -34,11 +38,16 @@ void main() {
   });
 
   setUp(() {
+    mockPlatform = MockDatadogSdkPlatform();
+    when(() => mockPlatform.updateTelemetryConfiguration(any(), any()))
+        .thenAnswer((_) => Future<void>.value());
+
     mockDatadog = MockDatadogSdk();
     when(() => mockDatadog.isFirstPartyHost(
         any(that: HasHost(equals('test_url'))))).thenReturn(true);
     when(() => mockDatadog.isFirstPartyHost(
         any(that: HasHost(equals('non_first_party'))))).thenReturn(false);
+    when(() => mockDatadog.platform).thenReturn(mockPlatform);
 
     mockResponse = MockStreamedResponse();
     when(() => mockResponse.stream)

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -15,6 +15,8 @@ import 'test_utils.dart';
 
 class MockDatadogSdk extends Mock implements DatadogSdk {}
 
+class MockDatadogSdkPlatform extends Mock implements DatadogSdkPlatform {}
+
 class MockDdRum extends Mock implements DdRum {}
 
 class MockHttpClient extends Mock implements HttpClient {}
@@ -41,6 +43,7 @@ class MockHttpClientResponse extends Mock implements HttpClientResponse {
 
 void main() {
   late MockDatadogSdk mockDatadog;
+  late MockDatadogSdkPlatform mockPlatform;
   late MockDdRum mockRum;
   late MockHttpClient mockClient;
 
@@ -51,11 +54,17 @@ void main() {
   });
 
   setUp(() {
+    mockPlatform = MockDatadogSdkPlatform();
+    when(() => mockPlatform.updateTelemetryConfiguration(any(), any()))
+        .thenAnswer((_) => Future<void>.value());
+
     mockDatadog = MockDatadogSdk();
     when(() => mockDatadog.isFirstPartyHost(
         any(that: HasHost(equals('test_url'))))).thenReturn(true);
     when(() => mockDatadog.isFirstPartyHost(
         any(that: HasHost(equals('non_first_party'))))).thenReturn(false);
+    when(() => mockDatadog.platform).thenReturn(mockPlatform);
+
     mockRum = MockDdRum();
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.tracingSamplingRate).thenReturn(50.0);


### PR DESCRIPTION
### What and why?

Adds methods to modify native configuration telemetry with Flutter specific telemetry

### How?

Each Flutter assignable property that is late initialized is tracked in an internal struct and updated as we learn more from the use of the SDK.  When the telemetry is sent, the mapper function transfers all of the known properties over to the telemetry configuration object.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests