### PR TITLE
feat: Add `batchProcessingLevel` to configuration

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android._InternalProxy
+import com.datadog.android.core.configuration.BatchProcessingLevel
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.log.Logs
 import com.datadog.android.ndk.NdkCrashReports
@@ -248,6 +249,9 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         (encoded["uploadFrequency"] as? String)?.let {
             builder = builder.setUploadFrequency(parseUploadFrequency(it))
         }
+        (encoded["batchProcessingLevel"] as? String)?.let {
+            builder = builder.setBatchProcessingLevel(parseBatchProcessingLevel(it))
+        }
         (encoded["additionalConfig"] as? Map<String, Any>)?.let {
             builder = builder.setAdditionalConfiguration(it)
         }
@@ -377,6 +381,15 @@ internal fun parseCoreLoggerLevel(level: String): Int {
         "CoreLoggerLevel.error" -> Log.ERROR
         "CoreLoggerLevel.critical" -> Log.ASSERT
         else -> Log.INFO
+    }
+}
+
+internal fun parseBatchProcessingLevel(level: String): BatchProcessingLevel {
+    return when (level) {
+        "BatchProcessingLevel.low" -> BatchProcessingLevel.LOW
+        "BatchProcessingLevel.medium" -> BatchProcessingLevel.MEDIUM
+        "BatchProcessingLevel.high" -> BatchProcessingLevel.HIGH
+        else -> BatchProcessingLevel.MEDIUM
     }
 }
 

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogSdkPluginTest.kt
@@ -17,6 +17,7 @@ import assertk.assertions.isNotNull
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android.api.context.UserInfo
+import com.datadog.android.core.configuration.BatchProcessingLevel
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.privacy.TrackingConsent
@@ -125,6 +126,19 @@ class DatadogSdkPluginTest {
     }
 
     @Test
+    fun `M parse all batch processing levels W parseBatchProcessingLevel`() {
+        // WHEN
+        val low = parseBatchProcessingLevel("BatchProcessingLevel.low")
+        val medium = parseBatchProcessingLevel("BatchProcessingLevel.medium")
+        val high = parseBatchProcessingLevel("BatchProcessingLevel.high")
+
+        // THEN
+        assertThat(low).isEqualTo(BatchProcessingLevel.LOW)
+        assertThat(medium).isEqualTo(BatchProcessingLevel.MEDIUM)
+        assertThat(high).isEqualTo(BatchProcessingLevel.HIGH)
+    }
+
+    @Test
     fun `M parse all upload frequency W parseUploadFrequency`() {
         // WHEN
         val frequent = parseUploadFrequency("UploadFrequency.frequent")
@@ -198,13 +212,13 @@ class DatadogSdkPluginTest {
             "site" to null,
             "batchSize" to null,
             "uploadFrequency" to null,
+            "batchProcessingLevel" to null,
             "firstPartyHosts" to listOf<String>(),
             "additionalConfig" to mapOf<String, Any?>()
         )
 
         // WHEN
         val config = plugin.configurationBuilderFromEncoded(encoded)!!.build()
-
 
         // THEN
         assertThat(config.getPrivate("clientToken")).isEqualTo(clientToken)
@@ -229,6 +243,7 @@ class DatadogSdkPluginTest {
             "site" to "DatadogSite.us3",
             "batchSize" to "BatchSize.small",
             "uploadFrequency" to "UploadFrequency.frequent",
+            "batchProcessingLevel" to "BatchProcessingLevel.low",
             "additionalConfig" to mapOf<String, Any?>(
                 additionalKey to additionalValue
             )
@@ -242,6 +257,7 @@ class DatadogSdkPluginTest {
         assertThat(config.getPrivate("crashReportsEnabled")).isEqualTo(true)
         assertThat(coreConfig.getPrivate("site")).isEqualTo(DatadogSite.US3)
         assertThat(coreConfig.getPrivate("batchSize")).isEqualTo(BatchSize.SMALL)
+        assertThat(coreConfig.getPrivate("batchProcessingLevel")).isEqualTo(BatchProcessingLevel.LOW)
         assertThat(config.getPrivate("service")).isEqualTo(service)
         assertThat(config.getPrivate("additionalConfig")).isEqualTo(mapOf(
             additionalKey to additionalValue

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogConfigurationTests.swift
@@ -32,6 +32,16 @@ class DatadogConfigurationTests: XCTestCase {
         XCTAssertEqual(rare, .rare)
     }
 
+    func testAllBatchProcessingLevels_AreParsedCorrectly() {
+        let low = Datadog.Configuration.BatchProcessingLevel.parseFromFlutter("BatchProcessingLevel.low")
+        let medium = Datadog.Configuration.BatchProcessingLevel.parseFromFlutter("BatchProcessingLevel.medium")
+        let high = Datadog.Configuration.BatchProcessingLevel.parseFromFlutter("BatchProcessingLevel.high")
+
+        XCTAssertEqual(low, .low)
+        XCTAssertEqual(medium, .medium)
+        XCTAssertEqual(high, .high)
+    }
+
     func testAllTrackingConsents_AreParsedCorrectly() {
         let granted = TrackingConsent.parseFromFlutter("TrackingConsent.granted")
         let notGranted = TrackingConsent.parseFromFlutter("TrackingConsent.notGranted")
@@ -86,6 +96,7 @@ class DatadogConfigurationTests: XCTestCase {
             "site": nil,
             "batchSize": nil,
             "uploadFrequency": nil,
+            "batchProcessingLevel": nil,
             "additionalConfig": [:] as [String: Any?]
         ]
 
@@ -96,6 +107,7 @@ class DatadogConfigurationTests: XCTestCase {
         XCTAssertEqual(config.env, "fakeEnvironment")
         XCTAssertEqual(config.site, .us1)
         XCTAssertEqual(config.batchSize, .medium)
+        XCTAssertEqual(config.batchProcessingLevel, .medium)
         XCTAssertEqual(config.uploadFrequency, .average)
 
     }
@@ -107,6 +119,7 @@ class DatadogConfigurationTests: XCTestCase {
             "site": "DatadogSite.eu1",
             "batchSize": "BatchSize.small",
             "uploadFrequency": "UploadFrequency.frequent",
+            "batchProcessingLevel": "BatchProcessingLevel.low",
             "trackingConsent": "TrackingConsent.pending",
             "additionalConfig": [:] as [String: Any?]
         ]
@@ -118,6 +131,7 @@ class DatadogConfigurationTests: XCTestCase {
         XCTAssertNil(config.service)
         XCTAssertEqual(config.batchSize, .small)
         XCTAssertEqual(config.uploadFrequency, .frequent)
+        XCTAssertEqual(config.batchProcessingLevel, .low)
     }
 
     func testCoreConfiguration_ServiceName_IsDecoded() {

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogCoreExtensions.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogCoreExtensions.swift
@@ -39,6 +39,17 @@ public extension Datadog.Configuration.UploadFrequency {
     }
 }
 
+public extension Datadog.Configuration.BatchProcessingLevel {
+    static func parseFromFlutter(_ value: String) -> Self {
+        switch value {
+        case "BatchProcessingLevel.low": return .low
+        case "BatchProcessingLevel.medium": return .medium
+        case "BatchProcessingLevel.high": return .high
+        default: return .medium
+        }
+    }
+}
+
 public extension DatadogSite {
     static func parseFromFlutter(_ value: String) -> Self {
         switch value {

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -34,6 +34,10 @@ extension Datadog.Configuration {
                                                  Datadog.Configuration.UploadFrequency.parseFromFlutter) {
             self.uploadFrequency = uploadFrequency
         }
+        if let batchProcessingLevel = convertOptional(encoded["batchProcessingLevel"], 
+                                                      Datadog.Configuration.BatchProcessingLevel.parseFromFlutter) {
+            self.batchProcessingLevel = batchProcessingLevel
+        }
 
         _internal_mutation { config in
             config.additionalConfiguration = encoded["additionalConfig"] as? [String: Any] ?? [:]

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -31,6 +31,23 @@ enum UploadFrequency {
   rare
 }
 
+/// Defines the maximum amount of batches processed sequentially without a delay
+/// within one reading/uploading cycle. [high] means that more data will
+/// be sent in a single upload cycle but more CPU and memory will be used to
+/// process the data. [low] means that less data will be sent in a
+/// single upload cycle but less CPU and memory will be used to process the
+/// data.
+enum BatchProcessingLevel {
+  /// Prefer less processing with smaller batches, but less CPU and memory usage
+  low,
+
+  /// Medium batch processing. This is the default.
+  medium,
+
+  /// Prefer higher processing sending larger batches, but more CPU and memory usage
+  high,
+}
+
 /// Possible values for the Data Tracking Consent given by the user of the app.
 ///
 /// This value should be used to grant the permission for Datadog SDK to store
@@ -105,6 +122,9 @@ class DatadogConfiguration {
   /// Sets the preferred frequency of uploading data to Datadog servers. This
   /// value impacts the frequency of performing network requests by the SDK.
   UploadFrequency? uploadFrequency;
+
+  /// Sets the level of batch processing
+  BatchProcessingLevel? batchProcessingLevel;
 
   /// Sets the current version number of the application.
   ///
@@ -201,6 +221,7 @@ class DatadogConfiguration {
     this.service,
     this.uploadFrequency,
     this.batchSize,
+    this.batchProcessingLevel,
     this.version,
     this.flavor,
     List<String>? firstPartyHosts,
@@ -252,6 +273,7 @@ class DatadogConfiguration {
       'service': service,
       'batchSize': batchSize?.toString(),
       'uploadFrequency': uploadFrequency?.toString(),
+      'batchProcessingLevel': batchProcessingLevel?.toString(),
       'additionalConfig': encodedAdditionalConfig,
     };
   }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -132,6 +132,7 @@ void main() {
       'service': null,
       'batchSize': null,
       'uploadFrequency': null,
+      'batchProcessingLevel': null,
       'additionalConfig': <String, Object?>{},
     });
   });
@@ -144,11 +145,13 @@ void main() {
     )
       ..batchSize = BatchSize.small
       ..uploadFrequency = UploadFrequency.frequent
+      ..batchProcessingLevel = BatchProcessingLevel.low
       ..site = DatadogSite.eu1;
 
     final encoded = configuration.encode();
     expect(encoded['batchSize'], 'BatchSize.small');
     expect(encoded['uploadFrequency'], 'UploadFrequency.frequent');
+    expect(encoded['batchProcessingLevel'], 'BatchProcessingLevel.low');
     expect(encoded['site'], 'DatadogSite.eu1');
   });
 


### PR DESCRIPTION
### What and why?

Higher batch processing levels allow Datadog to send larger batches at once, but requires additional CPU and memory to do so.  This option was added to native SDKs and is now being exposed to Flutter.

refs: RUM-1859

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
