### PR TITLE
feat: Dispatch iOS mappers to the main thread

### DIFF
--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -362,14 +362,16 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         let semaphore = DispatchSemaphore(value: 0)
 
         mainThreadMapperPerf.start()
-        methodChannel.invokeMethod(mapperName, arguments: ["event": encodedEvent]) { result in
-            if result == nil {
-                encodedResult = nil
-            } else if let result = result as? [String: Any] {
-                encodedResult = result
-            }
+        DispatchQueue.main.async {
+            methodChannel.invokeMethod(mapperName, arguments: ["event": encodedEvent]) { result in
+                if result == nil {
+                    encodedResult = nil
+                } else if let result = result as? [String: Any] {
+                    encodedResult = result
+                }
 
-            semaphore.signal()
+                semaphore.signal()
+            }
         }
 
         if semaphore.wait(timeout: .now() + DispatchTimeInterval.milliseconds(500)) == .timedOut {


### PR DESCRIPTION
### What and why?

Flutter method channels are only meant to be called on the main thread, so we're fixing the background calls for mappers to jump to the main thread first.

refs: RUM-1665 #496

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests