### PR TITLE
fix: Set trace headers to lowercase

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add an accessor for current session Id.
+* Fix OTel trace and span ids to be lower hex. See [#543]
 
 ## 2.1.1
 

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -93,9 +93,9 @@ class TracingUUID {
       case TraceIdRepresentation.hex:
         return value.toRadixString(16);
       case TraceIdRepresentation.hex16Chars:
-        return value.toRadixString(16).toUpperCase().padLeft(16, '0');
+        return value.toRadixString(16).padLeft(16, '0');
       case TraceIdRepresentation.hex32Chars:
-        return value.toRadixString(16).toUpperCase().padLeft(32, '0');
+        return value.toRadixString(16).padLeft(32, '0');
     }
   }
 }

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -69,7 +69,7 @@ void main() {
         context.traceId.asString(TraceIdRepresentation.hex32Chars);
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
-    final expectedHeader = '$traceString-$spanString-1';
+    final expectedHeader = '$traceString-$spanString-1'.toLowerCase();
 
     expect(headers['b3'], expectedHeader);
   });
@@ -92,8 +92,8 @@ void main() {
     final spanString =
         context.spanId.asString(TraceIdRepresentation.hex16Chars);
 
-    expect(headers['X-B3-TraceId'], traceString);
-    expect(headers['X-B3-SpanId'], spanString);
+    expect(headers['X-B3-TraceId'], traceString.toLowerCase());
+    expect(headers['X-B3-SpanId'], spanString.toLowerCase());
     expect(headers['X-B3-ParentSpanId'], isNull);
     expect(headers['X-B3-Sampled'], '1');
   });
@@ -121,8 +121,8 @@ void main() {
     final expectedParentHeader = '00-$traceString-$spanString-01';
     final expectedStateHeader = 'dd=s:1;o:rum;p:$spanString';
 
-    expect(headers['traceparent'], expectedParentHeader);
-    expect(headers['tracestate'], expectedStateHeader);
+    expect(headers['traceparent'], expectedParentHeader.toLowerCase());
+    expect(headers['tracestate'], expectedStateHeader.toLowerCase());
   });
 
   test('traceparent tracing headers are generated correctly { unsampled }', () {
@@ -137,7 +137,7 @@ void main() {
     final expectedParentHeader = '00-$traceString-$spanString-00';
     final expectedStateHeader = 'dd=s:0;o:rum;p:$spanString';
 
-    expect(headers['traceparent'], expectedParentHeader);
-    expect(headers['tracestate'], expectedStateHeader);
+    expect(headers['traceparent'], expectedParentHeader.toLowerCase());
+    expect(headers['tracestate'], expectedStateHeader.toLowerCase());
   });
 }


### PR DESCRIPTION
### What and why?

All OTel trace and span ids should be lower hex. We were incorrectly uppercasing them.

refs: #543

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
