### PR TITLE
chore: Apply changelog from 2.1.1 point releaes

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+## 2.1.1
 
+* Update iOS SDK to 2.5.1. For a full list of changes, see the [iOS Changelog](https://github.com/DataDog/dd-sdk-ios/blob/develop/CHANGELOG.md#251--20-12-2023)
+  * Fix `view.time_spent` being not reported correctly in RUM views.
 
 ## 2.1.0
 


### PR DESCRIPTION
### What and why?

Add the CHANGELOG items from releasing 2.1.1

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
