### PR TITLE
Add Gradle 8 support

### DIFF
--- a/examples/native-hybrid-app/flutter_module/pubspec.lock
+++ b/examples/native-hybrid-app/flutter_module/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: "../../../packages/datadog_tracking_http_client"
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.5.0"
   fake_async:
     dependency: transitive
     description:

--- a/packages/datadog_flutter_plugin/.vscode/settings.json
+++ b/packages/datadog_flutter_plugin/.vscode/settings.json
@@ -16,7 +16,8 @@
         "titleBar.activeBackground": "#7f757f",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#7f757f99",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "commandCenter.border": "#e7e7e799"
     },
     "peacock.color": "#7f757f",
     "rewrap.wrappingColumn": 80,

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.3"
+        classpath "com.android.tools.build:gradle:8.1.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -43,6 +43,7 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
+    namespace "com.datadoghq.flutter"
     compileSdkVersion 33
 
     compileOptions {

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.e2e_test_app"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/build.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -32,6 +32,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 04 16:56:33 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -73,6 +73,7 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+    namespace 'com.datadoghq.example.flutter'
 }
 
 flutter {

--- a/packages/datadog_flutter_plugin/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/datadog_flutter_plugin/example/android/app/src/debug/AndroidManifest.xml
@@ -4,8 +4,7 @@
   ~ Copyright 2016-Present Datadog, Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.datadoghq.example.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/packages/datadog_flutter_plugin/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/datadog_flutter_plugin/example/android/app/src/main/AndroidManifest.xml
@@ -4,8 +4,7 @@
   ~ Copyright 2016-Present Datadog, Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.datadoghq.example.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="datadog_flutter_plugin_example"
         android:icon="@mipmap/ic_launcher">

--- a/packages/datadog_flutter_plugin/example/android/app/src/profile/AndroidManifest.xml
+++ b/packages/datadog_flutter_plugin/example/android/app/src/profile/AndroidManifest.xml
@@ -4,8 +4,7 @@
   ~ Copyright 2016-Present Datadog, Inc.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.datadoghq.example.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"

--- a/packages/datadog_flutter_plugin/example/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle.properties
@@ -7,3 +7,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/packages/datadog_flutter_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.datadoghq.flutter.integrationtestapp"
     compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {

--- a/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -9,4 +9,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/packages/datadog_webview_tracking/example/ios/Podfile.lock
+++ b/packages/datadog_webview_tracking/example/ios/Podfile.lock
@@ -8,23 +8,23 @@ PODS:
     - DatadogSDK (~> 1)
     - Flutter
     - webview_flutter_wkwebview
-  - DatadogSDK (1.16.0)
-  - DatadogSDKCrashReporting (1.16.0):
-    - DatadogSDK (= 1.16.0)
+  - DatadogSDK (1.21.0)
+  - DatadogSDKCrashReporting (1.21.0):
+    - DatadogSDK (= 1.21.0)
     - PLCrashReporter (~> 1.11.0)
   - DictionaryCoder (1.0.8)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - PLCrashReporter (1.11.0)
+  - PLCrashReporter (1.11.1)
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_webview_tracking (from `.symlinks/plugins/datadog_webview_tracking/ios`)
-  - DatadogSDK (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
-  - DatadogSDKCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogSDK (from `https://github.com/DataDog/dd-sdk-ios`, tag `1.21.0`)
+  - DatadogSDKCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, tag `1.21.0`)
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
@@ -40,11 +40,11 @@ EXTERNAL SOURCES:
   datadog_webview_tracking:
     :path: ".symlinks/plugins/datadog_webview_tracking/ios"
   DatadogSDK:
-    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 1.21.0
   DatadogSDKCrashReporting:
-    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 1.21.0
   Flutter:
     :path: Flutter
   integration_test:
@@ -54,23 +54,23 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogSDK:
-    :commit: 9c78109db42fdddf4eac90da38d52f230b244d0f
     :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 1.21.0
   DatadogSDKCrashReporting:
-    :commit: 9c78109db42fdddf4eac90da38d52f230b244d0f
     :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 1.21.0
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: 286f35803b77ceb07bc1e0a383dd9fc231058473
   datadog_webview_tracking: b5e694f36f3a403043cec80bdf1cde72be7699a2
-  DatadogSDK: 7d2d3240a946a5a43b71ae4fa719919d9ed7fc22
-  DatadogSDKCrashReporting: 91f084ca0595a6159c263df9412b0ec7723eba44
+  DatadogSDK: b0498fc187080f51707b496f126c70c735f57f13
+  DatadogSDKCrashReporting: fd55b50ce3b3257fe96b6424f2526dd92eb086af
   DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
-  PLCrashReporter: 7a9dff14a23ba5d2e28c6160f0bb6fada5e71a8d
-  webview_flutter_wkwebview: d08f59cde5e8402c345c0bdda35ac0031352dcae
+  integration_test: 13825b8a9334a850581300559b8839134b124670
+  PLCrashReporter: 5d2d3967afe0efad61b3048d617e2199a5d1b787
+  webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 
-PODFILE CHECKSUM: 91b8fa7823a71ba0df7bcf3e0fcef9ad79dc7e9e
+PODFILE CHECKSUM: f7d8754bee27055a2291113a30aea7f4fffa7654
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/tools/e2e_generator/pubspec.lock
+++ b/tools/e2e_generator/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.16.1 <4.0.0"

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -418,4 +418,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.1 <3.0.0"
+  dart: ">=2.16.1 <4.0.0"

--- a/tools/third_party_scanner/pubspec.lock
+++ b/tools/third_party_scanner/pubspec.lock
@@ -282,4 +282,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"


### PR DESCRIPTION
### What and why?

Adds Gradle/AGP 8 support to `flutter_datadog_plugin`. Lacking Gradle 8 support in this plugin blocks all dependent projects to migrate to Gradle/AGP 8.

### How?

Bumps Gradle and AGP to versions 8+. Adds `namespace` to `build.gradle` files. Also, some dependencies were automatically updated during `prepare.sh` run. 

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests