### PR TITLE
🐛 Allow sdkVerbosity to be set prior to WidgetsFlutterBinding being initialized

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 * 🔥 BREAKING - Log functions (`debug`, `info`, `warn`) now use `attributes` as a named argument instead of a positional argument.
 * Allow errors to be sent on all log functions. See [#264][]
 * Disable tracing by default in iOS. Silences a benign warning from the SDK. See [#280][]
+* Allow setting sdkVerbosity prior to calling `DatadogSdk.runApp`
 
 ## 1.1.0
 

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -45,6 +45,8 @@ class DatadogSdk {
 
   DatadogSdk._();
 
+  bool _initialized = false;
+
   DdLogs? _logs;
   DdLogs? get logs => _logs;
 
@@ -84,7 +86,9 @@ class DatadogSdk {
   Verbosity get sdkVerbosity => internalLogger.sdkVerbosity;
   set sdkVerbosity(Verbosity value) {
     internalLogger.sdkVerbosity = value;
-    unawaited(_platform.setSdkVerbosity(value));
+    if (_initialized) {
+      unawaited(_platform.setSdkVerbosity(value));
+    }
   }
 
   /// Get an instance of a DatadogPlugin that was registered with
@@ -102,10 +106,10 @@ class DatadogSdk {
     _plugins.clear();
     _logs = null;
     _rum = null;
+    _initialized = false;
   }
 
-  /// A helper function that will initialize Datadog setup error reporting, and
-  /// automatic HttpClient tracing.
+  /// A helper function that will initialize Datadog and setup error reporting
   ///
   /// See also, [DdRum.handleFlutterError], [DatadogTrackingHttpClient]
   static Future<void> runApp(
@@ -135,6 +139,9 @@ class DatadogSdk {
 
   /// Initialize the DatadogSdk with the provided [configuration].
   Future<void> initialize(DdSdkConfiguration configuration) async {
+    // First set our SDK verbosity. We can assume WidgetsFlutterBinding has been initialized at this point
+    await _platform.setSdkVerbosity(internalLogger.sdkVerbosity);
+
     configuration.additionalConfig[DatadogConfigKey.source] = 'flutter';
     configuration.additionalConfig[DatadogConfigKey.sdkVersion] = sdkVersion;
 
@@ -157,6 +164,7 @@ class DatadogSdk {
     }
 
     _initializePlugins(configuration.additionalPlugins);
+    _initialized = true;
   }
 
   /// Attach the Datadog Flutter SDK to an already initialized Datadog Native
@@ -164,6 +172,9 @@ class DatadogSdk {
   Future<void> attachToExisting(
     DdSdkExistingConfiguration config,
   ) async {
+    // First set our SDK verbosity. We can assume WidgetsFlutterBinding has been initialized at this point
+    await _platform.setSdkVerbosity(internalLogger.sdkVerbosity);
+
     final attachResponse = await wrapAsync<AttachResponse>(
         'attachToExisting', internalLogger, null, () async {
       return await _platform.attachToExisting();
@@ -193,6 +204,7 @@ class DatadogSdk {
       }
 
       _initializePlugins(config.additionalPlugins);
+      _initialized = true;
     } else {
       internalLogger.error(
           'Failed to attach to an existing native instance of the Datadog SDK.');

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
-import 'package:datadog_flutter_plugin/src/datadog_sdk_platform_interface.dart';
 import 'package:datadog_flutter_plugin/src/logs/ddlogs_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -35,6 +34,7 @@ void main() {
     registerFallbackValue(TrackingConsent.granted);
     registerFallbackValue(LoggingConfiguration());
     registerFallbackValue(LateConfigurationProperty.trackErrors);
+    registerFallbackValue(Verbosity.verbose);
   });
 
   setUp(() {
@@ -46,6 +46,8 @@ void main() {
         .thenAnswer((_) => Future<AttachResponse?>.value(AttachResponse(
               rumEnabled: false,
             )));
+    when(() => mockPlatform.setSdkVerbosity(any()))
+        .thenAnswer((invocation) => Future<void>.value());
     when(() => mockPlatform.setUserInfo(any(), any(), any(), any()))
         .thenAnswer((_) => Future<void>.value());
     when(() => mockPlatform.addUserExtraInfo((any())))


### PR DESCRIPTION
### What and why?

Because we currently use runZonedGuarded to catch errors, we need to make sure WidgetsFlutterBinding.ensureInitialized is called inside runZonedGuarded.

This is an issue if you try to set sdkVerbosity (which requires the binding be initialized) before calling DatadogSdk.runApp. This fixes the issue by not calling into the platform channel until Datadog is initialized or during the initialization process.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests