### PR TITLE
update http to use latest version

### DIFF
--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_common_test
 description: Common helpers for testing Datadog libraries. Not meant to be a published package.
-version: 0.0.1
+version: 0.0.2
 publish_to: 'none'
 
 environment:

--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
-  http: ^0.13.4
+  http: ^1.1.0
   json_annotation: ^4.4.0
   uuid: ^3.0.6
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 
 
+## 1.5.0
+* Up-to-date http package
+
 ## 1.3.1
 
 * Fix not exporting `DatadogTrackingHttpClientListener` from @ClaireDavis.

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -139,10 +139,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "1.1.0"
   http_parser:
     dependency: transitive
     description:
@@ -346,5 +346,5 @@ packages:
     source: hosted
     version: "3.0.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   flutter_dotenv: ^5.0.2
-  http: ^0.13.4
+  http: ^1.1.0
   transparent_image: ^2.0.0
 
   datadog_flutter_plugin:

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   datadog_flutter_plugin: ^1.2.0
   uuid: ^3.0.5
-  http: ^0.13.5
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What and why?

This pull request aims to address the pain points related to resolving conflicts in projects that utilize the latest http package.

Currently, our project has been using an older version of http for an extended period. However, as time goes on, it becomes increasingly challenging to manage conflicts when integrating changes from the main repository. Updating the http package to the latest version will help alleviate these conflicts and ensure smoother integration in the future.

### How?

This pull request focuses solely on updating the http package to its latest version. By doing so, we can leverage the latest features, bug fixes, and improvements provided by the package. This update will also ensure that our project remains up-to-date with the latest industry standards and best practices.


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
