### PR TITLE
📌 Pin Android to 1.16.0

### DIFF
--- a/examples/native-hybrid-app/android/app/build.gradle
+++ b/examples/native-hybrid-app/android/app/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.16.0"
 }
 
 plugins {

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -10,7 +10,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.5.31"
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.16.0"
 
     repositories {
         google()


### PR DESCRIPTION
### What and why?

Pin Android to 1.16.0 for the moment.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests