### PR TITLE
🐛 Setup `consolePrint` sooner on iOS

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Bind `consolePrint` callback earlier in iOS to make sure initialization errors can be seen in the console. See [#328]
 
 ## 1.2.0
 
@@ -134,3 +134,4 @@
 [#280]: https://github.com/DataDog/dd-sdk-flutter/issues/280
 [#297]: https://github.com/DataDog/dd-sdk-flutter/issues/297
 [#305]: https://github.com/DataDog/dd-sdk-flutter/issues/305
+[#328]: https://github.com/DataDog/dd-sdk-flutter/issues/328

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -59,9 +59,8 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             let configArg = arguments["configuration"] as! [String: Any?]
             if let config = DatadogFlutterConfiguration(fromEncoded: configArg) {
                 if !Datadog.isInitialized {
-                    initialize(configuration: config)
-                    currentConfiguration = configArg as [AnyHashable: Any]
-
+                    // Set log callback before initialization so errors in initialization
+                    // get printed
                     if let setLogCallback = arguments["setLogCallback"] as? Bool,
                        setLogCallback {
                         oldConsolePrint = consolePrint
@@ -69,6 +68,9 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
                             self.channel.invokeMethod("logCallback", arguments: value)
                         }
                     }
+
+                    initialize(configuration: config)
+                    currentConfiguration = configArg as [AnyHashable: Any]
                 } else {
                     let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
                     if !dict.isEqual(to: currentConfiguration!) {


### PR DESCRIPTION
### What and why?

Late binding of the consolePrint function on iOS meant that initialization errors weren't seen in the Flutter console, and would only be seen if you were debugging in XCode.

Fixes #328

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests