### PR TITLE
feat: Add a finalizer for Loggers

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -94,7 +94,12 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
 
         getLogger(loggerHandle)?.let { logger ->
             try {
-                callLoggerMethod(logger, call, result)
+                if (call.method == "destroyLogger") {
+                    loggerRegistry.remove(loggerHandle)
+                    result.success(null)
+                } else {
+                    callLoggerMethod(logger, call, result)
+                }
             } catch (e: ClassCastException) {
                 result.error(
                     DatadogSdkPlugin.CONTRACT_VIOLATION,

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.datadog.android.Datadog
 import com.datadog.android.log.Logger
 import com.datadog.android.log.Logs
@@ -18,13 +19,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
-import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import io.mockk.clearAllMocks
-import io.mockk.clearStaticMockk
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
@@ -312,6 +310,33 @@ class DatadogLogsPluginTest {
 
         val logger = plugin.getLogger(loggerHandle)
         assertThat(logger).isNotNull()
+    }
+
+    @Test
+    fun `M removes logger W destroyLogger`(
+        @StringForgery loggerHandle: String
+    ) {
+        // GIVEN
+        val createCall = MethodCall("createLogger", mapOf(
+            "loggerHandle" to loggerHandle,
+            "configuration" to defaultLoggingConfig()
+        ))
+        val createResult = mockk<MethodChannel.Result>(relaxed = true)
+        plugin.onMethodCall(createCall, createResult)
+
+        val destroyCall = MethodCall("destroyLogger", mapOf(
+            "loggerHandle" to loggerHandle
+        ))
+        val destroyResult = mockk<MethodChannel.Result>(relaxed = true)
+
+        // WHEN
+        plugin.onMethodCall(destroyCall, destroyResult)
+
+        // THEN
+        verify { destroyResult.success(null) }
+
+        val logger = plugin.getLogger(loggerHandle)
+        assertThat(logger).isNull()
     }
 
     @Test

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
@@ -163,6 +163,30 @@ class DatadogLogsPluginTests: XCTestCase {
         XCTAssertNotNil(log)
     }
 
+    func testLogs_DestroyLogger_RemovesLoggerWithHandle() {
+        // Given
+        let createCall = FlutterMethodCall(methodName: "createLogger", arguments: [
+            "loggerHandle": "fake-uuid",
+            "configuration": defaultConfigArgs()
+        ] as [String: Any])
+        plugin.handle(createCall) { _ in }
+
+        // When
+        let destroyCall = FlutterMethodCall(methodName: "destroyLogger", arguments: [
+            "loggerHandle": "fake-uuid"
+        ] as [String: Any])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(destroyCall) { result in
+            resultStatus = .called(value: result)
+        }
+
+        XCTAssertEqual(resultStatus, .called(value: nil))
+
+        let log = plugin.logger(withHandle: "fake-uuid")
+        XCTAssertNil(log)
+    }
+
     func testLogCalls_WithMissingParameter_FailsWithContractViolation() {
         testContracts(contracts: contracts, plugin: plugin)
     }

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
@@ -116,6 +116,10 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
         }
 
         switch call.method {
+        case "destroyLogger":
+            loggerRegistry.removeValue(forKey: loggerHandle)
+            result(nil)
+
         case "log":
             if let message = arguments["message"] as? String,
                 let levelString = arguments["logLevel"] as? String {

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -1,7 +1,6 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
-// swiftlint:disable file_length
 
 import Flutter
 import UIKit
@@ -42,6 +41,7 @@ extension Datadog.Configuration {
     }
 }
 
+// swiftlint:disable type_body_length
 public class DatadogSdkPlugin: NSObject, FlutterPlugin {
     let channel: FlutterMethodChannel
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -16,6 +16,10 @@ export 'ddlog_event.dart';
 const _uuid = Uuid();
 
 class DatadogLogging {
+  static final Finalizer<DatadogLogger> _finalizer = Finalizer((logger) {
+    _platform.destroyLogger(logger.loggerHandle);
+  });
+
   static DatadogLogging? _instance;
 
   static DdLogsPlatform get _platform {
@@ -48,6 +52,7 @@ class DatadogLogging {
   DatadogLogger createLogger(DatadogLoggerConfiguration configuration) {
     final logger = DatadogLogger(core.internalLogger, configuration);
     DdLogsPlatform.instance.createLogger(logger.loggerHandle, configuration);
+    _finalizer.attach(logger, logger);
 
     return logger;
   }

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -40,6 +40,13 @@ class DdLogsMethodChannel extends DdLogsPlatform {
   }
 
   @override
+  Future<void> destroyLogger(String loggerHandle) {
+    return methodChannel.invokeMethod('destroyLogger', {
+      'loggerHandle': loggerHandle,
+    });
+  }
+
+  @override
   Future<void> log(
       String loggerHandle,
       LogLevel level,

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
@@ -28,6 +28,11 @@ class DdNoOpLogsPlatform extends DdLogsPlatform {
   }
 
   @override
+  Future<void> destroyLogger(String loggerHandle) {
+    return Future.value();
+  }
+
+  @override
   Future<void> log(
       String loggerHandle,
       LogLevel level,

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
@@ -41,6 +41,7 @@ abstract class DdLogsPlatform extends PlatformInterface {
 
   Future<void> createLogger(
       String loggerHandle, DatadogLoggerConfiguration config);
+  Future<void> destroyLogger(String loggerHandle);
 
   Future<void> log(
     String loggerHandle,

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -53,6 +53,11 @@ class DdLogsWeb extends DdLogsPlatform {
   }
 
   @override
+  Future<void> destroyLogger(String loggerHandle) async {
+    _activeLoggers.remove(loggerHandle);
+  }
+
+  @override
   Future<void> addAttribute(
       String loggerHandle, String key, Object value) async {
     final logger = _activeLoggers[loggerHandle];


### PR DESCRIPTION
### What and why?

Creating loggers can leak in native code if discarded in Dart. Adding the finalizer allows a logger that is no longer accessible in Dart to be removed from the log registry in native code, allowing native code to clean up the object.

refs: RUM-1069

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests