### PR TITLE
feat: Add `ignoreUrlPatterns`

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add the ability to ignore tracking on specific url patterns with `ignoreUrlPatterns`.
 
 ## 2.0.0
 

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -44,10 +44,14 @@ extension TrackingExtension on DatadogConfiguration {
   ///
   /// See also [DatadogConfiguration.firstPartyHostsWithTracingHeaders],
   /// [DatadogConfiguration.firstPartyHosts], [TracingHeaderType]
-  void enableHttpTracking({DatadogTrackingHttpClientListener? clientListener}) {
+  void enableHttpTracking(
+      {DatadogTrackingHttpClientListener? clientListener,
+      List<RegExp> ignoreUrlPatterns = const []}) {
     additionalConfig[trackResourcesConfigKey] = true;
-    addPlugin(
-        DdHttpTrackingPluginConfiguration(clientListener: clientListener));
+    addPlugin(DdHttpTrackingPluginConfiguration(
+      clientListener: clientListener,
+      ignoreUrlPatterns: ignoreUrlPatterns,
+    ));
   }
 }
 

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -105,7 +105,7 @@ class DatadogClient extends http.BaseClient {
             rumKey, rumHttpMethod, request.url.toString(), attributes);
       } catch (e, st) {
         datadogSdk.internalLogger.sendToDatadog(
-          '$DatadogClient encountered an error while attempting '
+          '$DatadogClient encountered an error while attempting'
           ' to track a send call: $e',
           st,
           e.runtimeType.toString(),

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -115,7 +115,7 @@ class DatadogTrackingHttpClient implements HttpClient {
           rum.startResource(rumKey, rumHttpMethod, url.toString());
         } catch (e, st) {
           datadogSdk.internalLogger.sendToDatadog(
-            '$DatadogTrackingHttpClient encountered an error while attempting '
+            '$DatadogTrackingHttpClient encountered an error while attempting'
             ' to track an _openUrl call: $e',
             st,
             e.runtimeType.toString(),

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
@@ -46,8 +46,12 @@ abstract class DatadogTrackingHttpClientListener {
 
 class DdHttpTrackingPluginConfiguration extends DatadogPluginConfiguration {
   DatadogTrackingHttpClientListener? clientListener;
+  List<RegExp> ignoreUrlPatterns;
 
-  DdHttpTrackingPluginConfiguration({this.clientListener});
+  DdHttpTrackingPluginConfiguration({
+    this.clientListener,
+    this.ignoreUrlPatterns = const [],
+  });
 
   @override
   DatadogPlugin create(DatadogSdk datadogInstance) {


### PR DESCRIPTION
### What and why?

Add a `ignoreUrlPatterns` parameter to the constructor of `DatadogClient` and the configuration of DatadogTrackingHttpClient to allow users to ignore specific Url patterns. This is useful when using a separate client for certain requests (such as the `datadog_gql_link`) but still want automatic tracking for all other URLs.

refs: RUM-1038

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
