### PR TITLE
fix: Fix automatic resource tracking in Flutter Web

### DIFF
--- a/examples/simple_example/ios/Podfile.lock
+++ b/examples/simple_example/ios/Podfile.lock
@@ -1,49 +1,82 @@
 PODS:
   - datadog_flutter_plugin (0.0.1):
-    - DatadogSDK (~> 1)
-    - DatadogSDKCrashReporting (~> 1)
+    - DatadogCore (~> 2)
+    - DatadogCrashReporting (~> 2)
+    - DatadogInternal (~> 2)
+    - DatadogLogs (~> 2)
+    - DatadogRUM (~> 2)
     - DictionaryCoder (= 1.0.8)
     - Flutter
-  - DatadogSDK (1.19.0)
-  - DatadogSDKCrashReporting (1.19.0):
-    - DatadogSDK (= 1.19.0)
-    - PLCrashReporter (~> 1.11.0)
+  - datadog_webview_tracking (0.0.1):
+    - DatadogWebViewTracking (~> 2)
+    - Flutter
+    - webview_flutter_wkwebview
+  - DatadogCore (2.4.0):
+    - DatadogInternal (= 2.4.0)
+  - DatadogCrashReporting (2.4.0):
+    - DatadogInternal (= 2.4.0)
+    - PLCrashReporter (~> 1.11.1)
+  - DatadogInternal (2.4.0)
+  - DatadogLogs (2.4.0):
+    - DatadogInternal (= 2.4.0)
+  - DatadogRUM (2.4.0):
+    - DatadogInternal (= 2.4.0)
+  - DatadogWebViewTracking (2.4.0):
+    - DatadogInternal (= 2.4.0)
   - DictionaryCoder (1.0.8)
   - Flutter (1.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - PLCrashReporter (1.11.0)
+  - PLCrashReporter (1.11.1)
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
+  - datadog_webview_tracking (from `.symlinks/plugins/datadog_webview_tracking/ios`)
   - Flutter (from `Flutter`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
 SPEC REPOS:
   trunk:
-    - DatadogSDK
-    - DatadogSDKCrashReporting
+    - DatadogCore
+    - DatadogCrashReporting
+    - DatadogInternal
+    - DatadogLogs
+    - DatadogRUM
+    - DatadogWebViewTracking
     - DictionaryCoder
     - PLCrashReporter
 
 EXTERNAL SOURCES:
   datadog_flutter_plugin:
     :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
+  datadog_webview_tracking:
+    :path: ".symlinks/plugins/datadog_webview_tracking/ios"
   Flutter:
     :path: Flutter
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: 286f35803b77ceb07bc1e0a383dd9fc231058473
-  DatadogSDK: 7608b3689363f4d4b0f09fbd7d1afa0c386e5dac
-  DatadogSDKCrashReporting: 46e492d957fa454101102e70b14f67bf33a36787
+  datadog_flutter_plugin: 89d7088ec5cc78c0ff2c24dbe7b7e67e6800a10b
+  datadog_webview_tracking: d46b58a9109c0d29e4d6ffdd4223cb23e4f328a9
+  DatadogCore: 67ce2f8cd2f58cc90bdee5486d847b49e4b31b0b
+  DatadogCrashReporting: 0d4bd014714946be77a1ed2d34897036892f2b7b
+  DatadogInternal: 5789bca7a0284b20655ba2a79738ac7d0cd56e70
+  DatadogLogs: 3b8c8778c32b780f916c2894b9d2c53bbf590803
+  DatadogRUM: 4207d091be536b888719969a7ca078e2c830819a
+  DatadogWebViewTracking: e7a5841f001f488fc0240d7cba1a984ab6c86e9a
   DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
-  PLCrashReporter: 7a9dff14a23ba5d2e28c6160f0bb6fada5e71a8d
+  PLCrashReporter: 5d2d3967afe0efad61b3048d617e2199a5d1b787
+  webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
 
 PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/examples/simple_example/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/simple_example/ios/Runner.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/examples/simple_example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/simple_example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ Release 2.0 introduces breaking changes. Follow the [Migration Guide](MIGRATING.
 * Update to v2.0 of Datadog SDKs.
 * Update UUID to ^4.0. See [#472]
 * Change default tracing headers for first party hosts to use both Datadog headers and W3C tracecontext headers.
+* Fix automatic resource tracking for Flutter Web
 
 ## 1.6.0
 

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -60,6 +60,8 @@ class DatadogSdk {
   }
 
   bool _initialized = false;
+  DatadogConfiguration? _configuration;
+  DatadogConfiguration? get configuration => _configuration;
 
   DatadogLogging? _logs;
   DatadogLogging? get logs => _logs;

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -74,7 +74,11 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
     try {
       if (configuration.rumConfiguration != null) {
         final rumWeb = DdRumPlatform.instance as DdRumWeb;
-        rumWeb.webInitialize(configuration, configuration.rumConfiguration!);
+        rumWeb.initialize(
+          configuration,
+          configuration.rumConfiguration!,
+          internalLogger,
+        );
         rumInitialized = true;
       }
     } catch (e) {

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -18,6 +18,11 @@ export 'src/internal_logger.dart';
 export 'src/rum/attributes.dart';
 export 'src/tracing/tracing_headers.dart';
 
+// Because resource tracking is in a separate package, but web needs resource
+// initialization during initialization, we put the configuration value in
+// additionalConfig under this key.
+const String trackResourcesConfigKey = '_dd.track_web_resources';
+
 /// A set of properties that Flutter can configure "late", meaning after the
 /// first call to [DatadogSdk.initialize].
 enum LateConfigurationProperty {
@@ -62,13 +67,13 @@ class FirstPartyHost {
   final String hostName;
   final Set<TracingHeaderType> headerTypes;
 
-  final RegExp _regExp;
+  final RegExp regExp;
 
   FirstPartyHost._(this.hostName, this.headerTypes)
-      : _regExp = RegExp('^(.*\\.)*${RegExp.escape(hostName)}\$');
+      : regExp = RegExp('^(.*\\.)*${RegExp.escape(hostName)}\$');
 
   bool matches(Uri uri) {
-    return _regExp.hasMatch(uri.host.toString());
+    return regExp.hasMatch(uri.host.toString());
   }
 
   static List<FirstPartyHost> createSanitized(

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -6,6 +6,7 @@
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 
 import 'src/tracking_http_client_plugin.dart'
     show DdHttpTrackingPluginConfiguration, DatadogTrackingHttpClientListener;
@@ -44,6 +45,7 @@ extension TrackingExtension on DatadogConfiguration {
   /// See also [DatadogConfiguration.firstPartyHostsWithTracingHeaders],
   /// [DatadogConfiguration.firstPartyHosts], [TracingHeaderType]
   void enableHttpTracking({DatadogTrackingHttpClientListener? clientListener}) {
+    additionalConfig[trackResourcesConfigKey] = true;
     addPlugin(
         DdHttpTrackingPluginConfiguration(clientListener: clientListener));
   }


### PR DESCRIPTION
### What and why?

Automatic resource tracking broke when we moved resource tracking to its own package. This re-enables that tracking and adds configurable tracing headers.

refs: RUM-2003

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests