### PR TITLE
feat: Support global log attributes

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `error.source_type` to logs when a stack trace is provided.
 * Fix default console print functions. See [#575] and [#574]
+* Add support for global attributes for logs.
 
 ## 2.3.0
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -74,11 +74,7 @@ class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler
     }
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-        if (call.method == "enable") {
-            enable(call, result)
-            return
-        } else if (call.method == "deinitialize") {
-            deinitialize(call, result)
+        if (handleGlobalMethod(call, result)) {
             return
         }
 
@@ -117,6 +113,37 @@ class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler
                 )
             }
         }
+    }
+
+    private fun handleGlobalMethod(call: MethodCall, result: MethodChannel.Result): Boolean {
+        if (call.method == "enable") {
+            enable(call, result)
+            return true
+        } else if (call.method == "deinitialize") {
+            deinitialize(call, result)
+            return true
+        } else if (call.method == "addGlobalAttribute") {
+            val key = call.argument<String>(LOG_KEY)
+            val value = call.argument<Any>(LOG_VALUE)
+            if (key != null && value != null) {
+                Logs.addAttribute(key, value)
+                result.success(null)
+            } else {
+                result.missingParameter(call.method)
+            }
+            return true
+        } else if (call.method == "removeGlobalAttribute") {
+            val key = call.argument<String>(LOG_KEY)
+            if (key != null) {
+                Logs.removeAttribute(key)
+                result.success(null)
+            } else {
+                result.missingParameter(call.method)
+            }
+            return true
+        }
+
+        return false
     }
 
     private fun enable(call: MethodCall, result: MethodChannel.Result) {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogLogsPluginTest.kt
@@ -215,6 +215,13 @@ class DatadogLogsPluginTest {
     }
 
     private val contracts = listOf(
+        Contract("addGlobalAttribute", mapOf(
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+            "value" to ContractParameter.Type(SupportedContractType.MAP),
+        )),
+        Contract("removeGlobalAttribute", mapOf(
+            "key" to ContractParameter.Type(SupportedContractType.STRING),
+        )),
         Contract("log", mapOf(
             "loggerHandle" to ContractParameter.Value("mock-logger"),
             "logLevel" to ContractParameter.Type(SupportedContractType.STRING),

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
@@ -96,6 +96,13 @@ class DatadogLogsPluginTests: XCTestCase {
     }
 
     let contracts = [
+        Contract(methodName: "addGlobalAttribute", requiredParameters: [
+            "key": .string,
+            "value": .map
+        ]),
+        Contract(methodName: "removeGlobalAttribute", requiredParameters: [
+            "key": .string            
+        ]),
         Contract(methodName: "log", requiredParameters: [
             "loggerHandle": .string,
             "logLevel": .string,
@@ -103,7 +110,8 @@ class DatadogLogsPluginTests: XCTestCase {
         ]),
         Contract(methodName: "addAttribute", requiredParameters: [
             "loggerHandle": .string,
-            "key": .string, "value": .map
+            "key": .string, 
+            "value": .map
         ]),
         Contract(methodName: "addTag", requiredParameters: [
             "loggerHandle": .string,

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -63,7 +63,7 @@ void main() {
         return logs.length >= 6;
       },
     );
-    expect(logs.length, greaterThanOrEqualTo(7));
+    expect(logs.length, greaterThanOrEqualTo(8));
 
     List<LogDecoder> firstLoggerLogs =
         logs.where((l) => l.loggerName != 'second_logger').toList();
@@ -78,6 +78,9 @@ void main() {
     expect(firstLoggerLogs[0].log['logger-attribute1'], 'string value');
     expect(firstLoggerLogs[0].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[0].log['stringAttribute'], 'string');
+    if (!kIsWeb) {
+      expect(firstLoggerLogs[0].log['global-attribute'], isNull);
+    }
 
     expect(firstLoggerLogs[1].status, 'info');
     expect(firstLoggerLogs[1].message, 'info message');
@@ -91,6 +94,9 @@ void main() {
         containsPair('internal', 'test'));
     expect(firstLoggerLogs[1].log['nestedAttribute'],
         containsPair('isValid', true));
+    if (!kIsWeb) {
+      expect(firstLoggerLogs[1].log['global-attribute'], isNull);
+    }
 
     expect(firstLoggerLogs[2].status, 'warn');
     expect(firstLoggerLogs[2].message, 'warn message');
@@ -101,6 +107,9 @@ void main() {
     expect(firstLoggerLogs[2].log['logger-attribute1'], 'string value');
     expect(firstLoggerLogs[2].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[2].log['doubleAttribute'], 10.34);
+    if (!kIsWeb) {
+      expect(firstLoggerLogs[2].log['global-attribute'], isNull);
+    }
 
     expect(firstLoggerLogs[3].status, 'error');
     expect(firstLoggerLogs[3].message, 'error message');
@@ -111,6 +120,9 @@ void main() {
     expect(firstLoggerLogs[3].log['logger-attribute1'], isNull);
     expect(firstLoggerLogs[3].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[3].log['attribute'], 'value');
+    if (!kIsWeb) {
+      expect(firstLoggerLogs[3].log['global-attribute'], 'global value');
+    }
 
     expect(firstLoggerLogs[4].status, 'error');
     expect(firstLoggerLogs[4].message, 'Encountered an error');
@@ -122,6 +134,9 @@ void main() {
     }
     expect(firstLoggerLogs[4].log['logger-attribute1'], isNull);
     expect(firstLoggerLogs[4].log['logger-attribute2'], 1000);
+    if (!kIsWeb) {
+      expect(firstLoggerLogs[4].log['global-attribute'], 'global value');
+    }
 
     List<LogDecoder> secondLoggerLogs =
         logs.where((l) => l.loggerName == 'second_logger').toList();
@@ -131,6 +146,9 @@ void main() {
     expect(secondLoggerLogs[0].log['second-logger-attribute'], 'second-value');
     expect(secondLoggerLogs[0].log['logger-attribute1'], isNull);
     expect(secondLoggerLogs[0].log['logger-attribute2'], isNull);
+    if (!kIsWeb) {
+      expect(secondLoggerLogs[0].log['global-attribute'], 'global value');
+    }
     expect(getNestedProperty<String>('logger.name', secondLoggerLogs[1].log),
         'second_logger');
 
@@ -139,8 +157,18 @@ void main() {
     expect(secondLoggerLogs[1].log['second-logger-attribute'], 'second-value');
     expect(secondLoggerLogs[1].log['logger-attribute1'], isNull);
     expect(secondLoggerLogs[1].log['logger-attribute2'], isNull);
+    if (!kIsWeb) {
+      expect(secondLoggerLogs[1].log['global-attribute'], 'global value');
+    }
     expect(secondLoggerLogs[1].errorMessage, 'Error Message');
     expect(secondLoggerLogs[1].errorStack, isNotNull);
+    expect(getNestedProperty<String>('logger.name', secondLoggerLogs[1].log),
+        'second_logger');
+
+    expect(secondLoggerLogs[2].status, 'info');
+    expect(secondLoggerLogs[2].message, 'Test local attribute override');
+    expect(secondLoggerLogs[2].log['second-logger-attribute'], 'second-value');
+    expect(secondLoggerLogs[2].log['global-attribute'], 'overridden');
     expect(getNestedProperty<String>('logger.name', secondLoggerLogs[1].log),
         'second_logger');
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -42,6 +42,8 @@ class _LoggingScenarioState extends State<LoggingScenario> {
     });
     logger.warn('warn message', attributes: {'doubleAttribute': 10.34});
 
+    DatadogSdk.instance.logs?.addAttribute('global-attribute', 'global value');
+
     logger.removeAttribute('logger-attribute1');
     logger.removeTagWithKey('tag1');
     logger.error('error message', attributes: {'attribute': 'value'});
@@ -66,6 +68,10 @@ class _LoggingScenarioState extends State<LoggingScenario> {
       errorMessage: 'Error Message',
       errorStackTrace: st,
     );
+
+    secondLogger.info('Test local attribute override', attributes: {
+      'global-attribute': 'overridden',
+    });
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs.dart
@@ -92,6 +92,28 @@ class DatadogLogging {
 
     return logger;
   }
+
+  /// Add a custom attribute to all future logs sent by all loggers.
+  ///
+  /// Values can be nested up to 10 levels deep. Keys using more than 10 levels
+  /// will be sanitized by SDK.
+  ///
+  /// All values must be supported by [StandardMessageCodec].
+  void addAttribute(String key, Object value) {
+    wrap('logs.addGlobalAttribute', core.internalLogger, {'value': value}, () {
+      return _platform.addGlobalAttribute(key, value);
+    });
+  }
+
+  /// Remove a custom attribute from all future logs sent by this logger.
+  ///
+  /// Previous logs won't lose the attribute value associated with this [key] if
+  /// they were created prior to this call.
+  void removeAttribute(String key) {
+    wrap('logs.removeGlobalAttribute', core.internalLogger, null, () {
+      return _platform.removeGlobalAttribute(key);
+    });
+  }
 }
 
 /// An interface for sending logs to Datadog.

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -32,6 +32,21 @@ class DdLogsMethodChannel extends DdLogsPlatform {
   }
 
   @override
+  Future<void> addGlobalAttribute(String key, Object value) {
+    return methodChannel.invokeMethod('addGlobalAttribute', {
+      'key': key,
+      'value': value,
+    });
+  }
+
+  @override
+  Future<void> removeGlobalAttribute(String key) {
+    return methodChannel.invokeMethod('removeGlobalAttribute', {
+      'key': key,
+    });
+  }
+
+  @override
   Future<void> deinitialize() {
     _core = null;
     _logEventMapper = null;

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_noop_platform.dart
@@ -12,6 +12,12 @@ class DdNoOpLogsPlatform extends DdLogsPlatform {
   }
 
   @override
+  Future<void> addGlobalAttribute(String key, Object value) async {}
+
+  @override
+  Future<void> removeGlobalAttribute(String key) async {}
+
+  @override
   Future<void> deinitialize() {
     return Future.value();
   }

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_platform_interface.dart
@@ -24,6 +24,9 @@ abstract class DdLogsPlatform extends PlatformInterface {
   Future<void> enable(DatadogSdk core, DatadogLoggingConfiguration config);
   Future<void> deinitialize();
 
+  Future<void> addGlobalAttribute(String key, Object value);
+  Future<void> removeGlobalAttribute(String key);
+
   Future<void> createLogger(
       String loggerHandle, DatadogLoggerConfiguration config);
   Future<void> destroyLogger(String loggerHandle);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -32,6 +32,12 @@ class DdLogsWeb extends DdLogsPlatform {
       DatadogSdk core, DatadogLoggingConfiguration config) async {}
 
   @override
+  Future<void> addGlobalAttribute(String key, Object value) async {}
+
+  @override
+  Future<void> removeGlobalAttribute(String key) async {}
+
+  @override
   Future<void> deinitialize() async {}
 
   @override

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
+import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/logs/ddlogs_method_channel.dart';
@@ -37,6 +38,26 @@ void main() {
         'loggerHandle': 'uuid',
         'configuration': config.encode(),
       })
+    ]);
+  });
+
+  test('addGlobalAttribute passed to method channel', () async {
+    final key = randomString();
+    final value = randomString();
+    await ddLogsPlatform.addGlobalAttribute(key, value);
+
+    expect(log, <Matcher>[
+      isMethodCall('addGlobalAttribute',
+          arguments: {'key': key, 'value': value})
+    ]);
+  });
+
+  test('removeGlobalAttribute passed to method channel', () async {
+    final key = randomString();
+    await ddLogsPlatform.removeGlobalAttribute(key);
+
+    expect(log, <Matcher>[
+      isMethodCall('removeGlobalAttribute', arguments: {'key': key})
     ]);
   });
 

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -42,6 +42,10 @@ void main() {
         .thenAnswer((_) => Future.value());
     when(() => mockPlatform.destroyLogger(any()))
         .thenAnswer((_) => Future.value());
+    when(() => mockPlatform.addGlobalAttribute(any(), any()))
+        .thenAnswer((_) => Future.value());
+    when(() => mockPlatform.removeGlobalAttribute(any()))
+        .thenAnswer((_) => Future.value());
 
     mockInternalLogger = MockInternalLogger();
     mockCore = MockDatadogSdk();
@@ -62,6 +66,21 @@ void main() {
       final logConfig =
           DatadogLoggerConfiguration(remoteLogThreshold: LogLevel.debug);
       ddLog = ddLogs.createLogger(logConfig);
+    });
+
+    test('logs.addAttribute calls to platform', () async {
+      final key = randomString();
+      final value = randomString();
+      ddLogs.addAttribute(key, value);
+
+      verify(() => mockPlatform.addGlobalAttribute(key, value));
+    });
+
+    test('logs.removeAttribute calls to platform', () async {
+      final key = randomString();
+      ddLogs.removeAttribute(key);
+
+      verify(() => mockPlatform.removeGlobalAttribute(key));
     });
 
     test('debug logs pass to platform', () async {


### PR DESCRIPTION
### What and why?

This allows attributes to be added, changed, and removed from all loggers managed by Datadog.

refs: RUM-3071

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
