### PR TITLE
👩‍💻 Use already provided HttpOverrides when available

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Have `DatadogTrackingHttpClient` use `HttpOverrides.current` if they already exist. See [#424] 
 * Fix rethrown execptions on `close` not having the correct stack trace.
 
 ## 1.2.1
@@ -52,3 +53,4 @@
 * Initial split of DatadogTrackingHttpClient into its own package
 
 [#355]: https://github.com/DataDog/dd-sdk-flutter/issues/355
+[#424]: https://github.com/DataDog/dd-sdk-flutter/issues/424

--- a/packages/datadog_tracking_http_client/README.md
+++ b/packages/datadog_tracking_http_client/README.md
@@ -16,6 +16,8 @@ final configuration = DdSdkConfiguration(
 )..enableHttpTracking()
 ```
 
+Note that the Datadog Tracking HTTP Client modifies [HttpOverrides.global](). If you need to provide your own `HttpOverrides`, make sure to initialize it prior to initializing Datadot. During initialization, Datadog will check the value of `HttpOverrides.current` and use this for client creation if it exists.
+
 ## Using http.Client wrapping
 
 This package also supplies a composable client usable with the [http pub package](https://pub.dev/packages/http) called `DatadogClient`. For most scenarios, Datadog recommends you use the HTTP tracking method above, but there are a few scenarios where using `DatadogClient` might make more sense:

--- a/packages/datadog_tracking_http_client/README.md
+++ b/packages/datadog_tracking_http_client/README.md
@@ -16,7 +16,7 @@ final configuration = DdSdkConfiguration(
 )..enableHttpTracking()
 ```
 
-Note that the Datadog Tracking HTTP Client modifies [HttpOverrides.global](). If you need to provide your own `HttpOverrides`, make sure to initialize it prior to initializing Datadot. During initialization, Datadog will check the value of `HttpOverrides.current` and use this for client creation if it exists.
+Note that the Datadog Tracking HTTP Client modifies `[HttpOverrides.global]()`. If you need to provide your own `HttpOverrides`, make sure to initialize it prior to initializing Datadog. During initialization, Datadog will check the value of `HttpOverrides.current` and use this for client creation if it exists.
 
 ## Using http.Client wrapping
 

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -17,7 +17,10 @@ extension TrackingExtension on DdSdkConfiguration {
   /// Configures network requests monitoring for Tracing and RUM features.
   ///
   /// If enabled, the SDK will override [HttpClient] creation (via
-  /// [HttpOverrides.global]) to provide its own implementation.
+  /// [HttpOverrides.global]) to provide its own implementation. If you need
+  /// to provide your own overrides to [HttpOverrides.global], do so before
+  /// initializing Datadog. The HTTP tracking plugin will use the provided
+  /// [HttpOverrides] before overwriting with its own.
   ///
   /// If the RUM feature is enabled, the SDK will send RUM Resources for all
   /// intercepted requests. The SDK will also generate and send tracing Spans

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -22,12 +22,15 @@ import 'tracking_http_client_plugin.dart';
 class DatadogTrackingHttpOverrides extends HttpOverrides {
   final DatadogSdk datadogSdk;
   final DdHttpTrackingPluginConfiguration configuration;
+  final HttpOverrides? existingOverrides;
 
-  DatadogTrackingHttpOverrides(this.datadogSdk, this.configuration);
+  DatadogTrackingHttpOverrides(
+      this.datadogSdk, this.configuration, this.existingOverrides);
 
   @override
   HttpClient createHttpClient(SecurityContext? context) {
-    var innerClient = super.createHttpClient(context);
+    var innerClient = existingOverrides?.createHttpClient(context) ??
+        super.createHttpClient(context);
     return DatadogTrackingHttpClient(datadogSdk, configuration, innerClient);
   }
 }

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
@@ -65,8 +65,12 @@ class _DdHttpTrackingPlugin extends DatadogPlugin {
 
   @override
   void initialize() {
-    HttpOverrides.global =
-        DatadogTrackingHttpOverrides(instance, configuration);
+    final existingOverrides = HttpOverrides.current;
+    HttpOverrides.global = DatadogTrackingHttpOverrides(
+      instance,
+      configuration,
+      existingOverrides,
+    );
     instance.updateConfigurationInfo(
         LateConfigurationProperty.trackNetworkRequests, true);
   }


### PR DESCRIPTION
### What and why?

The `DatadogTrackingHttpClient` sets `HttpOverrides.global` without checking if client code has already overridden it. This can lead to unexpected behavior when clients need to use `HttpOverrides`.

I've also added more documentation to the library to make it clear what's happening.

See #424

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests