### PR TITLE
💚 Stop sending telemetry on log tests

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_integration_test_app/integration_scenarios/scenario_runner.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,6 +23,9 @@ void main() {
     var recordedSession = await openTestScenario(
       tester,
       scenarioName: mappedLoggingScenarioRunner,
+      additionalConfig: {
+        DatadogConfigKey.telemetryConfigurationSampleRate: 0.0,
+      },
       menuTitle: 'Logging Scenario',
     );
     var logs = <LogDecoder>[];
@@ -48,7 +52,8 @@ void main() {
             .expand<dynamic>((e) => e)
             .whereType<Map<String, Object?>>()
             // Ignore RUM sessions
-            .where((e) => !(e).containsKey('session'))
+            .where(
+                (e) => !(e).containsKey('session') && e['type'] != 'telemetry')
             .forEach((e) => logs.add(LogDecoder(e)));
         return logs.length >= 5;
       },


### PR DESCRIPTION
### What and why?

Some telemetry is getting through (probably when it's sent on its own) and causing certain tests to flake. This sets the sample rate for telemetry on log tests to 0, which should prevent further flakeyness.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests