### PR TITLE
chore: Fix an issue in the release validator

### DIFF
--- a/tools/releaser/lib/release_validator.dart
+++ b/tools/releaser/lib/release_validator.dart
@@ -231,8 +231,9 @@ class ValidatePublishDryRun extends Command {
       return true;
     }
 
-    logger.info('ℹ️ Running `dart pub publish --dry-run`');
-    var process = await Process.start('dart', ['pub', 'publish', '--dry-run'],
+    logger.info('ℹ️ Running `flutter pub publish --dry-run`');
+    var process = await Process.start(
+        'flutter', ['pub', 'publish', '--dry-run'],
         workingDirectory: args.packageRoot);
     process.stdout
         .transform(utf8.decoder)


### PR DESCRIPTION
### What and why?

The Dart publish command now checks if you are publishing a Flutter package, and errors if you attempt do do so. Change `dart pub publish` to `flutter pub publish` as a result.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests