### PR TITLE
fix: Loosen js package version

### DIFF
--- a/packages/datadog_common_test/lib/datadog_common_test.dart
+++ b/packages/datadog_common_test/lib/datadog_common_test.dart
@@ -12,4 +12,3 @@ export 'src/decoders/span_decoder.dart';
 export 'src/mock_http_sever.dart';
 export 'src/request_log.dart';
 export 'src/testing_configuration.dart';
-export 'uri_matchers.dart';

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Add `error.source_type` to logs when a stack trace is provided.
 * Fix default console print functions. See [#575] and [#574]
-* Loosen the restriciton on the `js` package to allow `<0.8`. See [#572]
+* Loosen the restriction on the `js` package to allow `<0.8`. See [#572]
 
 ## 2.3.0
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `error.source_type` to logs when a stack trace is provided.
 * Fix default console print functions. See [#575] and [#574]
+* Loosen the restriciton on the `js` package to allow `<0.8`. See [#572]
 
 ## 2.3.0
 
@@ -254,5 +255,6 @@ Release 2.0 introduces breaking changes. Follow the [Migration Guide](MIGRATING.
 [#543]: https://github.com/DataDog/dd-sdk-flutter/pull/543
 [#554]: https://github.com/DataDog/dd-sdk-flutter/pull/554
 [#558]: https://github.com/DataDog/dd-sdk-flutter/issues/558
+[#572]: https://github.com/DataDog/dd-sdk-flutter/issues/572
 [#574]: https://github.com/DataDog/dd-sdk-flutter/issues/574
 [#575]: https://github.com/DataDog/dd-sdk-flutter/issues/575

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.6.3
+  js: ">=0.6.3 <0.8.0"
   plugin_platform_interface: ^2.0.2
   json_annotation: ^4.7.0
   uuid: ^4.0.0

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_gql_link/datadog_gql_link.dart';

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http.dart';

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';


### PR DESCRIPTION
### What and why?

The js package has updated to 0.7 with a breaking change, but it does not seem to affect us. Loosening the restriction to allow up to 0.8.

refs: #572

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
