### PR TITLE
💚 Hopefully fix bitrise stalling.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -77,7 +77,14 @@ workflows:
             pod repo update
 
             ./prepare.sh
-
+    - script:
+        title: Dart 2.15 fix junitreport
+        inputs:
+        - content: |-
+            #!/user/bin/env bash
+            set -e
+            dart pub global activate junitreport
+        
   run_conditioned_workflows:
     steps:
     - script:


### PR DESCRIPTION
### What and why?

Bitrise is stalling I think because of something weird going on with not being able to find the junitreport library. We're going to globally install it, as that fixed the issue for previous versions of flutter.

(cherry picked from commit 713eb8c67a202b24fc1405e1fa9fc63885a132ec)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests