### PR TITLE
✨ Add method to disable Datadog platform operations

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -51,7 +51,7 @@ class DatadogSdk {
   /// Not that this disables Datadog, and should only be used when performing
   /// headless integration tests where the underlying platform is not available
   static void initializeForTesting() {
-    DatadogSdkPlatform.instance = DatadogSdkNoopPlatform();
+    DatadogSdkPlatform.instance = DatadogSdkNoOpPlatform();
     DdLogsPlatform.instance = DdNoOpLogsPlatform();
     DdRumPlatform.instance = DdNoOpRumPlatform();
   }

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -10,9 +10,13 @@ import 'package:meta/meta.dart';
 
 import 'datadog_internal.dart';
 import 'src/datadog_configuration.dart';
+import 'src/datadog_noop_platform.dart';
 import 'src/datadog_plugin.dart';
 import 'src/logs/ddlogs.dart';
+import 'src/logs/ddlogs_noop_platform.dart';
 import 'src/logs/ddlogs_platform_interface.dart';
+import 'src/rum/ddrum_noop_platform.dart';
+import 'src/rum/ddrum_platform_interface.dart';
 import 'src/rum/rum.dart';
 import 'src/version.dart' show ddPackageVersion;
 
@@ -40,6 +44,16 @@ class DatadogSdk {
   static DatadogSdk get instance {
     _singleton ??= DatadogSdk._();
     return _singleton!;
+  }
+
+  /// Set Datadog to use No Op platform implementations.
+  ///
+  /// Not that this disables Datadog, and should only be used when performing
+  /// headless integration tests where the underlying platform is not available
+  static void initializeForTesting() {
+    DatadogSdkPlatform.instance = DatadogSdkNoopPlatform();
+    DdLogsPlatform.instance = DdNoOpLogsPlatform();
+    DdRumPlatform.instance = DdNoOpRumPlatform();
   }
 
   DatadogSdk._();
@@ -103,7 +117,7 @@ class DatadogSdk {
   }
 
   /// A helper function that will initialize Datadog and setup error reporting
-  /// 
+  ///
   /// See also, [DdRum.handleFlutterError], [DatadogTrackingHttpClient]
   static Future<void> runApp(
       DdSdkConfiguration configuration, AppRunner runner) async {

--- a/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import '../datadog_internal.dart';
+import 'datadog_configuration.dart';
+
+class DatadogSdkNoopPlatform extends DatadogSdkPlatform {
+  @override
+  Future<void> addUserExtraInfo(Map<String, Object?> extraInfo) {
+    return Future.value();
+  }
+
+  @override
+  Future<AttachResponse?> attachToExisting() async {
+    return AttachResponse(rumEnabled: false);
+  }
+
+  @override
+  Future<void> flushAndDeinitialize() {
+    return Future.value();
+  }
+
+  @override
+  Future<void> initialize(DdSdkConfiguration configuration,
+      {LogCallback? logCallback, required InternalLogger internalLogger}) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> sendTelemetryDebug(String message) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> sendTelemetryError(String message, String? stack, String? kind) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> setSdkVerbosity(Verbosity verbosity) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> setTrackingConsent(TrackingConsent trackingConsent) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> setUserInfo(
+      String? id, String? name, String? email, Map<String, Object?> extraInfo) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> updateTelemetryConfiguration(String property, bool value) {
+    return Future.value();
+  }
+}

--- a/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
@@ -5,7 +5,7 @@
 import '../datadog_internal.dart';
 import 'datadog_configuration.dart';
 
-class DatadogSdkNoopPlatform extends DatadogSdkPlatform {
+class DatadogSdkNoOpPlatform extends DatadogSdkPlatform {
   @override
   Future<void> addUserExtraInfo(Map<String, Object?> extraInfo) {
     return Future.value();

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import '../datadog_configuration.dart';
+import 'ddlogs_platform_interface.dart';
+
+class DdNoOpLogsPlatform extends DdLogsPlatform {
+  @override
+  Future<void> addAttribute(String loggerHandle, String key, Object value) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> addTag(String loggerHandle, String tag, [String? value]) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> createLogger(String loggerHandle, LoggingConfiguration config) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> log(
+      String loggerHandle,
+      LogLevel level,
+      String message,
+      String? errorMessage,
+      String? errorKind,
+      StackTrace? errorStackTrace,
+      Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> removeAttribute(String loggerHandle, String key) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> removeTag(String loggerHandle, String tag) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> removeTagWithKey(String loggerHandle, String key) {
+    return Future.value();
+  }
+}

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import '../datadog_configuration.dart';
+import '../internal_logger.dart';
+import 'ddrum.dart';
+import 'ddrum_platform_interface.dart';
+
+class DdNoOpRumPlatform extends DdRumPlatform {
+  @override
+  Future<void> addAttribute(String key, value) => Future.value();
+
+  @override
+  Future<void> addError(
+      Object error,
+      RumErrorSource source,
+      StackTrace? stackTrace,
+      String? errorType,
+      Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> addErrorInfo(
+      String message,
+      RumErrorSource source,
+      StackTrace? stackTrace,
+      String? errorType,
+      Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> addFeatureFlagEvaluation(String name, Object value) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> addTiming(String name) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> addUserAction(
+      RumUserActionType type, String name, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> initialize(
+      RumConfiguration configuration, InternalLogger internalLogger) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> removeAttribute(String key) => Future.value();
+
+  @override
+  Future<void> reportLongTask(DateTime at, int durationMs) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> startResourceLoading(String key, RumHttpMethod httpMethod,
+      String url, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> startUserAction(
+      RumUserActionType type, String name, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> startView(
+      String key, String name, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> stopResourceLoading(String key, int? statusCode,
+      RumResourceType kind, int? size, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> stopResourceLoadingWithError(
+      String key, Exception error, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> stopResourceLoadingWithErrorInfo(String key, String message,
+      String type, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> stopSession() => Future.value();
+
+  @override
+  Future<void> stopUserAction(
+      RumUserActionType type, String name, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> stopView(String key, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> updatePerformanceMetrics(
+      List<double> buildTimes, List<double> rasterTimes) {
+    return Future.value();
+  }
+}


### PR DESCRIPTION
### What and why?

When performing widget tests in headless environments (without an emulator, simulator, or real device) There's not "platform" implementation for the DatadogSdk to work with, and it will throw a `MissingPluginException`.

This change gives us a "NoOp" platform which we can use to essentially disable Datadog's functionality for headless tests.

refs: RUMM-3370 #446

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests