### PR TITLE
🐛 Fix minor issues affecting mappers

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
@@ -118,8 +118,8 @@ class RumConnectivity {
 
 @JsonSerializable()
 class RumCellular {
-  final String carrierName;
-  final String technology;
+  final String? carrierName;
+  final String? technology;
 
   RumCellular({
     required this.carrierName,
@@ -574,6 +574,18 @@ class RumActionId {
 
 enum RumErrorHandling { handled, unhandled }
 
+/// Error sources that include source used internally by Datadog SDKs
+enum RumInternalErrorSource {
+  source,
+  network,
+  webview,
+  console,
+  logger,
+  agent,
+  report,
+  custom,
+}
+
 @commonJsonOptions
 class RumError {
   final List<RumErrorCause>? causes;
@@ -583,7 +595,7 @@ class RumError {
   final bool? isCrash;
   String message;
   RumResourceSummary? resource;
-  final RumErrorSource source;
+  final RumInternalErrorSource source;
   final String? sourceType;
   String? stack;
   final String? type;


### PR DESCRIPTION
### What and why?

Two issues show up in telemetry related to mappers, one is a null value in RumCellular, the other is related to using `logger` as a source.

This allows RumCellular members to be null, and switches mappers to use an internal Source enum which allows  `logger` as a possible source, as well as some other missing sources.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests