### PR TITLE
👷 Fix releaser to remove bad `apply from`

### DIFF
--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -42,6 +42,9 @@ class UpdateGradleFilesCommand extends Command {
               '$versionPrefix = "${args.androidRelease}"');
         }
 
+        // Remove requests for external gradle files
+        if (line.contains("apply from: '../")) return null;
+
         if (line.contains('maven ')) {
           inMavenBlock = true;
         }

--- a/tools/releaser/lib/package_list.dart
+++ b/tools/releaser/lib/package_list.dart
@@ -15,6 +15,7 @@ final podfileList = [
 final gradleList = [
   'packages/datadog_flutter_plugin/android/build.gradle',
   'packages/datadog_flutter_plugin/example/android/app/build.gradle',
+  'packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle',
   'packages/datadog_flutter_webview/android/build.gradle',
   'examples/native-hybrid-app/android/app/build.gradle'
 ];

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -181,8 +181,7 @@ Future<bool> _updateReadmeVersions(CommandArguments args, Logger logger) async {
 | :-----: | :---------: | :---------: |
 | ${args.iOSRelease} | ${args.androidRelease} | 4.x.x |
 
-[//]: # (End SDK Table)
-''';
+[//]: # (End SDK Table)''';
         return line;
       }
 


### PR DESCRIPTION
### What and why?

When we release a the Dart package, we can't refer to files outside of the package. The `apply from` that ignores SR snapshots uses a file outside the package and can cause build failures, so it needs to be removed during the release process

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests