### PR TITLE
🐛 Fix crash on exit on iOS

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix a crash on exit on iOS. See [#390]
 * Add the ability to stop a RUM session. A new session is started on the next user interaction or on the next view start. See [#147]
 * Increase minimum Flutter version to 3.0, Dart 2.17. See [#386]
 
@@ -162,3 +163,4 @@
 [#334]: https://github.com/DataDog/dd-sdk-flutter/issues/334
 [#358]: https://github.com/DataDog/dd-sdk-flutter/issues/358
 [#372]: https://github.com/DataDog/dd-sdk-flutter/issues/372
+[#390]: https://github.com/DataDog/dd-sdk-flutter/issues/390

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -40,6 +40,7 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         let channel = FlutterMethodChannel(name: "datadog_sdk_flutter", binaryMessenger: registrar.messenger())
         let instance = SwiftDatadogSdkPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
+        registrar.addApplicationDelegate(instance)
         registrar.publish(instance)
 
         DatadogLogsPlugin.register(with: registrar)
@@ -285,6 +286,10 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
         default:
             return nil
         }
+    }
+
+    public func applicationWillTerminate(_ application: UIApplication) {
+        _onDetach()
     }
 
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   js: ^0.6.3
   plugin_platform_interface: ^2.0.2
-  json_annotation: ^4.4.0
+  json_annotation: ^4.8.0
   uuid: ^3.0.5
   meta: ^1.7.0
 


### PR DESCRIPTION
### What and why?

The fix we thought we applied in 1.2.2 (#348) didn't seem to work, so we're trying a different approach.

`detachFromEngine` still isn't being called when its supposed to, but `applicationWillTerminate` is being called, and its currently safe to detach twice even if `detachFromEngine` does get called. This should avoid crashes with the console logger attempting to call back to Flutter after its shut down.

Fixes #390

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests