### PR TITLE
fix: Fix enabling NDK crash reporting

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -10,6 +10,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android._InternalProxy
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.ndk.NdkCrashReports
 import com.datadog.android.privacy.TrackingConsent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -200,6 +201,11 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
                 configBuilder.build(),
                 trackingConsent
             )
+            (encoded["nativeCrashReportEnabled"] as? Boolean)?.let {
+                if (it) {
+                    NdkCrashReports.enable()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### What and why?

Missed re-enabling native crash reporting in Android during v2 migration. Adding it back in.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests