### PR TITLE
chore: Add missing CHANGELOG item

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add support for Gradle 8
 
 ## 1.0.0
 


### PR DESCRIPTION
### What and why?

Missed CHANGELOG item when adding Gradle 8 support.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests