### PR TITLE
fix: Fix platforms that don't support `lifecycleState`

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -92,15 +92,15 @@ class RumViewVisit {
 }
 
 class Dd {
-  final Map<String, dynamic> rawData;
+  final Map<String, dynamic>? rawData;
 
   Dd(this.rawData);
 
-  String? get traceId => rawData['trace_id'];
-  String? get spanId => rawData['span_id'];
+  String? get traceId => rawData?['trace_id'];
+  String? get spanId => rawData?['span_id'];
   int? get plan {
-    final session = rawData['session'] as Map<String, dynamic>;
-    return session['plan'];
+    final session = rawData?['session'] as Map<String, dynamic>?;
+    return session?['plan'];
   }
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -103,8 +103,11 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>>
   }
 
   void _startView(RumViewInfo? viewInfo) {
-    if (ambiguate(WidgetsBinding.instance)?.lifecycleState !=
-        AppLifecycleState.resumed) {
+    // For platforms that don't support app lifecycle state (lifecycleState is null)
+    // assume that the application is foregrounded.
+    final lifecycleState = ambiguate(WidgetsBinding.instance)?.lifecycleState ??
+        AppLifecycleState.resumed;
+    if (lifecycleState != AppLifecycleState.resumed) {
       _pendingView = viewInfo;
     } else {
       _currentView = viewInfo;


### PR DESCRIPTION
### What and why?

Web (and likely other platforms) that don't support `AppLifecycleState.lifecycleState` return `null`, which `DatadogNavigationObserver` was incorrectly classifying as a hidden applications. `ApplifecycleState.lifecycleState` returning `null` is now assumed to be an active application.

Fixed the rum_auto_instrumentation integration test for web.

refs: RUM-1025

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests