### PR TITLE
✨ Add the ability to forward events from web views to mobile sessions

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -75,7 +75,7 @@ class RumSessionDecoder {
 
 class RumViewVisit {
   final String id;
-  final String name;
+  final String? name;
   final String path;
 
   final List<RumViewEventDecoder> viewEvents = [];
@@ -217,7 +217,7 @@ class RumViewDecoder {
   final Map<String, dynamic> viewData;
 
   String get id => viewData['id'] as String;
-  String get name => viewData['name'] as String;
+  String? get name => viewData['name'] as String?;
   String get path => viewData['url'] as String;
   bool get isActive => viewData['is_active'] as bool;
   int get actionCount => viewData['action']['count'] as int;

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add Web View tracking through the `webview_flutter` package.
 * Bind `consolePrint` callback earlier in iOS to make sure initialization errors can be seen in the console. See [#328]
 * Fix `version` not properly populating on Flutter Web. See [#334]
 * Improve `RumUserActionDetector` to detect more widgets, including `BottomNavigationBar`, `Tab`, `Switch`, and `Radio`

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0"
+        classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -43,7 +43,7 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -9,7 +9,7 @@ group "com.datadoghq.flutter"
 version "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "1.6.21"
     ext.datadog_version = "1+"
 
     repositories {

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -43,7 +43,7 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 32
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -73,6 +73,8 @@ apply from: '../../../ignore_sr_snapshots.gradle'
 dependencies {
     implementation "com.datadoghq:dd-sdk-android:$datadog_version"
     implementation "com.datadoghq:dd-sdk-android-ndk:$datadog_version"
+
+    implementation project(":webview_flutter_android")
     
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.code.gson:gson:2.8.8"

--- a/packages/datadog_flutter_plugin/android/settings.gradle
+++ b/packages/datadog_flutter_plugin/android/settings.gradle
@@ -3,5 +3,42 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+import groovy.json.JsonSlurper
 
 rootProject.name = 'datadog_flutter_plugin'
+
+// Because Datadog depends on the native functionality of some plugins, we need to import
+// that native functionality, but only know where to look from the "app's" 
+// `.flutter-plugins-dependencies` dependencies file.
+// This logic is copied from flutter/packages/flutter_tools/gradle/app_plugin_loader.gradle
+def flutterProjectRoot = rootProject.projectDir.parentFile
+
+// If this logic is changed, also change the logic in module_plugin_loader.gradle.
+def pluginsFile = new File(flutterProjectRoot, 'example/.flutter-plugins-dependencies')
+if (!pluginsFile.exists()) {
+  return
+}
+
+def object = new JsonSlurper().parseText(pluginsFile.text)
+assert object instanceof Map
+assert object.plugins instanceof Map
+assert object.plugins.android instanceof List
+// Includes the Flutter plugins that support the Android platform.
+object.plugins.android.each { androidPlugin ->
+  assert androidPlugin.name instanceof String
+  assert androidPlugin.path instanceof String
+  // Skip self
+  if (androidPlugin.name == rootProject.name) {
+    return
+  }
+  // Skip plugins that have no native build (such as a Dart-only implementation
+  // of a federated plugin).
+  def needsBuild = androidPlugin.containsKey('native_build') ? androidPlugin['native_build'] : true
+  if (!needsBuild) {
+    return
+  }
+  def pluginDirectory = new File(androidPlugin.path, 'android')
+  assert pluginDirectory.exists()
+  include ":${androidPlugin.name}"
+  project(":${androidPlugin.name}").projectDir = pluginDirectory
+}

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -298,7 +298,9 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         }
     }
 
-    private fun mapTelemetryConfiguration(event: TelemetryConfigurationEvent): TelemetryConfigurationEvent {
+    private fun mapTelemetryConfiguration(
+        event: TelemetryConfigurationEvent
+    ): TelemetryConfigurationEvent {
         event.telemetry.configuration.trackViewsManually = telemetryOverrides.trackViewsManually
         event.telemetry.configuration.trackInteractions = telemetryOverrides.trackInteractions
         event.telemetry.configuration.trackErrors = telemetryOverrides.trackErrors

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -58,7 +58,7 @@ class DatadogSdkPluginTest {
             mock.versionCode = 1124
         }
         val mockPackageManager = mock<PackageManager> {
-            on { getPackageInfo(any<String>(), any()) } doReturn mockPackageInfo
+            on { getPackageInfo(any<String>(), any<Int>()) } doReturn mockPackageInfo
         }
         val mockPreferences = mock<SharedPreferences>()
         mockContext = mock<Context>() {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -95,6 +95,10 @@ class DatadogSdkPluginTest {
         )),
         Contract("telemetryError", mapOf(
             "message" to ContractParameter.Type(SupportedContractType.STRING)
+        )),
+        Contract("initWebView", mapOf(
+            "webViewIdentifier" to ContractParameter.Type(SupportedContractType.INT),
+            "allowedHosts" to ContractParameter.Type(SupportedContractType.LIST)
         ))
     )
 

--- a/packages/datadog_flutter_plugin/doc/rum/web_view_tracking.md
+++ b/packages/datadog_flutter_plugin/doc/rum/web_view_tracking.md
@@ -1,0 +1,53 @@
+## Overview
+
+Real User Monitoring allows you to monitor web views and eliminate blind spots in your hybrid Flutter applications
+
+You can perform the following:
+
+- Track user journeys across web and native components in mobile applications
+- Scope the root cause of latency to web pages or native components in mobile applications
+- Support users that have difficulty loading web pages on mobile devices
+
+## Setup
+
+### Prerequisites
+
+Set up the web page you want rendered on your mobile Flutter application with the RUM Browser SDK first. For more information, see [RUM Browser Monitoring][1].
+
+### Instrument your web views
+
+The RUM Flutter SDK provides APIs for you to control web view tracking when using the [`webview_flutter`][2] package. To add Web View Tracking, call the `trackDatadogEvents` extension method on `WebViewController`, providing the list of allowed hosts.
+
+For example:
+
+```dart
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+
+webViewController = WebViewController()
+  ..setJavaScriptMode(JavaScriptMode.unrestricted)
+  ..trackDatadogEvents(
+    DatadogSdk.instance,
+    ['myapp.example'],
+  )
+  ..loadRequest(Uri.parse('myapp.example'));
+```
+
+Note that `JavaScriptMode.unrestricted` is required for tracking to work on Android.
+
+## Access your web views
+
+Your web views appear as events and views in the [RUM Explorer][3] with associated `service` and `source` attributes. The `service` attribute indicates the web component the web view is generated from, and the `source` attribute denotes the mobile application's platform, such as Flutter. 
+
+Filter on your Flutter application and click a session. A side panel with a list of events in the session appears. 
+
+{{< img src="real_user_monitoring/ios/ios-webview-tracking.png" alt="Webview events captured in a session in the RUM Explorer" style="width:100%;">}}
+
+Click **Open View waterfall** to navigate from the session to a resource waterfall visualization in the view's **Performance** tab. 
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://docs.datadoghq.com/real_user_monitoring/browser/#npm
+[2]: https://https://pub.dev/packages/webview_flutter
+[3]: https://app.datadoghq.com/rum/explorer

--- a/packages/datadog_flutter_plugin/doc/rum/web_view_tracking.md
+++ b/packages/datadog_flutter_plugin/doc/rum/web_view_tracking.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Real User Monitoring allows you to monitor web views and eliminate blind spots in your hybrid Flutter applications
+Real User Monitoring allows you to monitor web views and eliminate blind spots in your hybrid Flutter applications.
 
 You can perform the following:
 

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/build.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -58,10 +58,9 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.datadoghq.example.flutter"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 32
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -60,7 +60,7 @@ android {
     defaultConfig {
         applicationId "com.datadoghq.example.flutter"
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.6.21'
 
     repositories {
         google()
@@ -16,7 +16,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.0'
+        classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"

--- a/packages/datadog_flutter_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -45,6 +45,10 @@ class FlutterSdkTests: XCTestCase {
         ]),
         Contract(methodName: "telemetryError", requiredParameters: [
             "message": .string
+        ]),
+        Contract(methodName: "initWebView", requiredParameters: [
+            "webViewIdentifier": .int,
+            "allowedHosts": .list
         ])
     ]
 

--- a/packages/datadog_flutter_plugin/example/lib/example_app.dart
+++ b/packages/datadog_flutter_plugin/example/lib/example_app.dart
@@ -10,6 +10,7 @@ import 'crash_reporting_screen.dart';
 import 'logging_screen.dart';
 import 'rum_screen.dart';
 import 'rum_user_actions_screen.dart';
+import 'rum_webview_screen.dart';
 
 class NavItem {
   final String label;
@@ -32,7 +33,8 @@ class _ExampleAppState extends State<ExampleApp> {
     NavItem(label: 'Logging', route: '/logging'),
     NavItem(label: 'RUM', route: '/rum'),
     NavItem(label: 'RUM Crash Reporting', route: '/rum_crash'),
-    NavItem(label: 'RUM User Actions', route: '/rum_user_actions')
+    NavItem(label: 'RUM User Actions', route: '/rum_user_actions'),
+    NavItem(label: 'RUM Web View Bridging', route: '/rum_web_view'),
   ];
 
   @override
@@ -47,6 +49,8 @@ class _ExampleAppState extends State<ExampleApp> {
         handler: Handler(handlerFunc: (_, __) => const CrashReportingScreen()));
     router.define('/rum_user_actions',
         handler: Handler(handlerFunc: (_, __) => const RumUserActionsScreen()));
+    router.define('/rum_web_view',
+        handler: Handler(handlerFunc: (_, __) => const RumWebViewScreen()));
   }
 
   @override

--- a/packages/datadog_flutter_plugin/example/lib/rum_webview_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_webview_screen.dart
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+final testUrl = Uri.parse('https://shopist.io');
+
+class RumWebViewScreen extends StatefulWidget {
+  const RumWebViewScreen({Key? key}) : super(key: key);
+
+  @override
+  State<RumWebViewScreen> createState() => _RumWebViewScreenState();
+}
+
+class _RumWebViewScreenState extends State<RumWebViewScreen> {
+  WebViewController? webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    webViewController = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..trackDatadogEvents(
+        DatadogSdk.instance,
+        ['shopist.io'],
+      )
+      ..loadRequest(testUrl);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Datadog WebView Test'),
+      ),
+      body: WebViewWidget(controller: webViewController!),
+    );
+  }
+}

--- a/packages/datadog_flutter_plugin/example/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/example/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 
   cupertino_icons: ^1.0.2
   flutter_dotenv: ^5.0.2
+  webview_flutter: ^4.0.2
+
   fluro: ^2.0.3
 
 dev_dependencies:

--- a/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
     defaultConfig {
         applicationId "com.datadoghq.flutter.integrationtestapp"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/webview_scenario_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/webview_scenario_test.dart
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('test webview integrations', (tester) async {
+    var serverRecorder = await openTestScenario(
+      tester,
+      menuTitle: 'WebView Scenario',
+    );
+
+    final requestLog = <RequestLog>[];
+    final rumLog = <RumEventDecoder>[];
+    await serverRecorder.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        requestLog.addAll(requests);
+        for (var request in requests) {
+          request.data.split('\n').forEach((e) {
+            dynamic jsonValue = json.decode(e);
+            if (jsonValue is Map<String, dynamic>) {
+              rumLog.add(RumEventDecoder(jsonValue));
+            }
+          });
+        }
+        final session = RumSessionDecoder.fromEvents(rumLog,
+            shouldDiscardApplicationLaunch: false);
+        return session.visits.length >= 2;
+      },
+    );
+
+    final session = RumSessionDecoder.fromEvents(rumLog,
+        shouldDiscardApplicationLaunch: false);
+    expect(session.visits.length, 2);
+
+    // First view is applicaiton start, second view should be the webview
+    final startView = session.visits[0];
+    String expectedApplicationId =
+        startView.viewEvents.first.rumEvent['application']['id'];
+    String expectedSessionId =
+        startView.viewEvents.first.rumEvent['session']['id'];
+
+    final browserView = session.visits[1];
+
+    for (var event in browserView.viewEvents) {
+      expect(event.rumEvent['application']['id'], expectedApplicationId);
+      expect(event.rumEvent['session']['id'], expectedSessionId);
+      expect(event.service, 'shopist-web-ui');
+      expect(event.rumEvent['source'], 'browser');
+    }
+    expect(browserView.resourceEvents.length, greaterThan(0));
+    for (var resource in browserView.resourceEvents) {
+      expect(resource.rumEvent['application']['id'], expectedApplicationId);
+      expect(resource.rumEvent['session']['id'], expectedSessionId);
+      expect(resource.service, 'shopist-web-ui');
+      expect(resource.rumEvent['source'], 'browser');
+    }
+  });
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
@@ -8,6 +8,7 @@ import '../auto_integration_scenarios/rum_auto_instrumentation_scenario.dart';
 import 'logging_scenario.dart';
 import 'rum_manual_error_reporting_scenario.dart';
 import 'rum_manual_instrumentation_scenario.dart';
+import 'webview_scenario.dart';
 
 class IntegrationScenariosScreen extends StatefulWidget {
   const IntegrationScenariosScreen({Key? key}) : super(key: key);
@@ -31,14 +32,21 @@ class _IntegrationScenariosScreenState
   final items = <ScenarioItem>[
     ScenarioItem(label: 'Logging Scenario', navItem: LoggingScenario.new),
     ScenarioItem(
-        label: 'Manual RUM Scenario',
-        navItem: RumManualInstrumentationScenario.new),
+      label: 'Manual RUM Scenario',
+      navItem: RumManualInstrumentationScenario.new,
+    ),
     ScenarioItem(
-        label: 'RUM Error Reporting Scenario',
-        navItem: RumManualErrorReportingScenario.new),
+      label: 'RUM Error Reporting Scenario',
+      navItem: RumManualErrorReportingScenario.new,
+    ),
     ScenarioItem(
-        label: 'Auto RUM Scenario',
-        navItem: RumAutoInstrumentationScenario.new),
+      label: 'Auto RUM Scenario',
+      navItem: RumAutoInstrumentationScenario.new,
+    ),
+    ScenarioItem(
+      label: 'WebView Scenario',
+      navItem: WebViewScenario.new,
+    ),
   ];
 
   @override

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/webview_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/webview_scenario.dart
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class WebViewScenario extends StatefulWidget {
+  const WebViewScenario({Key? key}) : super(key: key);
+
+  @override
+  State<WebViewScenario> createState() => _WebViewScenarioState();
+}
+
+class _WebViewScenarioState extends State<WebViewScenario> {
+  WebViewController? webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    webViewController = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..trackDatadogEvents(
+        DatadogSdk.instance,
+        ['shopist.io'],
+      )
+      ..loadRequest(Uri.parse('https://shopist.io'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Datadog WebView Test'),
+      ),
+      body: WebViewWidget(controller: webViewController!),
+    );
+  }
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -346,6 +346,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: dad1f2caa3272071275436984eb123276a6810dbe7cd6f4c60697640b56a4699
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.4"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: da98c8cdaebea4cf89481853f37ca93ccc8d31fc386f5b3c928aea3b6e83268c
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "8b2262dda5d26eabc600a7282a8c16a9473a0c765526afb0ffc33eef912f7968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: dcd9ad0ef0f608f399d7a54d0b289597385e59a89f04983a672b9348faddfd98
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
-  flutter: ">=1.20.0"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.0.0"

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_dotenv: ^5.0.2
   transparent_image: ^2.0.0
+  webview_flutter: ^4.0.4
 
   datadog_flutter_plugin:
     path: ../

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -373,7 +373,6 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
             return rumViewEvent
         }
 
-
         encoded["usr"] = extractUserExtraInfo(usrMember: encoded["usr"] as? [String: Any])
 
         let result = callEventMapper(mapperName: "mapViewEvent", event: rumViewEvent, encodedEvent: encoded) { encodedResult in

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -7,6 +7,7 @@ import UIKit
 import Datadog
 import DatadogCrashReporting
 import DictionaryCoder
+import webview_flutter_wkwebview
 
 public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
     struct ConfigurationTelemetryOverrides {
@@ -147,6 +148,21 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         case "updateTelemetryConfiguration":
             updateTelemetryConfiguration(arguments: arguments)
             result(nil)
+        case "initWebView":
+            if let number = arguments["webViewIdentifier"] as? NSNumber,
+               let allowedHosts = arguments["allowedHosts"] as? [String] {
+                let webViewIdentifier = number.intValue
+
+                // TODO: Add to app scenario, search for a FlutterViewController to get the
+                // registry
+                if let pluginRegistry = UIApplication.shared.delegate as? FlutterPluginRegistry,
+                   let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(forIdentifier: webViewIdentifier, with: pluginRegistry) {
+                    webview.configuration.userContentController.trackDatadogEvents(in: Set(allowedHosts))
+                }
+                result(nil)
+            } else {
+                result(FlutterError.missingParameter(methodName: call.method))
+            }
         case "getInternalVar":
             guard let varName = arguments["name"] as? String else {
                 result(nil)

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -285,12 +285,12 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
                 "total": [
                     "minMs": rum?.mapperPerf.minInMs,
                     "maxMs": rum?.mapperPerf.maxInMs,
-                    "avgMs": rum?.mapperPerf.avgInMs,
+                    "avgMs": rum?.mapperPerf.avgInMs
                 ],
                 "mainThread": [
                     "minMs": rum?.mainThreadMapperPerf.minInMs,
                     "maxMs": rum?.mainThreadMapperPerf.maxInMs,
-                    "avgMs": rum?.mainThreadMapperPerf.avgInMs,
+                    "avgMs": rum?.mainThreadMapperPerf.avgInMs
                 ],
                 "mapperTimeouts": rum?.mapperTimeouts
             ]

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
@@ -19,6 +19,7 @@ A new flutter plugin project.
   s.dependency 'DatadogSDK', '~> 1'
   s.dependency 'DatadogSDKCrashReporting', '~> 1'
   s.dependency 'DictionaryCoder', '1.0.8'
+  s.dependency 'webview_flutter_wkwebview'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -20,6 +20,7 @@ import 'src/version.dart' show ddPackageVersion;
 
 export 'src/datadog_configuration.dart';
 export 'src/datadog_plugin.dart';
+export 'src/datadog_webview.dart';
 export 'src/logs/ddlogs.dart';
 export 'src/rum/ddrum_events.dart';
 export 'src/rum/rum.dart';

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -90,6 +90,12 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   Future<void> updateTelemetryConfiguration(String property, bool value) async {
     // Not currently supported
   }
+
+  @override
+  Future<void> initWebView(
+      int webViewIdentifier, List<String> allowedHosts) async {
+    // Not currently supported
+  }
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -103,6 +103,14 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
     });
   }
 
+  @override
+  Future<void> initWebView(int webViewIdentifier, List<String> allowedHosts) {
+    return methodChannel.invokeMethod('initWebView', {
+      'webViewIdentifier': webViewIdentifier,
+      'allowedHosts': allowedHosts,
+    });
+  }
+
   Future<Object?> getInternalVar(String name) {
     return methodChannel.invokeMethod('getInternalVar', {'name': name});
   }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -63,4 +63,5 @@ abstract class DatadogSdkPlatform extends PlatformInterface {
   Future<void> flushAndDeinitialize();
 
   Future<void> updateTelemetryConfiguration(String property, bool value);
+  Future<void> initWebView(int webViewIdentifier, List<String> allowedHosts);
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_webview.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_webview.dart
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-Present Datadog, Inc.
+
+import 'package:webview_flutter/webview_flutter.dart';
+// ignore: depend_on_referenced_packages
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+// ignore: depend_on_referenced_packages
+import 'package:webview_flutter_wkwebview/webview_flutter_wkwebview.dart';
+
+import '../datadog_flutter_plugin.dart';
+
+extension DatadogWebview on WebViewController {
+  /// Enables the SDK to correlate Datadog RUM events and Logs from the WebView
+  /// with native RUM session.
+  ///
+  /// If the content loaded in WebView uses Datadog Browser SDK (`v4.2.0+`) and
+  /// matches specified [hosts], web events will be correlated with the RUM
+  /// session from native SDK.
+  ///
+  /// [hosts] does not support matching wildcards, but does support matching
+  /// subdomains of a given host.
+  void trackDatadogEvents(DatadogSdk datadog, List<String> hosts) {
+    int? webViewIdentifier;
+    final localPlatform = platform;
+    if (localPlatform is WebKitWebViewController) {
+      webViewIdentifier = localPlatform.webViewIdentifier;
+    } else if (localPlatform is AndroidWebViewController) {
+      webViewIdentifier = localPlatform.webViewIdentifier;
+    }
+
+    if (webViewIdentifier != null) {
+      datadog.platform.initWebView(webViewIdentifier, hosts);
+    }
+  }
+}

--- a/packages/datadog_flutter_plugin/pubspec.lock
+++ b/packages/datadog_flutter_plugin/pubspec.lock
@@ -628,6 +628,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: dad1f2caa3272071275436984eb123276a6810dbe7cd6f4c60697640b56a4699
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.4"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: da98c8cdaebea4cf89481853f37ca93ccc8d31fc386f5b3c928aea3b6e83268c
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "8b2262dda5d26eabc600a7282a8c16a9473a0c765526afb0ffc33eef912f7968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: dcd9ad0ef0f608f399d7a54d0b289597385e59a89f04983a672b9348faddfd98
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   yaml:
     dependency: transitive
     description:
@@ -638,4 +670,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=3.0.0"

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   json_annotation: ^4.4.0
   uuid: ^3.0.5
   meta: ^1.7.0
+  webview_flutter: ^4.0.4
   
 dev_dependencies:
   flutter_test:

--- a/packages/datadog_tracking_http_client/example/android/build.gradle
+++ b/packages/datadog_tracking_http_client/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -353,6 +353,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: "9ba213434f13e760ea0f175fbc4d6bb6aeafd7dfc6c7d973f15d3e47a5d6686e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.5"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: "48c8cfb023168473c0a3a4c21ffea6c23a32cc7156701c39f618b303c6a3c96e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: df6472164b3f4eaf3280422227f361dc8424b106726b7f21d79a8656ba53f71f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "283a38c2a2544768033864c698e0133aa9eee0f2c800f494b538a3d1044f7ecb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.0.0"

--- a/test_apps/stress_test/android/build.gradle
+++ b/test_apps/stress_test/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
### What and why?

Customers want the ability to track the full journey of a use, which may include interacting with WebViews which are already tracked by Datadog. This allows them to forward events from their WebViews to Mobile sessions.

This requires the use of the `webview_flutter` package, which is the main recommended package for Flutter.

Right now, this is embedded into the main `datadog_flutter_plugin` package, but I'm thinking about moving it to its own package prior to releasing it (or even before merging the PR).

### How?

We're utilizing the bridging interfaces Datadog has already written for `WKWebView` and Android's `WebView`. By utilizing an interface provided by `webview_flutter`, we're able to get the underlying platform controls and attach Datadog's observers.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests