### PR TITLE
🐛 Fix Flutter Web initialization to disable session replay

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -98,6 +98,10 @@ class Dd {
 
   String? get traceId => rawData['trace_id'];
   String? get spanId => rawData['span_id'];
+  int? get plan {
+    final session = rawData['session'] as Map<String, dynamic>;
+    return session['plan'];
+  }
 }
 
 class RumEventDecoder {

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix `version` not properly populating on Flutter Web. See [#334]
 * Improve `RumUserActionDetector` to detect more widgets, including `BottomNavigationBar`, `Tab`, `Switch`, and `Radio`
 * Remove an extra call to `FlutterError.presentError` made in `runApp`.  See [#358]
+* Set `sessionReplaySampleRate` to 0 during initialization for Browser as Session Replay is not supported.
 
 ## 1.2.2
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -89,6 +89,10 @@ void main() {
       );
     }
 
+    for (var log in rumLog) {
+      expect(log.dd.plan, 1);
+    }
+
     final session = RumSessionDecoder.fromEvents(rumLog);
     expect(session.visits.length, kIsWeb ? 4 : 3);
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -28,6 +28,7 @@ class DdRumWeb extends DdRumPlatform {
       clientToken: configuration.clientToken,
       site: siteStringForSite(configuration.site),
       sampleRate: rumConfiguration.sessionSamplingRate,
+      sessionReplaySampleRate: 0,
       service: configuration.serviceName,
       env: configuration.env,
       version: configuration.versionTag,
@@ -153,7 +154,7 @@ class _RumInitOptions {
   external bool? get trackInteractions;
   external String? get defaultPrivacyLevel;
   external num? get sampleRate;
-  external num? get replaySampleRate;
+  external num? get sessionReplaySampleRate;
   external bool? get silentMultipleInit;
   external String? get proxyUrl;
   external List<String> get allowedTracingOrigins;
@@ -169,7 +170,7 @@ class _RumInitOptions {
     bool? trackInteractions,
     String? defaultPrivacyLevel,
     num? sampleRate,
-    num? replaySampleRate,
+    num? sessionReplaySampleRate,
     bool? silentMultipleInit,
     String? proxyUrl,
     List<String> allowedTracingOrigins,


### PR DESCRIPTION
### What and why?

This sets the `sessionReplaySampleRate` to 0, as Flutter does not support Session Replay, and avoids the Browser SDK reporting the session as a replay session.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests