### PR TITLE
🐛 Potentially fix crash on exit on iOS

### DIFF
--- a/packages/datadog_flutter_plugin/example/lib/rum_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_screen.dart
@@ -23,6 +23,18 @@ class _RumScreenState extends State<RumScreen> {
   var sendResourceError = false;
   var errorMessage = '';
 
+  @override
+  void dispose() {
+    super.dispose();
+
+    if (inView) {
+      DatadogSdk.instance.rum
+          ?.stopView(viewKey.isEmpty ? 'FooRumScreen' : viewKey);
+      DatadogSdk.instance.rum
+          ?.addUserAction(RumUserActionType.custom, 'Testing Action');
+    }
+  }
+
   Future<void> _sendViewEvent() async {
     setState(() {
       performingOperation = true;

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -39,7 +39,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         let channel = FlutterMethodChannel(name: "datadog_sdk_flutter", binaryMessenger: registrar.messenger())
         let instance = SwiftDatadogSdkPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
-        registrar.addApplicationDelegate(instance)
+        registrar.publish(instance)
 
         DatadogLogsPlugin.register(with: registrar)
         DatadogRumPlugin.register(with: registrar)
@@ -284,11 +284,8 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    public func applicationWillTerminate(_ application: UIApplication) {
-        _onDetach()
-    }
-
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        registrar.publish(NSNull())
         _onDetach()
     }
 
@@ -298,6 +295,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         if let oldConsolePrint = oldConsolePrint {
             consolePrint = oldConsolePrint
         }
+        oldConsolePrint = nil
 
         logs?.onDetach()
         rum?.onDetach()


### PR DESCRIPTION
### What and why?

Fix a crash on exit caused by Datadog logging that a view isn't active during an event, which is happening while the app is shutting down and a the Flutter engine, and therefore the method channel for displaying the log, is no longer available.

To fix, we're overriding the method provided by Flutter for de-registering the plugin with the engine on shutdown, but I've yet to see this called in practice.

Fixes #341

### How?

This crash is difficult to reproduce, but I have not been able to with this code enabled in many attempts. I added some code to the RUM example to test stopping a view and immediately send an event on `dispose` if one is active, which was able to reproduce the crash fairly consistently, and I have not been able to reproduce.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests