### PR TITLE
📌 Pin Android to 1.19.0 to avoid Kotlin update.

### DIFF
--- a/examples/native-hybrid-app/android/app/build.gradle
+++ b/examples/native-hybrid-app/android/app/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.19.0"
 }
 
 plugins {

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -10,7 +10,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.6.21"
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.19.0"
 
     repositories {
         google()

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.19.0"
 }
 
 def localProperties = new Properties()

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.6.21'
-    ext.datadog_version = "1+"
+    ext.datadog_version = "1.19.0"
 
     repositories {
         google()

--- a/tools/releaser/lib/package_list.dart
+++ b/tools/releaser/lib/package_list.dart
@@ -16,6 +16,6 @@ final gradleList = [
   'packages/datadog_flutter_plugin/android/build.gradle',
   'packages/datadog_flutter_plugin/example/android/app/build.gradle',
   'packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle',
-  'packages/datadog_flutter_webview/android/build.gradle',
+  'packages/datadog_webview_tracking/android/build.gradle',
   'examples/native-hybrid-app/android/app/build.gradle'
 ];


### PR DESCRIPTION
### What and why?

Current Android SDK has updated to Kotlin 1.8 which is binary incompatible with what the current Flutter SDK expects. Going to pin to 1.19.0 for now until we can update.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests