### PR TITLE
✨ Support tracing header types per-host.

### DIFF
--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -115,7 +115,8 @@ void main() {
     });
 
     test('Interceptor calls proper rum functions', () async {
-      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+      when(() => mockDatadog.headerTypesForHost(any()))
+          .thenReturn({TracingHeaderType.datadog});
 
       final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
 
@@ -140,12 +141,12 @@ void main() {
     for (var tracingType in TracingHeaderType.values) {
       group('with tracing header type $tracingType', () {
         test('Interceptor calls send tracing attributes', () async {
-          when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+          when(() => mockDatadog.headerTypesForHost(any()))
+              .thenReturn({tracingType});
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
             channel,
-            tracingHeaderTypes: {tracingType},
           );
 
           final stub = GreeterClient(channel, interceptors: [interceptor]);
@@ -170,13 +171,13 @@ void main() {
         test(
             'Interceptor calls do not send tracing attributes when shouldSample returns false',
             () async {
-          when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+          when(() => mockDatadog.headerTypesForHost(any()))
+              .thenReturn({tracingType});
           when(() => mockRum.shouldSampleTrace()).thenReturn(false);
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
             channel,
-            tracingHeaderTypes: {tracingType},
           );
 
           final stub = GreeterClient(channel, interceptors: [interceptor]);
@@ -195,12 +196,12 @@ void main() {
         });
 
         test('Interceptor passes on proper metadata', () async {
-          when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+          when(() => mockDatadog.headerTypesForHost(any()))
+              .thenReturn({tracingType});
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
             channel,
-            tracingHeaderTypes: {tracingType},
           );
 
           final stub = GreeterClient(channel, interceptors: [interceptor]);
@@ -215,13 +216,13 @@ void main() {
         test(
             'Interceptor does not send traces metadata when shouldSample returns false',
             () async {
-          when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+          when(() => mockDatadog.headerTypesForHost(any()))
+              .thenReturn({tracingType});
           when(() => mockRum.shouldSampleTrace()).thenReturn(false);
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
             channel,
-            tracingHeaderTypes: {tracingType},
           );
 
           final stub = GreeterClient(channel, interceptors: [interceptor]);
@@ -238,7 +239,7 @@ void main() {
     test(
         'Interceptor calls do not send tracing attributes for non-first-party hosts',
         () async {
-      when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(false);
+      when(() => mockDatadog.headerTypesForHost(any())).thenReturn({});
 
       final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
 
@@ -274,7 +275,8 @@ void main() {
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.tracingSamplingRate).thenReturn(12);
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+    when(() => mockDatadog.headerTypesForHost(any()))
+        .thenReturn({TracingHeaderType.datadog});
 
     final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
 
@@ -320,7 +322,8 @@ void main() {
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.tracingSamplingRate).thenReturn(12);
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+    when(() => mockDatadog.headerTypesForHost(any()))
+        .thenReturn({TracingHeaderType.datadog});
 
     final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
 
@@ -361,7 +364,8 @@ void main() {
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.tracingSamplingRate).thenReturn(12);
-    when(() => mockDatadog.isFirstPartyHost(any())).thenReturn(true);
+    when(() => mockDatadog.headerTypesForHost(any()))
+        .thenReturn({TracingHeaderType.datadog});
 
     final interceptor = DatadogGrpcInterceptor(mockDatadog, channel);
 

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -18,44 +18,30 @@ extension TrackingExtension on DdSdkConfiguration {
   /// check the documentation on [DatadogTrackingHttpClient]
   ///
   /// If the RUM feature is enabled, the SDK will send RUM Resources for all
-  /// intercepted requests. The SDK will also generate and send tracing Spans for
-  /// each 1st-party request.
+  /// intercepted requests. The SDK will also generate and send tracing Spans
+  /// for each 1st-party request.
   ///
   /// The DatadogTracingHttpClient can additionally set tracing headers on your
   /// requests, which allows for distributed tracing. You can set which format
-  /// of tracing header using the [tracingHeaderTypes] parameter. Multiple
-  /// tracing formats are allowed. The percentage of resources traced in this
-  /// way is determined by [RumConfiguration.tracingSamplingRate].
+  /// of tracing headers when configuring firstParty hosts with
+  /// [DdSdkConfiguration.firstPartyHostsWithTracingHeaders]. The percentage of
+  /// resources traced in this way is determined by
+  /// [RumConfiguration.tracingSamplingRate].
   ///
-  /// Note that the client will not overwrite existing OTel tracing headers, and
-  /// will properly propogate these to Datadog Resources so it is safe to
-  /// manually add trace headers to your requests, rather than having Datadog
-  /// add them
   ///
   /// Note that this is call is not necessary if you only want to track requests
   /// made through [DatadogClient]
   ///
-  /// See also [firstPartyHosts], [TracingHeaderType]
-  void enableHttpTracking({
-    Set<TracingHeaderType>? tracingHeaderTypes = const {
-      TracingHeaderType.datadog
-    },
-  }) {
-    addPlugin(DdHttpTrackingPluginConfiguration(
-      tracingHeaderTypes: tracingHeaderTypes,
-    ));
+  /// See also [DdSdkConfiguration.firstPartyHostsWithTracingHeaders],
+  /// [DdSdkConfiguration.firstPartyHosts], [TracingHeaderType]
+  void enableHttpTracking() {
+    addPlugin(DdHttpTrackingPluginConfiguration());
   }
 }
 
 extension TrackingExtensionExisting on DdSdkExistingConfiguration {
   /// See [TrackingExtension.enableHttpTracking]
-  void enableHttpTracking({
-    Set<TracingHeaderType>? tracingHeaderTypes = const {
-      TracingHeaderType.datadog
-    },
-  }) {
-    addPlugin(DdHttpTrackingPluginConfiguration(
-      tracingHeaderTypes: tracingHeaderTypes,
-    ));
+  void enableHttpTracking() {
+    addPlugin(DdHttpTrackingPluginConfiguration());
   }
 }

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -46,8 +46,7 @@ class DatadogTrackingHttpOverrides extends HttpOverrides {
 /// [RumConfiguration.tracingSamplingRate].
 ///
 /// To specify which hosts are 1st party (and therefore should have tracing
-/// Spans sent), see [DdSdkConfiguration.firstPartyHosts]. You can also set
-/// first party hosts after initialization setting [DatadogSdk.firstPartyHosts]
+/// Spans sent), see [DdSdkConfiguration.firstPartyHostsWithTracingHeaders].
 ///
 /// Unlike [DatadogClient], the DatadogTrackingHttpClient is able to override
 /// all network operations that use [HttpClient], which includes requests made
@@ -305,14 +304,11 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
     _headersInjected = true;
 
     final rum = client.datadogSdk.rum;
-    bool isFirstParty = false;
-    var tracingHeaderTypes =
-        client.configuration.tracingHeaderTypes ?? <TracingHeaderType>{};
-
     try {
-      isFirstParty = client.datadogSdk.isFirstPartyHost(innerContext.uri);
+      final tracingHeaderTypes =
+          client.datadogSdk.headerTypesForHost(innerContext.uri);
 
-      if (rum != null && isFirstParty && tracingHeaderTypes.isNotEmpty) {
+      if (rum != null && tracingHeaderTypes.isNotEmpty) {
         bool shouldSample = rum.shouldSampleTrace();
 
         // No tracing context, generate one ourselves

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
@@ -10,9 +10,7 @@ import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import '../datadog_tracking_http_client.dart';
 
 class DdHttpTrackingPluginConfiguration extends DatadogPluginConfiguration {
-  final Set<TracingHeaderType>? tracingHeaderTypes;
-
-  DdHttpTrackingPluginConfiguration({required this.tracingHeaderTypes});
+  DdHttpTrackingPluginConfiguration();
 
   @override
   DatadogPlugin create(DatadogSdk datadogInstance) {


### PR DESCRIPTION
### What and why?

Instead of setting header types on each client, now we set them as part of `firstPartyHosts` during configuration.  This allows users to set different header types per host.

One oddity is when there are multiple matches, the code merges the two header requests and adds both. For example if you set:

```dart
  firstPartyHostsWithTracingHeaders: {
    'host.com': { TracingHeaderType.datadog },
    'api.host.com': {TracingHeaderType.b3 },
  },
```

Calls to `api.host.com` will have both Datadog and b3 headers injected .

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests