### PR TITLE
🧹 Modify code to support Flutter 2.8

### DIFF
--- a/packages/datadog_flutter_plugin/example/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/example/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^2.0.1
+  flutter_lints: '>= 1.0.0'
 
 flutter:
   uses-material-design: true

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -3,7 +3,6 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:meta/meta.dart';
@@ -280,7 +279,7 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
   }
 
   _ElementDescription? _getDetectingElementDescription(Element element,
-      List<HitTestEntry<HitTestTarget>> targets, String? treeAnnotation) {
+      List<HitTestEntry> targets, String? treeAnnotation) {
     final widget = element.widget;
     String? elementName;
     bool searchForBetter = false;
@@ -356,8 +355,8 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
 }
 
 Element? _findGestureDetectorElement(
-    Element rootElement, List<HitTestEntry<HitTestTarget>> hitTargets) {
-  final targets = List<HitTestEntry<HitTestTarget>>.from(hitTargets);
+    Element rootElement, List<HitTestEntry> hitTargets) {
+  final targets = List<HitTestEntry>.from(hitTargets);
   targets.removeLast();
 
   Element? detectorElement;


### PR DESCRIPTION
### What and why?

Modify some code that allows datadog_flutter_plugin to continue to support Flutter 2.8.

### How?

Downgrade lints to any version above 1.0, and remove generic parameter on HitTest (this generic parameter is marked as optional in later versions of Flutter and 3.0+ are able to omit it without issue)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests