### PR TITLE
✨Add support for `errorKind` on `addError` APIs

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix `version` not properly populating on Flutter Web. See [#334]
 * Improve `RumUserActionDetector` to detect more widgets, including `BottomNavigationBar`, `Tab`, `Switch`, and `Radio`
 * Remove an extra call to `FlutterError.presentError` made in `runApp`.  See [#358]
+* Support `errorType` on `DdRum.addError` and `DdRum.addErrorInfo`. See [#372]
 
 ## 1.2.2
 
@@ -149,3 +150,4 @@
 [#328]: https://github.com/DataDog/dd-sdk-flutter/issues/328
 [#334]: https://github.com/DataDog/dd-sdk-flutter/issues/334
 [#358]: https://github.com/DataDog/dd-sdk-flutter/issues/358
+[#372]: https://github.com/DataDog/dd-sdk-flutter/issues/372

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import com.datadog.android.Datadog
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumPerformanceMetric
@@ -47,6 +48,7 @@ class DatadogRumPlugin(
         const val PARAM_MESSAGE = "message"
         const val PARAM_SOURCE = "source"
         const val PARAM_STACK_TRACE = "stackTrace"
+        const val PARAM_ERROR_TYPE = "errorType"
         const val PARAM_TYPE = "type"
         const val PARAM_BUILD_TIMES = "buildTimes"
         const val PARAM_RASTER_TIMES = "rasterTimes"
@@ -87,7 +89,7 @@ class DatadogRumPlugin(
         GlobalRum.registerIfAbsent(rum!!)
     }
 
-    @Suppress("LongMethod", "ComplexMethod", "ComplexCondition")
+    @Suppress("LongMethod", "ComplexMethod", "ComplexCondition", "NestedBlockDepth")
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         try {
             when (call.method) {
@@ -175,10 +177,18 @@ class DatadogRumPlugin(
                     val message = call.argument<String>(PARAM_MESSAGE)
                     val sourceString = call.argument<String>(PARAM_SOURCE)
                     val attributes = call.argument<Map<String, Any?>>(PARAM_ATTRIBUTES)
-                    var stackTrace = call.argument<String>(PARAM_STACK_TRACE)
+                    val stackTrace = call.argument<String>(PARAM_STACK_TRACE)
+                    val errorType = call.argument<String>(PARAM_ERROR_TYPE)
                     if (message != null && sourceString != null && attributes != null) {
+                        var fullAttributes = attributes
+                        if (errorType != null) {
+                            fullAttributes = attributes + Pair(
+                                RumAttributes.INTERNAL_ERROR_TYPE,
+                                errorType
+                            )
+                        }
                         val source = parseRumErrorSource(sourceString)
-                        rum?.addErrorWithStacktrace(message, source, stackTrace, attributes)
+                        rum?.addErrorWithStacktrace(message, source, stackTrace, fullAttributes)
                         result.success(null)
                     } else {
                         result.missingParameter(call.method)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -328,6 +328,7 @@ class DatadogRumPluginTest {
     fun `M call monitor addError W addError is called`(
         @StringForgery message: String,
         @StringForgery stackTrace: String,
+        @StringForgery errorType: String,
         @StringForgery attributeKey: String,
         @StringForgery attributeValue: String
     ) {
@@ -336,6 +337,7 @@ class DatadogRumPluginTest {
             "message" to message,
             "source" to "RumErrorSource.network",
             "stackTrace" to stackTrace,
+            "errorType" to errorType,
             "attributes" to mapOf(
                 attributeKey to attributeValue
             )
@@ -348,7 +350,10 @@ class DatadogRumPluginTest {
 
         // THEN
         verify { mockRumMonitor.addErrorWithStacktrace(message, RumErrorSource.NETWORK,
-            stackTrace, mapOf(attributeKey to attributeValue)) }
+            stackTrace, mapOf(
+                attributeKey to attributeValue,
+                "_dd.error_type" to errorType
+            )) }
         verify { mockResult.success(null) }
     }
 

--- a/packages/datadog_flutter_plugin/example/.gitignore
+++ b/packages/datadog_flutter_plugin/example/.gitignore
@@ -32,7 +32,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -313,6 +313,7 @@ class DatadogRumPluginTests: XCTestCase {
             "message": "Error message",
             "source": "RumErrorSource.network",
             "stackTrace": nil,
+            "errorType": "MyErrorType",
             "attributes": [
                 "attribute_key": "attribute_value"
             ]
@@ -324,8 +325,8 @@ class DatadogRumPluginTests: XCTestCase {
         }
 
         XCTAssertEqual(mock.callLog, [
-            .addError(message: "Error message", type: nil, source: RUMErrorSource.network, stack: nil,
-                      attributes: ["attribute_key": "attribute_value"], file: nil, line: nil)
+            .addError(message: "Error message", type: "MyErrorType", source: RUMErrorSource.network,
+                      stack: nil, attributes: ["attribute_key": "attribute_value"], file: nil, line: nil)
         ])
         XCTAssertEqual(resultStatus, .called(value: nil))
     }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -62,6 +62,7 @@ void main() {
     var exceptionError = view.errorEvents[0];
     expect(exceptionError.message, contains(NullThrownError().toString()));
     expect(exceptionError.source, kIsWeb ? 'custom' : 'source');
+    expect(exceptionError.errorType, 'NullThrown');
     if (!kIsWeb) {
       expect(exceptionError.sourceType, 'flutter');
     }

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -31,7 +31,11 @@ class _RumManualErrorReportingScenarioState
   void _addErrors() {
     final rum = DatadogSdk.instance.rum;
     if (rum != null) {
-      rum.addError(NullThrownError(), RumErrorSource.source);
+      rum.addError(
+        NullThrownError(),
+        RumErrorSource.source,
+        errorType: 'NullThrown',
+      );
       rum.addErrorInfo('Rum error message', RumErrorSource.network);
     }
   }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -200,9 +200,17 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                 let encodedAttributes = castFlutterAttributesToSwift(attributes)
                 let source = RUMErrorSource.parseFromFlutter(sourceString)
                 let stackTrace = arguments["stackTrace"] as? String
+                let errorType = arguments["errorType"] as? String
 
-                rum.addError(message: message, source: source, stack: stackTrace, attributes: encodedAttributes,
-                             file: nil, line: nil)
+                rum.addError(
+                    message: message,
+                    type: errorType,
+                    source: source,
+                    stack: stackTrace,
+                    attributes: encodedAttributes,
+                    file: nil,
+                    line: nil
+                )
                 result(nil)
             } else {
                 result(

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -157,11 +157,17 @@ class DdRum {
 
   /// Notifies that the Exception or Error [error] occurred in currently
   /// presented View, with an origin of [source]. You can optionally set
-  /// additional [attributes] for this error
-  void addError(Object error, RumErrorSource source,
-      {StackTrace? stackTrace, Map<String, Object?> attributes = const {}}) {
+  /// additional [attributes] for this error, an [errorType] and a
+  /// [stackTrace]
+  void addError(
+    Object error,
+    RumErrorSource source, {
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes = const {},
+  }) {
     wrap('rum.addError', logger, attributes, () {
-      return _platform.addError(error, source, stackTrace, {
+      return _platform.addError(error, source, stackTrace, errorType, {
         DatadogPlatformAttributeKey.errorSourceType: 'flutter',
         ...attributes
       });
@@ -170,11 +176,17 @@ class DdRum {
 
   /// Notifies that an error occurred in currently presented View, with the
   /// supplied [message] and with an origin of [source]. You can optionally
-  /// supply a [stackTrace] and send additional [attributes] for this error
-  void addErrorInfo(String message, RumErrorSource source,
-      {StackTrace? stackTrace, Map<String, Object?> attributes = const {}}) {
+  /// supply a [stackTrace], [errorType], and send additional [attributes] for
+  /// this error
+  void addErrorInfo(
+    String message,
+    RumErrorSource source, {
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes = const {},
+  }) {
     wrap('rum.addErrorInfo', logger, attributes, () {
-      return _platform.addErrorInfo(message, source, stackTrace, {
+      return _platform.addErrorInfo(message, source, stackTrace, errorType, {
         DatadogPlatformAttributeKey.errorSourceType: 'flutter',
         ...attributes
       });

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -105,18 +105,29 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> addError(Object error, RumErrorSource source,
-      StackTrace? stackTrace, Map<String, Object?> attributes) {
-    return addErrorInfo(error.toString(), source, stackTrace, attributes);
+  Future<void> addError(
+    Object error,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes,
+  ) {
+    return addErrorInfo(
+        error.toString(), source, stackTrace, errorType, attributes);
   }
 
   @override
-  Future<void> addErrorInfo(String message, RumErrorSource source,
-      StackTrace? stackTrace, Map<String, Object?> attributes) {
+  Future<void> addErrorInfo(
+      String message,
+      RumErrorSource source,
+      StackTrace? stackTrace,
+      String? errorType,
+      Map<String, Object?> attributes) {
     return methodChannel.invokeMethod('addError', {
       'message': message,
       'source': source.toString(),
       'stackTrace': stackTrace?.toString(),
+      'errorType': errorType,
       'attributes': attributes
     });
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -39,10 +39,20 @@ abstract class DdRumPlatform extends PlatformInterface {
   Future<void> stopResourceLoadingWithErrorInfo(
       String key, String message, String type, Map<String, Object?> attributes);
 
-  Future<void> addError(Object error, RumErrorSource source,
-      StackTrace? stackTrace, Map<String, Object?> attributes);
-  Future<void> addErrorInfo(String message, RumErrorSource source,
-      StackTrace? stackTrace, Map<String, Object?> attributes);
+  Future<void> addError(
+    Object error,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes,
+  );
+  Future<void> addErrorInfo(
+    String message,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes,
+  );
 
   Future<void> addUserAction(
       RumUserActionType type, String name, Map<String, Object?> attributes);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -48,14 +48,24 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addError(Object error, RumErrorSource source,
-      StackTrace? stackTrace, Map<String, dynamic> attributes) async {
+  Future<void> addError(
+    Object error,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, dynamic> attributes,
+  ) async {
     _jsAddError(error.toString(), attributesToJs(attributes, 'attributes'));
   }
 
   @override
-  Future<void> addErrorInfo(String message, RumErrorSource source,
-      StackTrace? stackTrace, Map<String, dynamic> attributes) async {
+  Future<void> addErrorInfo(
+    String message,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, dynamic> attributes,
+  ) async {
     _jsAddError(message, attributesToJs(attributes, 'attributes'));
   }
 

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -136,7 +136,7 @@ void main() {
     final exception = TimeoutException(
         'Timeout retrieving resource', const Duration(seconds: 5));
     await ddRumPlatform.addError(exception, RumErrorSource.source, null,
-        {'attribute_key': 'attribute_value'});
+        'error_type', {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -144,6 +144,7 @@ void main() {
     expect(call.arguments['message'], exception.toString());
     expect(call.arguments['source'], 'RumErrorSource.source');
     expect(call.arguments['stackTrace'], isNull);
+    expect(call.arguments['errorType'], 'error_type');
     expect(call.arguments['attributes'], {
       // '_dd.error.source_type': 'flutter'
       'attribute_key': 'attribute_value'
@@ -152,7 +153,7 @@ void main() {
 
   test('addErrorInfo calls to platform with info', () async {
     await ddRumPlatform.addErrorInfo('Exception message', RumErrorSource.source,
-        null, {'attribute_key': 'attribute_value'});
+        null, 'error_type', {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -160,6 +161,7 @@ void main() {
     expect(call.arguments['message'], 'Exception message');
     expect(call.arguments['source'], 'RumErrorSource.source');
     expect(call.arguments['stackTrace'], isNull);
+    expect(call.arguments['errorType'], 'error_type');
     expect(call.arguments['attributes'], {
       // '_dd.error.source_type': 'flutter'
       'attribute_key': 'attribute_value'
@@ -171,7 +173,7 @@ void main() {
     final exception = TimeoutException(
         'Timeout retrieving resource', const Duration(seconds: 5));
     await ddRumPlatform.addError(exception, RumErrorSource.source, stackTrace,
-        {'attribute_key': 'attribute_value'});
+        null, {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -179,6 +181,7 @@ void main() {
     expect(call.arguments['message'], exception.toString());
     expect(call.arguments['source'], 'RumErrorSource.source');
     expect(call.arguments['stackTrace'], stackTrace.toString());
+    expect(call.arguments['errorType'], isNull);
     expect(call.arguments['attributes'], {
       // '_dd.error.source_type': 'flutter'
       'attribute_key': 'attribute_value'
@@ -188,7 +191,7 @@ void main() {
   test('addErrorInfo passes stack trace string', () async {
     final stackTrace = StackTrace.current;
     await ddRumPlatform.addErrorInfo('Exception message', RumErrorSource.source,
-        stackTrace, {'attribute_key': 'attribute_value'});
+        stackTrace, 'error_type', {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -196,6 +199,7 @@ void main() {
     expect(call.arguments['message'], 'Exception message');
     expect(call.arguments['source'], 'RumErrorSource.source');
     expect(call.arguments['stackTrace'], stackTrace.toString());
+    expect(call.arguments['errorType'], 'error_type');
     expect(call.arguments['attributes'], {
       // '_dd.error.source_type': 'flutter'
       'attribute_key': 'attribute_value'


### PR DESCRIPTION
### What and why?

When creating the initial API for RUM I missed adding `errorType` as a parameter on the `addError` methods. This adds that parameter back in.

Fixes #372

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests