### PR TITLE
✨ Add the ability to stop sessions

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add the ability to stop a RUM session. A new session is started on the next user interaction or on the next view start. See [#147]
 
 ## 1.3.2
 
@@ -146,6 +146,7 @@
 
 [#133]: https://github.com/DataDog/dd-sdk-flutter/issues/133
 [#143]: https://github.com/DataDog/dd-sdk-flutter/issues/143
+[#147]: https://github.com/DataDog/dd-sdk-flutter/issues/147
 [#148]: https://github.com/DataDog/dd-sdk-flutter/issues/148
 [#159]: https://github.com/DataDog/dd-sdk-flutter/issues/159
 [#175]: https://github.com/DataDog/dd-sdk-flutter/issues/175

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -106,6 +106,7 @@ class DatadogRumPlugin(
                 "reportLongTask" -> reportLongTask(call, result)
                 "updatePerformanceMetrics" -> updatePerformanceMetrics(call, result)
                 "addFeatureFlagEvaluation" -> addFeatureFlagEvaluation(call, result)
+                "stopSession" -> stopSession(call, result)
                 else -> {
                     result.notImplemented()
                 }
@@ -333,6 +334,11 @@ class DatadogRumPlugin(
         } else {
             result.missingParameter(call.method)
         }
+    }
+
+    private fun stopSession(call: MethodCall, result: Result) {
+        rum?.stopSession()
+        result.success(null)
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -554,7 +554,8 @@ class DatadogRumPluginTest {
         Contract("addFeatureFlagEvaluation", mapOf(
             "name" to ContractParameter.Type(SupportedContractType.STRING),
             "value" to ContractParameter.Type(SupportedContractType.ANY),
-        ))
+        )),
+        Contract("stopSession", mapOf())
     )
 
     @Test

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -154,7 +154,8 @@ class DatadogRumPluginTests: XCTestCase {
         Contract(methodName: "addFeatureFlagEvaluation", requiredParameters: [
             "name": .string,
             "value": .string
-        ])
+        ]),
+        Contract(methodName: "stopSession", requiredParameters: [:])
     ]
 
     func testRumPlugin_ContractViolationsThrowErrors() {

--- a/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
@@ -65,6 +65,7 @@ func testContracts(contracts: [Contract], plugin: FlutterPlugin, additionalArgum
         switch result {
         case .called(let value):
             let error = value as? FlutterError
+            XCTAssertNotEqual(value as? NSObject, FlutterMethodNotImplemented)
             XCTAssertNil(error, "\(contract.methodName) returned result \(String(describing: error)) on valid call")
 
         case .notCalled:

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_kiosk_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_kiosk_test.dart
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+Future<void> performUserInteractions(WidgetTester tester) async {
+  final startButton = find.widgetWithText(ElevatedButton, 'Start Session');
+  await tester.tap(startButton);
+  await tester.pumpAndSettle();
+
+  final downloadResourceButton =
+      find.widgetWithText(ElevatedButton, 'Download Resource');
+  await tester.tap(downloadResourceButton);
+  await tester.pumpAndSettle();
+  await tester.waitFor(downloadResourceButton, const Duration(seconds: 2),
+      (e) => (e.widget as ElevatedButton).enabled);
+
+  final userActionButton = find.widgetWithText(ElevatedButton, 'User Action');
+  await tester.tap(userActionButton);
+  await tester.pumpAndSettle();
+
+  await tester.pageBack();
+
+  // Wait
+  await tester.pump(const Duration(milliseconds: 500));
+
+  // Next session
+  await tester.tap(startButton);
+  await tester.pumpAndSettle();
+
+  await tester.tap(downloadResourceButton);
+  await tester.pumpAndSettle();
+  await tester.waitFor(downloadResourceButton, const Duration(seconds: 2),
+      (e) => (e.widget as ElevatedButton).enabled);
+  await tester.tap(userActionButton);
+  await tester.pumpAndSettle();
+
+  final finishButton = find.widgetWithText(ElevatedButton, 'Finish Test');
+  await tester.tap(finishButton);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('test rum scenario', (WidgetTester tester) async {
+    var recordedSession = await openTestScenario(
+      tester,
+      menuTitle: 'Kiosk RUM Scenario',
+    );
+
+    await performUserInteractions(tester);
+
+    var requestLog = <RequestLog>[];
+    var rumLog = <RumEventDecoder>[];
+    await recordedSession.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        requestLog.addAll(requests);
+        requests.map((e) => e.data.split('\n')).expand((e) => e).forEach((e) {
+          dynamic jsonValue = json.decode(e);
+          if (jsonValue is Map<String, Object?>) {
+            final rumEvent = RumEventDecoder.fromJson(jsonValue);
+            if (rumEvent != null) {
+              rumLog.add(rumEvent);
+            }
+          }
+        });
+        return RumSessionDecoder.fromEvents(rumLog).visits.length >=
+            (kIsWeb ? 5 : 3);
+      },
+    );
+
+    final sessions = RumSessionDecoder.fromEvents(rumLog);
+    expect(sessions.visits.length, 3);
+
+    final firstSession =
+        sessions.visits[0].viewEvents[0].rumEvent['session']['id'] as String;
+    final secondSession =
+        sessions.visits[1].viewEvents[0].rumEvent['session']['id'] as String;
+
+    expect(firstSession, isNot(secondSession));
+    final firstVisit = sessions.visits[0];
+    for (final viewEvent in firstVisit.viewEvents) {
+      expect(viewEvent.rumEvent['session']['id'], firstSession);
+    }
+    expect(
+        firstVisit.viewEvents.last.rumEvent['session']['is_active'], isFalse);
+
+    expect(firstVisit.resourceEvents.length, 1);
+    expect(
+        firstVisit.resourceEvents[0].rumEvent['session']['id'], firstSession);
+    expect(firstVisit.actionEvents.length, 1);
+    expect(firstVisit.actionEvents[0].rumEvent['session']['id'], firstSession);
+
+    final secondVisit = sessions.visits[1];
+    for (final viewEvent in secondVisit.viewEvents) {
+      expect(viewEvent.rumEvent['session']['id'], secondSession);
+    }
+    expect(
+        secondVisit.viewEvents.last.rumEvent['session']['is_active'], isTrue);
+
+    expect(secondVisit.resourceEvents.length, 1);
+    expect(
+        secondVisit.resourceEvents[0].rumEvent['session']['id'], secondSession);
+    expect(secondVisit.actionEvents.length, 1);
+    expect(
+        secondVisit.actionEvents[0].rumEvent['session']['id'], secondSession);
+  });
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../auto_integration_scenarios/rum_auto_instrumentation_scenario.dart';
+import 'kiosk_integration_scenario.dart';
 import 'logging_scenario.dart';
 import 'rum_manual_error_reporting_scenario.dart';
 import 'rum_manual_instrumentation_scenario.dart';
@@ -42,6 +43,10 @@ class _IntegrationScenariosScreenState
       label: 'Auto RUM Scenario',
       navItem: RumAutoInstrumentationScenario.new,
     ),
+    ScenarioItem(
+      label: 'Kiosk RUM Scenario',
+      navItem: KioskIntegrationScenario.new,
+    )
   ];
 
   @override

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/kiosk_integration_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/kiosk_integration_scenario.dart
@@ -1,0 +1,195 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+
+class KioskIntegrationScenario extends StatefulWidget {
+  const KioskIntegrationScenario({Key? key}) : super(key: key);
+
+  @override
+  State<KioskIntegrationScenario> createState() =>
+      _KioskIntegrationScenarioState();
+}
+
+class _KioskIntegrationScenarioState extends State<KioskIntegrationScenario>
+    implements RouteAware {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void didPush() {}
+
+  @override
+  void didPop() {}
+
+  @override
+  void didPushNext() {}
+
+  @override
+  void didPopNext() {
+    DatadogSdk.instance.rum?.stopSession();
+  }
+
+  void _startSession() {
+    Navigator.of(context).push<void>(MaterialPageRoute(builder: (context) {
+      return const KioskTrackedStreen();
+    }));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Kiosk Splash Screen')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: _startSession,
+          child: const Text('Start Session'),
+        ),
+      ),
+    );
+  }
+}
+
+class KioskTrackedStreen extends StatefulWidget {
+  const KioskTrackedStreen({Key? key}) : super(key: key);
+
+  @override
+  State<KioskTrackedStreen> createState() => _KioskTrackedStreenState();
+}
+
+class _KioskTrackedStreenState extends State<KioskTrackedStreen>
+    implements RouteAware {
+  final String viewKey = 'KioskTrackedStreen';
+
+  bool _resourceDownloadInProgress = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void didPush() {
+    DatadogSdk.instance.rum?.startView(viewKey);
+  }
+
+  @override
+  void didPop() {
+    DatadogSdk.instance.rum?.stopView(viewKey);
+  }
+
+  @override
+  void didPushNext() {
+    DatadogSdk.instance.rum?.stopView(viewKey);
+  }
+
+  @override
+  void didPopNext() {
+    DatadogSdk.instance.rum?.startView(viewKey);
+  }
+
+  Future<void> _downloadResource() async {
+    setState(() {
+      _resourceDownloadInProgress = true;
+    });
+
+    const resourceKey = '/resource/1';
+    DatadogSdk.instance.rum?.startResourceLoading(
+        resourceKey, RumHttpMethod.get, 'https://foo.com/resources/1');
+    await Future<void>.delayed(const Duration(milliseconds: 300));
+    DatadogSdk.instance.rum
+        ?.stopResourceLoading(resourceKey, 200, RumResourceType.image);
+
+    setState(() {
+      _resourceDownloadInProgress = false;
+    });
+  }
+
+  void _userAction() {
+    DatadogSdk.instance.rum
+        ?.addUserAction(RumUserActionType.tap, 'Kiosk User Action');
+  }
+
+  void _finishTest() {
+    Navigator.of(context).push<void>(
+        MaterialPageRoute(builder: (_) => const TestFinishedWaitScreen()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Kiosk Tracked Screen'),
+      ),
+      body: Center(
+        child: Column(
+          children: [
+            ElevatedButton(
+              onPressed: _resourceDownloadInProgress ? null : _downloadResource,
+              child: _resourceDownloadInProgress
+                  ? const CircularProgressIndicator()
+                  : const Text('Download Resource'),
+            ),
+            ElevatedButton(
+              onPressed: _userAction,
+              child: const Text('User Action'),
+            ),
+            ElevatedButton(
+              onPressed: _finishTest,
+              child: const Text('Finish Test'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TestFinishedWaitScreen extends StatefulWidget {
+  const TestFinishedWaitScreen({Key? key}) : super(key: key);
+
+  @override
+  State<TestFinishedWaitScreen> createState() => _TestFinishedWaitScreenState();
+}
+
+class _TestFinishedWaitScreenState extends State<TestFinishedWaitScreen>
+    implements RouteAware {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void didPush() {
+    DatadogSdk.instance.rum?.startView('TestFinished');
+  }
+
+  @override
+  void didPop() {}
+
+  @override
+  void didPushNext() {}
+
+  @override
+  void didPopNext() {}
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Test Complete'),
+      ),
+      body: const Center(
+        child: Text('Test is complete.'),
+      ),
+    );
+  }
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -78,7 +78,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.4.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -316,6 +316,9 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                     FlutterError.missingParameter(methodName: call.method)
                 )
             }
+        case "stopSession":
+            rum.stopSession()
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -319,6 +319,16 @@ class DdRum {
     });
   }
 
+  /// Stops the current session. A new session will start in response to a call
+  /// to [startView], [addUserAction], or [startUserAction]. If the session is
+  /// started because of a call to [addUserAction] or [startUserAction], the
+  /// last know view is restarted in the new session.
+  void stopSession() {
+    wrap('rum.stopSession', logger, null, () {
+      return _platform.stopSession();
+    });
+  }
+
   /// Uses the configured [RumConfiguration.tracingSamplingRate] to determine if
   /// a sample should be traced.
   ///

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -176,6 +176,11 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
+  Future<void> stopSession() {
+    return methodChannel.invokeMethod('stopSession', <String, Object?>{});
+  }
+
+  @override
   Future<void> reportLongTask(DateTime at, int durationMs) {
     return methodChannel.invokeMethod('reportLongTask', {
       'at': at.millisecondsSinceEpoch,

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -65,6 +65,7 @@ abstract class DdRumPlatform extends PlatformInterface {
   Future<void> removeAttribute(String key);
 
   Future<void> addFeatureFlagEvaluation(String name, Object value);
+  Future<void> stopSession();
 
   Future<void> reportLongTask(DateTime at, int durationMs);
   Future<void> updatePerformanceMetrics(

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -140,6 +140,11 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
+  Future<void> stopSession() async {
+    _jsStopSession();
+  }
+
+  @override
   Future<void> reportLongTask(DateTime at, int durationMs) async {
     // NOOP - The browser SDK will report this automatically
   }
@@ -207,3 +212,6 @@ external void _jsAddAction(String action, dynamic context);
 
 @JS('addFeatureFlagEvaluation')
 external void _jsAddFeatureFlagEvaluation(String name, dynamic value);
+
+@JS('stopSession')
+external void _jsStopSession();

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -264,6 +264,23 @@ void main() {
     ]);
   });
 
+  test('addFeatureFlagEvaluation calls to platform', () async {
+    await ddRumPlatform.addFeatureFlagEvaluation('key_name', 'key_value');
+
+    expect(log, [
+      isMethodCall('addFeatureFlagEvaluation', arguments: {
+        'name': 'key_name',
+        'value': 'key_value',
+      })
+    ]);
+  });
+
+  test('stopSession calls to platform', () async {
+    await ddRumPlatform.stopSession();
+
+    expect(log, [isMethodCall('stopSession', arguments: <String, Object?>{})]);
+  });
+
   test('reportLongTask calls to platform', () async {
     final now = DateTime.now();
     final duration = Random().nextInt(1000) + 100;

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -78,7 +78,7 @@ packages:
       path: "../../datadog_flutter_plugin"
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.4.0"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:


### PR DESCRIPTION
### What and why?

RUM sessions can be stopped with a call to DdRum.stopSession. This set the current session as inactive and start a new session the next time `startView`, `addUserAction`, or `startUserAction` is called.

Fixes #147

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests