### PR TITLE
Update for tracking_http_client 1.3.1 release

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.3.1
 
 * Fix not exporting `DatadogTrackingHttpClientListener` from @ClaireDavis.
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 1.3.1
 
 * Fix not exporting `DatadogTrackingHttpClientListener` from @ClaireDavis.

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 1.3.1
+version: 1.4.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 1.4.0
+version: 1.3.1
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 


### PR DESCRIPTION
### What and why?

Update for changes related to the datadog_tracking_http_client 1.3.1 release

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests