### PR TITLE
💚 Fix e2e tests by ignoring dev snapshots on android

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
@@ -67,6 +67,8 @@ flutter {
     source '../..'
 }
 
+apply from: '../../../../../ignore_sr_snapshots.gradle'
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }


### PR DESCRIPTION
### What and why?

Dev snapshots still have an extra configuration property. We need to ignore them in order to run correctly on Android.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests