### PR TITLE
fix: Loggers incorrectly used themselves as their finalizer token

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,3 @@ If needed, a description of how this PR accomplishes what it does.
 
 - [ ] This pull request has appropriate unit and / or integration tests 
 - [ ] This pull request references a Github or JIRA issue
-
-### CI Configuration (optional)
-- [ ] Run unit tests
-- [ ] Run integration tests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,6 @@ workflows:
   _launch_ios_simulator:
     steps:
     - script:
-        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         title: Launch iOS Simulator
         inputs:
         - content: |-
@@ -100,12 +99,11 @@ workflows:
   _start_android_emulator:
     steps:
     - avd-manager@1:
-        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         inputs:
         - api_level: '30'
         - emulator_channel: 0
     - wait-for-android-emulator@1:
-        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
+        title: Wait for Android Emulator
   analyze:
     steps:
     - script:
@@ -134,8 +132,6 @@ workflows:
   core_build:
     envs:
     - FLUTTER_VERSION: stable
-    - DD_RUN_UNIT_TESTS: '1'
-    - DD_RUN_INTEGRATION_TESTS: '1'
     after_run:
     - _setup
     - check_dependencies
@@ -146,7 +142,6 @@ workflows:
   integration_android:
     steps:
     - script:
-        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         title: Android Integration Tests
         inputs:
         - content: |-
@@ -161,8 +156,6 @@ workflows:
   integration_android_from_stage:
     envs:
     - FLUTTER_VERSION: stable
-    - DD_RUN_UNIT_TESTS: '1'
-    - DD_RUN_INTEGRATION_TESTS: '1'
     after_run:
     - _setup
     - _start_android_emulator
@@ -175,7 +168,6 @@ workflows:
   integration_ios:
     steps:
     - script:
-        run_if: '{{enveq "DD_RUN_INTEGRATION_TESTS" "1"}}'
         title: iOS Integration Tests
         inputs:
         - content: |-
@@ -186,8 +178,6 @@ workflows:
   integration_ios_from_stage:
     envs:
     - FLUTTER_VERSION: stable
-    - DD_RUN_UNIT_TESTS: '1'
-    - DD_RUN_INTEGRATION_TESTS: '1'
     after_run:
     - _setup
     - _launch_ios_simulator
@@ -226,8 +216,6 @@ workflows:
   integration_web_from_stage:
     envs:
     - FLUTTER_VERSION: stable
-    - DD_RUN_UNIT_TESTS: '1'
-    - DD_RUN_INTEGRATION_TESTS: '1'
     after_run:
     - _setup
     - _install_chrome
@@ -240,8 +228,6 @@ workflows:
   nightly_android:
     envs:
     - FLUTTER_VERSION: stable
-    - DD_RUN_UNIT_TESTS: '1'
-    - DD_RUN_INTEGRATION_TESTS: '1'
     before_run:
     - _setup
     - _start_android_emulator
@@ -260,8 +246,6 @@ workflows:
   nightly_ios:
     envs:
     - FLUTTER_VERSION: stable
-    - DD_RUN_UNIT_TESTS: '1'
-    - DD_RUN_INTEGRATION_TESTS: '1'
     before_run:
     - _setup
     - _launch_ios_simulator
@@ -283,7 +267,6 @@ workflows:
   unit_test:
     steps:
     - script:
-        run_if: '{{enveq "DD_RUN_UNIT_TESTS" "1"}}'
         title: All Unit Tests
         inputs:
         - content: |-

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* `DatadogLogger` will no longer leak its reference to its native Logger.
 
 ## 2.0.0
 

--- a/packages/datadog_flutter_plugin/lib/src/helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/helpers.dart
@@ -27,7 +27,7 @@ bool _handleError(Object error, StackTrace stackTrace, String methodName,
     logger.error(
         'This may be a bug in the Datadog SDK. Please report it to Datadog.');
     logger.sendToDatadog(
-      'Platform exception caught by wrap(): ${error.toString()}',
+      'Platform exception caught by wrap($methodName): ${error.toString()}',
       stackTrace,
       'PlatformException',
     );

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -16,8 +16,8 @@ export 'ddlog_event.dart';
 const _uuid = Uuid();
 
 class DatadogLogging {
-  static final Finalizer<DatadogLogger> _finalizer = Finalizer((logger) {
-    _platform.destroyLogger(logger.loggerHandle);
+  static final Finalizer<String> _finalizer = Finalizer((loggerHandle) {
+    _platform.destroyLogger(loggerHandle);
   });
 
   static DatadogLogging? _instance;
@@ -52,7 +52,7 @@ class DatadogLogging {
   DatadogLogger createLogger(DatadogLoggerConfiguration configuration) {
     final logger = DatadogLogger(core.internalLogger, configuration);
     DdLogsPlatform.instance.createLogger(logger.loggerHandle, configuration);
-    _finalizer.attach(logger, logger);
+    _finalizer.attach(logger, logger.loggerHandle);
 
     return logger;
   }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -82,6 +82,8 @@ void main() {
     DdLogsPlatform.instance = mockLogsPlatform;
     when(() => mockLogsPlatform.enable(any(), any()))
         .thenAnswer((_) => Future.value());
+    when(() => mockLogsPlatform.destroyLogger(any()))
+        .thenAnswer((_) => Future.value());
 
     mockRumPlatform = MockRumPlatform();
     when(() => mockRumPlatform.enable(any(), any()))

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -38,6 +38,8 @@ void main() {
         .thenAnswer((_) => Future.value());
     when(() => mockPlatform.createLogger(any(), any()))
         .thenAnswer((_) => Future.value());
+    when(() => mockPlatform.destroyLogger(any()))
+        .thenAnswer((_) => Future.value());
 
     mockInternalLogger = MockInternalLogger();
     mockCore = MockDatadogSdk();


### PR DESCRIPTION
### What and why?

Objects in Dart cannot use themselves as finalizer tokens, otherwise they create a circular reference that leaks. I made this mistake in the initial implementation, but new versions of Dart throw if you do that.

This uses the logger handle as the finalization token (which was the only thing we needed anyway).

Also add the missing changelog item, and remove the no longer needed CI configuration.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

### CI Configuration (optional)
- [ ] Run unit tests
- [ ] Run integration tests