### PR TITLE
👷 Fix releaser being overzealous with version pinning

### DIFF
--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -21,7 +21,8 @@ class UpdateGradleFilesCommand extends Command {
   }
 
   Future<bool> _updateGradleFiles(CommandArguments args, Logger logger) async {
-    for (var filePath in gradleList) {
+    for (var filePath
+        in gradleList.where((e) => e.contains(args.packageName))) {
       final file = File(path.join(args.gitDir.path, filePath));
       if (!file.existsSync()) {
         logger.shout('❌ Could not find file $filePath');


### PR DESCRIPTION
### What and why?

When releasing non-core packages, releaser was removing version information from the core package, which was obviously not correct.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests