### PR TITLE
💚 Fix android unit tests with v2 changes

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -191,15 +191,19 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         }
     }
 
+    internal fun stop() {
+        simpleInvokeOn("stop", Datadog)
+
+        val rumRegisteredField = GlobalRum::class.java.getDeclaredField("isRegistered")
+        rumRegisteredField.isAccessible = true
+        val isRegistered: AtomicBoolean = rumRegisteredField.get(null) as AtomicBoolean
+        isRegistered.set(false)
+    }
+
     internal fun invokePrivateShutdown(result: Result) {
         executor.submit {
             simpleInvokeOn("flushAndShutdownExecutors", Datadog)
-            simpleInvokeOn("stop", Datadog)
-
-            val rumRegisteredField = GlobalRum::class.java.getDeclaredField("isRegistered")
-            rumRegisteredField.isAccessible = true
-            val isRegistered: AtomicBoolean = rumRegisteredField.get(null) as AtomicBoolean
-            isRegistered.set(false)
+            stop()
         }.get()
 
         result.success(null)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -74,8 +74,7 @@ class DatadogSdkPluginTest {
 
     @AfterEach
     fun afterEach() {
-        val mockResult = mock<MethodChannel.Result>()
-        plugin.invokePrivateShutdown(mockResult)
+        plugin.stop()
     }
 
     val contracts = listOf(
@@ -289,8 +288,6 @@ class DatadogSdkPluginTest {
     @Test
     fun `M issue warning W attachToExisting has no existing instance`() {
         // GIVEN
-        Datadog.setVerbosity(Log.INFO)
-
         val methodCall = MethodCall(
             "attachToExisting",
             mapOf<String, Object?>()
@@ -393,8 +390,18 @@ class DatadogSdkPluginTest {
     }
 
     @Test
-    fun `M set sdk verbosity W called through MethodChannel`() {
+    fun `M set sdk verbosity W called through MethodChannel`(
+        forge: Forge
+    ) {
         // GIVEN
+        val configuration = DatadogFlutterConfiguration(
+            clientToken = forge.aString(),
+            env = "prod",
+            nativeCrashReportEnabled = false,
+            trackingConsent = TrackingConsent.GRANTED
+        )
+        plugin.initialize(configuration)
+
         var methodCall = MethodCall(
             "setSdkVerbosity",
             mapOf( "value" to "Verbosity.info" )
@@ -405,7 +412,8 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCall, mockResult)
 
         // THEN
-        val setVerbosity: Int = Datadog.getFieldValue("libraryVerbosity")
+        var sdkCore: Any = Datadog.getFieldValue<Any, Datadog>("globalSdkCore")
+        val setVerbosity: Int = sdkCore?.getFieldValue("libraryVerbosity")
         assertThat(setVerbosity).equals(Log.INFO)
         verify(mockResult).success(null)
     }
@@ -433,8 +441,8 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCall, mockResult)
 
         // THEN
-        var coreFeature = Class.forName("com.datadog.android.core.internal.CoreFeature")
-            .kotlin.objectInstance
+        var coreFeature: Any = Datadog.getFieldValue<Any, Datadog>("globalSdkCore")
+            ?.getFieldValue("coreFeature")
         var trackingConsent: TrackingConsent? = coreFeature
             ?.getFieldValue<Any, Any>("trackingConsentProvider")
             ?.getFieldValue("consent")
@@ -473,8 +481,8 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCall, mockResult)
 
         // THEN
-        var coreFeature = Class.forName("com.datadog.android.core.internal.CoreFeature")
-            .kotlin.objectInstance
+        var coreFeature: Any = Datadog.getFieldValue<Any, Datadog>("globalSdkCore")
+            ?.getFieldValue("coreFeature")
         var userInfo: UserInfo? = coreFeature
             ?.getFieldValue<Any, Any>("userInfoProvider")
             ?.getFieldValue("internalUserInfo")
@@ -517,8 +525,8 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCall, mockResult)
 
         // THEN
-        var coreFeature = Class.forName("com.datadog.android.core.internal.CoreFeature")
-            .kotlin.objectInstance
+        var coreFeature: Any = Datadog.getFieldValue<Any, Datadog>("globalSdkCore")
+            ?.getFieldValue("coreFeature")
         var userInfo: UserInfo? = coreFeature
             ?.getFieldValue<Any, Any>("userInfoProvider")
             ?.getFieldValue("internalUserInfo")
@@ -555,8 +563,8 @@ class DatadogSdkPluginTest {
         plugin.onMethodCall(methodCall, mockResult)
 
         // THEN
-        var coreFeature = Class.forName("com.datadog.android.core.internal.CoreFeature")
-            .kotlin.objectInstance
+        var coreFeature: Any = Datadog.getFieldValue<Any, Datadog>("globalSdkCore")
+            ?.getFieldValue("coreFeature")
         var userInfo: UserInfo? = coreFeature
             ?.getFieldValue<Any, Any>("userInfoProvider")
             ?.getFieldValue("internalUserInfo")


### PR DESCRIPTION
### What and why?

Some properties were moved into the SdkCore / CoreFeature objects, which the unit tests access to make sure they're sending the right data. Use `stop` instead of `flushAndShutdownExectutors` in unit tests (still needed for Integration tests).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests