### PR TITLE
⬆️ Raise minimum supported version to Flutter 3.0+

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add the ability to stop a RUM session. A new session is started on the next user interaction or on the next view start. See [#147]
+* Increase minimum Flutter version to 3.0, Dart 2.17. See [#386]
 
 ## 1.3.2
 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -3,7 +3,8 @@
 
 Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real-time performance and user journeys of your Flutter application’s individual users.
 
-RUM supports monitoring for Flutter Android and iOS applications for Flutter 2.8+.
+Datadog RUM SDK versions < 1.4 support monitoring for Flutter 2.8+.
+Datadog RUM SDK versions >= 1.4 support monitoring for Flutter 3.0+.
 
 ## Current Datadog SDK Versions
 
@@ -14,9 +15,6 @@ RUM supports monitoring for Flutter Android and iOS applications for Flutter 2.8
 | 1.17.0 | 1.18.1 | 4.x.x |
 
 [//]: # (End SDK Table)
-
-
-
 
 ### iOS
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -60,7 +60,7 @@ void main() {
     expect(view.errorEvents.length, 3);
 
     var exceptionError = view.errorEvents[0];
-    expect(exceptionError.message, contains(NullThrownError().toString()));
+    expect(exceptionError.message, contains(TypeError().toString()));
     expect(exceptionError.source, kIsWeb ? 'custom' : 'source');
     expect(exceptionError.errorType, 'NullThrown');
     if (!kIsWeb) {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -32,7 +32,7 @@ class _RumManualErrorReportingScenarioState
     final rum = DatadogSdk.instance.rum;
     if (rum != null) {
       rum.addError(
-        NullThrownError(),
+        TypeError(),
         RumErrorSource.source,
         errorType: 'NullThrown',
       );

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.lock
@@ -127,7 +127,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_integration_test_app
 description: App to do integration testing for the Datadog Flutter SDK
-publish_to: 'none'
+publish_to: "none"
 version: 1.0.0
 
 environment:
@@ -8,6 +8,8 @@ environment:
 
 dependencies:
   flutter:
+    sdk: flutter
+  flutter_web_plugins:
     sdk: flutter
 
   cupertino_icons: ^1.0.2
@@ -20,7 +22,7 @@ dependencies:
   datadog_common_test:
     path: ../../datadog_common_test
   http: ^0.13.4
-    
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlog_event.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlog_event.dart
@@ -113,7 +113,7 @@ class LogEvent {
   @JsonKey(name: '_dd')
   final LogEventDd dd;
 
-  @JsonKey(ignore: true)
+  @JsonKey(includeFromJson: false, includeToJson: false)
   Map<String, Object?> attributes = {};
 
   String ddtags;

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -222,7 +222,6 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     _ElementDescription? detectingElement;
 
     String? rumTreeAnnotation;
-    bool excludingSemantics = false;
     RenderObject? lastRenderObject;
 
     void elementVisitor(Element element) {
@@ -278,8 +277,8 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     return detectingElement;
   }
 
-  _ElementDescription? _getDetectingElementDescription(Element element,
-      List<HitTestEntry> targets, String? treeAnnotation) {
+  _ElementDescription? _getDetectingElementDescription(
+      Element element, List<HitTestEntry> targets, String? treeAnnotation) {
     final widget = element.widget;
     String? elementName;
     bool searchForBetter = false;

--- a/packages/datadog_flutter_plugin/pubspec.lock
+++ b/packages/datadog_flutter_plugin/pubspec.lock
@@ -638,4 +638,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=3.0.0"

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.4.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=1.20.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
@@ -17,11 +17,11 @@ dependencies:
   json_annotation: ^4.4.0
   uuid: ^3.0.5
   meta: ^1.7.0
-  
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: '>=1.0.0'
+  flutter_lints: ">=1.0.0"
   mocktail: ^0.3.0
   json_serializable: ^6.3.1
   build_runner: ^2.1.11

--- a/packages/datadog_webview_tracking/README.md
+++ b/packages/datadog_webview_tracking/README.md
@@ -1,11 +1,11 @@
 ## Overview
 
-This package is an extension to the [`datadog_flutter_plugin`][1]. It allows 
-Real User Monitoring allows to monitor web views and eliminate blind spots in your hybrid Flutter applications.
+This package is an extension to the [`datadog_flutter_plugin`][1]. It allows
+Real User Monitoring to monitor web views and eliminate blind spots in your hybrid Flutter applications.
 
-## Instrumentint your web views
+## Instrumenting your web views
 
-The RUM Flutter SDK provides APIs for you to control web view tracking when using the [`webview_flutter`][2] package. 
+The RUM Flutter SDK provides APIs for you to control web view tracking when using the [`webview_flutter`][2] package.
 
 Add both the `datadog_webview_tracking` package and the `webview_flutter` package to your `pubspec.yaml`:
 


### PR DESCRIPTION
### What and why?

Flutter 3.0 has been out for almost a year, and we have a bug related to attempting to support down to Flutter 2.8 (#386) so we're going to limit support to 3.0+ starting with the release of SDK version 1.4.

Additionally fix some deprecation warnings that were waiting on an update to Flutter 3 and other documentation issues.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests