### PR TITLE
🐛 Fix Android pin to 1.16.0

### DIFF
--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.16.0"
 }
 
 def localProperties = new Properties()

--- a/tools/releaser/lib/package_list.dart
+++ b/tools/releaser/lib/package_list.dart
@@ -13,6 +13,6 @@ final podfileList = [
 // Location of gradle files
 final gradleList = [
   'packages/datadog_flutter_plugin/android/build.gradle',
-  'packages/datadog_flutter_plugin/example/android/build.gradle',
+  'packages/datadog_flutter_plugin/example/android/app/build.gradle',
   'examples/native-hybrid-app/android/app/build.gradle',
 ];


### PR DESCRIPTION
### What and why?

I missed a file when pinning Android 1.16.0 (the pinning script was pointing to the wrong file).

This fixes the pin and the pinning script.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests