### PR TITLE
🔊 Add flutter doctor to diagnose bitrise issue

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -282,6 +282,14 @@ workflows:
     before_run:
     - _launch_ios_simulator
     steps:
+      - script:
+          title: Run flutter doctor
+          inputs:
+          - content: |-
+              #!/usr/bin/env/ bash
+              flutter doctor
+          - working_dir: "$BITRISE_SOURCE_DIR"
+
       - flutter-test@1:
           inputs:
           - project_location: "$BITRISE_SOURCE_DIR/packages/datadog_flutter_plugin/e2e_test_app"


### PR DESCRIPTION
### What and why?

We're having nightly tests fail about 50% of the time complaining that an iOS simulator isn't started. Bitrise has asked that we add a `flutter doctor` call so they can help diagnose.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests