### PR TITLE
🍒 Cherry pick #355 fix to 1.2.x release branch

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -13,6 +13,7 @@ import 'src/internal_logger.dart';
 
 export 'src/attributes.dart';
 export 'src/datadog_sdk_platform_interface.dart';
+export 'src/internal_logger.dart';
 export 'src/rum/attributes.dart';
 export 'src/tracing/tracing_headers.dart';
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix an invalid assertion when processing stream errors. See [#355]
+
 ## 1.2.0
 
 * Add methods for enabling the DatadogTrackingHttpClient in add-to-app scenarios.
@@ -42,3 +46,5 @@
 ## 1.0.0-alpha.1
 
 * Initial split of DatadogTrackingHttpClient into its own package
+
+[#355]: https://github.com/DataDog/dd-sdk-flutter/issues/355

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -471,16 +471,19 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
     return innerResponse.listen(
       onData,
       cancelOnError: cancelOnError,
-      onError: (Object e, StackTrace? st) {
+      onError: (Object e, StackTrace st) {
         _onError(e, st);
         if (onError == null) {
           return;
         }
-        if (onError is void Function(Object, StackTrace?)) {
+        if (onError is void Function(Object, StackTrace)) {
           onError(e, st);
-        } else {
-          assert(onError is void Function(Object));
+        } else if (onError is void Function(Object)) {
           onError(e);
+        } else {
+          datadogSdk.internalLogger.warn(
+              "Tracking HTTP client intercepted an error, but doesn't recognize the `onError` callback."
+              ' Expected either `void Function(Object, StackTrace)` or `void Function(Object)`.');
         }
       },
       onDone: () {

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_flutter_plugin/src/internal_logger.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client_plugin.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
### What and why?

Want to do a hotfix on 1.2.x to fix the assert reported in #355.

onError in the DatadogTrackingHttpClient was asserting that onError was a `void Function(Object)`, which fails in the assertion if onError is `void Function(dynamic)` (though the `is` test passes in this case).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests