### PR TITLE
fix(ios): Don't force unwrap `currentConfiguration`

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix an issue where initializing the DatadogSDK from multiple engines would crash on iOS. This does not provide multiple engine support.
+* Fix an issue where initializing the Datadog SDK from multiple engines would crash on iOS. This does not provide multiple engine support.
 
 ## 2.2.0
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Fix an issue where initializing the DatadogSDK from multiple engines would crash on iOS. This does not provide multiple engine support.
 
 ## 2.2.0
 

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -105,15 +105,21 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
                             CrashReporting.enable()
                         }
                     }
-                } else {
+                } else if let currentConfiguration = currentConfiguration {
                     let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
-                    if !dict.isEqual(to: currentConfiguration!) {
+                    if !dict.isEqual(to: currentConfiguration) {
                         consolePrint(
                             "🔥 Reinitialziing the DatadogSDK with different options, even after a hot restart," +
                             " is not supported. Cold restart your application to change your current configuation.",
                             .error
                         )
                     }
+                } else {
+                    consolePrint(
+                        "🔥 The DatadogSDK is already initialized but no previous configuration exists. Did you mean" +
+                        " to use attachToExisting? Note: Datadog does not currently support multiple Flutter engines on iOS.",
+                        .error
+                    )
                 }
                 result(nil)
             } else {


### PR DESCRIPTION
### What and why?

In the instance where `initialize` is called but Datadog is already initialized, if no previous configuration existed the force unwrap would cause a crash.  This can happen in cases where multiple calls to `initialize` were made in multiple engines.

This does not fix multiple engines support, but prevents the crash.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
