### PR TITLE
chore: Fix SDK Table

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -7,7 +7,7 @@ Datadog RUM SDK versions >= 1.4 support monitoring for Flutter 3.0+.
 
 ## Current Datadog SDK Versions
 
-[//]: # "SDK Table"
+[//]: # (SDK Table)
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |


### PR DESCRIPTION
### What and why?

Automatic updates of the SDK table are broken because at some point (SDK Table) was replaced with "SDK Table"

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests