### PR TITLE
fix: Re-add `consolePrint`

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * `DatadogLogger` will no longer leak its reference to its native Logger.
-* Fix debug output from native DatadogSdk on iOS.
+* Fix debug output from native `DatadogSdk` on iOS.
 
 ## 2.0.0
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * `DatadogLogger` will no longer leak its reference to its native Logger.
+* Fix debug output from native DatadogSdk on iOS.
 
 ## 2.0.0
 

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -86,7 +86,18 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
             if let config = Datadog.Configuration.init(fromEncoded: configArg),
                let trackingConsentString: String = try? castUnwrap(arguments["trackingConsent"]) {
                 let trackingConsent = TrackingConsent.parseFromFlutter(trackingConsentString)
+
                 if !Datadog.isInitialized() {
+                    // Set log callback before initialization so errors in initialization
+                    // get printed
+                    if let setLogCallback = arguments["setLogCallback"] as? Bool,
+                       setLogCallback {
+                        oldConsolePrint = consolePrint
+                        consolePrint = { value in
+                            self.callLogCallback(value)
+                        }
+                    }
+
                     initialize(configuration: config, trackingConsent: trackingConsent)
                     currentConfiguration = configArg as [AnyHashable: Any]
 


### PR DESCRIPTION
### What and why?

This adds the output from the native iOS SDK into the Flutter console for easier debugging. It was accidentally removed during the v2 upgrade.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
