### PR TITLE
Use JitPack only for specific dependencies

### DIFF
--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -27,7 +27,12 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url("https://jitpack.io") }
+        maven {
+             url("https://jitpack.io")
+             content {
+                includeGroup "com.github.xgouchet.Elmyr"
+             }
+        }
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots/"
         }


### PR DESCRIPTION
### What and why?

jitpack.io (which is backed by JCenter) is not quite stable lately with long downtimes, so let's use lookup in this repo only for dependencies which are in this repo. Since only test dependency is currently using it, it will prevent breaking the build of dependent projects which are building this one from the sources (like Shopist Flutter).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests