### PR TITLE
feat: Update browser SDK to v5

### DIFF
--- a/examples/simple_example/web/index.html
+++ b/examples/simple_example/web/index.html
@@ -38,8 +38,8 @@
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js"></script>
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <script>

--- a/packages/datadog_flutter_plugin/MIGRATING.md
+++ b/packages/datadog_flutter_plugin/MIGRATING.md
@@ -36,9 +36,21 @@ In addition, the following APIs have changed:
 | `DatadogSdk.runApp` | `DatadogSdk.runApp` | Added `trackingConsent` parameter |
 | `DatadogSdk.initialize` | `DatadogSdk.initialize` | Added `trackingConsent` parameter |
 | `DatadogSdk.createLogger` | `DatadogLogging.createLogger` | Moved |
- 
 
-# Logs Product Changes
+## Flutter Web Changes
+
+Clients using Flutter Web should update to using the Datadog Browser SDK v5.  Change the following import in your `index.html`:
+
+```diff
+-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
+-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js"></script>
++  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
++  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
+```
+ 
+Note that Datadog provides one CDN bundle per site. See the [Browser SDK README](https://github.com/DataDog/browser-sdk/#cdn-bundles) for a list of all site URLs.
+
+## Logs Product Changes
 
 As with `1.x`, Datadog Logging can be enabled by setting the `DatadogConfiguration.loggingConfiguration` member. However, unlike `1.x`, Datadog will not create a default logger for you. `DatadogSdk.logs` is now and instance of `DatadogLogging`, which can be used to create logs. Many options were moved to `DatadogLoggerConfiguration` to give developers more granular support over individual loggers.
 
@@ -56,7 +68,7 @@ The following APIs have changed:
 | `LoggingConfiguration.loggerName` | `DatadogLoggerConfiguration.name` | | 
 | `LoggingConfiguration.sampleRate` | `DatadogLoggerConfiguration.remoteSampleRate` | |
 
-# RUM Product Changes
+## RUM Product Changes
 
 The following APIs have changed:
 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -11,7 +11,7 @@ Datadog RUM SDK versions >= 1.4 support monitoring for Flutter 3.0+.
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 1.19.0 | 1.19.1 | 4.x.x |
+| 1.19.0 | 1.19.1 | 5.x.x |
 
 [//]: # (End SDK Table)
 
@@ -25,16 +25,18 @@ On Android, your `minSdkVersion` must be >= 21, and if you are using Kotlin, it 
 
 ### Web
 
-`⚠️ Datadog support for Flutter Web is still in early development`
-
 On Web, add the following to your `index.html` under your `head` tag:
 
 ```html
-<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
-<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js"></script>
+<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
+<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
 ```
 
-This loads the CDN-delivered Datadog Browser SDKs for Logs and RUM. The synchronous CDN-delivered version of the Datadog Browser SDK is the only version supported by the Flutter plugin.
+This loads the CDN-delivered Datadog Browser SDKs for Logs and RUM. The synchronous CDN-delivered version of the Datadog Browser SDK is the only version currently supported by the Flutter plugin.
+
+Note that Datadog provides one CDN bundle per site. See the [Browser SDK README](https://github.com/DataDog/browser-sdk/#cdn-bundles) for a list of all site URLs.
+
+See [Flutter Web Support](#web_support) for information on current support for Flutter Web
 
 ## Setup
 
@@ -200,6 +202,20 @@ final configuration = DatadogConfiguration(
 ```
 
 In order to enable Datadog Distributed Tracing, the `DatadogConfiguration.firstPartyHosts` property in your configuration object must be set to a domain that supports distributed tracing. You can also modify the sampling rate for Datadog distributed tracing by setting the `traceSampleRate` on your `DatadogRumConfiguration`.
+
+## <a name="web_support"></a>Flutter Web Support 
+
+The following Datadog SDK features are not supported in Flutter Web:
+
+  * Tags on logs are not supported
+  * Event mappers are not supported.
+  * Manually tracking resources (`start/stopResource`) is not supported.
+  * All manually reported actions (`addAction`) are reported as type `custom`.
+  * Starting long running actions (`start/stopAction`) is not supported.
+  * New sessions are not created after a call to `stopSession`.
+  * Long task length is not configurable
+
+If you have a need for any of these features, please reach out to your CSM and submit a feature request.
 
 ## Data Storage
 

--- a/packages/datadog_flutter_plugin/example/web/index.html
+++ b/packages/datadog_flutter_plugin/example/web/index.html
@@ -23,8 +23,8 @@
   <link rel="manifest" href="manifest.json">
 
   <!-- Datadog -->
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js"></script>
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -113,7 +113,7 @@ void verifyCommonTags(
   final sdkVersion = request.tags['sdk_version'];
   if (kIsWeb) {
     // Returning the browser version of the SDK.
-    expect(sdkVersion?.startsWith('4.'), true);
+    expect(sdkVersion?.startsWith('5.'), true);
   } else {
     expect(sdkVersion, DatadogSdk.sdkVersion);
   }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -91,7 +91,10 @@ void main() {
 
     for (var log in rumLog) {
       if (log.eventType != 'telemetry') {
-        expect(log.dd.plan, 1);
+        // Web does not use "plan" anymore
+        if (!kIsWeb) {
+          expect(log.dd.plan, 1);
+        }
       }
     }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/web/index.html
+++ b/packages/datadog_flutter_plugin/integration_test_app/web/index.html
@@ -26,8 +26,8 @@
   <link rel="manifest" href="manifest.json">
 
   <!-- Datadog -->
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js"></script>
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -20,7 +20,7 @@ class DdLogsWeb extends DdLogsPlatform {
     init(_LogInitOptions(
       clientToken: configuration.clientToken,
       env: configuration.env,
-      proxyUrl: configuration.loggingConfiguration?.customEndpoint,
+      proxy: configuration.loggingConfiguration?.customEndpoint,
       site: siteStringForSite(configuration.site),
       service: configuration.service,
       version: configuration.versionTag,
@@ -56,7 +56,7 @@ class DdLogsWeb extends DdLogsPlatform {
   Future<void> addAttribute(
       String loggerHandle, String key, Object value) async {
     final logger = _activeLoggers[loggerHandle];
-    logger?.addContext(key, valueToJs(value, 'value'));
+    logger?.setContextProperty(key, valueToJs(value, 'value'));
   }
 
   @override
@@ -65,7 +65,7 @@ class DdLogsWeb extends DdLogsPlatform {
   @override
   Future<void> removeAttribute(String loggerHandle, String key) async {
     final logger = _activeLoggers[loggerHandle];
-    logger?.removeContext(key);
+    logger?.removeContextProperty(key);
   }
 
   @override
@@ -129,7 +129,7 @@ class _LogInitOptions {
   external String get clientToken;
   external String get site;
   external String get env;
-  external String? get proxyUrl;
+  external String? get proxy;
   external String? get service;
   external String? get version;
 
@@ -138,7 +138,7 @@ class _LogInitOptions {
     String site,
     String env,
     String? service,
-    String? proxyUrl,
+    String? proxy,
     String? version,
   });
 }
@@ -162,8 +162,8 @@ class Logger {
   external void log(
       String message, dynamic messageContext, String status, JSError? error);
 
-  external void addContext(String key, dynamic value);
-  external void removeContext(String key);
+  external void setContextProperty(String key, dynamic value);
+  external void removeContextProperty(String key);
 
   external void setHandler(List<String> handler);
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -14,8 +14,6 @@ import '../web_helpers.dart';
 import 'ddrum_platform_interface.dart';
 
 class DdRumWeb extends DdRumPlatform {
-  final Map<String, Object?> currentAttributes = {};
-
   // Because Web needs the full SDK configuration, we have a separate init method
   void webInitialize(DatadogConfiguration configuration,
       DatadogRumConfiguration rumConfiguration) {
@@ -23,12 +21,12 @@ class DdRumWeb extends DdRumPlatform {
       applicationId: rumConfiguration.applicationId,
       clientToken: configuration.clientToken,
       site: siteStringForSite(configuration.site),
-      sampleRate: rumConfiguration.sessionSamplingRate,
+      sessionSampleRate: rumConfiguration.sessionSamplingRate,
       sessionReplaySampleRate: 0,
       service: configuration.service,
       env: configuration.env,
       version: configuration.versionTag,
-      proxyUrl: rumConfiguration.customEndpoint,
+      proxy: rumConfiguration.customEndpoint,
       // allowedTracingOrigins: configuration.firstPartyHosts,
       trackViewsManually: true,
       trackFrustrations: rumConfiguration.trackFrustrations,
@@ -43,8 +41,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> addAttribute(String key, dynamic value) async {
-    currentAttributes[key] = value;
-    _jsSetRumGlobalContext(attributesToJs(currentAttributes, 'context'));
+    _jsSetGlobalContextProperty(key, valueToJs(value, 'context'));
   }
 
   @override
@@ -92,8 +89,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> removeAttribute(String key) async {
-    currentAttributes.remove(key);
-    _jsSetRumGlobalContext(attributesToJs(currentAttributes, 'context'));
+    _jsRemoveGlobalContextProperty(key);
   }
 
   @override
@@ -179,11 +175,11 @@ class _RumInitOptions {
   external bool? get trackFrustrations;
   external bool? get trackLongTasks;
   external String? get defaultPrivacyLevel;
-  external num? get sampleRate;
+  external num? get sessionSampleRate;
   external num? get sessionReplaySampleRate;
   external bool? get silentMultipleInit;
-  external String? get proxyUrl;
-  external List<String> get allowedTracingOrigins;
+  external String? get proxy;
+  external List<String> get allowedTracingUrls;
   external List<String> get enableExperimentalFeatures;
 
   external factory _RumInitOptions({
@@ -198,11 +194,11 @@ class _RumInitOptions {
     bool? trackFrustrations,
     bool? trackLongTasks,
     String? defaultPrivacyLevel,
-    num? sampleRate,
+    num? sessionSampleRate,
     num? sessionReplaySampleRate,
     bool? silentMultipleInit,
-    String? proxyUrl,
-    List<String> allowedTracingOrigins,
+    String? proxy,
+    List<String> allowedTracingUrls,
     List<String> enableExperimentalFeatures,
   });
 }
@@ -213,8 +209,11 @@ external void init(_RumInitOptions configuration);
 @JS('startView')
 external void _jsStartView(String name);
 
-@JS('setRumGlobalContext')
-external void _jsSetRumGlobalContext(dynamic context);
+@JS('setGlobalContextProperty')
+external void _jsSetGlobalContextProperty(String property, dynamic context);
+
+@JS('removeGlobalContextProperty')
+external void _jsRemoveGlobalContextProperty(String property);
 
 @JS('addTiming')
 external void _jsAddTiming(String name);


### PR DESCRIPTION
### What and why?

Updated the SDK to use Datadog Browser SDK v5.

All current integration tests pass. Added documentation around what features of the SDK are not supported in Flutter Web.

refs: RUM-1487

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests