### PR TITLE
fix: Fix default console logging functions

### DIFF
--- a/examples/simple_example/lib/screens/network_screen.dart
+++ b/examples/simple_example/lib/screens/network_screen.dart
@@ -8,7 +8,7 @@ import '../custom_card.dart';
 
 class NetworkScreen extends StatelessWidget {
   static const images = [
-    'https://placekitten.com/300/300',
+    'https://picsum.photos/200',
     'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
   ];
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add `error.source_type` to logs when a stack trace is provided.
+* Fix default console print functions. See [#575] and [#574]
 
 ## 2.3.0
 
@@ -253,3 +254,5 @@ Release 2.0 introduces breaking changes. Follow the [Migration Guide](MIGRATING.
 [#543]: https://github.com/DataDog/dd-sdk-flutter/pull/543
 [#554]: https://github.com/DataDog/dd-sdk-flutter/pull/554
 [#558]: https://github.com/DataDog/dd-sdk-flutter/issues/558
+[#574]: https://github.com/DataDog/dd-sdk-flutter/issues/574
+[#575]: https://github.com/DataDog/dd-sdk-flutter/issues/575

--- a/packages/datadog_flutter_plugin/lib/src/logs/log_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/log_configuration.dart
@@ -67,8 +67,8 @@ void simpleConsolePrint(
 CustomConsoleLogFunction simpleConsolePrintForLevel(LogLevel level) {
   return ((inLevel, message, errorMessage, errorKind, stackTrace, attributes) {
     if (kDebugMode) {
-      if (inLevel.index > level.index) {
-        print('[${level.name}] $message');
+      if (inLevel.index >= level.index) {
+        print('[${inLevel.name}] $message');
       }
     }
   });
@@ -145,7 +145,7 @@ class DatadogLoggerConfiguration {
     this.bundleWithTraceEnabled = true,
     this.networkInfoEnabled = true,
     double remoteSampleRate = 100,
-    this.customConsoleLogFunction,
+    this.customConsoleLogFunction = simpleConsolePrint,
   }) {
     this.remoteSampleRate = remoteSampleRate;
   }

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
@@ -94,8 +94,8 @@ void main() async {
 
     final view1 = session.visits[1];
     expect(view1.viewEvents.last.view.resourceCount, 2);
-    expect(view1.resourceEvents[0].url, 'https://placekitten.com/300/300');
-    // placekitten.com doesn't set contentType headers properly, so don't test it
+    // After redirects, we don't end up with a picsum.photos url.
+    expect(view1.resourceEvents[0].url.contains('picsum.photos'), isTrue);    
     expect(view1.resourceEvents[1].url,
         'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png');
     // Allow this to fail since we don't have as much control over them

--- a/packages/datadog_tracking_http_client/example/lib/http/rum_http_instrumentation_scenario.dart
+++ b/packages/datadog_tracking_http_client/example/lib/http/rum_http_instrumentation_scenario.dart
@@ -28,7 +28,7 @@ class _RumHttpInstrumentationScenarioState
   // scenario is run on its own, as they are not made through the http
   // package
   final images = [
-    'https://placekitten.com/300/300',
+    'https://picsum.photos/200',
     'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
   ];
 

--- a/packages/datadog_tracking_http_client/example/lib/io_http_client/rum_http_client_instrumentation_scenario.dart
+++ b/packages/datadog_tracking_http_client/example/lib/io_http_client/rum_http_client_instrumentation_scenario.dart
@@ -22,7 +22,7 @@ class RumHttpClientInstrumentationScenario extends StatefulWidget {
 class _RumHttpClientInstrumentationScenarioState
     extends State<RumHttpClientInstrumentationScenario> {
   final images = [
-    'https://placekitten.com/300/300',
+    'https://picsum.photos/200',
     'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
   ];
 


### PR DESCRIPTION
### What and why?

simpleConsolePrint as the default log printer was being overwritten in the configuration to null.

Additionally, `simpleConsolePrintForLevel` wrote the configured level and not the actual log level, and didn't log to console when the levels were equal.

refs: #574 #575

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
