### PR TITLE
fix: Use `default` over `AppLifecycleState.hidden`

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -93,7 +93,7 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>>
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:
-      case AppLifecycleState.hidden:
+      default:
         if (_currentView != null) {
           _pendingView = _currentView;
           _stopView(_currentView);

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_long_task_observer.dart
@@ -37,7 +37,7 @@ class RumLongTaskObserver with WidgetsBindingObserver {
       case AppLifecycleState.detached:
         stopLongTaskDetection();
         break;
-      case AppLifecycleState.hidden:
+      default:
         stopLongTaskDetection();
         break;
     }


### PR DESCRIPTION
### What and why?

`AppLifecycleState.hidden` was added in 3.13.0, below our minimum supported version, so we're going to remove it and replace it with `default` instead. 

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests