### PR TITLE
feat: Add tracestate headers when using W3C tracecontext

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -42,6 +42,7 @@ class OTelHttpTracingHeaders {
 
 class W3CTracingHeaders {
   static const traceparent = 'traceparent';
+  static const tracestate = 'tracestate';
 }
 
 enum TraceIdRepresentation {
@@ -194,13 +195,18 @@ Map<String, String> getTracingHeaders(
       }
       break;
     case TracingHeaderType.tracecontext:
-      final headerValue = [
+      final parentHeaderValue = [
         '00', // Version Code
         context.traceId.asString(TraceIdRepresentation.hex32Chars),
         context.spanId.asString(TraceIdRepresentation.hex16Chars),
         context.sampled ? '01' : '00'
       ].join('-');
-      headers[W3CTracingHeaders.traceparent] = headerValue;
+      final stateHeaderValue = [
+        's:$sampledString',
+        'o:rum',
+      ].join(';');
+      headers[W3CTracingHeaders.traceparent] = parentHeaderValue;
+      headers[W3CTracingHeaders.tracestate] = stateHeaderValue;
       break;
   }
 

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -118,9 +118,11 @@ void main() {
         context.traceId.asString(TraceIdRepresentation.hex32Chars);
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
-    final expectedHeader = '00-$traceString-$spanString-01';
+    final expectedParentHeader = '00-$traceString-$spanString-01';
+    const expectedStateHeader = 's:1;o:rum';
 
-    expect(headers['traceparent'], expectedHeader);
+    expect(headers['traceparent'], expectedParentHeader);
+    expect(headers['tracestate'], expectedStateHeader);
   });
 
   test('traceparent tracing headers are generated correctly { unsampled }', () {
@@ -132,8 +134,10 @@ void main() {
         context.traceId.asString(TraceIdRepresentation.hex32Chars);
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
-    final expectedHeader = '00-$traceString-$spanString-00';
+    final expectedParentHeader = '00-$traceString-$spanString-00';
+    const expectedStateHeader = 's:0;o:rum';
 
-    expect(headers['traceparent'], expectedHeader);
+    expect(headers['traceparent'], expectedParentHeader);
+    expect(headers['tracestate'], expectedStateHeader);
   });
 }

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -818,6 +818,15 @@ void verifyHeaders(
       traceInt = BigInt.tryParse(headerParts[1], radix: 16);
       spanInt = BigInt.tryParse(headerParts[2], radix: 16);
       expect(headerParts[3], shouldSample ? '01' : '00');
+      final stateHeader = headers['tracestate']!;
+      final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
+          (Map<String, String> value, element) {
+        final split = element.split(':');
+        value[split[0]] = split[1];
+        return value;
+      });
+      expect(stateParts['s'], shouldSample ? '1' : '0');
+      expect(stateParts['o'], 'rum');
       break;
   }
 

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -65,12 +65,21 @@ void main() {
         spanInt = BigInt.tryParse(metadata['x-b3-spanid'] ?? '', radix: 16);
         break;
       case TracingHeaderType.tracecontext:
-        var header = metadata['traceparent']!;
-        var headerParts = header.split('-');
+        var parentHeader = metadata['traceparent']!;
+        var headerParts = parentHeader.split('-');
         expect(headerParts[0], '00');
         traceInt = BigInt.tryParse(headerParts[1], radix: 16);
         spanInt = BigInt.tryParse(headerParts[2], radix: 16);
         expect(headerParts[3], sampled ? '01' : '00');
+        final stateHeader = metadata['tracestate']!;
+        final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
+            (Map<String, String> value, element) {
+          final split = element.split(':');
+          value[split[0]] = split[1];
+          return value;
+        });
+        expect(stateParts['s'], sampled ? '1' : '0');
+        expect(stateParts['o'], 'rum');
         break;
     }
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -94,6 +94,15 @@ void main() {
         traceInt = BigInt.tryParse(headerParts[1], radix: 16);
         spanInt = BigInt.tryParse(headerParts[2], radix: 16);
         expect(headerParts[3], '01');
+        final stateHeader = headers['tracestate']!;
+        final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
+            (Map<String, String> value, element) {
+          final split = element.split(':');
+          value[split[0]] = split[1];
+          return value;
+        });
+        expect(stateParts['s'], '1');
+        expect(stateParts['o'], 'rum');
         break;
     }
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -172,6 +172,16 @@ void main() {
         traceInt = BigInt.tryParse(headerParts[1], radix: 16);
         spanInt = BigInt.tryParse(headerParts[2], radix: 16);
         expect(headerParts[3], '01');
+        var stateHeader = verify(() => headers.add('tracestate', captureAny()))
+            .captured[0] as String;
+        final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
+            (Map<String, String> value, element) {
+          final split = element.split(':');
+          value[split[0]] = split[1];
+          return value;
+        });
+        expect(stateParts['s'], '1');
+        expect(stateParts['o'], 'rum');
         break;
     }
 


### PR DESCRIPTION
### What and why?

In order to correctly correlate distributed traces when using tracecontext, we need to supply some vendor specific extensions in `tracestate`.  This adds the sampling priority (which is always either 1 or 0 for Flutter) and the origin (always 'rum')

refs: RUM-1925

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests