### PR TITLE
feat: Change default tracing headers

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -6,6 +6,7 @@ Release 2.0 introduces breaking changes. Follow the [Migration Guide](MIGRATING.
 
 * Update to v2.0 of Datadog SDKs.
 * Update UUID to ^4.0. See [#472]
+* Change default tracing headers for first party hosts to use both Datadog headers and W3C tracecontext headers.
 
 ## 1.6.0
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -156,7 +156,10 @@ class DatadogConfiguration {
   set firstPartyHosts(List<String> hosts) {
     firstPartyHostsWithTracingHeaders.clear();
     for (var entry in hosts) {
-      firstPartyHostsWithTracingHeaders[entry] = {TracingHeaderType.datadog};
+      firstPartyHostsWithTracingHeaders[entry] = {
+        TracingHeaderType.datadog,
+        TracingHeaderType.tracecontext
+      };
     }
   }
 
@@ -216,10 +219,12 @@ class DatadogConfiguration {
         final headerTypes = firstPartyHostsWithTracingHeaders[entry];
         if (headerTypes == null) {
           firstPartyHostsWithTracingHeaders[entry] = {
-            TracingHeaderType.datadog
+            TracingHeaderType.datadog,
+            TracingHeaderType.tracecontext,
           };
         } else {
           headerTypes.add(TracingHeaderType.datadog);
+          headerTypes.add(TracingHeaderType.tracecontext);
         }
       }
     }
@@ -309,7 +314,10 @@ class DatadogAttachConfiguration {
   set firstPartyHosts(List<String> hosts) {
     firstPartyHostsWithTracingHeaders.clear();
     for (var entry in hosts) {
-      firstPartyHostsWithTracingHeaders[entry] = {TracingHeaderType.datadog};
+      firstPartyHostsWithTracingHeaders[entry] = {
+        TracingHeaderType.datadog,
+        TracingHeaderType.tracecontext
+      };
     }
   }
 
@@ -358,10 +366,12 @@ class DatadogAttachConfiguration {
         final headerTypes = firstPartyHostsWithTracingHeaders[entry];
         if (headerTypes == null) {
           firstPartyHostsWithTracingHeaders[entry] = {
-            TracingHeaderType.datadog
+            TracingHeaderType.datadog,
+            TracingHeaderType.tracecontext
           };
         } else {
           headerTypes.add(TracingHeaderType.datadog);
+          headerTypes.add(TracingHeaderType.tracecontext);
         }
       }
     }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -247,7 +247,11 @@ void main() {
 
     expect(datadogSdk.firstPartyHosts.length, 2);
     expect(datadogSdk.firstPartyHosts[0].hostName, 'example.com');
+    expect(datadogSdk.firstPartyHosts[0].headerTypes,
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
     expect(datadogSdk.firstPartyHosts[1].hostName, 'datadoghq.com');
+    expect(datadogSdk.firstPartyHosts[1].headerTypes,
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
   });
 
   test('attachToExisting with loggingEnabled creates Logging bridge', () async {
@@ -303,11 +307,11 @@ void main() {
 
     expect(datadogSdk.firstPartyHosts.length, 2);
     expect(datadogSdk.firstPartyHosts[0].hostName, 'example.com');
-    expect(
-        datadogSdk.firstPartyHosts[0].headerTypes, {TracingHeaderType.datadog});
+    expect(datadogSdk.firstPartyHosts[0].headerTypes,
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
     expect(datadogSdk.firstPartyHosts[1].hostName, 'datadoghq.com');
-    expect(
-        datadogSdk.firstPartyHosts[1].headerTypes, {TracingHeaderType.datadog});
+    expect(datadogSdk.firstPartyHosts[1].headerTypes,
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
   });
 
   test('first party hosts with tracing headers set to sdk', () async {
@@ -346,8 +350,8 @@ void main() {
     expect(datadogSdk.firstPartyHosts[0].hostName, 'example.com');
     expect(datadogSdk.firstPartyHosts[0].headerTypes, {TracingHeaderType.b3});
     expect(datadogSdk.firstPartyHosts[1].hostName, 'datadoghq.com');
-    expect(
-        datadogSdk.firstPartyHosts[1].headerTypes, {TracingHeaderType.datadog});
+    expect(datadogSdk.firstPartyHosts[1].headerTypes,
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
   });
 
   test('headerTypesForHost with no hosts returns empty set', () async {
@@ -375,7 +379,8 @@ void main() {
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
 
     var uri = Uri.parse('https://datadoghq.com/path');
-    expect(datadogSdk.headerTypesForHost(uri), {TracingHeaderType.datadog});
+    expect(datadogSdk.headerTypesForHost(uri),
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
   });
 
   test(
@@ -392,7 +397,8 @@ void main() {
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
 
     var uri = Uri.parse('https://test.datadoghq.com/path');
-    expect(datadogSdk.headerTypesForHost(uri), {TracingHeaderType.datadog});
+    expect(datadogSdk.headerTypesForHost(uri),
+        {TracingHeaderType.datadog, TracingHeaderType.tracecontext});
   });
 
   test('headerTypesForHost with matching subdomain does not match root',


### PR DESCRIPTION
### What and why?

Change the default tracing headers to use both Datadog's format as well as the W3C tracecontext header types.

refs: RUM-1557

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests