### PR TITLE
⬆️ Update iOS SDK to 1.23.0

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Add the ability to specify a sampling rate for loggers.
 * Add a "NoOp" platform, usable when performing headless Flutter widget tests.
+* Update iOS SDK to 1.23.0
+  * RUM payloads are now optimised by including less view updates
+  * Prevent attributes from propagating from Errors and LongTasks to Views
 
 ## 1.5.1
 

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
   # End Datadog Pod Overrides
   
 end

--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
   # End Datadog Pod Overrides
 
   target 'flutter_datadog_plugin_tests' do

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_tracking_http_client/example/ios/Podfile
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile
@@ -34,8 +34,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_webview_tracking/example/ios/Podfile
+++ b/packages/datadog_webview_tracking/example/ios/Podfile
@@ -33,8 +33,8 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
-  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.21.0'
+  pod 'DatadogSDK', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
+  pod 'DatadogSDKCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '1.23.0'
   # End Datadog Pod Overrides
 
   target 'datadog_webview_tracking_tests' do


### PR DESCRIPTION
### What and why?

Pulls in iOS SDK changes that prevent propagation of attributes from errors and long tasks to views as well as view update debouncing.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests