### PR TITLE
📌 Pin iOS native version to last 1.x version

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
   # End Datadog Pod Overrides
   
 end

--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
   # End Datadog Pod Overrides
 
   target 'flutter_datadog_plugin_tests' do

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_tracking_http_client/example/ios/Podfile
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile
@@ -34,8 +34,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_webview_tracking/example/ios/Podfile
+++ b/packages/datadog_webview_tracking/example/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
   # End Datadog Pod Overrides
 
   target 'datadog_webview_tracking_tests' do


### PR DESCRIPTION
### What and why?

Using latest from develop now pulls in 2.0, which the Flutter SDK isn't ready for. Pinning to the last version of 1.x until we're ready to update.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests