### PR TITLE
✨ Add log sample rate to loggers.

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-
+* Add the ability to specify a sampling rate for loggers.
+* Add a "NoOp" platform, usable when performing headless Flutter widget tests.
 
 ## 1.5.1
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogConfigurationTest.kt
@@ -161,7 +161,7 @@ class DatadogConfigurationTest {
         @StringForgery additionalKey: String,
         @StringForgery additionalValue: String,
         @StringForgery firstPartyHost: String,
-        @FloatForgery telemetrySampleRate: Float
+        @FloatForgery telemetrySampleRate: Float,
     ) {
         // GIVEN
         val encoded = mapOf(

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -225,8 +225,7 @@ class DatadogSdk {
   ///
   /// This can be used in addition to or instead of the default logger at [logs]
   DdLogs createLogger(LoggingConfiguration configuration) {
-    final logger =
-        DdLogs(internalLogger, configuration.datadogReportingThreshold);
+    final logger = DdLogs(internalLogger, configuration);
     wrap('createLogger', internalLogger, null, () {
       return DdLogsPlatform.instance
           .createLogger(logger.loggerHandle, configuration);

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 
 import '../datadog_flutter_plugin.dart';
@@ -195,6 +196,16 @@ class LoggingConfiguration {
   /// sent to Datadog from this logger.
   String? loggerName;
 
+  double _sampleRate = 100;
+
+  /// The sampling rate for this logger.
+  ///
+  /// The sampling rate must be a value between `0.0` and `100.0`. A value of `0.0`
+  /// means no logs will be processed, `100.0` means all logs will be processed.
+  /// The default is `100.0`
+  double get sampleRate => _sampleRate;
+  set sampleRate(double value) => _sampleRate = clampDouble(value, 0, 100);
+
   LoggingConfiguration({
     this.sendNetworkInfo = false,
     this.printLogsToConsole = false,
@@ -202,8 +213,11 @@ class LoggingConfiguration {
     this.datadogReportingThreshold = Verbosity.verbose,
     this.bundleWithRum = true,
     this.bundleWithTrace = true,
+    double sampleRate = 100,
     this.loggerName,
-  });
+  }) {
+    this.sampleRate = sampleRate;
+  }
 
   Map<String, Object?> encode() {
     return {

--- a/packages/datadog_flutter_plugin/lib/src/sampler.dart
+++ b/packages/datadog_flutter_plugin/lib/src/sampler.dart
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'dart:math';
+
+class RateBasedSampler {
+  final double sampleRate;
+  late final Random random;
+
+  /// [sampleRate] should be between 0 and 1
+  RateBasedSampler(this.sampleRate) {
+    try {
+      random = Random.secure();
+    } on UnsupportedError {
+      random = Random();
+    }
+  }
+
+  bool sample() {
+    if (sampleRate <= 0.0) return false;
+    if (sampleRate >= 1.0) return true;
+    return random.nextDouble() <= sampleRate;
+  }
+}

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -268,6 +268,28 @@ void main() {
         logger!.loggerHandle, loggingConfiguration));
   });
 
+  test('initialize with logging sample rate creates logger with sample rate',
+      () async {
+    when(() => mockLogsPlatform.createLogger(any(), any()))
+        .thenAnswer((_) => Future<void>.value());
+
+    final loggingConfiguration = LoggingConfiguration();
+    final configuration = DdSdkConfiguration(
+      clientToken: 'clientToken',
+      env: 'env',
+      site: DatadogSite.us1,
+      trackingConsent: TrackingConsent.pending,
+      loggingConfiguration: loggingConfiguration,
+    );
+    await datadogSdk.initialize(configuration);
+
+    final logger = datadogSdk.logs;
+
+    expect(logger, isNotNull);
+    verify(() => mockLogsPlatform.createLogger(
+        logger!.loggerHandle, loggingConfiguration));
+  });
+
   test('attachToExisting calls out to platform', () async {
     await datadogSdk.attachToExisting(DdSdkExistingConfiguration());
 

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -268,28 +268,6 @@ void main() {
         logger!.loggerHandle, loggingConfiguration));
   });
 
-  test('initialize with logging sample rate creates logger with sample rate',
-      () async {
-    when(() => mockLogsPlatform.createLogger(any(), any()))
-        .thenAnswer((_) => Future<void>.value());
-
-    final loggingConfiguration = LoggingConfiguration();
-    final configuration = DdSdkConfiguration(
-      clientToken: 'clientToken',
-      env: 'env',
-      site: DatadogSite.us1,
-      trackingConsent: TrackingConsent.pending,
-      loggingConfiguration: loggingConfiguration,
-    );
-    await datadogSdk.initialize(configuration);
-
-    final logger = datadogSdk.logs;
-
-    expect(logger, isNotNull);
-    verify(() => mockLogsPlatform.createLogger(
-        logger!.loggerHandle, loggingConfiguration));
-  });
-
   test('attachToExisting calls out to platform', () async {
     await datadogSdk.attachToExisting(DdSdkExistingConfiguration());
 

--- a/packages/datadog_tracking_http_client/example/pubspec.lock
+++ b/packages/datadog_tracking_http_client/example/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_webview_tracking/example/pubspec.lock
+++ b/packages/datadog_webview_tracking/example/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: "../../datadog_flutter_plugin"
       relative: true
     source: path
-    version: "1.5.0"
+    version: "1.6.0"
   datadog_webview_tracking:
     dependency: "direct main"
     description:


### PR DESCRIPTION
### What and why?

There was a request to add `sampleRate` to Flutter loggers, similar to those that exist on Web and Native. Because of platform differences, Flutter handles log sampling itself, and keeps the sampling rate at the native level at 100%

This also differs slightly from Web, as each log is sampled, instead of each session.

refs: RUMM-3467

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests