### PR TITLE
✅ Re-enable telemetry integration tests

### DIFF
--- a/packages/datadog_common_test/lib/src/testing_configuration.dart
+++ b/packages/datadog_common_test/lib/src/testing_configuration.dart
@@ -8,6 +8,7 @@ class TestingConfiguration {
   String? clientToken;
   String? applicationId;
   List<String> firstPartyHosts;
+  Map<String, Object?> additionalConfig;
 
   TestingConfiguration({
     this.scenario,
@@ -15,5 +16,6 @@ class TestingConfiguration {
     this.clientToken,
     this.applicationId,
     this.firstPartyHosts = const [],
+    this.additionalConfig = const {},
   });
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -49,8 +49,12 @@ Future<RecordingServerClient> startMockServer() async {
   }
 }
 
-Future<RecordingServerClient> openTestScenario(WidgetTester tester,
-    {String? scenarioName, String? menuTitle}) async {
+Future<RecordingServerClient> openTestScenario(
+  WidgetTester tester, {
+  String? scenarioName,
+  String? menuTitle,
+  Map<String, Object?> additionalConfig = const {},
+}) async {
   var client = await startMockServer();
 
   // These need to be set as const in order to work, so we
@@ -63,11 +67,13 @@ Future<RecordingServerClient> openTestScenario(WidgetTester tester,
       : null;
 
   app.testingConfiguration = TestingConfiguration(
-      scenario: scenarioName,
-      customEndpoint: client.sessionEndpoint,
-      clientToken: clientToken,
-      applicationId: applicationId,
-      firstPartyHosts: ['localhost']);
+    scenario: scenarioName,
+    customEndpoint: client.sessionEndpoint,
+    clientToken: clientToken,
+    applicationId: applicationId,
+    firstPartyHosts: ['localhost'],
+    additionalConfig: additionalConfig,
+  );
 
   await app.main();
   await tester.pumpAndSettle();

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/configuration_telemetry_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/configuration_telemetry_test.dart
@@ -2,13 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2021 Datadog, Inc.
 
-@Skip(
-    'Android no longer sends configuration telemetry 100% of the time. RUMM-2921')
-
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_integration_test_app/auto_integration_scenarios/scenario_runner.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -24,8 +22,13 @@ void main() {
   testWidgets('test telemetry scenario', (
     WidgetTester tester,
   ) async {
-    var serverRecorder = await openTestScenario(tester,
-        scenarioName: autoInstrumentationScenarioName);
+    var serverRecorder = await openTestScenario(
+      tester,
+      scenarioName: autoInstrumentationScenarioName,
+      additionalConfig: {
+        DatadogConfigKey.telemetryConfigurationSampleRate: 100.0,
+      },
+    );
 
     await performRumUserFlow(tester);
     var endTime = DateTime.now().add(const Duration(seconds: 6));
@@ -64,7 +67,7 @@ void main() {
     if (telemetryEvent != null) {
       final config = telemetryEvent.telemetryConfiguration!;
       expect(config['track_views_manually'], false);
-      expect(config['track_interactions'], false);
+      expect(config['track_interactions'], true);
       expect(config['track_errors'], true);
       expect(config['track_network_requests'], false);
       expect(config['track_native_views'], false);

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -48,7 +48,7 @@ void main() {
         });
         var visits = RumSessionDecoder.fromEvents(rumLog).visits;
         return visits.length == 1 &&
-            visits[0].viewEvents.last.view.errorCount == 3;
+            visits[0].viewEvents.last.view?.errorCount == 3;
       },
     );
 
@@ -56,7 +56,7 @@ void main() {
     expect(session.visits.length, 1);
 
     final view = session.visits[0];
-    expect(view.viewEvents.last.view.errorCount, 3);
+    expect(view.viewEvents.last.view?.errorCount, 3);
     expect(view.errorEvents.length, 3);
 
     var exceptionError = view.errorEvents[0];

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_no_auto_instrumentation_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_no_auto_instrumentation_test.dart
@@ -50,7 +50,7 @@ void main() {
       print('Got a RUM log!? (actually ${rumLog.length})');
       for (var log in rumLog) {
         // ignore: avoid_print
-        print('Log: { event: ${log.eventType}, view: ${log.view.name}');
+        print('Log: { event: ${log.eventType}, view: ${log.viewInfo?.name}');
       }
     }
     expect(session.visits.isEmpty, isTrue);

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/scenario_runner.dart
@@ -47,6 +47,10 @@ Future<void> runScenario({
           )
         : null,
   );
+  if (testingConfiguration?.additionalConfig != null) {
+    configuration.additionalConfig
+        .addAll(testingConfiguration!.additionalConfig);
+  }
 
   await DatadogSdk.runApp(configuration, () async {
     runApp(const DatadogAutoIntegrationTestApp());

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
@@ -101,6 +101,10 @@ Future<void> runScenario({
           )
         : null,
   );
+  if (testingConfiguration?.additionalConfig != null) {
+    configuration.additionalConfig
+        .addAll(testingConfiguration!.additionalConfig);
+  }
 
   if (testingConfiguration?.scenario == mappedInstrumentationScenarioName) {
     // Add mapping to rum configuration

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -60,6 +60,10 @@ Future<void> runScenario({
         ? RumConfiguration(applicationId: applicationId)
         : null,
   );
+  if (testingConfiguration?.additionalConfig != null) {
+    configuration.additionalConfig
+        .addAll(testingConfiguration!.additionalConfig);
+  }
 
   await DatadogSdk.instance.initialize(configuration);
 

--- a/packages/datadog_flutter_plugin/lib/src/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/attributes.dart
@@ -8,6 +8,8 @@ class DatadogConfigKey {
   static const nativeViewTracking = '_dd.native_view_tracking';
   static const version = '_dd.version';
   static const variant = '_dd.variant';
+  static const telemetryConfigurationSampleRate =
+      '_dd.telemetry.configuration_sample_rate';
 
   static const trackMapperPerformance = '_dd.track_mapper_performance';
 }


### PR DESCRIPTION
### What and why?

We now have a configuration option that supports enabling configuration telemetry at 100%, which means I can consistently test it with an integration test. This takes advantage of that new option and re-enables the test.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests