### PR TITLE
fix: Add parent id to tracestate

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -195,15 +195,18 @@ Map<String, String> getTracingHeaders(
       }
       break;
     case TracingHeaderType.tracecontext:
+      final spanString =
+          context.spanId.asString(TraceIdRepresentation.hex16Chars);
       final parentHeaderValue = [
         '00', // Version Code
         context.traceId.asString(TraceIdRepresentation.hex32Chars),
-        context.spanId.asString(TraceIdRepresentation.hex16Chars),
+        spanString,
         context.sampled ? '01' : '00'
       ].join('-');
       final stateHeaderValue = [
         's:$sampledString',
         'o:rum',
+        'p:$spanString',
       ].join(';');
       headers[W3CTracingHeaders.traceparent] = parentHeaderValue;
       headers[W3CTracingHeaders.tracestate] = 'dd=$stateHeaderValue';

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -119,7 +119,7 @@ void main() {
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
     final expectedParentHeader = '00-$traceString-$spanString-01';
-    const expectedStateHeader = 'dd=s:1;o:rum';
+    final expectedStateHeader = 'dd=s:1;o:rum;p:$spanString';
 
     expect(headers['traceparent'], expectedParentHeader);
     expect(headers['tracestate'], expectedStateHeader);
@@ -135,7 +135,7 @@ void main() {
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
     final expectedParentHeader = '00-$traceString-$spanString-00';
-    const expectedStateHeader = 'dd=s:0;o:rum';
+    final expectedStateHeader = 'dd=s:0;o:rum;p:$spanString';
 
     expect(headers['traceparent'], expectedParentHeader);
     expect(headers['tracestate'], expectedStateHeader);

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
-import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_gql_link/datadog_gql_link.dart';
@@ -824,6 +823,7 @@ void verifyHeaders(
       final stateParts = getDdTraceState(stateHeader);
       expect(stateParts['s'], shouldSample ? '1' : '0');
       expect(stateParts['o'], 'rum');
+      expect(stateParts['p'], headerParts[2]);
       break;
   }
 

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -77,6 +77,7 @@ void main() {
         final stateParts = getDdTraceState(stateHeader);
         expect(stateParts['s'], sampled ? '1' : '0');
         expect(stateParts['o'], 'rum');
+        expect(stateParts['p'], headerParts[2]);
         break;
     }
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -99,6 +99,7 @@ void main() {
         final stateParts = getDdTraceState(stateHeader);
         expect(stateParts['s'], '1');
         expect(stateParts['o'], 'rum');
+        expect(stateParts['p'], headerParts[2]);
         break;
     }
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -178,6 +178,7 @@ void main() {
         final stateParts = getDdTraceState(stateHeader);
         expect(stateParts['s'], '1');
         expect(stateParts['o'], 'rum');
+        expect(stateParts['p'], headerParts[2]);
         break;
     }
 


### PR DESCRIPTION
### What and why?

Add the parent span id to the `tracestate` header to ensure a complete trace in the event of a broken proxy.

refs: RUM-1925

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests