### PR TITLE
feat: Re-enable log and rum mappers

### DIFF
--- a/examples/simple_example/pubspec.lock
+++ b/examples/simple_example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   crypto:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       path: "../../packages/datadog_flutter_plugin"
       relative: true
     source: path
-    version: "1.6.0"
+    version: "1.7.0"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:
@@ -71,6 +71,13 @@ packages:
       relative: true
     source: path
     version: "1.5.0"
+  datadog_webview_tracking:
+    dependency: "direct main"
+    description:
+      path: "../../packages/datadog_webview_tracking"
+      relative: true
+    source: path
+    version: "1.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -114,7 +121,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -178,18 +185,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -279,10 +286,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -319,10 +326,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   transparent_image:
     dependency: "direct main"
     description:
@@ -355,6 +362,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: "82f6787d5df55907aa01e49bd9644f4ed1cc82af7a8257dd9947815959d2e755"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.4"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: ddc167c6676f57c8b367d19fcbee267d6dc6adf81bd6c3cb87981d30746e0a6d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.10.1"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "6d9213c65f1060116757a7c473247c60f3f7f332cac33dc417c9e362a9a13e4f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "485af05f2c5f83c7f78c20e236b170ad02df7153b299ae9917345be43871d29f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.0"
   win32:
     dependency: transitive
     description:
@@ -372,5 +419,5 @@ packages:
     source: hosted
     version: "1.0.1"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
+  flutter: ">=3.7.0"

--- a/examples/simple_example/pubspec.yaml
+++ b/examples/simple_example/pubspec.yaml
@@ -9,12 +9,17 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
 
   cupertino_icons: ^1.0.2
   datadog_flutter_plugin:
     path: ../../packages/datadog_flutter_plugin
   datadog_tracking_http_client:
     path: ../../packages/datadog_tracking_http_client
+  datadog_webview_tracking:
+    path: ../../packages/datadog_webview_tracking
+    
   go_router: ^7.0.0
   path_provider: ^2.0.0
   flutter_dotenv: ^5.1.0

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -5,15 +5,22 @@
  */
 package com.datadoghq.flutter
 
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
+import com.datadog.android.Datadog
+import com.datadog.android.event.EventMapper
 import com.datadog.android.log.Logger
 import com.datadog.android.log.Logs
 import com.datadog.android.log.LogsConfiguration
+import com.datadog.android.log.model.LogEvent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.lang.ClassCastException
 import java.lang.NullPointerException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -28,6 +35,14 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
         const val LOG_KEY = "key"
         const val LOG_TAG = "tag"
         const val LOG_VALUE = "value"
+
+        // See DatadogSdkPlugin's description of this same member
+        private var previousConfiguration: Map<String, Any?>? = null
+
+        // For testing purposes only
+        internal fun resetConfig() {
+            previousConfiguration = null
+        }
     }
 
     private lateinit var channel: MethodChannel
@@ -56,17 +71,7 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         if (call.method == "enable") {
-            val encodedConfig = call.argument<Map<String, Any?>>("configuration")
-            if (encodedConfig != null) {
-                val config = LogsConfiguration.Builder()
-                    .withEncoded(encodedConfig)
-                    .build()
-
-                Logs.enable(config)
-                result.success(null)
-            } else {
-                result.invalidOperation("Bad configuration when enabling logging feature")
-            }
+            enable(call, result)
             return
         }
 
@@ -99,6 +104,36 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
                     )
                 )
             }
+        }
+    }
+
+    private fun enable(call: MethodCall, result: MethodChannel.Result) {
+        val encodedConfig = call.argument<Map<String, Any?>>("configuration")
+        if (previousConfiguration == null) {
+            if (encodedConfig != null) {
+                val config = LogsConfiguration.Builder()
+                    .withEncoded(encodedConfig)
+
+                val attachLogMeapper = (encodedConfig["attachLogMapper"] as? Boolean) ?: false
+                if (attachLogMeapper) {
+                    config.setEventMapper(
+                        object : EventMapper<LogEvent> {
+                            override fun map(event: LogEvent): LogEvent? {
+                                return mapLogEvent(event)
+                            }
+                        }
+                    )
+                }
+
+                Logs.enable(config.build())
+                previousConfiguration = encodedConfig
+                result.success(null)
+            } else {
+                result.invalidOperation("Bad configuration when enabling logging feature")
+            }
+        } else if (previousConfiguration != encodedConfig) {
+            // Maybe use DevLogger instead?
+            Log.e(DATADOG_FLUTTER_TAG, MESSAGE_INVALID_LOGGER_REINITIALIZATION)
         }
     }
 
@@ -216,6 +251,82 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
             }
         }
     }
+
+    @Suppress("TooGenericExceptionCaught")
+    internal fun mapLogEvent(event: LogEvent): LogEvent? {
+        val jsonEvent = event.toJson().asFlutterMap()
+        var modifiedJson: Map<String, Any?>? = null
+
+        val latch = CountDownLatch(1)
+
+        val handler = Handler(Looper.getMainLooper())
+        handler.post {
+            try {
+                channel.invokeMethod(
+                    "mapLogEvent",
+                    mapOf(
+                        "event" to jsonEvent
+                    ),
+                    object : MethodChannel.Result {
+                        override fun success(result: Any?) {
+                            @Suppress("UNCHECKED_CAST")
+                            modifiedJson = result as? Map<String, Any?>
+                            latch.countDown()
+                        }
+
+                        override fun error(
+                            errorCode: String,
+                            errorMessage: String?,
+                            errorDetails: Any?
+                        ) {
+                            // No telemetry needed, this is likely an issue in user code
+                            latch.countDown()
+                        }
+
+                        override fun notImplemented() {
+                            Datadog._internalProxy()._telemetry.error(
+                                "mapLogEvent returned notImplemented."
+                            )
+                            latch.countDown()
+                        }
+                    }
+                )
+            } catch (e: Exception) {
+                Datadog._internalProxy()._telemetry.error("Attempting call mapLogEvent failed.", e)
+                latch.countDown()
+            }
+        }
+
+        try {
+            // Stalls until the method channel finishes
+            if (!latch.await(1, TimeUnit.SECONDS)) {
+                Datadog._internalProxy()._telemetry.debug("logMapper timed out")
+                return event
+            }
+
+            return modifiedJson?.let {
+                if (!it.containsKey("_dd.mapper_error")) {
+                    val modifiedEvent = LogEvent.fromJsonObject(modifiedJson!!.toJsonObject())
+
+                    event.status = modifiedEvent.status
+                    event.message = modifiedEvent.message
+                    event.ddtags = modifiedEvent.ddtags
+                    event.logger.name = modifiedEvent.logger.name
+
+                    event.additionalProperties.clear()
+                    event.additionalProperties.putAll(modifiedEvent.additionalProperties)
+                }
+                event
+            }
+        } catch (e: Exception) {
+            Datadog._internalProxy()._telemetry.error(
+                "Attempt to deserialize mapped log event failed, or latch await was interrupted." +
+                    " Returning unmodified event.",
+                e
+            )
+            return event
+        }
+    }
 }
 
 fun LogsConfiguration.Builder.withEncoded(encoded: Map<String, Any?>): LogsConfiguration.Builder {
@@ -261,3 +372,7 @@ internal fun parseLogLevel(logLevel: String): Int {
         else -> Log.INFO
     }
 }
+
+internal const val MESSAGE_INVALID_LOGGER_REINITIALIZATION =
+    "🔥 Re-enabling the Datadog Logging with different options is not supported, even after a" +
+        " hot restart. Cold restart your application to change your current configuration."

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -5,21 +5,17 @@
  */
 package com.datadoghq.flutter
 
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android._InternalProxy
 import com.datadog.android.core.configuration.Configuration
-import com.datadog.android.log.model.LogEvent
 import com.datadog.android.privacy.TrackingConsent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
@@ -299,145 +295,6 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         method?.let {
             it.isAccessible = true
             it.invoke(target)
-        }
-    }
-
-//    private fun attachEventMappers(
-//        config: DatadogFlutterConfiguration,
-//        configBuilder: Configuration.Builder
-//    ) {
-//        if (config.attachLogMapper) {
-//            configBuilder.setLogEventMapper(
-//                object : EventMapper<LogEvent> {
-//                    override fun map(event: LogEvent): LogEvent? {
-//                        return mapLogEvent(event)
-//                    }
-//                }
-//            )
-//        }
-//
-//        config.rumConfiguration?.let {
-//            if (it.attachViewEventMapper) {
-//                configBuilder.setRumViewEventMapper(
-//                    object : ViewEventMapper {
-//                        override fun map(event: ViewEvent): ViewEvent {
-//                            return rumPlugin.mapViewEvent(event)
-//                        }
-//                    }
-//                )
-//            }
-//            if (it.attachActionEventMapper) {
-//                configBuilder.setRumActionEventMapper(
-//                    object : EventMapper<ActionEvent> {
-//                        override fun map(event: ActionEvent): ActionEvent? {
-//                            return rumPlugin.mapActionEvent(event)
-//                        }
-//                    }
-//                )
-//            }
-//            if (it.attachResourceEventMapper) {
-//                configBuilder.setRumResourceEventMapper(
-//                    object : EventMapper<ResourceEvent> {
-//                        override fun map(event: ResourceEvent): ResourceEvent? {
-//                            return rumPlugin.mapResourceEvent(event)
-//                        }
-//                    }
-//                )
-//            }
-//            if (it.attachErrorEventMapper) {
-//                configBuilder.setRumErrorEventMapper(
-//                    object : EventMapper<ErrorEvent> {
-//                        override fun map(event: ErrorEvent): ErrorEvent? {
-//                            return rumPlugin.mapErrorEvent(event)
-//                        }
-//                    }
-//                )
-//            }
-//            if (it.attachLongTaskEventMapper) {
-//                configBuilder.setRumLongTaskEventMapper(
-//                    object : EventMapper<LongTaskEvent> {
-//                        override fun map(event: LongTaskEvent): LongTaskEvent? {
-//                            return rumPlugin.mapLongTaskEvent(event)
-//                        }
-//                    }
-//                )
-//            }
-//        }
-//    }
-
-    @Suppress("TooGenericExceptionCaught")
-    internal fun mapLogEvent(event: LogEvent): LogEvent? {
-        val jsonEvent = event.toJson().asMap()
-        var modifiedJson: Map<String, Any?>? = null
-
-        val latch = CountDownLatch(1)
-
-        val handler = Handler(Looper.getMainLooper())
-        handler.post {
-            try {
-                channel.invokeMethod(
-                    "mapLogEvent",
-                    mapOf(
-                        "event" to jsonEvent
-                    ),
-                    object : Result {
-                        override fun success(result: Any?) {
-                            @Suppress("UNCHECKED_CAST")
-                            modifiedJson = result as? Map<String, Any?>
-                            latch.countDown()
-                        }
-
-                        override fun error(
-                            errorCode: String,
-                            errorMessage: String?,
-                            errorDetails: Any?
-                        ) {
-                            // No telemetry needed, this is likely an issue in user code
-                            latch.countDown()
-                        }
-
-                        override fun notImplemented() {
-                            Datadog._internalProxy()._telemetry.error(
-                                "mapLogEvent returned notImplemented."
-                            )
-                            latch.countDown()
-                        }
-                    }
-                )
-            } catch (e: Exception) {
-                Datadog._internalProxy()._telemetry.error("Attempting call mapLogEvent failed.", e)
-                latch.countDown()
-            }
-        }
-
-        try {
-            // Stalls until the method channel finishes
-            if (!latch.await(1, TimeUnit.SECONDS)) {
-                Datadog._internalProxy()._telemetry.debug("logMapper timed out")
-                return event
-            }
-
-            return modifiedJson?.let {
-                if (!it.containsKey("_dd.mapper_error")) {
-                    val modifiedEvent = LogEvent.fromJsonObject(modifiedJson!!.toJsonObject())
-
-                    event.status = modifiedEvent.status
-                    event.message = modifiedEvent.message
-                    event.ddtags = modifiedEvent.ddtags
-                    event.logger.name = modifiedEvent.logger.name
-
-                    event.additionalProperties.clear()
-                    event.additionalProperties.putAll(modifiedEvent.additionalProperties)
-                }
-                event
-            }
-        } catch (e: Exception) {
-            Datadog._internalProxy()._telemetry.error(
-                "Attempt to deserialize mapped log event failed, or latch await was interrupted." +
-                    " Returning unmodified event.",
-                e
-            )
-            return event
         }
     }
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/Helpers.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/Helpers.kt
@@ -50,12 +50,12 @@ internal fun Any?.fromJsonElement(): Any? {
             }
             array
         }
-        is JsonObject -> this.asMap()
+        is JsonObject -> this.asFlutterMap()
         else -> this
     }
 }
 
-internal fun JsonObject.asMap(): Map<String, Any?> {
+internal fun JsonObject.asFlutterMap(): Map<String, Any?> {
     val map = mutableMapOf<String, Any?>()
     entrySet().forEach {
         map[it.key] = it.value.fromJsonElement()
@@ -63,9 +63,9 @@ internal fun JsonObject.asMap(): Map<String, Any?> {
     return map
 }
 
-internal fun JsonElement?.asMap(): Map<String, Any?> {
+internal fun JsonElement?.asFlutterMap(): Map<String, Any?> {
     return if (this is JsonObject) {
-        this.asMap()
+        this.asFlutterMap()
     } else {
         emptyMap()
     }

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
@@ -9,7 +9,9 @@ import android.util.Log
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import com.datadog.android.Datadog
 import com.datadog.android.log.Logger
+import com.datadog.android.log.Logs
 import com.datadog.android.log.LogsConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.BeforeEach
@@ -21,9 +23,16 @@ import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.mockk.clearAllMocks
+import io.mockk.clearStaticMockk
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.lang.reflect.Method
 
 @ExtendWith(ForgeExtension::class)
 class DatadogLogsPluginTest {
@@ -38,6 +47,12 @@ class DatadogLogsPluginTest {
         plugin.addLogger("mock-logger", mockLogger)
     }
 
+    @AfterEach
+    fun afterEach() {
+        DatadogLogsPlugin.resetConfig();
+        unmockkStatic(Log::class)
+        unmockkStatic(Logs::class)
+    }
 
     @Test
     fun `M decode LogsConfiguration W LogsConfiguration fromEncoded`(
@@ -84,6 +99,100 @@ class DatadogLogsPluginTest {
         assertThat(builder.getPrivate("networkInfoEnabled")).isEqualTo(networkInfoEnabled)
         assertThat(builder.getPrivate("bundleWithRumEnabled")).isEqualTo(bundleWithRumEnabled)
         assertThat(builder.getPrivate("bundleWithTraceEnabled")).isEqualTo(bundleWithTraceEnabled)
+    }
+
+    @Test
+    fun `M call Logs enable with correct config W method channel sends enable`() {
+        // GIVEN
+        mockkStatic(Logs::class)
+        val config = mapOf<String, Any?>()
+        val methodCall = MethodCall(
+            "enable",
+            mapOf(
+                "configuration" to config
+            )
+        )
+
+        // WHEN
+        val mockResult = mock<MethodChannel.Result>()
+        plugin.onMethodCall(methodCall, mockResult)
+
+        // THEN
+        val baseConfig = LogsConfiguration.Builder().build()
+        io.mockk.verify {
+            Logs.enable(baseConfig)
+        }
+    }
+
+    @Test
+    fun `M not issue warning W enable called with same configuration`(
+        forge: Forge
+    ) {
+        // GIVEN
+        mockkStatic(Log::class)
+        Datadog.setVerbosity(Log.INFO)
+
+        val config = mapOf<String, Any?>()
+        val methodCall = MethodCall(
+            "enable",
+            mapOf(
+                "configuration" to config
+            )
+        )
+        val mockResult = mock<MethodChannel.Result>()
+        plugin.onMethodCall(methodCall, mockResult)
+
+        // WHEN
+        val methodCallB = MethodCall(
+            "initialize",
+            mapOf(
+                "configuration" to config
+            )
+        )
+        val mockResultB = mock<MethodChannel.Result>()
+        plugin.onMethodCall(methodCallB, mockResultB)
+
+        // THEN
+        io.mockk.verify(exactly = 0) {
+            Log.println(any(), eq(DATADOG_FLUTTER_TAG), any())
+        }
+    }
+
+    @Test
+    fun `M issue warning W enable called with different configuration`(
+        forge: Forge
+    ) {
+        // GIVEN
+        mockkStatic(Log::class)
+        Datadog.setVerbosity(Log.INFO)
+
+        val methodCall = MethodCall(
+            "enable",
+            mapOf(
+                "configuration" to mapOf(
+                    "attachLogMapper" to false
+                )
+            )
+        )
+        val mockResult = mock<MethodChannel.Result>()
+        plugin.onMethodCall(methodCall, mockResult)
+
+        // WHEN
+        val methodCallB = MethodCall(
+            "enable",
+            mapOf(
+                "configuration" to mapOf(
+                    "attachLogMapper" to true
+                )
+            )
+        )
+        val mockResultB = mock<MethodChannel.Result>()
+        plugin.onMethodCall(methodCallB, mockResultB)
+
+        // THEN
+        io.mockk.verify(exactly = 1) {
+            Log.e(DATADOG_FLUTTER_TAG, MESSAGE_INVALID_LOGGER_REINITIALIZATION)
+        }
     }
 
     @Test

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -319,7 +319,6 @@ class DatadogSdkPluginTest {
             "env" to forge.anAlphabeticalString(),
             "trackingConsent" to "TrackingConsent.granted",
             "nativeCrashReportEnabled" to true,
-            "loggingConfiguration" to null
         )
         val methodCall = MethodCall(
             "initialize",
@@ -363,7 +362,6 @@ class DatadogSdkPluginTest {
                     "env" to forge.anAlphabeticalString(),
                     "trackingConsent" to "TrackingConsent.granted",
                     "nativeCrashReportEnabled" to true,
-                    "loggingConfiguration" to null
                 )
             )
         )
@@ -381,7 +379,6 @@ class DatadogSdkPluginTest {
                     "env" to forge.anAlphabeticalString(),
                     "trackingConsent" to "TrackingConsent.granted",
                     "nativeCrashReportEnabled" to true,
-                    "loggingConfiguration" to null
                 )
             )
         )

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
@@ -196,6 +196,59 @@ class DatadogLogsPluginTests: XCTestCase {
         }
     }
 
+    func testRepeatEnable_FromMethodChannelSameOptions_DoesNothing() {
+        let configuration: [String: Any?] = [:]
+
+        let methodCallA = FlutterMethodCall(
+            methodName: "enable",
+            arguments: [
+                "configuration": configuration
+            ] as [String: Any]
+        )
+        plugin.handle(methodCallA) { _ in }
+
+        var loggedConsoleLines: [String] = []
+        consolePrint = { str in loggedConsoleLines.append(str) }
+
+        let methodCallB = FlutterMethodCall(
+            methodName: "initialize",
+            arguments: [
+                "configuration": configuration
+            ] as [String: Any]
+        )
+        plugin.handle(methodCallB) { _ in }
+
+        print(loggedConsoleLines)
+
+        XCTAssertTrue(loggedConsoleLines.isEmpty)
+    }
+
+    func testRepeatEnable_FromMethodChannelDifferentOptions_PrintsError() {
+        let methodCallA = FlutterMethodCall(
+            methodName: "enable",
+            arguments: [
+                "configuration": [:] as [String: Any?]
+            ] as [String: Any]
+        )
+        plugin.handle(methodCallA) { _ in }
+
+        var loggedConsoleLines: [String] = []
+        consolePrint = { str in loggedConsoleLines.append(str) }
+
+        let methodCallB = FlutterMethodCall(
+            methodName: "enable",
+            arguments: [
+                "configuration": [
+                    "customEndpoint": "http://localhost"
+                ] as [String: Any?]
+            ] as [String: Any]
+        )
+        plugin.handle(methodCallB) { _ in }
+
+        XCTAssertFalse(loggedConsoleLines.isEmpty)
+        XCTAssertTrue(loggedConsoleLines.first?.contains("🔥") == true)
+    }
+
     func testParseLogLevel_ParsesLevelsCorrectly() {
         let debug = LogLevel.parseLogLevelFromFlutter("LogLevel.debug")
         let info = LogLevel.parseLogLevelFromFlutter("LogLevel.info")

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -363,8 +363,10 @@ class FlutterSdkTests: XCTestCase {
         XCTAssertEqual(callResult, .called(value: nil))
     }
 
+    // Not sure how to check what changes have been made to the Configuraiton Telemetry in v2
 //    func testConfigurationOverrides_FromMethodChannel_AreOverridden() {
 //        let plugin = DatadogSdkPlugin(channel: FlutterMethodChannel())
+//        plugin.core?.
 //
 //        let trackViewsManually: Bool = .random()
 //        let trackInteractions: Bool = .random()
@@ -389,7 +391,6 @@ class FlutterSdkTests: XCTestCase {
 //        }
 //
 //        callAndCheck(property: "trackViewsManually", value: trackViewsManually) {
-//            plugin.core?.telemetry
 //            XCTAssertEqual(plugin.configurationTelemetryOverrides.trackViewsManually, trackViewsManually)
 //        }
 //        callAndCheck(property: "trackInteractions", value: trackInteractions) {

--- a/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/crash_reporting_screen.dart
@@ -223,6 +223,7 @@ class _CrashReportingScreenState extends State<CrashReportingScreen> {
       case CrashType.ffiCallbackException:
         if (!kIsWeb) {
           var value = nativeCrashPlugin.ffiCallbackTest(32, nativeCallback);
+          // ignore: use_build_context_synchronously
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(

--- a/packages/datadog_flutter_plugin/example/lib/main.dart
+++ b/packages/datadog_flutter_plugin/example/lib/main.dart
@@ -22,17 +22,13 @@ LogEvent? _logEventMapper(LogEvent event) {
 
 RumViewEvent _viewEventMapper(RumViewEvent event) {
   if (event.view.name == 'overwrite me') {
-    event.view.name = 'overwritten';
+    event.view.url = 'overwritten url';
   }
 
   return event;
 }
 
 RumActionEvent? _actionEventMapper(RumActionEvent event) {
-  if (event.view.name == 'overwrite me') {
-    event.view.name = 'overwritten';
-  }
-
   if (event.action.target?.name == 'discard') {
     return null;
   } else if (event.action.target?.name == 'censor me!') {
@@ -86,7 +82,9 @@ void main() async {
     version: '1.2.3',
     site: DatadogSite.us1,
     nativeCrashReportEnabled: true,
-    loggingConfiguration: DatadogLoggingConfiguration(),
+    loggingConfiguration: DatadogLoggingConfiguration(
+      eventMapper: _logEventMapper,
+    ),
     rumConfiguration: applicationId != null
         ? DatadogRumConfiguration(
             applicationId: applicationId,

--- a/packages/datadog_flutter_plugin/example/lib/main.dart
+++ b/packages/datadog_flutter_plugin/example/lib/main.dart
@@ -92,11 +92,11 @@ void main() async {
             applicationId: applicationId,
             detectLongTasks: true,
             reportFlutterPerformance: true,
-            rumViewEventMapper: _viewEventMapper,
-            rumActionEventMapper: _actionEventMapper,
-            rumResourceEventMapper: _resourceEventMapper,
-            rumErrorEventMapper: _errorEventMapper,
-            rumLongTaskEventMapper: _longTaskEventMapper,
+            viewEventMapper: _viewEventMapper,
+            actionEventMapper: _actionEventMapper,
+            resourceEventMapper: _resourceEventMapper,
+            errorEventMapper: _errorEventMapper,
+            longTaskEventMapper: _longTaskEventMapper,
           )
         : null,
   );

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
@@ -135,5 +135,5 @@ void main() {
         expect(log.threadName, 'main');
       }
     }
-  }, skip: true);
+  });
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_mapping_test.dart
@@ -21,7 +21,7 @@ void main() {
   // mappers:
   //  * viewMapper renames ThirdManualRumView to ThirdView
   //  * actionMapper changes 'Tapped Download' to 'Download'
-  //  * actionMapper discards the 'Next Page' tap
+  //  * actionMapper discards the 'Next Screen' tap
   //  * actionMapper discards 'User Scrolling' events
   //  * resourceMapper and errorMapper rewite the urls to replace 'fake_url' with 'my_url'
   //  * longTask mapper discards all long tasks less than 200 ms
@@ -93,5 +93,5 @@ void main() {
         expect(event.viewName, 'ThirdView');
       }
     }
-  }, skip: true);
+  });
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_mapping_test.dart
@@ -19,7 +19,7 @@ void main() {
 
   // This is the same test as rum_manual_test.dart, but with the following
   // mappers:
-  //  * viewMapper renames ThirdManualRumView to ThirdView
+  //  * viewMapper renames ThirdManualRumView URL to ThirdView
   //  * actionMapper changes 'Tapped Download' to 'Download'
   //  * actionMapper discards the 'Next Screen' tap
   //  * actionMapper discards 'User Scrolling' events
@@ -86,12 +86,7 @@ void main() {
     }
 
     final view3 = session.visits[2];
-    expect(view3.name, 'ThirdView');
-
-    if (view3.longTaskEvents.isNotEmpty) {
-      for (var event in view3.longTaskEvents) {
-        expect(event.viewName, 'ThirdView');
-      }
-    }
+    expect(view3.name, 'ThirdManualRumView');
+    expect(view3.viewEvents.first.view.viewData['url'], 'ThirdView');
   });
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/scenario_runner.dart
@@ -32,7 +32,9 @@ Future<void> runScenario({
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,
     firstPartyHosts: firstPartyHosts,
-    loggingConfiguration: DatadogLoggingConfiguration(),
+    loggingConfiguration: DatadogLoggingConfiguration(
+      customEndpoint: customEndpoint,
+    ),
     rumConfiguration: applicationId != null
         ? DatadogRumConfiguration(
             applicationId: applicationId,

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
@@ -106,13 +106,11 @@ Future<void> runScenario({
 
   if (testingConfiguration?.scenario == mappedInstrumentationScenarioName) {
     // Add mapping to rum configuration
-    configuration.rumConfiguration?.rumViewEventMapper = mapRumViewEvent;
-    configuration.rumConfiguration?.rumActionEventMapper = mapRumActionEvent;
-    configuration.rumConfiguration?.rumResourceEventMapper =
-        mapRumResourceEvent;
-    configuration.rumConfiguration?.rumErrorEventMapper = mapRumErrorEvent;
-    configuration.rumConfiguration?.rumLongTaskEventMapper =
-        mapRumLongTaskEvent;
+    configuration.rumConfiguration?.viewEventMapper = mapRumViewEvent;
+    configuration.rumConfiguration?.actionEventMapper = mapRumActionEvent;
+    configuration.rumConfiguration?.resourceEventMapper = mapRumResourceEvent;
+    configuration.rumConfiguration?.errorEventMapper = mapRumErrorEvent;
+    configuration.rumConfiguration?.longTaskEventMapper = mapRumLongTaskEvent;
   }
 
   await DatadogSdk.runApp(configuration, TrackingConsent.granted, () async {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
@@ -85,7 +85,10 @@ Future<void> runScenario({
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,
     firstPartyHosts: firstPartyHosts,
-    loggingConfiguration: DatadogLoggingConfiguration(),
+    loggingConfiguration: DatadogLoggingConfiguration(
+      logEventMapper: _mapLogEvent,
+      customEndpoint: customEndpoint,
+    ),
     rumConfiguration: applicationId != null
         ? DatadogRumConfiguration(
             applicationId: applicationId,

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
@@ -14,7 +14,7 @@ const mappedInstrumentationScenarioName =
 
 RumViewEvent mapRumViewEvent(RumViewEvent event) {
   if (event.view.name == 'ThirdManualRumView') {
-    event.view.name = 'ThirdView';
+    event.view.url = 'ThirdView';
   }
 
   return event;
@@ -56,10 +56,6 @@ RumLongTaskEvent? mapRumLongTaskEvent(RumLongTaskEvent event) {
     return null;
   }
 
-  if (event.view.name == 'ThirdManualRumView') {
-    event.view.name = 'ThirdView';
-  }
-
   return event;
 }
 
@@ -86,7 +82,7 @@ Future<void> runScenario({
     nativeCrashReportEnabled: true,
     firstPartyHosts: firstPartyHosts,
     loggingConfiguration: DatadogLoggingConfiguration(
-      logEventMapper: _mapLogEvent,
+      eventMapper: _mapLogEvent,
       customEndpoint: customEndpoint,
     ),
     rumConfiguration: applicationId != null

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -50,14 +50,18 @@ Future<void> runScenario({
     uploadFrequency: UploadFrequency.frequent,
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,
-    loggingConfiguration:
-        DatadogLoggingConfiguration(customEndpoint: customEndpoint),
+    loggingConfiguration: DatadogLoggingConfiguration(
+      customEndpoint: customEndpoint,
+    ),
     rumConfiguration: applicationId != null
         ? DatadogRumConfiguration(
             applicationId: applicationId,
             customEndpoint: customEndpoint,
             telemetrySampleRate: 100,
             additionalConfig: testingConfiguration?.additionalConfig ?? {},
+            rumActionEventMapper: (event) => event,
+            rumViewEventMapper: (event) => event,
+            rumResourceEventMapper: (event) => event,
           )
         : null,
   )..additionalConfig['_dd.needsClearTextHttp'] = true;

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -59,9 +59,9 @@ Future<void> runScenario({
             customEndpoint: customEndpoint,
             telemetrySampleRate: 100,
             additionalConfig: testingConfiguration?.additionalConfig ?? {},
-            rumActionEventMapper: (event) => event,
-            rumViewEventMapper: (event) => event,
-            rumResourceEventMapper: (event) => event,
+            actionEventMapper: (event) => event,
+            viewEventMapper: (event) => event,
+            resourceEventMapper: (event) => event,
           )
         : null,
   )..additionalConfig['_dd.needsClearTextHttp'] = true;

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -328,63 +328,6 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
     }
 }
 
-// struct FlutterLogEventMapper: LogEventMapper {
-//    static let reservedAttributeNames: Set<String> = [
-//        "host", "message", "status", "service", "source", "ddtags",
-//        "dd.trace_id", "dd.span_id",
-//        "application_id", "session_id", "view.id", "user_action.id"
-//    ]
-//
-//    let channel: FlutterMethodChannel
-//
-//    public init(channel: FlutterMethodChannel) {
-//        self.channel = channel
-//    }
-//
-//    func map(event: LogEvent, callback: @escaping (LogEvent) -> Void) {
-//        guard let encoded = logEventToFlutterDictionary(event: event) else {
-//            // TELEMETRY
-//            callback(event)
-//            return
-//        }
-//
-//        channel.invokeMethod("mapLogEvent", arguments: ["event": encoded]) { result in
-//            guard let result = result as? [String: Any] else {
-//                // Don't call the callback, this event was discarded
-//                return
-//            }
-//
-//            if result["_dd.mapper_error"] != nil {
-//                // Error in the mapper, return the unmapped event
-//                callback(event)
-//            }
-//
-//            // Don't bother to decode, just pull modifiable properties straight from the
-//            // dictionary.
-//            var event = event
-//            if let message = result["message"] as? String {
-//                event.message = message
-//            }
-//            if let tags = result["ddtags"] as? String {
-//                let splitTags = tags.split(separator: ",").map { String($0) }
-//                event.tags = splitTags
-//            }
-//
-//            // Go through all remaining attributes and add them on to the user
-//            // attibutes so long as they aren't reserved
-//            event.attributes.userAttributes.removeAll()
-//            for (key, value) in result {
-//                if FlutterLogEventMapper.reservedAttributeNames.contains(key) {
-//                    continue
-//                }
-//                event.attributes.userAttributes[key] = castAnyToEncodable(value)
-//            }
-//
-//            callback(event)
-//        }
-//    }
-// }
-
 extension FlutterError {
     public enum DdErrorCodes {
         static let contractViolation = "DatadogSdk:ContractViolation"

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -75,7 +75,6 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
       if (configuration.rumConfiguration != null) {
         final rumWeb = DdRumPlatform.instance as DdRumWeb;
         rumWeb.webInitialize(configuration, configuration.rumConfiguration!);
-        await rumWeb.enable(configuration.rumConfiguration!);
         rumInitialized = true;
       }
     } catch (e) {

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -5,13 +5,6 @@
 import '../datadog_flutter_plugin.dart';
 import '../datadog_internal.dart';
 
-/// A function that allows you to modify or drop specific [LogEvent]s before
-/// they are sent to Datadog.
-///
-/// The [LogEventMapper] can modify any mutable (non-final) properties in the
-/// [LogEvent], or return null to drop the log entirely.
-typedef LogEventMapper = LogEvent? Function(LogEvent event);
-
 /// Defines the Datadog SDK policy when batching data together before uploading
 /// it to Datadog servers. Smaller batches mean smaller but more network
 /// requests, whereas larger batches mean fewer but larger network requests.

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -15,16 +15,28 @@ export 'ddlog_event.dart';
 const _uuid = Uuid();
 
 class DatadogLogging {
+  static DatadogLogging? _instance;
+
+  static DdLogsPlatform get _platform {
+    return DdLogsPlatform.instance;
+  }
+
   final DatadogSdk core;
 
   DatadogLogging._(this.core);
 
   static Future<DatadogLogging?> enable(
       DatadogSdk core, DatadogLoggingConfiguration config) async {
+    if (_instance != null) {
+      core.internalLogger
+          .error('DatadogLogging is already enabled. Second call is ignored.');
+      return _instance;
+    }
+
     DatadogLogging? logging;
 
     await wrapAsync('logs.enable', core.internalLogger, null, () {
-      DdLogsPlatform.instance.enable(config);
+      _platform.enable(core, config);
       logging = DatadogLogging._(core);
     });
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -24,7 +24,7 @@ class DdLogsMethodChannel extends DdLogsPlatform {
   Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config) {
     // NOTE: This will break when / if we move to multiple Datadog SDK instances
     _core = core;
-    _logEventMapper = config.logEventMapper;
+    _logEventMapper = config.eventMapper;
     return methodChannel.invokeMethod('enable', {
       'configuration': config.encode(),
     });

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -5,16 +5,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../datadog_flutter_plugin.dart';
 import 'ddlogs_platform_interface.dart';
-import 'log_configuration.dart';
 
 class DdLogsMethodChannel extends DdLogsPlatform {
   @visibleForTesting
   final MethodChannel methodChannel =
       const MethodChannel('datadog_sdk_flutter.logs');
 
+  DatadogSdk? _core;
+  LogEventMapper? _logEventMapper;
+
+  DdLogsMethodChannel() {
+    methodChannel.setMethodCallHandler(_handleMethodCall);
+  }
+
   @override
-  Future<void> enable(DatadogLoggingConfiguration config) {
+  Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config) {
+    // NOTE: This will break when / if we move to multiple Datadog SDK instances
+    _core = core;
+    _logEventMapper = config.logEventMapper;
     return methodChannel.invokeMethod('enable', {
       'configuration': config.encode(),
     });
@@ -89,5 +99,78 @@ class DdLogsMethodChannel extends DdLogsPlatform {
       'loggerHandle': loggerHandle,
       'key': key,
     });
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'mapLogEvent':
+        return _mapLogEvent(call);
+    }
+  }
+
+  Map<Object?, Object?>? _mapLogEvent(MethodCall call) {
+    // This is the same list as in LogEvent.kt
+    const reservedAttributes = [
+      'status',
+      'service',
+      'message',
+      'date',
+      'logger',
+      '_dd',
+      'usr',
+      'network',
+      'error',
+      'ddtags'
+    ];
+
+    try {
+      final logEventJson = call.arguments['event'] as Map;
+      if (_logEventMapper == null) {
+        final st = StackTrace.current;
+        _core?.internalLogger.sendToDatadog(
+            'Log event mapper called but no logEventMapper is set,',
+            st,
+            'InternalDatadogError');
+        return logEventJson;
+      }
+      final logEvent = LogEvent.fromJson(logEventJson);
+      // Pull out any extra attributes
+      for (final item in logEventJson.entries) {
+        final key = item.key as String;
+        if (!reservedAttributes.contains(key)) {
+          logEvent.attributes[key] = item.value;
+        }
+      }
+
+      LogEvent? mappedLogEvent = logEvent;
+      try {
+        mappedLogEvent = _logEventMapper?.call(logEvent);
+        if (mappedLogEvent == null) {
+          return null;
+        }
+      } catch (e) {
+        // User error, return unmapped, but report
+        _core?.internalLogger.error(
+            'logEventMapper threw an exception: ${e.toString()}.\nReturning unmapped event.');
+      }
+
+      final mappedJson = mappedLogEvent!.toJson();
+      for (final item in mappedLogEvent.attributes.entries) {
+        // Put extra attributes back
+        if (!reservedAttributes.contains(item.key)) {
+          mappedJson[item.key] = item.value;
+        }
+      }
+      return mappedJson;
+    } catch (e, st) {
+      _core?.internalLogger.sendToDatadog(
+          'Error mapping log event: ${e.toString()}',
+          st,
+          e.runtimeType.toString());
+    }
+
+    // Return a special map which will indicate to native code something went wrong, and
+    // we should send the unmodified event.
+    return {'_dd.mapper_error': 'mapper error'};
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
@@ -2,12 +2,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
+import '../../datadog_flutter_plugin.dart';
 import 'ddlogs_platform_interface.dart';
-import 'log_configuration.dart';
 
 class DdNoOpLogsPlatform extends DdLogsPlatform {
   @override
-  Future<void> enable(DatadogLoggingConfiguration config) {
+  Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config) {
     throw UnimplementedError();
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
@@ -4,8 +4,8 @@
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../../datadog_flutter_plugin.dart';
 import 'ddlogs_method_channel.dart';
-import 'log_configuration.dart';
 
 // Private for now until we can ensure all SDKs support all levels
 enum LogLevel {
@@ -37,7 +37,7 @@ abstract class DdLogsPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> enable(DatadogLoggingConfiguration config);
+  Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config);
 
   Future<void> createLogger(
       String loggerHandle, DatadogLoggerConfiguration config);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -26,7 +26,8 @@ class DdLogsWeb extends DdLogsPlatform {
   }
 
   @override
-  Future<void> enable(DatadogLoggingConfiguration config) async {}
+  Future<void> enable(
+      DatadogSdk core, DatadogLoggingConfiguration config) async {}
 
   @override
   Future<void> createLogger(

--- a/packages/datadog_flutter_plugin/lib/src/logs/log_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/log_configuration.dart
@@ -33,17 +33,17 @@ class DatadogLoggingConfiguration {
 
   /// A function that allows you to modify or drop specific [LogEvent]s
   /// before they are sent to Datadog.
-  LogEventMapper? logEventMapper;
+  LogEventMapper? eventMapper;
 
   DatadogLoggingConfiguration({
     this.customEndpoint,
-    this.logEventMapper,
+    this.eventMapper,
   });
 
   Map<String, Object?> encode() {
     return {
       'customEndpoint': customEndpoint,
-      'attachLogMapper': logEventMapper != null,
+      'attachLogMapper': eventMapper != null,
     };
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -98,7 +98,7 @@ class DatadogRum {
       DatadogSdk core, DatadogRumConfiguration configuration) async {
     DatadogRum? rum;
     await wrapAsync('rum.enable', core.internalLogger, null, () {
-      DdRumPlatform.instance.enable(configuration);
+      DdRumPlatform.instance.enable(core, configuration);
       rum = DatadogRum._(configuration, core.internalLogger);
 
       core.updateConfigurationInfo(

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
@@ -236,7 +236,7 @@ class RumViewDetails {
   final RumCount? longTask;
   final double? memoryAverage;
   final double? memoryMax;
-  String? name;
+  final String? name;
   String? referrer;
   final double? refreshRateAverage;
   final double? refreshRateMin;
@@ -410,7 +410,7 @@ class RumActionTarget {
 class RumViewSummary {
   final String id;
   final bool? inForeground;
-  String? name;
+  final String? name;
   String? referrer;
   String url;
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -15,17 +15,18 @@ class DdRumMethodChannel extends DdRumPlatform {
       const MethodChannel('datadog_sdk_flutter.rum');
 
   @override
-  Future<void> enable(DatadogRumConfiguration configuration) async {
-    // final callbackHandler = MethodCallHandler(
-    //   viewEventMapper: configuration.rumViewEventMapper,
-    //   actionEventMapper: configuration.rumActionEventMapper,
-    //   resourceEventMapper: configuration.rumResourceEventMapper,
-    //   errorEventMapper: configuration.rumErrorEventMapper,
-    //   longTaskEventMapper: configuration.rumLongTaskEventMapper,
-    //   internalLogger: internalLogger,
-    // );
+  Future<void> enable(
+      DatadogSdk core, DatadogRumConfiguration configuration) async {
+    final callbackHandler = MethodCallHandler(
+      viewEventMapper: configuration.rumViewEventMapper,
+      actionEventMapper: configuration.rumActionEventMapper,
+      resourceEventMapper: configuration.rumResourceEventMapper,
+      errorEventMapper: configuration.rumErrorEventMapper,
+      longTaskEventMapper: configuration.rumLongTaskEventMapper,
+      internalLogger: core.internalLogger,
+    );
 
-    // methodChannel.setMethodCallHandler(callbackHandler.handleMethodCall);
+    methodChannel.setMethodCallHandler(callbackHandler.handleMethodCall);
 
     return methodChannel.invokeMethod('enable', {
       'configuration': configuration.encode(),

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -18,11 +18,11 @@ class DdRumMethodChannel extends DdRumPlatform {
   Future<void> enable(
       DatadogSdk core, DatadogRumConfiguration configuration) async {
     final callbackHandler = MethodCallHandler(
-      viewEventMapper: configuration.rumViewEventMapper,
-      actionEventMapper: configuration.rumActionEventMapper,
-      resourceEventMapper: configuration.rumResourceEventMapper,
-      errorEventMapper: configuration.rumErrorEventMapper,
-      longTaskEventMapper: configuration.rumLongTaskEventMapper,
+      viewEventMapper: configuration.viewEventMapper,
+      actionEventMapper: configuration.actionEventMapper,
+      resourceEventMapper: configuration.resourceEventMapper,
+      errorEventMapper: configuration.errorEventMapper,
+      longTaskEventMapper: configuration.longTaskEventMapper,
       internalLogger: core.internalLogger,
     );
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -2,9 +2,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
-import 'ddrum.dart';
+import '../../datadog_flutter_plugin.dart';
 import 'ddrum_platform_interface.dart';
-import 'rum_configuration.dart';
 
 class DdNoOpRumPlatform extends DdRumPlatform {
   @override
@@ -47,7 +46,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> enable(DatadogRumConfiguration configuration) {
+  Future<void> enable(DatadogSdk core, DatadogRumConfiguration configuration) {
     return Future.value();
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -21,7 +21,7 @@ abstract class DdRumPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> enable(DatadogRumConfiguration configuration);
+  Future<void> enable(DatadogSdk core, DatadogRumConfiguration configuration);
   Future<void> startView(
       String key, String name, Map<String, Object?> attributes);
   Future<void> stopView(String key, Map<String, Object?> attributes);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -34,7 +34,8 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> enable(DatadogRumConfiguration configuration) async {}
+  Future<void> enable(
+      DatadogSdk core, DatadogRumConfiguration configuration) async {}
 
   @override
   Future<void> addAttribute(String key, dynamic value) async {

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -141,23 +141,23 @@ class DatadogRumConfiguration {
 
   /// A function that allows you to modify or drop specific [RumViewEvent]s
   /// before they are sent to Datadog.
-  RumViewEventMapper? rumViewEventMapper;
+  RumViewEventMapper? viewEventMapper;
 
   /// A function that allows you to modify or drop specific [RumActionEvent]s
   /// before they are sent to Datadog.
-  RumActionEventMapper? rumActionEventMapper;
+  RumActionEventMapper? actionEventMapper;
 
   /// A function that allows you to modify or drop specific [RumResourceEvent]s
   /// before they are sent to Datadog.
-  RumResourceEventMapper? rumResourceEventMapper;
+  RumResourceEventMapper? resourceEventMapper;
 
   /// A function that allows you to modify or drop specific [RumResourceEvent]s
   /// before they are sent to Datadog.
-  RumErrorEventMapper? rumErrorEventMapper;
+  RumErrorEventMapper? errorEventMapper;
 
   /// A function that allows you to modify or drop specific [RumLongTaskEvent]s
   /// before they are sent to Datadog.
-  RumLongTaskEventMapper? rumLongTaskEventMapper;
+  RumLongTaskEventMapper? longTaskEventMapper;
 
   Map<String, Object?> additionalConfig;
 
@@ -172,11 +172,11 @@ class DatadogRumConfiguration {
     this.reportFlutterPerformance = false,
     this.customEndpoint,
     this.telemetrySampleRate = 20.0,
-    this.rumViewEventMapper,
-    this.rumActionEventMapper,
-    this.rumResourceEventMapper,
-    this.rumErrorEventMapper,
-    this.rumLongTaskEventMapper,
+    this.viewEventMapper,
+    this.actionEventMapper,
+    this.resourceEventMapper,
+    this.errorEventMapper,
+    this.longTaskEventMapper,
     this.additionalConfig = const <String, Object>{},
   })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
         tracingSamplingRate = max(0, min(tracingSamplingRate, 100)),
@@ -206,11 +206,11 @@ class DatadogRumConfiguration {
       'reportFlutterPerformance': reportFlutterPerformance,
       'customEndpoint': customEndpoint,
       'telemetrySampleRate': telemetrySampleRate,
-      'attachViewEventMapper': rumViewEventMapper != null,
-      'attachActionEventMapper': rumActionEventMapper != null,
-      'attachResourceEventMapper': rumResourceEventMapper != null,
-      'attachErrorEventMapper': rumErrorEventMapper != null,
-      'attachLongTaskEventMapper': rumLongTaskEventMapper != null,
+      'attachViewEventMapper': viewEventMapper != null,
+      'attachActionEventMapper': actionEventMapper != null,
+      'attachResourceEventMapper': resourceEventMapper != null,
+      'attachErrorEventMapper': errorEventMapper != null,
+      'attachLongTaskEventMapper': longTaskEventMapper != null,
       'additionalConfig': additionalConfig,
     };
   }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -44,6 +44,7 @@ void main() {
     registerFallbackValue(InternalLogger());
     registerFallbackValue(CoreLoggerLevel.error);
     registerFallbackValue(DatadogRumConfiguration(applicationId: ''));
+    registerFallbackValue(DatadogSdk.instance);
   });
 
   setUp(() {
@@ -78,11 +79,11 @@ void main() {
 
     mockLogsPlatform = MockDdLogsPlatform();
     DdLogsPlatform.instance = mockLogsPlatform;
-    when(() => mockLogsPlatform.enable(any()))
+    when(() => mockLogsPlatform.enable(any(), any()))
         .thenAnswer((_) => Future.value());
 
     mockRumPlatform = MockRumPlatform();
-    when(() => mockRumPlatform.enable(any()))
+    when(() => mockRumPlatform.enable(any(), any()))
         .thenAnswer((_) => Future<void>.value());
     DdRumPlatform.instance = mockRumPlatform;
   });
@@ -226,7 +227,7 @@ void main() {
     final logs = datadogSdk.logs;
 
     expect(logs, isNotNull);
-    verify(() => mockLogsPlatform.enable(loggingConfiguration));
+    verify(() => mockLogsPlatform.enable(datadogSdk, loggingConfiguration));
   });
 
   test('initialize with rum configuration creates RUM', () async {
@@ -254,7 +255,7 @@ void main() {
 
     final rum = datadogSdk.rum;
     expect(rum, isNotNull);
-    verify(() => mockRumPlatform.enable(rumConfiguration));
+    verify(() => mockRumPlatform.enable(datadogSdk, rumConfiguration));
   });
 
   // test('attachToExisting calls out to platform', () async {

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -30,10 +30,12 @@ void main() {
     registerFallbackValue(LogLevel.info);
     registerFallbackValue(DatadogLoggingConfiguration());
     registerFallbackValue(DatadogLoggerConfiguration());
+    registerFallbackValue(DatadogSdk.instance);
 
     mockPlatform = MockDdLogsPlatform();
     DdLogsPlatform.instance = mockPlatform;
-    when(() => mockPlatform.enable(any())).thenAnswer((_) => Future.value());
+    when(() => mockPlatform.enable(any(), any()))
+        .thenAnswer((_) => Future.value());
     when(() => mockPlatform.createLogger(any(), any()))
         .thenAnswer((_) => Future.value());
 

--- a/test_apps/stress_test/lib/main.dart
+++ b/test_apps/stress_test/lib/main.dart
@@ -21,8 +21,9 @@ void main() async {
     env: dotenv.get('DD_ENV', fallback: ''),
     site: DatadogSite.us1,
     nativeCrashReportEnabled: true,
-    //logEventMapper: (event) => event,
-    loggingConfiguration: DatadogLoggingConfiguration(),
+    loggingConfiguration: DatadogLoggingConfiguration(
+      logEventMapper: (event) => event,
+    ),
     rumConfiguration: applicationId != null
         ? DatadogRumConfiguration(
             applicationId: applicationId,

--- a/test_apps/stress_test/lib/main.dart
+++ b/test_apps/stress_test/lib/main.dart
@@ -22,7 +22,7 @@ void main() async {
     site: DatadogSite.us1,
     nativeCrashReportEnabled: true,
     loggingConfiguration: DatadogLoggingConfiguration(
-      logEventMapper: (event) => event,
+      eventMapper: (event) => event,
     ),
     rumConfiguration: applicationId != null
         ? DatadogRumConfiguration(

--- a/test_apps/stress_test/lib/main.dart
+++ b/test_apps/stress_test/lib/main.dart
@@ -29,11 +29,11 @@ void main() async {
             applicationId: applicationId,
             reportFlutterPerformance: true,
             detectLongTasks: true,
-            rumViewEventMapper: (event) => event,
-            rumActionEventMapper: (event) => event,
-            rumResourceEventMapper: (event) => event,
-            rumErrorEventMapper: (event) => event,
-            rumLongTaskEventMapper: (event) => event,
+            viewEventMapper: (event) => event,
+            actionEventMapper: (event) => event,
+            resourceEventMapper: (event) => event,
+            errorEventMapper: (event) => event,
+            longTaskEventMapper: (event) => event,
           )
         : null,
   )..additionalConfig[DatadogConfigKey.trackMapperPerformance] = true;


### PR DESCRIPTION
### What and why?

Log and RUM mappers were disabled initially to focus on core features of v2. This re-enables them.

refs: RUM-1067

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests