### PR TITLE
chore: Fix issue native core package version pinning

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Loosen restrictions on native SDK versions to allow `datadog_flutter_plugin` to dictate them.
 
 ## 2.0.0
 

--- a/tools/releaser/lib/cocoapod_util.dart
+++ b/tools/releaser/lib/cocoapod_util.dart
@@ -19,8 +19,11 @@ class RemovePodOverridesCommand extends Command {
       return false;
     }
 
-    if (!await _pinPodspecVersion(args, logger)) {
-      return false;
+    // Other packages can keep looser version constraints
+    if (args.packageName == 'datadog_flutter_plugin') {
+      if (!await _pinPodspecVersion(args, logger)) {
+        return false;
+      }
     }
 
     return true;

--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -34,11 +34,14 @@ class UpdateGradleFilesCommand extends Command {
       bool inMavenBlock = false;
       bool writeMavenBlock = true;
       await transformFile(file, logger, args.dryRun, (line) {
-        final versionMatch = versionRegex.firstMatch(line);
-        if (versionMatch != null) {
-          final oldVersion = versionMatch.group(1);
-          line = line.replaceFirst('$versionPrefix = "$oldVersion"',
-              '$versionPrefix = "${args.androidRelease}"');
+        // Other packages can keep looser version constraints
+        if (args.packageName == 'datadog_flutter_plugin') {
+          final versionMatch = versionRegex.firstMatch(line);
+          if (versionMatch != null) {
+            final oldVersion = versionMatch.group(1);
+            line = line.replaceFirst('$versionPrefix = "$oldVersion"',
+                '$versionPrefix = "${args.androidRelease}"');
+          }
         }
 
         // Remove requests for external gradle files
@@ -55,16 +58,17 @@ class UpdateGradleFilesCommand extends Command {
             writeMavenBlock = false;
           }
           if (line.contains('}')) {
+            String? returnLine;
             inMavenBlock = false;
             if (writeMavenBlock) {
-              line = mavenBlock.toString();
+              returnLine = mavenBlock.toString();
             }
 
             // Reset to default values
             mavenBlock.clear();
             writeMavenBlock = true;
 
-            return line;
+            return returnLine;
           }
           return null;
         }


### PR DESCRIPTION
### What and why?

Non-core packages should likely keep looser version constraints to the native package, so that the core package can dictate what version is needed. Otherwise non-core packages that have native dependencies will need to be updated even if no internal have changed.

Also fix an issue where removing the snapshot override in maven resulted in an errant curly brace

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
