### PR TITLE
✨ Use PlatformDispatcher.instance.onError over runZonedGuarded

### DIFF
--- a/packages/datadog_flutter_plugin/example/lib/main.dart
+++ b/packages/datadog_flutter_plugin/example/lib/main.dart
@@ -77,55 +77,42 @@ RumLongTaskEvent? _longTaskEventMapper(RumLongTaskEvent event) {
 }
 
 void main() async {
-  runZonedGuarded(() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    await dotenv.load();
+  await dotenv.load();
 
-    var applicationId = dotenv.maybeGet('DD_APPLICATION_ID');
+  var applicationId = dotenv.maybeGet('DD_APPLICATION_ID');
 
-    final configuration = DdSdkConfiguration(
-      clientToken: dotenv.get('DD_CLIENT_TOKEN', fallback: ''),
-      env: dotenv.get('DD_ENV', fallback: ''),
-      site: DatadogSite.us1,
-      trackingConsent: TrackingConsent.granted,
-      nativeCrashReportEnabled: true,
-      logEventMapper: _logEventMapper,
-      loggingConfiguration: LoggingConfiguration(
-        sendNetworkInfo: true,
-        printLogsToConsole: true,
-      ),
-      rumConfiguration: applicationId != null
-          ? RumConfiguration(
-              applicationId: applicationId,
-              detectLongTasks: true,
-              rumViewEventMapper: _viewEventMapper,
-              rumActionEventMapper: _actionEventMapper,
-              rumResourceEventMapper: _resourceEventMapper,
-              rumErrorEventMapper: _errorEventMapper,
-              rumLongTaskEventMapper: _longTaskEventMapper,
-            )
-          : null,
-    );
+  final configuration = DdSdkConfiguration(
+    clientToken: dotenv.get('DD_CLIENT_TOKEN', fallback: ''),
+    env: dotenv.get('DD_ENV', fallback: ''),
+    site: DatadogSite.us1,
+    trackingConsent: TrackingConsent.granted,
+    nativeCrashReportEnabled: true,
+    logEventMapper: _logEventMapper,
+    loggingConfiguration: LoggingConfiguration(
+      sendNetworkInfo: true,
+      printLogsToConsole: true,
+    ),
+    rumConfiguration: applicationId != null
+        ? RumConfiguration(
+            applicationId: applicationId,
+            detectLongTasks: true,
+            rumViewEventMapper: _viewEventMapper,
+            rumActionEventMapper: _actionEventMapper,
+            rumResourceEventMapper: _resourceEventMapper,
+            rumErrorEventMapper: _errorEventMapper,
+            rumLongTaskEventMapper: _longTaskEventMapper,
+          )
+        : null,
+  );
 
-    final ddsdk = DatadogSdk.instance;
-    ddsdk.sdkVerbosity = Verbosity.verbose;
-
-    await DatadogSdk.instance.initialize(configuration);
-
-    FlutterError.onError = (FlutterErrorDetails details) {
-      FlutterError.presentError(details);
-      ddsdk.rum?.handleFlutterError(details);
-    };
-
+  final ddsdk = DatadogSdk.instance;
+  ddsdk.sdkVerbosity = Verbosity.verbose;
+  DatadogSdk.runApp(configuration, () async {
     ddsdk.setUserInfo(id: 'test_id', extraInfo: {
       'user_attribute_1': true,
       'user_attribute_2': 'testing',
     });
 
-    runApp(const ExampleApp());
-  }, (e, s) {
-    DatadogSdk.instance.rum
-        ?.addErrorInfo(e.toString(), RumErrorSource.source, stackTrace: s);
-    throw e;
+    return runApp(const ExampleApp());
   });
 }


### PR DESCRIPTION
### What and why?

Flutter 3.1 added `PlatformDispatcher.instane.onError` which could be used to catch errors without using `runZonedGuarded`, however there was a bug with Flutter Web with this method that was fixed in Flutter 3.3.

I've replaced the `runZonedGuarded` code with `PlatformDispatcher` and upped the minimum version required for the SDK to 3.3.

I've also changed the example to use `runApp` by default, as it no longer needs to be careful about when it calls `WidgetFlutterBinding.ensureInitialized`

Fixes #416 

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests