### PR TITLE
chore: Changes related to release of datadog_gql_link 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This is the monorepo for Datadog Flutter packages. To get started, check the
 | datadog_tracking_http_client | [![Pub](https://img.shields.io/pub/v/datadog_tracking_http_client.svg)](https://pub.dev/packages/datadog_tracking_http_client) | [packages/datadog_tracking_http_client](packages/datadog_tracking_http_client/) | 
 | datadog_webview_tracking | [![Pub](https://img.shields.io/pub/v/datadog_webview_tracking.svg)](https://pub.dev/packages/datadog_webview_tracking) | [packages/datadog_webview_tracking](packages/datadog_webview_tracking/) 
 | datadog_grpc_interceptor | [![Pub](https://img.shields.io/pub/v/datadog_grpc_interceptor.svg)](https://pub.dev/packages/datadog_grpc_interceptor) | [packages/datadog_grpc_interceptor](packages/datadog_grpc_interceptor/) | 
+| datadog_gql_link | [![Pub](https://img.shields.io/pub/v/datadog_gql_link.svg)](https://pub.dev/packages/datadog_gql_link) | [packages/datadog_gql_link](packages/datadog_gql_link/) | 
 
 # Contributing
 

--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 1.0.0
 
 * Initial release of datadog_gql_link

--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -1,3 +1,5 @@
-## 0.1.0
+# Changelog
+
+## 1.0.0
 
 * Initial release of datadog_gql_link

--- a/packages/datadog_gql_link/LICENSE
+++ b/packages/datadog_gql_link/LICENSE
@@ -1,4 +1,3 @@
-TODO: Add your license here.
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -1,6 +1,8 @@
 name: datadog_gql_link
 description: A package for tracking GraphQL calls in Datadog compatible with gql_link 
-version: 0.1.0
+homepage: http://datadoghq.com
+repository: https://github.com/DataDog/dd-sdk-flutter
+version: 1.0.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -2,7 +2,7 @@ name: datadog_gql_link
 description: A package for tracking GraphQL calls in Datadog compatible with gql_link 
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
-version: 1.0.0
+version: 1.1.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
### What and why?

Updates to CHANGELOG and pubsepc for release.

Also Added missing LICENSE as well as added gql_link to the main README.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
