### PR TITLE
chore(build): Fix integration tests not failing on failure

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -101,8 +101,10 @@ scripts:
     run: |
       mkdir -p $MELOS_ROOT_PATH/.build/test-results
       cd example
+
+      bash -c 'set -euxo pipefail \
       flutter test integration_test --machine -d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID \
-      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_ios_integration.xml"
+      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_ios_integration.xml"'
     packageFilters:
       dirExists:  'example/integration_test'
       ignore: 'datadog_flutter_plugin'
@@ -113,8 +115,10 @@ scripts:
     exec: |
       mkdir -p $MELOS_ROOT_PATH/.build/test-results
       cd integration_test_app
+      
+      bash -c 'set -euxo pipefail; \
       flutter test integration_test --machine -d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID \
-      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_ios_integration.xml"
+      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_ios_integration.xml"'
     packageFilters:
       scope: 'datadog_flutter_plugin'
 
@@ -127,8 +131,10 @@ scripts:
     run: |
       mkdir -p $MELOS_ROOT_PATH/.build/test-results
       cd example
+
+      bash -c 'set -euxo pipefail; \
       flutter test integration_test --machine -d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID \
-      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_android_integration.xml"
+      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_android_integration.xml"'
     packageFilters:
       dirExists:  'example/integration_test'
       ignore: 'datadog_flutter_plugin'
@@ -139,8 +145,10 @@ scripts:
     exec: | 
       mkdir -p $MELOS_ROOT_PATH/.build/test-results
       cd integration_test_app
+      
+      bash -c 'set -euxo pipefail; \
       flutter test integration_test --machine -d emulator --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID \
-      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_android_integration.xml"
+      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_android_integration.xml"'
     packageFilters:
       scope: 'datadog_flutter_plugin'
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -102,7 +102,7 @@ scripts:
       mkdir -p $MELOS_ROOT_PATH/.build/test-results
       cd example
 
-      bash -c 'set -euxo pipefail \
+      bash -c 'set -euxo pipefail; \
       flutter test integration_test --machine -d iPhone --dart-define DD_CLIENT_TOKEN=$DD_CLIENT_TOKEN,DD_APPLICATION_ID=$DD_APPLICATION_ID \
       | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_ios_integration.xml"'
     packageFilters:

--- a/packages/datadog_common_test/lib/src/mock_http_sever.dart
+++ b/packages/datadog_common_test/lib/src/mock_http_sever.dart
@@ -69,8 +69,9 @@ class RecordingHttpServer {
         print(parsed.data);
         print('---- END REQUEST ----');
       }
-    } catch (e) {
+    } catch (e, st) {
       print('Failed parsing request: $e');
+      print(st.toString());
     }
 
     request.response.write('Hello, world!');

--- a/packages/datadog_common_test/lib/src/request_log.dart
+++ b/packages/datadog_common_test/lib/src/request_log.dart
@@ -65,7 +65,7 @@ class RequestLog {
         (contentEncoding.contains('deflate') ||
             contentEncoding.contains('gzip'));
     if (isZipped) {
-      decoded = await utf8.fuse(gzip).decoder.bind(request).single;
+      decoded = await utf8.fuse(gzip).decoder.bind(request).join();
     } else {
       decoded = await utf8.decodeStream(request);
     }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/configuration_telemetry_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/configuration_telemetry_test.dart
@@ -70,7 +70,9 @@ void main() {
       expect(config['track_views_manually'], false);
       expect(config['track_interactions'], true);
       expect(config['track_errors'], true);
-      expect(config['track_network_requests'], false);
+      // iOS's value for this isn't quite right, because we setup url session tracking
+      // even if it's not being used.
+      expect(config['track_network_requests'], Platform.isIOS);
       expect(config['track_native_views'], false);
       expect(config['track_cross_platform_long_tasks'], true);
       expect(config['track_flutter_performance'], true);

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
@@ -63,7 +63,7 @@ void main() {
     //   * logger-attribute2 should always be null
     //   * 'message' is replaced by 'xxxxxxxx'
     //   * the info message from the second_logger is not sent
-    expect(logs.length, equals(5));
+    expect(logs.length, equals(6));
 
     List<LogDecoder> firstLoggerLogs =
         logs.where((l) => l.loggerName != 'second_logger').toList();
@@ -111,6 +111,17 @@ void main() {
     expect(firstLoggerLogs[3].log['logger-attribute1'], isNull);
     expect(firstLoggerLogs[3].log['logger-attribute2'], isNull);
     expect(firstLoggerLogs[3].log['attribute'], 'value');
+
+    expect(firstLoggerLogs[4].status, 'error');
+    expect(firstLoggerLogs[4].message, 'Encountered an error');
+    expect(firstLoggerLogs[4].errorMessage, isNotNull);
+    if (!kIsWeb) {
+      expect(firstLoggerLogs[4].errorSourceType, 'flutter');
+      expect(firstLoggerLogs[4].tags, isNot(contains('my-tag')));
+      expect(firstLoggerLogs[4].tags, isNot(contains('tag1:tag-value')));
+    }
+    expect(firstLoggerLogs[4].log['logger-attribute1'], isNull);
+    expect(firstLoggerLogs[4].log['logger-attribute2'], isNull);
 
     List<LogDecoder> secondLoggerLogs =
         logs.where((l) => l.loggerName == 'second_logger').toList();

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -63,7 +63,7 @@ void main() {
         return logs.length >= 6;
       },
     );
-    expect(logs.length, greaterThanOrEqualTo(6));
+    expect(logs.length, greaterThanOrEqualTo(7));
 
     List<LogDecoder> firstLoggerLogs =
         logs.where((l) => l.loggerName != 'second_logger').toList();

--- a/packages/datadog_tracking_http_client/example/lib/main.dart
+++ b/packages/datadog_tracking_http_client/example/lib/main.dart
@@ -65,6 +65,10 @@ Future<void> main() async {
           )
         : null,
   );
+  if (testingConfiguration != null) {
+    // Add clear text if we're running an actual test.
+    configuration.additionalConfig['_dd.needsClearTextHttp'] = true;
+  }
 
   if (RumAutoInstrumentationScenarioConfig.instance.enableIoHttpTracking) {
     configuration.enableHttpTracking();


### PR DESCRIPTION
### What and why?

`tojunit` was disguising integration test failures. Add `set-euxo pipefail` to fix.

This will fail until #569 is merged.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
