### PR TITLE
✨ Add sessionId getter and sessionStarted callback

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add a `sessionId` getter to DdRum, as well as a `sessionStarted` callback. See [#442]
 
 ## 1.5.1
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -354,7 +354,7 @@ class DatadogRumPlugin(
                 "rumSessionStarted",
                 mapOf(
                     "sessionId" to sessionId,
-                    "sampled" to isDiscarded,
+                    "sampledOut" to isDiscarded,
                 )
             )
         }

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -133,7 +133,8 @@ class SessionFooter extends StatefulWidget {
 }
 
 class _SessionFooterState extends State<SessionFooter> {
-  String get currentSessionId => DatadogSdk.instance.rum?.sessionId ?? '<none>';
+  String get currentSessionId =>
+      DatadogSdk.instance.rum?.sessionId?.sessionId ?? '<none>';
 
   @override
   void initState() {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -115,7 +115,61 @@ class DatadogIntegrationTestApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       navigatorObservers: [routeObserver],
-      home: const IntegrationScenariosScreen(),
+      home: const Column(
+        children: [
+          Expanded(child: IntegrationScenariosScreen()),
+          SessionFooter(),
+        ],
+      ),
     );
+  }
+}
+
+class SessionFooter extends StatefulWidget {
+  const SessionFooter({super.key});
+
+  @override
+  State<SessionFooter> createState() => _SessionFooterState();
+}
+
+class _SessionFooterState extends State<SessionFooter> {
+  String get currentSessionId => DatadogSdk.instance.rum?.sessionId ?? '<none>';
+
+  @override
+  void initState() {
+    super.initState();
+
+    DatadogSdk.instance.rum?.sessionStarted = (sessionId) {
+      setState(() {});
+    };
+
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      final sessionFooterOverlay = OverlayEntry(builder: (context) {
+        return SafeArea(
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: IntrinsicHeight(
+              child: Container(
+                color: Colors.blueAccent,
+                child: Center(
+                  child: Text(
+                    key: const Key('sessionId'),
+                    'sessionId: $currentSessionId',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      });
+
+      Overlay.of(context).insert(sessionFooterOverlay);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
   }
 }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -375,6 +375,18 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         return usrMember
     }
 
+    func rumSessionStarted(_ sessionId: String, _ sampled: Bool) {
+        // Dispatch to the main thread. This is partially to combat Flutter shutdown
+        // occuring while we're still processing events
+        let callbackArgs: [String: Any] = [
+            "sessionId": sessionId,
+            "sampled": sampled
+        ]
+        DispatchQueue.main.async {
+            DatadogRumPlugin.methodChannel?.invokeMethod("rumSessionStarted", arguments: callbackArgs)
+        }
+    }
+
     func viewEventMapper(rumViewEvent: RUMViewEvent) -> RUMViewEvent {
         if trackMapperPerf {
             mapperPerf.start()

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -380,7 +380,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         // occuring while we're still processing events
         let callbackArgs: [String: Any] = [
             "sessionId": sessionId,
-            "sampled": sampled
+            "sampledOut": sampled
         ]
         DispatchQueue.main.async {
             DatadogRumPlugin.methodChannel?.invokeMethod("rumSessionStarted", arguments: callbackArgs)

--- a/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/SwiftDatadogSdkPlugin.swift
@@ -178,20 +178,24 @@ public class SwiftDatadogSdkPlugin: NSObject, FlutterPlugin {
             _ = ddConfiguration._internal.setLogEventMapper(FlutterLogEventMapper(channel: channel))
         }
 
-        if configuration.rumConfiguration?.attachViewEventMapper == true {
-            _ = ddConfiguration.setRUMViewEventMapper(DatadogRumPlugin.instance.viewEventMapper)
-        }
-        if configuration.rumConfiguration?.attachActionEventMapper == true {
-            _ = ddConfiguration.setRUMActionEventMapper(DatadogRumPlugin.instance.actionEventMapper)
-        }
-        if configuration.rumConfiguration?.attachResourceEventMapper == true {
-            _ = ddConfiguration.setRUMResourceEventMapper(DatadogRumPlugin.instance.resourceEventMapper)
-        }
-        if configuration.rumConfiguration?.attachErrorEventMapper == true {
-            _ = ddConfiguration.setRUMErrorEventMapper(DatadogRumPlugin.instance.errorEventMapper)
-        }
-        if configuration.rumConfiguration?.attachLongTaskMapper == true {
-            _ = ddConfiguration.setRUMLongTaskEventMapper(DatadogRumPlugin.instance.longTaskEventMapper)
+        if let rumConfiguration = configuration.rumConfiguration {
+            ddConfiguration.onRUMSessionStart(DatadogRumPlugin.instance.rumSessionStarted)
+
+            if rumConfiguration.attachViewEventMapper {
+                _ = ddConfiguration.setRUMViewEventMapper(DatadogRumPlugin.instance.viewEventMapper)
+            }
+            if rumConfiguration.attachActionEventMapper {
+                _ = ddConfiguration.setRUMActionEventMapper(DatadogRumPlugin.instance.actionEventMapper)
+            }
+            if rumConfiguration.attachResourceEventMapper {
+                _ = ddConfiguration.setRUMResourceEventMapper(DatadogRumPlugin.instance.resourceEventMapper)
+            }
+            if rumConfiguration.attachErrorEventMapper {
+                _ = ddConfiguration.setRUMErrorEventMapper(DatadogRumPlugin.instance.errorEventMapper)
+            }
+            if rumConfiguration.attachLongTaskMapper {
+                _ = ddConfiguration.setRUMLongTaskEventMapper(DatadogRumPlugin.instance.longTaskEventMapper)
+            }
         }
 
         Datadog.initialize(appContext: Datadog.AppContext(),

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -84,6 +84,14 @@ RumResourceType resourceTypeFromContentType(ContentType? type) {
   return RumResourceType.native;
 }
 
+@immutable
+class DdRumSessionInfo {
+  final String sessionId;
+  final bool isSampledOut;
+
+  const DdRumSessionInfo(this.sessionId, this.isSampledOut);
+}
+
 class DdRum {
   static DdRumPlatform get _platform {
     return DdRumPlatform.instance;
@@ -96,18 +104,22 @@ class DdRum {
 
   RumLongTaskObserver? _longTaskObserver;
 
-  /// Get the last active session id, or an empty string if a session hasn't started
+  /// Get the last active session id
   ///
-  /// Session ids are updated when a new session is started in Datadog, usually
+  /// On mobile, session ids are updated when a new session is started in Datadog, usually
   /// as a result of a user action. If you are using [stopSession], [sessionId] will
-  /// continue to return the last active session until a new session starts.
+  /// continue to return the last active session until a new session starts. Untracked
+  /// sessions will have [DdRumSessionInfo.isSampledOut] set to `true`
+  ///
+  /// On web, sessionId is the currently active session, or `null` if the current session
+  /// has been sampled out or if there is no active session.
   ///
   /// You can also listen to sessions start events by setting [sessionStarted]
-  String get sessionId => _platform.sessionId;
+  DdRumSessionInfo? get sessionId => _platform.sessionInfo;
 
   /// Get the current callback listening for `sessionStarted` events.
   ///
-  /// This callback does not work for Flutter Web.
+  /// This callback does not work on Flutter Web.
   SessionStartedCallback? get sessionStarted => _platform.sessionStarted;
 
   /// Set the method to be called when new sessions are started in Datadog RUM.

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -96,6 +96,28 @@ class DdRum {
 
   RumLongTaskObserver? _longTaskObserver;
 
+  /// Get the last active session id, or an empty string if a session hasn't started
+  ///
+  /// Session ids are updated when a new session is started in Datadog, usually
+  /// as a result of a user action. If you are using [stopSession], [sessionId] will
+  /// continue to return the last active session until a new session starts.
+  ///
+  /// You can also listen to sessions start events by setting [sessionStarted]
+  String get sessionId => _platform.sessionId;
+
+  /// Get the current callback listening for `sessionStarted` events.
+  ///
+  /// This callback does not work for Flutter Web.
+  SessionStartedCallback? get sessionStarted => _platform.sessionStarted;
+
+  /// Set the method to be called when new sessions are started in Datadog RUM.
+  ///
+  /// If a session is sampled out, [sessionId] will be an empty string.
+  ///
+  /// This callback does not work on Flutter Web.
+  set sessionStarted(SessionStartedCallback? callback) =>
+      _platform.sessionStarted = callback;
+
   DdRum(this.configuration, this.logger) {
     // Never use long task observer on web -- the Browser SDK should
     // capture stalls on the main thread automatically.

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -17,14 +17,12 @@ class DdRumMethodChannel extends DdRumPlatform {
   InternalLogger? _internalLogger;
   MapperCallbackHelper? _callbackHelper;
 
-  String _lastSessionId = '';
+  DdRumSessionInfo? _lastSessionInfo;
   @override
-  String get sessionId => _lastSessionId;
+  DdRumSessionInfo? get sessionInfo => _lastSessionInfo;
 
   @override
-  void Function(String)? sessionStarted;
-
-  bool _sessionIsSampled = false;
+  void Function(DdRumSessionInfo)? sessionStarted;
 
   DdRumMethodChannel() {
     methodChannel.setMethodCallHandler(handleMethodCall);
@@ -225,14 +223,9 @@ class DdRumMethodChannel extends DdRumPlatform {
   void _rumSessionStarted(MethodCall call) {
     try {
       final sessionId = call.arguments['sessionId'] as String;
-      final sampled = call.arguments['sampled'] as bool;
-      _sessionIsSampled = sampled;
-      if (!sampled) {
-        _lastSessionId = sessionId;
-      } else {
-        _lastSessionId = '';
-      }
-      sessionStarted?.call(sessionId);
+      final sampledOut = call.arguments['sampledOut'] as bool;
+      _lastSessionInfo = DdRumSessionInfo(sessionId, sampledOut);
+      sessionStarted?.call(_lastSessionInfo!);
     } catch (e, st) {
       _internalLogger?.sendToDatadog(
           'Error in rumSessionStarted: $e', st, e.runtimeType.toString());

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -8,6 +8,8 @@ import '../../datadog_flutter_plugin.dart';
 import '../internal_logger.dart';
 import 'ddrum_method_channel.dart';
 
+typedef SessionStartedCallback = void Function(String sessionId);
+
 abstract class DdRumPlatform extends PlatformInterface {
   DdRumPlatform() : super(token: _token);
 
@@ -21,6 +23,9 @@ abstract class DdRumPlatform extends PlatformInterface {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }
+
+  String get sessionId;
+  SessionStartedCallback? sessionStarted;
 
   Future<void> initialize(
       RumConfiguration configuration, InternalLogger internalLogger);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -8,7 +8,7 @@ import '../../datadog_flutter_plugin.dart';
 import '../internal_logger.dart';
 import 'ddrum_method_channel.dart';
 
-typedef SessionStartedCallback = void Function(String sessionId);
+typedef SessionStartedCallback = void Function(DdRumSessionInfo sessionId);
 
 abstract class DdRumPlatform extends PlatformInterface {
   DdRumPlatform() : super(token: _token);
@@ -24,7 +24,7 @@ abstract class DdRumPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  String get sessionId;
+  DdRumSessionInfo? get sessionInfo;
   SessionStartedCallback? sessionStarted;
 
   Future<void> initialize(

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -39,6 +39,11 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
+  String get sessionId {
+    return getInternalContext()?.session_id ?? '';
+  }
+
+  @override
   Future<void> initialize(
       RumConfiguration configuration, InternalLogger internalLogger) async {}
 
@@ -215,3 +220,13 @@ external void _jsAddFeatureFlagEvaluation(String name, dynamic value);
 
 @JS('stopSession')
 external void _jsStopSession();
+
+@JS()
+@anonymous
+class _InternalContext {
+  external String? application_id;
+  external String? session_id;
+}
+
+@JS('getInternalContext')
+external _InternalContext? getInternalContext();

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -39,8 +39,12 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  String get sessionId {
-    return getInternalContext()?.session_id ?? '';
+  DdRumSessionInfo? get sessionInfo {
+    final sessionId = getInternalContext()?.session_id;
+    if (sessionId == null) {
+      return null;
+    }
+    return DdRumSessionInfo(sessionId, false);
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
@@ -3,5 +3,6 @@
 // Copyright 2019-Present Datadog, Inc.
 
 export 'ddrum.dart';
+export 'ddrum_platform_interface.dart' show SessionStartedCallback;
 export 'navigation_observer.dart';
 export 'rum_user_action_detector.dart';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_method_channel.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -307,5 +307,29 @@ void main() {
         'rasterTimes': [0.11, 0.25],
       }),
     ]);
+  });
+
+  test('sessionId returns empty string for no session', () {
+    expect(ddRumPlatform.sessionId, isEmpty);
+  });
+
+  test('rumSessionStarted from method channel sets sessionId', () async {
+    await ddRumPlatform.initialize(
+        RumConfiguration(applicationId: 'fake-application-id'),
+        InternalLogger());
+    await ambiguate(TestDefaultBinaryMessengerBinding.instance)
+        ?.defaultBinaryMessenger
+        .handlePlatformMessage(
+          'datadog_sdk_flutter.rum',
+          const StandardMethodCodec().encodeMethodCall(
+            const MethodCall(
+              'rumSessionStarted',
+              {'sessionId': 'fake-session-id', 'sampled': true},
+            ),
+          ),
+          null,
+        );
+
+    expect(ddRumPlatform.sessionId, 'fake-session-id');
   });
 }

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -309,11 +309,11 @@ void main() {
     ]);
   });
 
-  test('sessionId returns empty string for no session', () {
-    expect(ddRumPlatform.sessionId, isEmpty);
+  test('sessionInfo returns null for no session', () {
+    expect(ddRumPlatform.sessionInfo, isNull);
   });
 
-  test('rumSessionStarted from method channel sets sessionId', () async {
+  test('rumSessionStarted from method channel sets sessionInfo', () async {
     await ddRumPlatform.initialize(
         RumConfiguration(applicationId: 'fake-application-id'),
         InternalLogger());
@@ -324,17 +324,17 @@ void main() {
           const StandardMethodCodec().encodeMethodCall(
             const MethodCall(
               'rumSessionStarted',
-              {'sessionId': 'fake-session-id', 'sampled': false},
+              {'sessionId': 'fake-session-id', 'sampledOut': false},
             ),
           ),
           null,
         );
 
-    expect(ddRumPlatform.sessionId, 'fake-session-id');
+    expect(ddRumPlatform.sessionInfo?.sessionId, 'fake-session-id');
+    expect(ddRumPlatform.sessionInfo?.isSampledOut, isFalse);
   });
 
-  test(
-      'rumSessionStarted from method channel sets sessionId to empty if sampled',
+  test('rumSessionStarted from method channel sets sessionInfo if sampled out',
       () async {
     await ddRumPlatform.initialize(
         RumConfiguration(applicationId: 'fake-application-id'),
@@ -346,22 +346,23 @@ void main() {
           const StandardMethodCodec().encodeMethodCall(
             const MethodCall(
               'rumSessionStarted',
-              {'sessionId': 'fake-session-id', 'sampled': true},
+              {'sessionId': 'fake-session-id', 'sampledOut': true},
             ),
           ),
           null,
         );
 
-    expect(ddRumPlatform.sessionId, '');
+    expect(ddRumPlatform.sessionInfo?.sessionId, 'fake-session-id');
+    expect(ddRumPlatform.sessionInfo?.isSampledOut, true);
   });
 
   test('rumSessionStarted from method channel calls callback', () async {
     await ddRumPlatform.initialize(
         RumConfiguration(applicationId: 'fake-application-id'),
         InternalLogger());
-    String? callbackSessionId;
-    ddRumPlatform.sessionStarted = (sessionId) {
-      callbackSessionId = sessionId;
+    DdRumSessionInfo? callbackSessionInfo;
+    ddRumPlatform.sessionStarted = (sessionInfo) {
+      callbackSessionInfo = sessionInfo;
     };
 
     await ambiguate(TestDefaultBinaryMessengerBinding.instance)
@@ -371,12 +372,13 @@ void main() {
           const StandardMethodCodec().encodeMethodCall(
             const MethodCall(
               'rumSessionStarted',
-              {'sessionId': 'fake-session-id', 'sampled': false},
+              {'sessionId': 'fake-session-id', 'sampledOut': false},
             ),
           ),
           null,
         );
 
-    expect(callbackSessionId, 'fake-session-id');
+    expect(callbackSessionInfo?.sessionId, 'fake-session-id');
+    expect(callbackSessionInfo?.isSampledOut, false);
   });
 }


### PR DESCRIPTION
### What and why?

sessionStarted does not work on Flutter web, but the session gets updated properly in the UI of the integration test app on re-build of the overlay.

refs: RUMM-3345, #442

### How?

For mobile, the platform channel memoizes the last seen session id and returns it. In cases where the session is sampled out, sessionId returns an empty string.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests