### PR TITLE
fix: adding export for DatadogTrackingHttpClientListener

### DIFF
--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -12,6 +12,8 @@ import 'src/tracking_http_client_plugin.dart'
 
 export 'src/tracking_http.dart';
 export 'src/tracking_http_client.dart';
+export 'src/tracking_http_client_plugin.dart'
+    show DatadogTrackingHttpClientListener;
 
 extension TrackingExtension on DdSdkConfiguration {
   /// Configures network requests monitoring for Tracing and RUM features.


### PR DESCRIPTION
### What and why?

What changes does this pull request introduce and why is it necessary?

This pr adds an export for `DatadogTrackingHttpClientListener` so that it can be implemented by consuming applications

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests