### PR TITLE
fix: Error setting firstPartyHosts in Flutter Web

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -13,7 +13,7 @@ For complete documentation, see the [official Datadog documentation][11].
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 2.6.0 | 2.5.0 | 4.x.x |
+| 2.6.0 | 2.5.0 | 5.x.x |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -37,7 +37,7 @@ class DdRumWeb extends DdRumPlatform {
       allowedTracingUrls: [
         for (final host in sanitizedFirstPartyHosts)
           _TracingUrl(
-            match: host.regExp,
+            match: host.regExp.toJs(),
             propagatorTypes:
                 host.headerTypes.map(_headerTypeToPropagatorType).toList(),
           )
@@ -200,11 +200,11 @@ String _headerTypeToPropagatorType(TracingHeaderType type) {
 @JS()
 @anonymous
 class _TracingUrl {
-  external RegExp match;
+  external JSRegExp match;
   external List<String> propagatorTypes;
 
   external factory _TracingUrl({
-    RegExp match,
+    JSRegExp match,
     List<String> propagatorTypes,
   });
 }
@@ -250,6 +250,12 @@ class _RumInitOptions {
     List<dynamic> allowedTracingUrls,
     List<String> enableExperimentalFeatures,
   });
+}
+
+extension ToJs on RegExp {
+  JSRegExp toJs() {
+    return JSRegExp(pattern);
+  }
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -3,6 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import 'package:flutter/foundation.dart';
+import 'package:js/js.dart';
 import 'package:js/js_util.dart' as jsutil;
 
 import '../datadog_flutter_plugin.dart';
@@ -57,6 +58,11 @@ dynamic valueToJs(Object? value, String parameterName) {
 // Regex specifying the format of a frame in a Dart stack trace.
 final _dartLineRegex =
     RegExp(r'(?<file>.+) (?<location>\d+:\d+)\s*(?<function>.+)');
+
+@JS('RegExp')
+class JSRegExp {
+  external factory JSRegExp([String? pattern, String? flags]);
+}
 
 String? convertWebStackTrace(StackTrace? stackTrace) {
   if (stackTrace == null) return null;

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -179,7 +179,7 @@ Future<bool> _updateReadmeVersions(CommandArguments args, Logger logger) async {
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| ${args.iOSRelease} | ${args.androidRelease} | 4.x.x |
+| ${args.iOSRelease} | ${args.androidRelease} | 5.x.x |
 
 [//]: # (End SDK Table)''';
         return line;


### PR DESCRIPTION
### What and why?

The Browser SDK is checking if the type supplied to firstPartyHosts is a RegExp, but the Dart RegExp returns `false` for that check.  Fix it so that we create a JavaScript RegExp.

Note, this only works because the RegExp is very simple in this case. More complicated RegExes may not convert properly.

refs: #554

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
