### PR TITLE
📝 Fix missing version in CHNAGELOG for tracking_http_client

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add methods for enabling the DatadogTrackingHttpClient in add-to-app scenarios.
 * Send trace sample rate (`dd.rule_psr`) for APM's traffic ingestion control page.
 * Added DatadogClient for use with the `http` pub package.
-* Fix an issue where convenience methods on DataodgTrackingHttpClient weren't being tracked properly
+* Fix an issue where convenience methods on DatadogTrackingHttpClient weren't being tracked properly
 * Support for OTel b3 header injection
 
 ## 1.1.0
@@ -16,6 +16,10 @@
 
 * Updated to use `datadog_flutter_plugin` 1.0.0-rc.1
 * Added internal error reporting (telemetry)
+
+## 1.0.1
+
+* Stable release of 1.0.x
 
 ## 1.0.1-rc.1
 

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -27,7 +27,7 @@ class UpdateVersionsCommand extends Command {
       }
     }
 
-    return _updateChangelog(
+    return _updateChangelogUnreleasedChanges(
         args.packageRoot, args.version, logger, args.dryRun);
   }
 }
@@ -61,6 +61,9 @@ class BumpVersionCommand extends Command {
         }
         break;
     }
+    logger.info('🔀 Adding "Unreleased" back into CHANGELOG');
+    await _updateChangelogAddUnreleased(args.packageRoot, logger, args.dryRun);
+
     logger.info('🔀 Bumping version to $newVersion');
     return updateVersions(
         args.packageRoot, newVersion.toString(), logger, args.dryRun);
@@ -121,7 +124,7 @@ Future<bool> _updateVersionDartFile(
   return true;
 }
 
-Future<bool> _updateChangelog(
+Future<bool> _updateChangelogUnreleasedChanges(
     String packageRoot, String version, Logger logger, bool dryRun) async {
   final changelogFile = File(path.join(packageRoot, 'CHANGELOG.md'));
   if (!changelogFile.existsSync()) {
@@ -131,8 +134,28 @@ Future<bool> _updateChangelog(
 
   await transformFile(changelogFile, logger, dryRun, (element) {
     if (element.startsWith('## Unreleased')) {
-      element = '## Unreleased\n\n## $version';
+      element = '## $version';
     }
+    return element;
+  });
+
+  return true;
+}
+
+Future<bool> _updateChangelogAddUnreleased(
+    String packageRoot, Logger logger, bool dryRun) async {
+  final changelogFile = File(path.join(packageRoot, 'CHANGELOG.md'));
+  if (!changelogFile.existsSync()) {
+    logger.shout('⁉️ Could not find CHANGELOG.md at ${changelogFile.path}');
+    return false;
+  }
+
+  bool firstLine = true;
+  await transformFile(changelogFile, logger, dryRun, (element) {
+    if (firstLine) {
+      element = '## Unreleased\n\n' + element;
+    }
+
     return element;
   });
 


### PR DESCRIPTION
### What and why?

Release of 1.0.1 was missed in the change log on develop. 

Also fix the deployment script to not add "Unreleased" back into the CHANGELOG until we request to bump for the next version (that keeps it out of the released CHANGELOG)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests