### PR TITLE
chore: Fix several releaser script bugs

### DIFF
--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -29,6 +29,12 @@ void main(List<String> arguments) async {
       help: "Don't perform checks on branch names or un-staged files",
       defaultsTo: false,
     )
+    ..addFlag(
+      'skip-changelog-check',
+      help:
+          "Don't check if there are any items in the changelog (for debuging the releaser only)",
+      defaultsTo: false,
+    )
     ..addOption(
       'ios-version',
       help: 'Explicitly set the iOS release this release will target',
@@ -103,20 +109,20 @@ void main(List<String> arguments) async {
     CreateBranchCommand(choreBranch),
     UpdateVersionsCommand(),
     CommitChangesCommand(
-        '🚀 Preparing for release of ${commandArgs.packageName} ${commandArgs.version}.'),
+        'chore: Preparing for release of ${commandArgs.packageName} ${commandArgs.version}.'),
     CreateReleaseBranchCommand(),
     RemoveDependencyOverridesCommand(),
     RemovePodOverridesCommand(),
     UpdateGradleFilesCommand(),
     CommitChangesCommand(
-      '🧹 Remove dependency overrides for release of ${commandArgs.packageName} ${commandArgs.version}.',
+      'chore: Remove dependency overrides for release of ${commandArgs.packageName} ${commandArgs.version}.',
       noChangesOkay: true,
     ),
     ValidatePublishDryRun(),
     SwitchBranchCommand(choreBranch),
     BumpVersionCommand(versionBumpType),
     CommitChangesCommand(
-        '📝 Bump version of ${commandArgs.packageName} to next potential release.'),
+        'chore: Bump version of ${commandArgs.packageName} to next potential release.'),
   ];
 
   for (final command in commands) {
@@ -136,6 +142,7 @@ Future<CommandArguments?> _validateArguments(ArgResults argResults) async {
   final version = argResults['version'];
   bool dryRun = argResults['dry-run'];
   bool skipGitChecks = argResults['skip-git-checks'];
+  bool skipChangelogCheck = argResults['skip-changelog-check'];
 
   final gitDir = await getGitDir();
   if (gitDir == null) {
@@ -147,6 +154,7 @@ Future<CommandArguments?> _validateArguments(ArgResults argResults) async {
     packageRoot: path.join(gitDir.path, 'packages', packageName),
     gitDir: gitDir,
     skipGitChecks: skipGitChecks,
+    skipChangelogCheck: skipChangelogCheck,
     version: version,
     iOSRelease: argResults['ios-version'],
     androidRelease: argResults['android-version'],

--- a/tools/releaser/lib/cocoapod_util.dart
+++ b/tools/releaser/lib/cocoapod_util.dart
@@ -13,8 +13,6 @@ final specDependencyPattern =
     RegExp(r"\s+s\.dependency\s+'(?<dependency>Datadog.+)', '.+");
 
 class RemovePodOverridesCommand extends Command {
-  final podspecLocation = 'ios/datadog_flutter_plugin.podspec';
-
   @override
   Future<bool> run(CommandArguments args, Logger logger) async {
     if (!await _removePodfileOverrides(args, logger)) {
@@ -31,9 +29,7 @@ class RemovePodOverridesCommand extends Command {
   Future<bool> _removePodfileOverrides(
       CommandArguments args, Logger logger) async {
     logger.info('ℹ️ Removing overrides from Podfiles.');
-    // Only modify files in the package we're shipping
-    for (var filePath
-        in podfileList.where((e) => e.contains(args.packageName))) {
+    for (var filePath in podfileList) {
       final file = File(path.join(args.gitDir.path, filePath));
       if (!file.existsSync()) {
         logger.shout('❌ Could not find file $filePath');
@@ -59,6 +55,8 @@ class RemovePodOverridesCommand extends Command {
   }
 
   Future<bool> _pinPodspecVersion(CommandArguments args, Logger logger) async {
+    final podspecLocation = 'ios/${args.packageName}.podspec';
+
     final file = File(path.join(
         args.gitDir.path, 'packages/${args.packageName}', podspecLocation));
 

--- a/tools/releaser/lib/command.dart
+++ b/tools/releaser/lib/command.dart
@@ -18,6 +18,9 @@ class CommandArguments {
   // Skip git and branch checks during the validate step
   final bool skipGitChecks;
 
+  // Skip changelog check
+  final bool skipChangelogCheck;
+
   // The version we're releasing
   final String version;
 
@@ -35,6 +38,7 @@ class CommandArguments {
     required this.packageRoot,
     required this.gitDir,
     required this.skipGitChecks,
+    required this.skipChangelogCheck,
     required this.version,
     required this.iOSRelease,
     required this.androidRelease,

--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -21,8 +21,7 @@ class UpdateGradleFilesCommand extends Command {
   }
 
   Future<bool> _updateGradleFiles(CommandArguments args, Logger logger) async {
-    for (var filePath
-        in gradleList.where((e) => e.contains(args.packageName))) {
+    for (var filePath in gradleList) {
       final file = File(path.join(args.gitDir.path, filePath));
       if (!file.existsSync()) {
         logger.shout('❌ Could not find file $filePath');
@@ -59,8 +58,6 @@ class UpdateGradleFilesCommand extends Command {
             inMavenBlock = false;
             if (writeMavenBlock) {
               line = mavenBlock.toString();
-            } else {
-              line = '';
             }
 
             // Reset to default values

--- a/tools/releaser/lib/release_validator.dart
+++ b/tools/releaser/lib/release_validator.dart
@@ -34,12 +34,14 @@ class ValidateReleaseCommand extends Command {
     bool isValid = true;
 
     isValid &= _validateVersionNumber(args.version, logger);
-    isValid &= await _validateChangeLog(packagePath, logger);
+    if (!args.skipChangelogCheck) {
+      isValid &= await _validateChangeLog(packagePath, logger);
+    }
 
     if (isValid) {
       // The only package that as a dependency on the iOS SDK version is datadog_flutter_plugin,
       // so only check / pin if that's the package we're releasing.
-      if (args.packageName == 'datadog_flutter_plugin') {
+      if (_hasNativeDependency(args.packageName)) {
         if (!await _validateiOSRelease(packagePath, args, logger)) {
           return false;
         }
@@ -50,6 +52,11 @@ class ValidateReleaseCommand extends Command {
     }
 
     return isValid;
+  }
+
+  bool _hasNativeDependency(String packageName) {
+    return packageName == 'datadog_flutter_plugin' ||
+        packageName == 'datadog_webview_tracking';
   }
 
   bool _validateVersionNumber(String versionNumber, Logger logger) {

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -176,7 +176,7 @@ Future<bool> _updateReadmeVersions(CommandArguments args, Logger logger) async {
 
         // Write the new version table:
         line = '''[//]: # (SDK Table)
-        
+
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
 | ${args.iOSRelease} | ${args.androidRelease} | 4.x.x |


### PR DESCRIPTION
### What and why?

The following bugs were fixed in the releaser script:
  * Native SDK versions set for non-core packages are now correct.
  * Dependency overrides are now removed from all packages during a release (fixes issues with building non-core packages during release).
  * Replaced gitmoji with conventional commits.
  * Removed a blank line when removing gradle dependency overrides
  * Removed extra whitespace when updating the SDK table.

refs: RUM-2140

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
