### PR TITLE
fix: Add 'dd=' to tracestate header

### DIFF
--- a/packages/datadog_common_test/lib/datadog_common_test.dart
+++ b/packages/datadog_common_test/lib/datadog_common_test.dart
@@ -12,3 +12,4 @@ export 'src/decoders/span_decoder.dart';
 export 'src/mock_http_sever.dart';
 export 'src/request_log.dart';
 export 'src/testing_configuration.dart';
+export 'uri_matchers.dart';

--- a/packages/datadog_common_test/lib/src/data_helpers.dart
+++ b/packages/datadog_common_test/lib/src/data_helpers.dart
@@ -3,6 +3,8 @@
 // Copyright 2019-Present Datadog, Inc.
 import 'dart:math';
 
+import 'package:collection/collection.dart';
+
 final _random = Random();
 const _alphas = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const _numerics = '0123456789';
@@ -36,4 +38,18 @@ extension DurationHelpers on Duration {
   int get inNanoseconds {
     return inMicroseconds * 1000;
   }
+}
+
+Map<String, String> getDdTraceState(String header) {
+  final list = header.split(',');
+  final ddTraceState =
+      list.firstWhereOrNull((e) => e.startsWith('dd='))?.substring(3);
+  if (ddTraceState == null) return {};
+
+  return ddTraceState.split(';').fold<Map<String, String>>({},
+      (Map<String, String> value, element) {
+    final split = element.split(':');
+    value[split[0]] = split[1];
+    return value;
+  });
 }

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -206,7 +206,7 @@ Map<String, String> getTracingHeaders(
         'o:rum',
       ].join(';');
       headers[W3CTracingHeaders.traceparent] = parentHeaderValue;
-      headers[W3CTracingHeaders.tracestate] = stateHeaderValue;
+      headers[W3CTracingHeaders.tracestate] = 'dd=$stateHeaderValue';
       break;
   }
 

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -119,7 +119,7 @@ void main() {
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
     final expectedParentHeader = '00-$traceString-$spanString-01';
-    const expectedStateHeader = 's:1;o:rum';
+    const expectedStateHeader = 'dd=s:1;o:rum';
 
     expect(headers['traceparent'], expectedParentHeader);
     expect(headers['tracestate'], expectedStateHeader);
@@ -135,7 +135,7 @@ void main() {
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
     final expectedParentHeader = '00-$traceString-$spanString-00';
-    const expectedStateHeader = 's:0;o:rum';
+    const expectedStateHeader = 'dd=s:0;o:rum';
 
     expect(headers['traceparent'], expectedParentHeader);
     expect(headers['tracestate'], expectedStateHeader);

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
@@ -819,12 +820,8 @@ void verifyHeaders(
       spanInt = BigInt.tryParse(headerParts[2], radix: 16);
       expect(headerParts[3], shouldSample ? '01' : '00');
       final stateHeader = headers['tracestate']!;
-      final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
-          (Map<String, String> value, element) {
-        final split = element.split(':');
-        value[split[0]] = split[1];
-        return value;
-      });
+
+      final stateParts = getDdTraceState(stateHeader);
       expect(stateParts['s'], shouldSample ? '1' : '0');
       expect(stateParts['o'], 'rum');
       break;

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -21,5 +21,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   mocktail: ^0.3.0
   protobuf: ^2.1.0
+  datadog_common_test:
+    path: ../datadog_common_test
 
 flutter:

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_grpc_interceptor/datadog_grpc_interceptor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,13 +72,9 @@ void main() {
         traceInt = BigInt.tryParse(headerParts[1], radix: 16);
         spanInt = BigInt.tryParse(headerParts[2], radix: 16);
         expect(headerParts[3], sampled ? '01' : '00');
+
         final stateHeader = metadata['tracestate']!;
-        final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
-            (Map<String, String> value, element) {
-          final split = element.split(':');
-          value[split[0]] = split[1];
-          return value;
-        });
+        final stateParts = getDdTraceState(stateHeader);
         expect(stateParts['s'], sampled ? '1' : '0');
         expect(stateParts['o'], 'rum');
         break;

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:datadog_common_test/uri_matchers.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http.dart';
@@ -94,13 +94,9 @@ void main() {
         traceInt = BigInt.tryParse(headerParts[1], radix: 16);
         spanInt = BigInt.tryParse(headerParts[2], radix: 16);
         expect(headerParts[3], '01');
+
         final stateHeader = headers['tracestate']!;
-        final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
-            (Map<String, String> value, element) {
-          final split = element.split(':');
-          value[split[0]] = split[1];
-          return value;
-        });
+        final stateParts = getDdTraceState(stateHeader);
         expect(stateParts['s'], '1');
         expect(stateParts['o'], 'rum');
         break;

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:datadog_common_test/uri_matchers.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
@@ -172,14 +172,10 @@ void main() {
         traceInt = BigInt.tryParse(headerParts[1], radix: 16);
         spanInt = BigInt.tryParse(headerParts[2], radix: 16);
         expect(headerParts[3], '01');
-        var stateHeader = verify(() => headers.add('tracestate', captureAny()))
-            .captured[0] as String;
-        final stateParts = stateHeader.split(';').fold<Map<String, String>>({},
-            (Map<String, String> value, element) {
-          final split = element.split(':');
-          value[split[0]] = split[1];
-          return value;
-        });
+        final stateHeader =
+            verify(() => headers.add('tracestate', captureAny())).captured[0]
+                as String;
+        final stateParts = getDdTraceState(stateHeader);
         expect(stateParts['s'], '1');
         expect(stateParts['o'], 'rum');
         break;


### PR DESCRIPTION
### What and why?

`dd=` prefixed was missed in the original PR.

refs: RUM-1925

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests