### PR TITLE
🐛 Fix web not properly populating version from config

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -411,6 +411,15 @@ class DdSdkConfiguration {
   /// upload` command in order for symbolication to work.
   String? version;
 
+  /// Get the defined version as a Datadog compliant tag.
+  ///
+  /// Because 'version' is a Datadog tag, it needs to comply with the rules in
+  /// [Defining
+  /// Tags](https://docs.datadoghq.com/getting_started/tagging/#defining-tags)
+  /// Datadog documentation. This returns your supplied version with on that
+  /// automatically replaces `+` with `-`.
+  String? get versionTag => version?.replaceAll('+', '-');
+
   /// Set the current flavor (variant) of the application
   ///
   /// This must match the flavor set during symbol upload in order for stack
@@ -552,8 +561,7 @@ class DdSdkConfiguration {
     // Add version to additional config as part of encoding
     final encodedAdditionalConfig = Map<String, Object?>.from(additionalConfig);
     if (version != null) {
-      final fixedVersion = version?.replaceAll('+', '-');
-      encodedAdditionalConfig[DatadogConfigKey.version] = fixedVersion;
+      encodedAdditionalConfig[DatadogConfigKey.version] = versionTag;
     }
 
     if (flavor != null) {

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -9,7 +9,6 @@ library ddlogs_flutter_web;
 import 'package:js/js.dart';
 
 import '../../datadog_flutter_plugin.dart';
-import '../attributes.dart';
 import '../web_helpers.dart';
 import 'ddlogs_platform_interface.dart';
 
@@ -17,16 +16,13 @@ class DdLogsWeb extends DdLogsPlatform {
   final Map<String, Logger> _activeLoggers = {};
 
   static void initLogs(DdSdkConfiguration configuration) {
-    String? version =
-        configuration.additionalConfig[DatadogConfigKey.version] as String?;
-
     init(_LogInitOptions(
       clientToken: configuration.clientToken,
       env: configuration.env,
       site: siteStringForSite(configuration.site),
       proxyUrl: configuration.customLogsEndpoint,
       service: configuration.serviceName,
-      version: version,
+      version: configuration.versionTag,
     ));
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -9,7 +9,6 @@ library ddrum_flutter_web;
 import 'package:js/js.dart';
 
 import '../../datadog_flutter_plugin.dart';
-import '../../datadog_internal.dart';
 import '../internal_logger.dart';
 import '../web_helpers.dart';
 import 'ddrum_platform_interface.dart';
@@ -24,9 +23,6 @@ class DdRumWeb extends DdRumPlatform {
       return;
     }
 
-    String? version =
-        configuration.additionalConfig[DatadogConfigKey.version] as String?;
-
     init(_RumInitOptions(
       applicationId: rumConfiguration.applicationId,
       clientToken: configuration.clientToken,
@@ -34,7 +30,7 @@ class DdRumWeb extends DdRumPlatform {
       sampleRate: rumConfiguration.sessionSamplingRate,
       service: configuration.serviceName,
       env: configuration.env,
-      version: version,
+      version: configuration.versionTag,
       proxyUrl: configuration.rumConfiguration?.customEndpoint,
       allowedTracingOrigins: configuration.firstPartyHosts,
       trackViewsManually: true,


### PR DESCRIPTION
### What and why?

Web was using an old internal property for version which was replaced with a configuration property.

Fixes #334

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests