### PR TITLE
fix:  Fix Android losing data on backgrounding

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `DatadogLogger` will no longer leak its reference to its native Logger.
 * Fix debug output from native `DatadogSdk` on iOS.
 * Fix `LogLevel` being private. See [#518]
+* Make `DatadogRumPlugin` a singleton on Android to avoid losing its connection to the `RUMMonitor` during backgrounding.
 
 ## 2.0.0
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
 import org.json.JSONArray
 import org.json.JSONObject
 
-class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
+class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler {
     companion object LogParameterNames {
         const val LOG_LEVEL = "logLevel"
         const val LOG_MESSAGE = "message"
@@ -38,6 +38,10 @@ class DatadogLogsPlugin : MethodChannel.MethodCallHandler {
 
         // See DatadogSdkPlugin's description of this same member
         private var previousConfiguration: Map<String, Any?>? = null
+
+        val instance: DatadogLogsPlugin by lazy {
+            DatadogLogsPlugin()
+        }
 
         // For testing purposes only
         internal fun resetConfig() {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.system.measureNanoTime
 
 @Suppress("StringLiteralDuplication")
-class DatadogRumPlugin(
+class DatadogRumPlugin internal constructor(
     rumInstance: RumMonitor? = null
 ) : MethodChannel.MethodCallHandler {
     companion object RumParameterNames {
@@ -68,6 +68,10 @@ class DatadogRumPlugin(
 
         // See DatadogSdkPlugin's description of this same member
         private var previousConfiguration: Map<String, Any?>? = null
+
+        val instance: DatadogRumPlugin by lazy {
+            DatadogRumPlugin()
+        }
 
         // For testing purposes only
         internal fun resetConfig() {
@@ -100,13 +104,11 @@ class DatadogRumPlugin(
         channel.setMethodCallHandler(null)
     }
 
-//    fun attachToExistingSdk() {
-//        rum = GlobalRum.get()
-//    }
-
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method != "enable" && rum == null) {
-            result.invalidOperation("Attempting to use RUM when it has not been enabled")
+            result.invalidOperation(
+                "Attempting to call ${call.method} on RUM when it has not been enabled"
+            )
             return
         }
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -62,8 +62,9 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         SynchronousQueue()
     )
 
-    val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin()
-    val rumPlugin: DatadogRumPlugin = DatadogRumPlugin()
+    // Because Flutter recreates the plugin, we have to rely on singletons for the contained plugins
+    val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin.instance
+    val rumPlugin: DatadogRumPlugin = DatadogRumPlugin.instance
 
     override fun onAttachedToEngine(
         flutterPluginBinding: FlutterPlugin.FlutterPluginBinding


### PR DESCRIPTION
### What and why?

Android is recreating the main DatadogSdkPlugin on background / foregrounding the application, which recreates the DatadogRumPlugin, which loses its previous reference to the RUMMonitor.  This is causing telemetry to report that RUM is being used when it's not enabled, and likely leading to lost data.

The fast fix is to have DatadogRumPlugin be a singleton, which is what's done here. I've made DatadogLogsPlugin one as well, although that was likely not needed.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
