### PR TITLE
chore: Fix bitrise when no artifacts are created

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -79,6 +79,7 @@ workflows:
             if [ "$(uname)" == "Darwin" ]; then
               pod repo update
             fi
+            mkdir -p $BITRISE_SOURCE_DIR/.build/test-results/
 
             dart pub global activate melos
             melos bootstrap


### PR DESCRIPTION
### What and why?

Bitrise upload artifacts fails if a directory doesn't exist. Not all of our builds produce artifacts, so setup will create the needed directory just to prevent the failure.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests