### PR TITLE
fix(rum): null passed to `addAttribute` should remove attributes

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix default console print functions. See [#575] and [#574]
 * Loosen the restriction on the `js` package to allow `<0.8`. See [#572]
 * Add support for global attributes for logs.
+* Passing `null` to `addAttribute` now calls `removeAttribute` instead of silently failing.
 
 ## 2.3.0
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -347,8 +347,13 @@ class DatadogRum {
 
   /// Adds a custom attribute with [key] and [value] to all future events sent
   /// by the RUM monitor. Note that [value] must be supported by
-  /// [StandardMessageCodec].
+  /// [StandardMessageCodec]. Passing a [value] of null is the same as calling
+  /// [removeAttribute]
   void addAttribute(String key, dynamic value) {
+    if (value == null) {
+      removeAttribute(key);
+      return;
+    }
     wrap('rum.addAttributes', logger, {'value': value}, () {
       return _platform.addAttribute(key, value);
     });

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -22,6 +22,14 @@ class MockDdLogsPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements DdLogsPlatform {}
 
+void silentLogger(
+    LogLevel level,
+    String message,
+    String? errorMessage,
+    String? errorKind,
+    StackTrace? stackTrace,
+    Map<String, Object?> attributes) {}
+
 void main() {
   late MockDatadogSdk mockCore;
   late MockInternalLogger mockInternalLogger;
@@ -63,8 +71,10 @@ void main() {
               mockPlatform.log(any(), any(), any(), any(), any(), any(), any()))
           .thenAnswer((invocation) => Future<void>.value());
 
-      final logConfig =
-          DatadogLoggerConfiguration(remoteLogThreshold: LogLevel.debug);
+      final logConfig = DatadogLoggerConfiguration(
+        remoteLogThreshold: LogLevel.debug,
+        customConsoleLogFunction: silentLogger,
+      );
       ddLog = ddLogs.createLogger(logConfig);
     });
 
@@ -187,6 +197,7 @@ void main() {
     final logConfig = DatadogLoggerConfiguration(
       remoteLogThreshold: LogLevel.debug,
       remoteSampleRate: sampleRate,
+      customConsoleLogFunction: silentLogger,
     );
     final logger = ddLogs.createLogger(logConfig);
     for (var i = 0; i < 1000; ++i) {
@@ -212,8 +223,10 @@ void main() {
     });
 
     test('threshold set to verbose always calls platform', () async {
-      final config =
-          DatadogLoggerConfiguration(remoteLogThreshold: LogLevel.debug);
+      final config = DatadogLoggerConfiguration(
+        remoteLogThreshold: LogLevel.debug,
+        customConsoleLogFunction: silentLogger,
+      );
       logger = ddLogs.createLogger(config);
 
       logger.debug('Debug message');
@@ -234,8 +247,10 @@ void main() {
 
     test('threshold set to middle sends call proper platform methods',
         () async {
-      final config =
-          DatadogLoggerConfiguration(remoteLogThreshold: LogLevel.warning);
+      final config = DatadogLoggerConfiguration(
+        remoteLogThreshold: LogLevel.warning,
+        customConsoleLogFunction: silentLogger,
+      );
       logger = ddLogs.createLogger(config);
 
       logger.debug('Debug message');
@@ -261,7 +276,10 @@ void main() {
     });
 
     test('sample set to none does not call platform', () async {
-      final config = DatadogLoggerConfiguration(remoteSampleRate: 0.0);
+      final config = DatadogLoggerConfiguration(
+        remoteSampleRate: 0.0,
+        customConsoleLogFunction: silentLogger,
+      );
       logger = ddLogs.createLogger(config);
 
       logger.debug('Debug message');

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -240,4 +240,26 @@ void main() {
     // Then
     expect(sessionId, fakeSessionId);
   });
+
+  test('addAttribute with null calls remove attribute instead', () async {
+    // Given
+    DdRumPlatform.instance = mockRumPlatform;
+    when(() => mockRumPlatform.enable(any(), any()))
+        .thenAnswer((_) => Future.value());
+    when(() => mockRumPlatform.removeAttribute(any()))
+        .thenAnswer((_) => Future.value());
+    final rum = await DatadogRum.enable(
+        mockDatadogSdk,
+        DatadogRumConfiguration(
+          applicationId: 'applicationId',
+          detectLongTasks: false,
+        ));
+
+    // when
+    rum!.addAttribute('attribute-key', null);
+
+    // Then
+    verify(() => mockRumPlatform.removeAttribute('attribute-key'));
+    verifyNever(() => mockRumPlatform.addAttribute(any(), any()));
+  });
 }


### PR DESCRIPTION
### What and why?

Passing `null` to `addAttribute` is causing a telemetry error complaining about a contract violation on the native side. The result is that the attribute wouldn't be changed.  This changes it so that if `null` is passed to `addAttribute`, it calls `removeAttribute` instead, which will prevent the contract violation and is likely more consistent with expectations.

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
