### PR TITLE
🐛 Fix assert on non-standard `onError` function

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -14,6 +14,7 @@ import 'src/internal_logger.dart';
 export 'src/attributes.dart';
 export 'src/datadog_sdk_platform_interface.dart';
 export 'src/helpers.dart';
+export 'src/internal_logger.dart';
 export 'src/rum/attributes.dart';
 export 'src/tracing/tracing_headers.dart';
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Fix an invalid assertion when processing stream errors. See [#355]
 
 ## 1.2.0
 
@@ -46,3 +46,5 @@
 ## 1.0.0-alpha.1
 
 * Initial split of DatadogTrackingHttpClient into its own package
+
+[#355]: https://github.com/DataDog/dd-sdk-flutter/issues/355

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -471,16 +471,19 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
     return innerResponse.listen(
       onData,
       cancelOnError: cancelOnError,
-      onError: (Object e, StackTrace? st) {
+      onError: (Object e, StackTrace st) {
         _onError(e, st);
         if (onError == null) {
           return;
         }
-        if (onError is void Function(Object, StackTrace?)) {
+        if (onError is void Function(Object, StackTrace)) {
           onError(e, st);
-        } else {
-          assert(onError is void Function(Object));
+        } else if (onError is void Function(Object)) {
           onError(e);
+        } else {
+          datadogSdk.internalLogger.warn(
+              "Tracking HTTP client intercepted an error, but doesn't recognize the `onError` callback."
+              ' Expected either `void Function(Object, StackTrace)` or `void Function(Object)`.');
         }
       },
       onDone: () {


### PR DESCRIPTION
### What and why?

onError in the DatadogTrackingHttpClient was asserting that onError was a `void Function(Object)`, which fails in the assertion if onError is `void Function(dynamic)` (though the `is` test passes in this case).

Fixes #355

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests