### PR TITLE
fix: Fix CoreLoggerLevel enum parsing in iOS

### DIFF
--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -227,7 +227,7 @@ class FlutterSdkTests: XCTestCase {
         plugin.initialize(configuration: flutterConfig, trackingConsent: .granted)
         let methodCall = FlutterMethodCall(
             methodName: "setSdkVerbosity", arguments: [
-                "value": "DatadogCoreLoggerLevel.debug"
+                "value": "CoreLoggerLevel.warn"
             ])
 
         var callResult = ResultStatus.notCalled
@@ -235,7 +235,7 @@ class FlutterSdkTests: XCTestCase {
             callResult = ResultStatus.called(value: result)
         }
 
-        XCTAssertEqual(Datadog.verbosityLevel, .debug)
+        XCTAssertEqual(Datadog.verbosityLevel, .warn)
         XCTAssertEqual(callResult, .called(value: nil))
     }
 

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogCoreExtensions.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogCoreExtensions.swift
@@ -56,10 +56,10 @@ public extension DatadogSite {
 extension CoreLoggerLevel {
     static func parseFromFlutter(_ value: String) -> Self {
         switch value {
-        case "DatadogCoreLoggerLevel.debug": return .debug
-        case "DatadogCoreLoggerLevel.warn": return .warn
-        case "DatadogCoreLoggerLevel.error": return .error
-        case "DatadogCoreLoggerLevel.critical": return .critical
+        case "CoreLoggerLevel.debug": return .debug
+        case "CoreLoggerLevel.warn": return .warn
+        case "CoreLoggerLevel.error": return .error
+        case "CoreLoggerLevel.critical": return .critical
         default: return .debug
         }
     }


### PR DESCRIPTION
### What and why?

Parsing of CoreLoggerLevel was incorrectly looking for `DatadogCoreLoggerLevel` on iOS, which defaulted it to `debug`.

Correct the parsing to use the correct string.

I've checked Android and it parses the enum correclty. 

### Review checklist

- [X] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
