### PR TITLE
fix: int truncation in Flutter Web during trace id generation

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fix an issue where initializing the Datadog SDK from multiple engines would crash on iOS. This does not provide multiple engine support.
+* Fix an issue where Trace Id generation would throw a range error on Flutter web. See [#558]
 
 ## 2.2.0
 
@@ -236,3 +237,4 @@ Release 2.0 introduces breaking changes. Follow the [Migration Guide](MIGRATING.
 [#472]: https://github.com/DataDog/dd-sdk-flutter/issues/472
 [#518]: https://github.com/DataDog/dd-sdk-flutter/issues/518
 [#543]: https://github.com/DataDog/dd-sdk-flutter/pull/543
+[#558]: https://github.com/DataDog/dd-sdk-flutter/issues/558

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../datadog_internal.dart';
@@ -118,7 +119,7 @@ TracingUUID _generateTraceId() {
   // we assume it needs to be a positive signed 64-bit int, so only
   // use 63-bits.
   final highBits = _traceRandom.nextInt(1 << 31);
-  final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+  final lowBits = BigInt.from(_traceRandom.nextInt(pow(2, 32).toInt()));
 
   var traceId = BigInt.from(highBits) << 32;
   traceId += lowBits;


### PR DESCRIPTION
### What and why?

Flutter web only supports 32-bit integers as part of shifting, and will truncate past that. This resulted in a range error when generating a TraceId in Flutter Web for the gql_link packages.

refs: #558

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
