### PR TITLE
👷 Fix adding 'Unreleased' back to changelog

### DIFF
--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -150,10 +150,9 @@ Future<bool> _updateChangelogAddUnreleased(
     return false;
   }
 
-  bool firstLine = true;
   await transformFile(changelogFile, logger, dryRun, (element) {
-    if (firstLine) {
-      element = '## Unreleased\n\n' + element;
+    if (element.startsWith('# Changelog')) {
+      element += '\n\n## Unreleased\n\n';
     }
 
     return element;


### PR DESCRIPTION
### What and why?

Unreleased being pushed into the changelog was broken.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests