### PR TITLE
Fix tracecontext header by lowercase the value

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -208,7 +208,7 @@ Map<String, String> getTracingHeaders(
         'o:rum',
         'p:$spanString',
       ].join(';');
-      headers[W3CTracingHeaders.traceparent] = parentHeaderValue;
+      headers[W3CTracingHeaders.traceparent] = parentHeaderValue.toLowerCase();
       headers[W3CTracingHeaders.tracestate] = 'dd=$stateHeaderValue';
       break;
   }

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -118,7 +118,7 @@ void main() {
         context.traceId.asString(TraceIdRepresentation.hex32Chars);
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
-    final expectedParentHeader = '00-$traceString-$spanString-01';
+    final expectedParentHeader = '00-$traceString-$spanString-01'.toLowerCase();
     final expectedStateHeader = 'dd=s:1;o:rum;p:$spanString';
 
     expect(headers['traceparent'], expectedParentHeader);
@@ -134,7 +134,7 @@ void main() {
         context.traceId.asString(TraceIdRepresentation.hex32Chars);
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
-    final expectedParentHeader = '00-$traceString-$spanString-00';
+    final expectedParentHeader = '00-$traceString-$spanString-00'.toLowerCase();
     final expectedStateHeader = 'dd=s:0;o:rum;p:$spanString';
 
     expect(headers['traceparent'], expectedParentHeader);


### PR DESCRIPTION
### What and why?

We've observed that the generated traceparent header from DD is UpperCase. It makes Otel doesn't recognize it as a valid traceparent.

|Uppercase (DD generated)|Lowecase (Proposed)|
|:---|:---|
|![Uppercase](https://github.com/DataDog/dd-sdk-flutter/assets/38237452/1709b07d-d728-42a5-b7f3-cd6b68d10e91)|![Lowercase](https://github.com/DataDog/dd-sdk-flutter/assets/38237452/e2f16828-2740-49c6-a731-53c9fddf54fb)|

![image](https://github.com/DataDog/dd-sdk-flutter/assets/38237452/6bbe0de5-6fe6-41b7-a399-26dd7ad32b6d)


reference:
* https://www.w3.org/TR/trace-context/#traceparent-header-field-values

### How?
LowerCase the traceparent header value

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
