### PR TITLE
📝 Better documentation for viewInfoExtractor

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -155,6 +155,28 @@ Alternately, you can use the `DatadogRouteAwareMixin` property in conjunction wi
 
 Note that, by default, `DatadogRouteAwareMixin` uses the name of the widget as the name of the View. However, this **does not work with obfuscated code** as the name of the Widget class is lost during obfuscation. To keep the correct view name, override `rumViewInfo`:
 
+To rename your views or supply custom paths, provide a [`viewInfoExtractor`][10] callback. This function can fall back to the default behavior of the observer by calling `defaultviewInfoExtractor`. For example:
+
+```dart
+RumViewInfo? infoExtractor(Route<dynamic> route) {
+  var name = route.settings.name;
+  if (name == 'my_named_route') {
+    return RumViewInfo(
+      name: 'MyDifferentName',
+      attributes: {'extra_attribute': 'attribute_value'},
+    );
+  }
+
+  return defaultViewInfoExtractor(route);
+}
+
+var observer = DatadogNavigationObserver(
+  datadogSdk: DatadogSdk.instance,
+  viewInfoExtractor: infoExtractor,
+);
+```
+
+
 ```dart
 class _MyHomeScreenState extends State<MyHomeScreen>
     with RouteAware, DatadogRouteAwareMixin {
@@ -210,3 +232,4 @@ For more information, see [Apache License, v2.0][5].
 [7]: https://pub.dev/packages/datadog_tracking_http_client
 [8]: https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/DdSdkConfiguration-class.html
 [9]: https://support.apple.com/guide/security/security-of-runtime-process-sec15bfe098e/web
+[10]: https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/ViewInfoExtractor.html

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -34,6 +34,10 @@ class RumViewInfo {
 /// See [DatadogNavigationObserver.viewInfoExtractor].
 typedef ViewInfoExtractor = RumViewInfo? Function(Route<dynamic> route);
 
+/// The function that provides the default route naming behavior for
+/// [DatadogNavigationObserver]. If the supplied route is a PageRoute and contains
+/// a name, it returns a [RumViewInfo] with the supplied name. Otherwise it returns
+/// `null`.
 RumViewInfo? defaultViewInfoExtractor(Route<dynamic> route) {
   if (route is PageRoute) {
     var name = route.settings.name;
@@ -60,6 +64,7 @@ RumViewInfo? defaultViewInfoExtractor(Route<dynamic> route) {
 /// different name, path, or extra attributes to any route.
 class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>>
     with WidgetsBindingObserver {
+  /// A callback to supply view information to the observer. See [ViewInfoExtractor].
   final ViewInfoExtractor viewInfoExtractor;
   final DatadogSdk datadogSdk;
 


### PR DESCRIPTION
### What and why?

Realized `viewInfoExtractor` takes the place of the native `viewPredicate`s, it just was poorly documented. Adding new documentation to the repo.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests