### PR TITLE
👷 Created a script to make pinning versions easier

### DIFF
--- a/tools/releaser/bin/pinner.dart
+++ b/tools/releaser/bin/pinner.dart
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-Present Datadog, Inc.
+
+// This command is used to pin / unpin to specific versions of the iOS / Android
+// codebase while still using version overrides. This can be useful for ongoing
+// development close to a release.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:git/git.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:releaser/cocoapod_util.dart';
+import 'package:releaser/helpers.dart';
+import 'package:releaser/package_list.dart';
+
+void main(List<String> arguments) async {
+  Logger.root.level = Level.INFO;
+  Logger.root.onRecord.listen((event) {
+    print(event.message);
+  });
+
+  final argParser = ArgParser()
+    ..addOption('version', abbr: 'v')
+    ..addOption('platform',
+        abbr: 'p', allowed: ['ios', 'android'], mandatory: true)
+    ..addFlag(
+      'remove',
+      abbr: 'r',
+      help: 'Remove the version pin and set back to develop / snapshots',
+      negatable: false,
+    );
+
+  ArgResults argResults;
+  try {
+    argResults = argParser.parse(arguments);
+  } on FormatException catch (e) {
+    Logger.root.shout('❌ ${e.message}');
+    _printUsage(argParser);
+    return;
+  }
+
+  if (argResults['remove'] != true && argResults['version'] == null) {
+    Logger.root.shout('❌ Must specify a version or set --remove.');
+    return;
+  }
+
+  final gitDir = await getGitDir();
+  if (gitDir == null) {
+    Logger.root.shout('💥 Could not establish your current git directory.');
+    exit(1);
+  }
+
+  final version = argResults['version'] as String?;
+  switch (argResults['platform']) {
+    case 'ios':
+      _pinIOS(gitDir, version);
+      break;
+    case 'android':
+      _pinAndroid(gitDir, version);
+      break;
+  }
+}
+
+void _printUsage(ArgParser argParser) {
+  print('\nUsage: pinner.dart [options]');
+  print('\n${argParser.usage}');
+}
+
+void _pinIOS(GitDir gitDir, String? version) async {
+  final specDependencyPattern = RegExp(
+      r"(?<ws>\s+)pod '(?<dependency>.+)', :git => '(?<git>[^']*?)', :(?<overrideType>\w+) => '(?<override>[^']*?)'");
+
+  final versionString =
+      version != null ? ":tag => '$version'" : ":branch => 'develop'";
+
+  for (final podfile in podfileList) {
+    final file = File(path.join(gitDir.path, podfile));
+    if (!file.existsSync()) {
+      Logger.root.shout('❌ Could not find file $podfile');
+      return;
+    }
+
+    bool inOverride = false;
+    await transformFile(file, Logger.root, false, (line) {
+      if (inOverride) {
+        if (line.startsWith(overridesEndPattern)) {
+          inOverride = false;
+        } else {
+          final match = specDependencyPattern.firstMatch(line);
+          if (match != null) {
+            line =
+                "${match.namedGroup('ws')}pod '${match.namedGroup('dependency')}', :git => '${match.namedGroup('git')}', $versionString";
+          }
+        }
+      } else if (line.startsWith(overridesStartPattern)) {
+        inOverride = true;
+      }
+
+      return line;
+    });
+  }
+}
+
+void _pinAndroid(GitDir gitDir, String? version) async {
+  const versionPrefix = 'ext.datadog_version';
+  final versionRegex = RegExp('$versionPrefix = "(.*)"');
+
+  final versionString = version ?? '1+';
+
+  for (final filePath in gradleList) {
+    final file = File(path.join(gitDir.path, filePath));
+    if (!file.existsSync()) {
+      Logger.root.shout('❌ Could not find file $filePath');
+      return;
+    }
+
+    await transformFile(file, Logger.root, false, (line) {
+      final versionMatch = versionRegex.firstMatch(line);
+      if (versionMatch != null) {
+        final oldVersion = versionMatch.group(1);
+        line = line.replaceFirst('$versionPrefix = "$oldVersion"',
+            '$versionPrefix = "$versionString"');
+      }
+
+      return line;
+    });
+  }
+}

--- a/tools/releaser/lib/cocoapod_util.dart
+++ b/tools/releaser/lib/cocoapod_util.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as path;
 
 import 'command.dart';
 import 'helpers.dart';
+import 'package_list.dart';
 
 final overridesStartPattern = RegExp(r'\s+# Datadog Pod Overrides');
 final overridesEndPattern = RegExp(r'\s+# End Datadog Pod Overrides');
@@ -12,13 +13,6 @@ final specDependencyPattern =
     RegExp(r"\s+s\.dependency\s+'(?<dependency>Datadog.+)', '.+");
 
 class RemovePodOverridesCommand extends Command {
-  final podfileLocations = [
-    'packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile',
-    'packages/datadog_flutter_plugin/example/ios/Podfile',
-    'packages/datadog_flutter_plugin/integration_test_app/ios/Podfile',
-    'packages/datadog_tracking_http_client/example/ios/Podfile',
-  ];
-
   final podspecLocation =
       'packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec';
 
@@ -38,7 +32,7 @@ class RemovePodOverridesCommand extends Command {
   Future<bool> _removePodfileOverrides(
       CommandArguments args, Logger logger) async {
     logger.info('ℹ️ Removing overrides from Podfiles.');
-    for (var filePath in podfileLocations) {
+    for (var filePath in podfileList) {
       final file = File(path.join(args.gitDir.path, filePath));
       if (!file.existsSync()) {
         logger.shout('❌ Could not find file $filePath');

--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -5,14 +5,9 @@ import 'package:path/path.dart' as path;
 
 import 'command.dart';
 import 'helpers.dart';
+import 'package_list.dart';
 
 class UpdateGradleFilesCommand extends Command {
-  final gradleFileLocations = [
-    'packages/datadog_flutter_plugin/android/build.gradle',
-    'packages/datadog_flutter_plugin/example/android/build.gradle',
-    'examples/native-hybrid-app/android/app/build.gradle',
-  ];
-
   static const versionPrefix = 'ext.datadog_version';
   final versionRegex = RegExp('$versionPrefix = "(.*)"');
 
@@ -26,7 +21,7 @@ class UpdateGradleFilesCommand extends Command {
   }
 
   Future<bool> _updateGradleFiles(CommandArguments args, Logger logger) async {
-    for (var filePath in gradleFileLocations) {
+    for (var filePath in gradleList) {
       final file = File(path.join(args.gitDir.path, filePath));
       if (!file.existsSync()) {
         logger.shout('❌ Could not find file $filePath');

--- a/tools/releaser/lib/package_list.dart
+++ b/tools/releaser/lib/package_list.dart
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-Present Datadog, Inc.
+
+// Locations of Podfiles
+final podfileList = [
+  'packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile',
+  'packages/datadog_flutter_plugin/example/ios/Podfile',
+  'packages/datadog_flutter_plugin/integration_test_app/ios/Podfile',
+  'packages/datadog_tracking_http_client/example/ios/Podfile',
+];
+
+// Location of gradle files
+final gradleList = [
+  'packages/datadog_flutter_plugin/android/build.gradle',
+  'packages/datadog_flutter_plugin/example/android/build.gradle',
+  'examples/native-hybrid-app/android/app/build.gradle',
+];


### PR DESCRIPTION
### What and why?

Because the Flutter SDK release has lagged a bit, and the Native SDKs are diverging a bit from released versions, I have a need to pin to the most recent version during development.

Since I can see this happening in the future as well, I wrote a script to pin to released versions and quickly revert back to source as needed.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests