### PR TITLE
🐛 Remove extra call to `presentError` in onError callback

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bind `consolePrint` callback earlier in iOS to make sure initialization errors can be seen in the console. See [#328]
 * Fix `version` not properly populating on Flutter Web. See [#334]
 * Improve `RumUserActionDetector` to detect more widgets, including `BottomNavigationBar`, `Tab`, `Switch`, and `Radio`
+* Remove an extra call to `FlutterError.presentError` made in `runApp`.  See [#358]
 
 ## 1.2.2
 
@@ -147,3 +148,4 @@
 [#305]: https://github.com/DataDog/dd-sdk-flutter/issues/305
 [#328]: https://github.com/DataDog/dd-sdk-flutter/issues/328
 [#334]: https://github.com/DataDog/dd-sdk-flutter/issues/334
+[#358]: https://github.com/DataDog/dd-sdk-flutter/issues/358

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -11,7 +11,6 @@ import 'package:meta/meta.dart';
 import 'datadog_internal.dart';
 import 'src/datadog_configuration.dart';
 import 'src/datadog_plugin.dart';
-import 'src/helpers.dart';
 import 'src/internal_logger.dart';
 import 'src/logs/ddlogs.dart';
 import 'src/logs/ddlogs_platform_interface.dart';
@@ -113,7 +112,6 @@ class DatadogSdk {
       WidgetsFlutterBinding.ensureInitialized();
       final originalOnError = FlutterError.onError;
       FlutterError.onError = (details) {
-        FlutterError.presentError(details);
         DatadogSdk.instance.rum?.handleFlutterError(details);
         originalOnError?.call(details);
       };


### PR DESCRIPTION
### What and why?

Because the `originalOnError` will by default call `presentError`, clients were getting duplicate error messages from the double call. Remove the extraneous `presentError`

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests