### PR TITLE
🐛 Fix web failing to load if Datadog initialization fails

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix an issue where failing to load Datadog modules on Web threw an error (and potentially broke application loading).
 * Add the ability to specify a sampling rate for loggers.
 * Add a "NoOp" platform, usable when performing headless Flutter widget tests.
 

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -154,13 +154,13 @@ class DatadogSdk {
 
     _setFirstPartyHosts(configuration.firstPartyHostsWithTracingHeaders);
 
-    await _platform.initialize(configuration,
+    var result = await _platform.initialize(configuration,
         logCallback: _platformLog, internalLogger: internalLogger);
 
-    if (configuration.loggingConfiguration != null) {
+    if (result.logs && configuration.loggingConfiguration != null) {
       _logs = createLogger(configuration.loggingConfiguration!);
     }
-    if (configuration.rumConfiguration != null) {
+    if (result.rum && configuration.rumConfiguration != null) {
       _rum = DdRum(configuration.rumConfiguration!, internalLogger);
       await _rum!.initialize();
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
@@ -22,9 +22,11 @@ class DatadogSdkNoOpPlatform extends DatadogSdkPlatform {
   }
 
   @override
-  Future<void> initialize(DdSdkConfiguration configuration,
-      {LogCallback? logCallback, required InternalLogger internalLogger}) {
-    return Future.value();
+  Future<PlatformInitializationResult> initialize(
+      DdSdkConfiguration configuration,
+      {LogCallback? logCallback,
+      required InternalLogger internalLogger}) async {
+    return const PlatformInitializationResult(logs: false, rum: false);
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -43,7 +43,7 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
   }
 
   @override
-  Future<void> initialize(
+  Future<PlatformInitializationResult> initialize(
     DdSdkConfiguration configuration, {
     LogCallback? logCallback,
     required InternalLogger internalLogger,
@@ -63,6 +63,8 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       'dartVersion': Platform.version,
       'setLogCallback': logCallback != null,
     });
+
+    return const PlatformInitializationResult(logs: true, rum: true);
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
+import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '../datadog_flutter_plugin.dart';
@@ -31,6 +32,17 @@ class AttachResponse {
   }
 }
 
+/// Result from initializing the platform. Individual members are set to [false]
+/// If there is an error loading that feature, such as being unable to load
+/// required JavaScript modules on web.
+@immutable
+class PlatformInitializationResult {
+  final bool logs;
+  final bool rum;
+
+  const PlatformInitializationResult({required this.logs, required this.rum});
+}
+
 abstract class DatadogSdkPlatform extends PlatformInterface {
   DatadogSdkPlatform() : super(token: _token);
 
@@ -54,7 +66,7 @@ abstract class DatadogSdkPlatform extends PlatformInterface {
   Future<void> sendTelemetryDebug(String message);
   Future<void> sendTelemetryError(String message, String? stack, String? kind);
 
-  Future<void> initialize(
+  Future<PlatformInitializationResult> initialize(
     DdSdkConfiguration configuration, {
     LogCallback? logCallback,
     required InternalLogger internalLogger,


### PR DESCRIPTION
### What and why?

If Datadog scripts fail to load (or are not in in the html at all), the SDK will through an error during initialization, which will stop the entire application from loading (if the error isn't caught).  This changes web initialization to report the error instead and not throw.

refs: RUMM-3501

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests