### PR TITLE
🐛 Fix rethrown exceptions not properly preserving stacktrace

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/helpers.dart
@@ -11,6 +11,10 @@ import 'internal_logger.dart';
 
 typedef WrappedCall<T> = FutureOr<T?> Function();
 
+bool _willHandleError(Object e) {
+  return e is ArgumentError || e is PlatformException;
+}
+
 // Returns true if the error was handled, false if the error should be re-thrown
 bool _handleError(Object error, StackTrace stackTrace, String methodName,
     InternalLogger logger, Map<String, Object?>? serializedAttributes) {
@@ -44,10 +48,8 @@ void wrap(
     var result = call();
     if (result is Future) {
       result.catchError((dynamic e, StackTrace st) {
-        if (!_handleError(e, st, methodName, logger, attributes)) {
-          throw e;
-        }
-      });
+        _handleError(e, st, methodName, logger, attributes);
+      }, test: _willHandleError);
     }
   } catch (e, st) {
     if (!_handleError(e, st, methodName, logger, attributes)) {

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Fix rethrown execptions on `close` not having the correct stack trace.
+
+## 1.2.1
+
 * Fix an invalid assertion when processing stream errors. See [#355]
 
 ## 1.2.0

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -291,7 +291,7 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
     return innerContext.close().then((value) {
       return _DatadogTrackingHttpResponse(
           client.datadogSdk, value, rumKey, _tracingContext);
-    }, onError: (Object e, StackTrace? st) async {
+    }, onError: (Object e, StackTrace? st) {
       _onStreamError(e, st);
       throw e;
     });


### PR DESCRIPTION
### What and why?

Dart has "rethrow" within catch blocks to preserve stack traces, and Futures will preserve stack traces if you "throw" the same exception so long as it is not inside an `async` block. The `close` method had its `onError` marked as async by accident, so it was not preserving the stack trace properly.

Fixes RUMM-3264

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests