### PR TITLE
fix: Move `LogLevel` to public file

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * `DatadogLogger` will no longer leak its reference to its native Logger.
+* Fix `LogLevel` being private. See [#518]
 
 ## 2.0.0
 
@@ -208,3 +209,4 @@ Release 2.0 introduces breaking changes. Follow the [Migration Guide](MIGRATING.
 [#416]: https://github.com/DataDog/dd-sdk-flutter/issues/416
 [#462]: https://github.com/DataDog/dd-sdk-flutter/issues/462
 [#472]: https://github.com/DataDog/dd-sdk-flutter/issues/472
+[#518]: https://github.com/DataDog/dd-sdk-flutter/issues/518

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -90,7 +90,7 @@ class DatadogSdk {
   /// Internal extension access to the configured platform
   DatadogSdkPlatform get platform => _platform;
 
-  /// Set the verbosity of the Datadog SDK. Set to [CoreLoggerLevel.info] by
+  /// Set the verbosity of the Datadog SDK. Set to [CoreLoggerLevel.warn] by
   /// default. All internal logging is enabled only when [kDebugMode] is
   /// set.
   CoreLoggerLevel get sdkVerbosity => internalLogger.sdkVerbosity;
@@ -121,7 +121,7 @@ class DatadogSdk {
 
   /// A helper function that will initialize Datadog and setup error reporting
   ///
-  /// See also, [DdRum.handleFlutterError], [DatadogTrackingHttpClient]
+  /// See also, [DatadogRum.handleFlutterError], [DatadogTrackingHttpClient]
   static Future<void> runApp(
     DatadogConfiguration configuration,
     TrackingConsent trackingConsent,

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -49,7 +49,7 @@ enum LateConfigurationProperty {
   /// Whether native views are being tracked. Currently unused.
   trackNativeViews,
 
-  /// Whether [DatadogConfiguration.reportFlutterPerformance] was set to true
+  /// Whether [DatadogRumConfiguration.reportFlutterPerformance] was set to true
   trackFlutterPerformance,
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -35,7 +35,7 @@ class AttachResponse {
   }
 }
 
-/// Result from initializing the platform. Individual members are set to [false]
+/// Result from initializing the platform. Individual members are set to `false`
 /// If there is an error loading that feature, such as being unable to load
 /// required JavaScript modules on web.
 @immutable

--- a/packages/datadog_flutter_plugin/lib/src/internal_logger.dart
+++ b/packages/datadog_flutter_plugin/lib/src/internal_logger.dart
@@ -39,7 +39,7 @@ class InternalLogger {
 
   /// Send a log to the Datadog org, not to the customer's org. This feature is
   /// used mostly to track potential issues in the Datadog SDK. The rate at which
-  /// data is sent to Datadog is set by [DatadogConfiguration.telemetrySampleRate]
+  /// data is sent to Datadog is set by [DatadogRumConfiguration.telemetrySampleRate]
   void sendToDatadog(String message, StackTrace? stack, String? kind) {
     DatadogSdkPlatform.instance
         .sendTelemetryError(message, stack.toString(), kind);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -15,6 +15,32 @@ export 'ddlog_event.dart';
 
 const _uuid = Uuid();
 
+/// Log levels defined by Datadog. Note that not all levels
+/// are supported by the Flutter SDK currently, although any
+/// level can be used for [DatadogLoggerConfiguration.remoteLogThreshold].
+enum LogLevel {
+  debug,
+  info,
+
+  /// Currently unsupported
+  // ignore: unused_field
+  notice,
+  warning,
+  error,
+
+  /// Currently unsupported
+  // ignore: unused_field
+  critical,
+
+  /// Currently unsupported
+  // ignore: unused_field
+  alert,
+
+  /// Currently unsupported
+  // ignore: unused_field
+  emergency
+}
+
 class DatadogLogging {
   static final Finalizer<String> _finalizer = Finalizer((loggerHandle) {
     _platform.destroyLogger(loggerHandle);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
@@ -7,22 +7,6 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '../../datadog_flutter_plugin.dart';
 import 'ddlogs_method_channel.dart';
 
-// Private for now until we can ensure all SDKs support all levels
-enum LogLevel {
-  debug,
-  info,
-  // ignore: unused_field
-  notice,
-  warning,
-  error,
-  // ignore: unused_field
-  critical,
-  // ignore: unused_field
-  alert,
-  // ignore: unused_field
-  emergency
-}
-
 abstract class DdLogsPlatform extends PlatformInterface {
   DdLogsPlatform() : super(token: _token);
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/log_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/log_configuration.dart
@@ -4,8 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
-import 'ddlog_event.dart';
-import 'ddlogs_platform_interface.dart';
+import 'ddlogs.dart';
 
 /// A function that allows you to modify or drop specific [LogEvent]s before
 /// they are sent to Datadog.

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
 
-/// Information about a View that will be passed to [DdRum.startView]
+/// Information about a View that will be passed to [DatadogRum.startView]
 class RumViewInfo {
   /// The name of the view
   final String name;
@@ -26,10 +26,10 @@ class RumViewInfo {
 }
 
 /// A function that can be used to supply custom information to
-/// [DdRum.startView].
+/// [DatadogRum.startView].
 ///
 /// Returning `null` from this function will prevent the call
-/// to [DdRum.startView].
+/// to [DatadogRum.startView].
 ///
 /// See [DatadogNavigationObserver.viewInfoExtractor].
 typedef ViewInfoExtractor = RumViewInfo? Function(Route<dynamic> route);
@@ -299,10 +299,10 @@ class DatadogNavigationObserverProvider extends InheritedWidget {
   final DatadogNavigationObserver navObserver;
 
   const DatadogNavigationObserverProvider({
-    Key? key,
+    super.key,
     required this.navObserver,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   @override
   bool updateShouldNotify(

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -78,10 +78,10 @@ class RumUserActionDetector extends StatefulWidget {
   final Widget child;
 
   const RumUserActionDetector({
-    Key? key,
+    super.key,
     required this.rum,
     required this.child,
-  }) : super(key: key);
+  });
 
   @override
   StatefulElement createElement() {
@@ -407,10 +407,10 @@ class RumUserActionAnnotation extends StatelessWidget {
   final Widget child;
 
   const RumUserActionAnnotation({
-    Key? key,
+    super.key,
     required this.description,
     required this.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
@@ -5,7 +5,6 @@
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/logs/ddlogs_method_channel.dart';
-import 'package:datadog_flutter_plugin/src/logs/ddlogs_platform_interface.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -26,8 +26,8 @@ typedef DatadogClientAttributesProvider = Map<String, Object?> Function(
 /// network requests and sending them to Datadog.
 ///
 /// If the RUM feature is enabled, the SDK will send information about RUM
-/// Resources (calling [DdRum.startResource], [DdRum.stopResource], and
-/// [DdRum.stopResourceWithErrorInfo]) for all intercepted requests.
+/// Resources (calling [DatadogRum.startResource], [DatadogRum.stopResource], and
+/// [DatadogRum.stopResourceWithErrorInfo]) for all intercepted requests.
 ///
 /// This can additionally set tracing headers on your requests, which allows for
 /// distributed tracing. You can set which format of tracing header using the

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -39,8 +39,8 @@ class DatadogTrackingHttpOverrides extends HttpOverrides {
 /// sending them to Datadog
 ///
 /// If the RUM feature is enabled, the SDK will send information about RUM
-/// Resources (calling [DdRum.startResource], [DdRum.stopResource], and
-/// [DdRum.stopResourceWithErrorInfo] for all intercepted requests.
+/// Resources (calling [DatadogRum.startResource], [DatadogRum.stopResource], and
+/// [DatadogRum.stopResourceWithErrorInfo] for all intercepted requests.
 ///
 /// The SDK will also create a tracing Span for each 1st-party request, and add
 /// extra HTTP headers to further propagate the trace. The percentage of


### PR DESCRIPTION
### What and why?

LogLevel is now used for `DatadogLogConfiguration.remoteLogLevel`, whereas before it was internal. Move it to a public file so that the remote log level can be configured.

LogLevel currently has all possible log levels, though only some are supported. Unsupported levels are documented, but it shouldn't be possible to send a log with an unsupported level.

Also update some out of date documentation.

refs: #518

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
