### PR TITLE
feat: Always enable urlSessionTracking on iOS

### DIFF
--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -17,7 +17,8 @@ public extension RUM.Configuration {
         }
 
         self.init(applicationID: applicationId)
-
+        
+        urlSessionTracking = .init()
         sessionSampleRate = (encoded["sessionSampleRate"] as? NSNumber)?.floatValue ?? 100.0
         longTaskThreshold = (encoded["longTaskThreshold"] as? NSNumber)?.doubleValue ?? 0.1
         trackFrustrations = (encoded["trackFrustrations"] as? NSNumber)?.boolValue ?? true


### PR DESCRIPTION
### What and why?

Setup the `RUM.Configuration` object to setup `urlSessionTracking` by default. This should allow Flutter applications that perform native network calls to setup URL tracking after initialization.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
