### PR TITLE
✅ Add a unit test to webview tracking package

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -219,6 +219,12 @@ workflows:
         - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/example"
         - tests_path_pattern: "integration_test"
         - additional_params: "-d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
+    - flutter-test@1:
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
+        inputs:
+        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_webview_plugin/example"
+        - tests_path_pattern: "integration_test"
+        - additional_params: "-d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
   
   integration_ios:
     before_run:
@@ -236,6 +242,13 @@ workflows:
         - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_tracking_http_client/example"
         - tests_path_pattern: "integration_test"
         - additional_params: "-d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
+    - flutter-test@1:
+        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
+        inputs:
+        - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_webview_plugin/example"
+        - tests_path_pattern: "integration_test"
+        - additional_params: "-d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID"
+        
 
   integration_web:
     steps:

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -17,7 +17,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-
+  mocktail: ^0.3.0
+  plugin_platform_interface: ^2.0.2
+  
 flutter:
   plugin:
     platforms:

--- a/packages/datadog_webview_tracking/test/datadog_webview_tracking_test.dart
+++ b/packages/datadog_webview_tracking/test/datadog_webview_tracking_test.dart
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_webview_tracking/datadog_webview_tracking.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+
+class MockDatadogSdk extends Mock implements DatadogSdk {}
+
+class MockInternalLogger extends Mock implements InternalLogger {}
+
+class MockWebviewPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements WebViewPlatform {}
+
+class MockAndroidWebViewController extends Mock
+    with MockPlatformInterfaceMixin
+    implements AndroidWebViewController {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(const PlatformWebViewControllerCreationParams());
+  });
+
+  test('track webview calls to platform', () {
+    final mockDatadog = MockDatadogSdk();
+    // ignore: invalid_use_of_internal_member
+    when(() => mockDatadog.internalLogger).thenReturn(MockInternalLogger());
+
+    final mockWebiewPlatform = MockWebviewPlatform();
+    final mockAndroidController = MockAndroidWebViewController();
+    when(() => mockWebiewPlatform.createPlatformWebViewController(any()))
+        .thenReturn(mockAndroidController);
+    when(() => mockAndroidController.webViewIdentifier).thenReturn(148221);
+    WebViewPlatform.instance = mockWebiewPlatform;
+
+    final List<MethodCall> log = [];
+
+    methodChannel.setMockMethodCallHandler((call) {
+      log.add(call);
+      return null;
+    });
+
+    WebViewController().trackDatadogEvents(mockDatadog, ['host_a', 'host_b']);
+
+    expect(log, [
+      isMethodCall('initWebView', arguments: {
+        'webViewIdentifier': 148221,
+        'allowedHosts': ['host_a', 'host_b']
+      })
+    ]);
+  });
+}


### PR DESCRIPTION
### What and why?

Add a very simple method channel test to the webview tracking package, and make sure integration tests are run on CI. Both were missed with the initial merge of the feature.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests