### PR TITLE
feat: Update flutter_webview_plugin to Gradle 8

### DIFF
--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -30,6 +30,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.datadoghq.flutter.webview"
     compileSdkVersion 33
 
     compileOptions {
@@ -50,7 +51,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         multiDexEnabled true
     }
 }

--- a/packages/datadog_webview_tracking/android/src/main/AndroidManifest.xml
+++ b/packages/datadog_webview_tracking/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.datadog_webview_tracking">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/datadog_webview_tracking/example/android/app/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.example.datadog_webview_tracking"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
@@ -44,7 +45,7 @@ android {
 
     defaultConfig {
         applicationId "com.datadoghq.flutter.webview.example"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/datadog_webview_tracking/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/datadog_webview_tracking/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.datadog_webview_tracking_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="datadog_webview_tracking_example"
         android:name="${applicationName}"

--- a/packages/datadog_webview_tracking/example/android/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"

--- a/packages/datadog_webview_tracking/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_webview_tracking/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip

--- a/packages/datadog_webview_tracking/example/pubspec.lock
+++ b/packages/datadog_webview_tracking/example/pubspec.lock
@@ -357,18 +357,18 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: "34f83c2f0f64c75ad75c77a2ccfc8d2e531afbe8ad41af1fd787d6d33336aa90"
+      sha256: b0cd33dd7d3dd8e5f664e11a19e17ba12c352647269921a3b568406b001f1dff
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.3"
+    version: "3.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: df6472164b3f4eaf3280422227f361dc8424b106726b7f21d79a8656ba53f71f
+      sha256: "6d9213c65f1060116757a7c473247c60f3f7f332cac33dc417c9e362a9a13e4f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.6.0"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
@@ -379,4 +379,4 @@ packages:
     version: "3.2.3"
 sdks:
   dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.7.0"

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   datadog_flutter_plugin: ^1.3.0
   webview_flutter: ^4.0.4
-  webview_flutter_android: ^3.4.3
+  webview_flutter_android: ^3.8.2
   webview_flutter_wkwebview: ^3.2.3
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

When we updated the main package to gradle 8 in #462, we missed support for the `flutter_webview_plugin` package.

This updates the package to support gradle 8 and updates the minimum version of the Android dependency to the version that supports Gradle 8. 

refs: RUM-1328

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [x] Run unit tests
- [x] Run integration tests