### PR TITLE
🐛 Fix b3 and tracecontext header generation

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -169,8 +169,8 @@ Map<String, String> getTracingHeaders(
     case TracingHeaderType.b3:
       if (context.sampled) {
         final headerValue = [
-          context.spanId.asString(TraceIdRepresentation.hex32Chars),
-          context.traceId.asString(TraceIdRepresentation.hex16Chars),
+          context.traceId.asString(TraceIdRepresentation.hex32Chars),
+          context.spanId.asString(TraceIdRepresentation.hex16Chars),
           sampledString,
           context.parentSpanId?.asString(TraceIdRepresentation.hex16Chars),
         ].whereType<String>().join('-');
@@ -196,8 +196,8 @@ Map<String, String> getTracingHeaders(
     case TracingHeaderType.tracecontext:
       final headerValue = [
         '00', // Version Code
-        context.spanId.asString(TraceIdRepresentation.hex32Chars),
-        context.traceId.asString(TraceIdRepresentation.hex16Chars),
+        context.traceId.asString(TraceIdRepresentation.hex32Chars),
+        context.spanId.asString(TraceIdRepresentation.hex16Chars),
         context.sampled ? '01' : '00'
       ].join('-');
       headers[W3CTracingHeaders.traceparent] = headerValue;

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/src/tracing/tracing_headers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('generateTracingContext generates 64-bit values', () {
+    final context = generateTracingContext(true);
+
+    expect(context.traceId.value.bitLength, lessThanOrEqualTo(63));
+    expect(context.spanId.value.bitLength, lessThanOrEqualTo(63));
+    expect(context.sampled, true);
+  });
+
+  test('Datadog attributes generated correctly', () {
+    final context = generateTracingContext(true);
+
+    final attributes = generateDatadogAttributes(context, 30.0);
+
+    expect(attributes['_dd.trace_id'],
+        context.traceId.asString(TraceIdRepresentation.decimal));
+    expect(attributes['_dd.span_id'],
+        context.spanId.asString(TraceIdRepresentation.decimal));
+    expect(attributes['_dd.rule_psr'], 0.3);
+  });
+
+  test('Sampled context does not generate datadog attributes', () {
+    final context = generateTracingContext(false);
+
+    final attributes = generateDatadogAttributes(context, 30.0);
+
+    expect(attributes['_dd.trace_id'], isNull);
+    expect(attributes['_dd.span_id'], isNull);
+    expect(attributes['_dd.rule_psr'], 0.3);
+  });
+
+  test('Datadog tracing headers are generated correctly { sampled }', () {
+    final context = generateTracingContext(true);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.datadog);
+
+    expect(headers['x-datadog-trace-id'],
+        context.traceId.asString(TraceIdRepresentation.decimal));
+    expect(headers['x-datadog-parent-id'],
+        context.spanId.asString(TraceIdRepresentation.decimal));
+    expect(headers['x-datadog-sampling-priority'], '1');
+    expect(headers['x-datadog-origin'], 'rum');
+  });
+
+  test('Datadog tracing headers are generated correctly { unsampled }', () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.datadog);
+
+    expect(headers['x-datadog-trace-id'], isNull);
+    expect(headers['x-datadog-parent-id'], isNull);
+    expect(headers['x-datadog-sampling-priority'], '0');
+    expect(headers['x-datadog-origin'], 'rum');
+  });
+
+  test('b3 tracing headers are generated correctly { sampled }', () {
+    final context = generateTracingContext(true);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.b3);
+
+    final traceString =
+        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+    final spanString =
+        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+    final expectedHeader = '$traceString-$spanString-1';
+
+    expect(headers['b3'], expectedHeader);
+  });
+
+  test('b3 tracing headers are generated correctly { unsampled }', () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.b3);
+
+    expect(headers['b3'], '0');
+  });
+
+  test('b3multi tracing headers are generated correctly { sampled }', () {
+    final context = generateTracingContext(true);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.b3multi);
+
+    final traceString =
+        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+    final spanString =
+        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+
+    expect(headers['X-B3-TraceId'], traceString);
+    expect(headers['X-B3-SpanId'], spanString);
+    expect(headers['X-B3-ParentSpanId'], isNull);
+    expect(headers['X-B3-Sampled'], '1');
+  });
+
+  test('b3multi tracing headers are generated correctly { unsampled }', () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.b3multi);
+
+    expect(headers['X-B3-TraceId'], isNull);
+    expect(headers['X-B3-SpanId'], isNull);
+    expect(headers['X-B3-ParentSpanId'], isNull);
+    expect(headers['X-B3-Sampled'], '0');
+  });
+
+  test('tracecontext tracing headers are generated correctly { sampled }', () {
+    final context = generateTracingContext(true);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.tracecontext);
+
+    final traceString =
+        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+    final spanString =
+        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+    final expectedHeader = '00-$traceString-$spanString-01';
+
+    expect(headers['traceparent'], expectedHeader);
+  });
+
+  test('traceparent tracing headers are generated correctly { unsampled }', () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(context, TracingHeaderType.tracecontext);
+
+    final traceString =
+        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+    final spanString =
+        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+    final expectedHeader = '00-$traceString-$spanString-00';
+
+    expect(headers['traceparent'], expectedHeader);
+  });
+}


### PR DESCRIPTION
### What and why?

TraceId and SpanId were swapped in both b3 and tracecontext header generation.

Added more unit test coverage for these functions as well.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests