### PR TITLE
chore: Fix `flushAndDeinitialize`

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -77,6 +77,9 @@ class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler
         if (call.method == "enable") {
             enable(call, result)
             return
+        } else if (call.method == "deinitialize") {
+            deinitialize(call, result)
+            return
         }
 
         val loggerHandle = call.argument<String>("loggerHandle")
@@ -144,6 +147,11 @@ class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler
             // Maybe use DevLogger instead?
             Log.e(DATADOG_FLUTTER_TAG, MESSAGE_INVALID_LOGGER_REINITIALIZATION)
         }
+    }
+
+    private fun deinitialize(call: MethodCall, result: MethodChannel.Result) {
+        previousConfiguration = null
+        result.success(null)
     }
 
     @Suppress("LongMethod", "ComplexMethod", "NestedBlockDepth")

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -115,6 +115,7 @@ class DatadogRumPlugin internal constructor(
         try {
             when (call.method) {
                 "enable" -> enable(call, result)
+                "deinitialize" -> deinitialize(call, result)
                 "startView" -> startView(call, result)
                 "stopView" -> stopView(call, result)
                 "addTiming" -> addTiming(call, result)
@@ -146,7 +147,7 @@ class DatadogRumPlugin internal constructor(
         }
     }
 
-    fun enable(call: MethodCall, result: Result) {
+    private fun enable(call: MethodCall, result: Result) {
         val encodedConfig = call.argument<Map<String, Any?>>("configuration")
         val applicationId = encodedConfig?.get("applicationId") as? String
         if (previousConfiguration == null) {
@@ -180,6 +181,15 @@ class DatadogRumPlugin internal constructor(
             // Maybe use DevLogger instead?
             Log.e(DATADOG_FLUTTER_TAG, MESSAGE_INVALID_RUM_REINITIALIZATION)
         }
+
+        result.success(null)
+    }
+
+    private fun deinitialize(call: MethodCall, result: Result) {
+        previousConfiguration = null
+        rum = null
+
+        result.success(null)
     }
 
     fun attachToExistingSdk(monitor: RumMonitor) {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -332,8 +332,6 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         executor.submit {
             simpleInvokeOn("flushAndShutdownExecutors", Datadog)
             Datadog.stopInstance()
-
-            // TODO: deregister logs / RUM plugin
         }.get()
 
         result.success(null)

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile.lock
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile.lock
@@ -1,0 +1,95 @@
+PODS:
+  - datadog_flutter_plugin (0.0.1):
+    - DatadogCore (~> 2)
+    - DatadogCrashReporting (~> 2)
+    - DatadogInternal (~> 2)
+    - DatadogLogs (~> 2)
+    - DatadogRUM (~> 2)
+    - DictionaryCoder (= 1.0.8)
+    - Flutter
+  - DatadogCore (2.5.0):
+    - DatadogInternal (= 2.5.0)
+  - DatadogCrashReporting (2.5.0):
+    - DatadogInternal (= 2.5.0)
+    - PLCrashReporter (~> 1.11.1)
+  - DatadogInternal (2.5.0)
+  - DatadogLogs (2.5.0):
+    - DatadogInternal (= 2.5.0)
+  - DatadogRUM (2.5.0):
+    - DatadogInternal (= 2.5.0)
+  - DictionaryCoder (1.0.8)
+  - Flutter (1.0.0)
+  - integration_test (0.0.1):
+    - Flutter
+  - PLCrashReporter (1.11.1)
+
+DEPENDENCIES:
+  - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
+  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - Flutter (from `Flutter`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
+
+SPEC REPOS:
+  trunk:
+    - DictionaryCoder
+    - PLCrashReporter
+
+EXTERNAL SOURCES:
+  datadog_flutter_plugin:
+    :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
+  DatadogCore:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogCrashReporting:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogInternal:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogLogs:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogRUM:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  Flutter:
+    :path: Flutter
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
+
+CHECKOUT OPTIONS:
+  DatadogCore:
+    :commit: a53e62ed1f39cf3b525eeac607d6805a24513c09
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogCrashReporting:
+    :commit: a53e62ed1f39cf3b525eeac607d6805a24513c09
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogInternal:
+    :commit: a53e62ed1f39cf3b525eeac607d6805a24513c09
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogLogs:
+    :commit: a53e62ed1f39cf3b525eeac607d6805a24513c09
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogRUM:
+    :commit: a53e62ed1f39cf3b525eeac607d6805a24513c09
+    :git: https://github.com/DataDog/dd-sdk-ios
+
+SPEC CHECKSUMS:
+  datadog_flutter_plugin: 89d7088ec5cc78c0ff2c24dbe7b7e67e6800a10b
+  DatadogCore: a152fbcc24ea1a6b937c9844b1c1d5b86f0a375e
+  DatadogCrashReporting: 53b458152130de5505901e025e0dd031ce057f31
+  DatadogInternal: 96448807156495aa41a9f177b8c849a404618948
+  DatadogLogs: 2e67adf2e2cccd84b880b42f52e56cd0b8c7ef82
+  DatadogRUM: d807827ad24ae6c738867e853df38c6cb2bb555b
+  DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  integration_test: 13825b8a9334a850581300559b8839134b124670
+  PLCrashReporter: 5d2d3967afe0efad61b3048d617e2199a5d1b787
+
+PODFILE CHECKSUM: d68d1f8ed6795ad080bf4a1367ecb6cae1411562
+
+COCOAPODS: 1.12.1

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -216,10 +216,12 @@
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -252,6 +254,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -339,7 +342,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -418,7 +421,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -467,7 +470,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner/Info.plist
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<false/>
 	<key>FLTEnableImpeller</key>
   	<false />
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
@@ -81,6 +81,9 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
         if call.method == "enable" {
             enable(arguments: arguments, result: result)
             return
+        } else if call.method == "deinitialize" {
+            deinitialize(arguments: arguments, result: result)
+            return
         }
 
         guard let loggerHandle = arguments["loggerHandle"] as? String else {
@@ -233,6 +236,11 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
                 FlutterError.missingParameter(methodName: "enable")
             )
         }
+    }
+
+    private func deinitialize(arguments: [String: Any?], result: @escaping FlutterResult) {
+        currentConfiguration = nil        
+        result(nil)
     }
 }
 

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -94,6 +94,11 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "enable":
             enable(arguments: arguments, call: call)
+            result(nil)
+
+        case "deinitialize":
+            deinitialize(arguments: arguments, call: call)
+            result(nil)
 
         case "startView":
             if let key = arguments["key"] as? String,
@@ -325,6 +330,13 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                     " is not supported. Cold restart your application to change your current configuation."
                 )
             }
+        }
+    }
+
+    private func deinitialize(arguments: [String: Any?], call: FlutterMethodCall) {
+        if rum != nil {
+            currentConfiguration = nil
+            rum = nil
         }
     }
 

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -114,8 +114,12 @@ class DatadogSdk {
       plugin.shutdown();
     }
     _plugins.clear();
+    _rum?.deinitialize();
     _rum = null;
+
+    _logs?.deinitialize();
     _logs = null;
+
     _initialized = false;
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -75,6 +75,16 @@ class DatadogLogging {
     return logging;
   }
 
+  /// FOR INTERNAL USE ONLY
+  /// Deinitialize this Logs instance. Note that this does not propertly
+  /// deregister this Logs instance from the default Core, since this should
+  /// only be called from the Core
+  @internal
+  void deinitialize() {
+    wrap('rum.deinitialize', core.internalLogger, null,
+        () => _platform.deinitialize());
+  }
+
   DatadogLogger createLogger(DatadogLoggerConfiguration configuration) {
     final logger = DatadogLogger(core.internalLogger, configuration);
     DdLogsPlatform.instance.createLogger(logger.loggerHandle, configuration);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -81,7 +81,7 @@ class DatadogLogging {
   /// only be called from the Core
   @internal
   void deinitialize() {
-    wrap('rum.deinitialize', core.internalLogger, null,
+    wrap('logs.deinitialize', core.internalLogger, null,
         () => _platform.deinitialize());
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -31,6 +31,13 @@ class DdLogsMethodChannel extends DdLogsPlatform {
   }
 
   @override
+  Future<void> deinitialize() {
+    _core = null;
+    _logEventMapper = null;
+    return methodChannel.invokeMethod('deinitialize', {});
+  }
+
+  @override
   Future<void> createLogger(
       String loggerHandle, DatadogLoggerConfiguration config) {
     return methodChannel.invokeMethod('createLogger', {

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
@@ -8,7 +8,12 @@ import 'ddlogs_platform_interface.dart';
 class DdNoOpLogsPlatform extends DdLogsPlatform {
   @override
   Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config) {
-    throw UnimplementedError();
+    return Future.value();
+  }
+
+  @override
+  Future<void> deinitialize() {
+    return Future.value();
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
@@ -22,6 +22,7 @@ abstract class DdLogsPlatform extends PlatformInterface {
   }
 
   Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config);
+  Future<void> deinitialize();
 
   Future<void> createLogger(
       String loggerHandle, DatadogLoggerConfiguration config);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -32,6 +32,9 @@ class DdLogsWeb extends DdLogsPlatform {
       DatadogSdk core, DatadogLoggingConfiguration config) async {}
 
   @override
+  Future<void> deinitialize() async {}
+
+  @override
   Future<void> createLogger(
       String loggerHandle, DatadogLoggerConfiguration config) async {
     var loggerHandlers = [

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -158,6 +158,15 @@ class DatadogRum {
         LateConfigurationProperty.trackCrossPlatformLongTasks, detectLongTasks);
   }
 
+  /// FOR INTERNAL USE ONLY
+  /// Deinitialize this RUM instance. Note that this does not propertly
+  /// deregister this RUM instance from the default Core, since this should
+  /// only be called from the Core
+  @internal
+  void deinitialize() {
+    wrap('rum.deinitialize', logger, null, () => _platform.deinitialize());
+  }
+
   /// Notifies that the View identified by [key] starts being presented to the
   /// user. This view will show as [name] in the RUM explorer, and defaults to
   /// [key] if it is not provided. You can also attach custom [attributes],

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -34,6 +34,11 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
+  Future<void> deinitialize() {
+    return methodChannel.invokeMethod('deinitialize', {});
+  }
+
+  @override
   Future<void> addTiming(String name) {
     return methodChannel.invokeMethod(
       'addTiming',

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -51,6 +51,11 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
+  Future<void> deinitialize() {
+    return Future.value();
+  }
+
+  @override
   Future<void> removeAttribute(String key) => Future.value();
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -22,6 +22,7 @@ abstract class DdRumPlatform extends PlatformInterface {
   }
 
   Future<void> enable(DatadogSdk core, DatadogRumConfiguration configuration);
+  Future<void> deinitialize();
   Future<void> startView(
       String key, String name, Map<String, Object?> attributes);
   Future<void> stopView(String key, Map<String, Object?> attributes);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -55,6 +55,9 @@ class DdRumWeb extends DdRumPlatform {
       DatadogSdk core, DatadogRumConfiguration configuration) async {}
 
   @override
+  Future<void> deinitialize() async {}
+
+  @override
   Future<void> addAttribute(String key, dynamic value) async {
     _jsSetGlobalContextProperty(key, valueToJs(value, 'context'));
   }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -82,12 +82,16 @@ void main() {
     DdLogsPlatform.instance = mockLogsPlatform;
     when(() => mockLogsPlatform.enable(any(), any()))
         .thenAnswer((_) => Future.value());
+    when(() => mockLogsPlatform.deinitialize())
+        .thenAnswer((_) => Future.value());
     when(() => mockLogsPlatform.destroyLogger(any()))
         .thenAnswer((_) => Future.value());
 
     mockRumPlatform = MockRumPlatform();
     when(() => mockRumPlatform.enable(any(), any()))
         .thenAnswer((_) => Future<void>.value());
+    when(() => mockRumPlatform.deinitialize())
+        .thenAnswer((_) => Future.value());
     DdRumPlatform.instance = mockRumPlatform;
   });
 


### PR DESCRIPTION
### What and why?

Nightly monitors are failing because since v2.0 the `flushAndDeinitialize` code was broken, not properly shutting down the two "sub plugins."

This adds a `deinitialize` method to both sub-plugins to clean them out so they're prepared for re-initialization.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
