### PR TITLE
feat: Support custom error fingerprinting

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
@@ -23,4 +23,11 @@ class LogDecoder {
   String get errorMessage => getNestedProperty('error.message', log);
   String get errorStack => getNestedProperty('error.stack', log);
   String get errorSourceType => getNestedProperty('error.source_type', log);
+  String? get errorFingerprint {
+    if (!kManualIsWeb) {
+      return getNestedProperty('error.fingerprint', log);
+    } else {
+      return log['error.fingerprint'] as String?;
+    }
+  }
 }

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -212,6 +212,7 @@ class RumErrorEventDecoder extends RumEventDecoder {
   String get stack => rumEvent['error']['stack'];
   String get source => rumEvent['error']['source'];
   String get sourceType => rumEvent['error']['source_type'];
+  String get fingerprint => rumEvent['error']['fingerprint'];
 
   String? get resourceUrl => rumEvent['error']['resource']?['url'];
   String? get resourceMethod => rumEvent['error']['resource']?['method'];

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Loosen the restriction on the `js` package to allow `<0.8`. See [#572]
 * Add support for global attributes for logs.
 * Passing `null` to `addAttribute` now calls `removeAttribute` instead of silently failing.
+* Add support for custom error fingerprints with `DatadogAttributes.errorFingerprint`.
 
 ## 2.3.0
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -356,6 +356,7 @@ class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler
                     event.message = modifiedEvent.message
                     event.ddtags = modifiedEvent.ddtags
                     event.logger.name = modifiedEvent.logger.name
+                    event.error?.fingerprint = modifiedEvent.error?.fingerprint
 
                     event.additionalProperties.clear()
                     event.additionalProperties.putAll(modifiedEvent.additionalProperties)

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -703,6 +703,7 @@ class DatadogRumPlugin internal constructor(
                         }
 
                         event.error.stack = encodedError["stack"] as? String
+                        event.error.fingerprint = encodedError["fingerprint"] as? String
                     }
 
                     (encodedResult["view"] as? Map<String, Any?>)?.let {

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
@@ -55,7 +55,7 @@ void main() {
             .where(
                 (e) => !(e).containsKey('session') && e['type'] != 'telemetry')
             .forEach((e) => logs.add(LogDecoder(e)));
-        return logs.length >= 5;
+        return logs.length >= 6;
       },
     );
 
@@ -63,6 +63,7 @@ void main() {
     //   * logger-attribute2 should always be null
     //   * 'message' is replaced by 'xxxxxxxx'
     //   * the info message from the second_logger is not sent
+    //   * all error fingerprints on the second-logger are replaced with 'mapped print'
     expect(logs.length, equals(6));
 
     List<LogDecoder> firstLoggerLogs =
@@ -133,6 +134,7 @@ void main() {
     expect(secondLoggerLogs[0].log['logger-attribute2'], isNull);
     expect(secondLoggerLogs[0].errorMessage, 'Error Message');
     expect(secondLoggerLogs[0].errorStack, isNotNull);
+    expect(secondLoggerLogs[0].errorFingerprint, 'mapped print');
     expect(getNestedProperty<String>('logger.name', secondLoggerLogs[0].log),
         'second_logger');
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -60,7 +60,7 @@ void main() {
               return !(e).containsKey('session') && e['type'] != 'telemetry';
             })
             .forEach((e) => logs.add(LogDecoder(e)));
-        return logs.length >= 6;
+        return logs.length >= 8;
       },
     );
     expect(logs.length, greaterThanOrEqualTo(8));
@@ -162,6 +162,7 @@ void main() {
     }
     expect(secondLoggerLogs[1].errorMessage, 'Error Message');
     expect(secondLoggerLogs[1].errorStack, isNotNull);
+    expect(secondLoggerLogs[1].errorFingerprint, 'custom-fingerprint');
     expect(getNestedProperty<String>('logger.name', secondLoggerLogs[1].log),
         'second_logger');
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -70,6 +70,7 @@ void main() {
     var manualError = view.errorEvents[1];
     expect(manualError.message, contains('Rum error message'));
     expect(manualError.source, kIsWeb ? 'custom' : 'network');
+    expect(manualError.fingerprint, 'custom-fingerprint');
 
     var thrownError = view.errorEvents[2];
     expect(thrownError.message, contains('This was an error!'));

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -171,6 +171,7 @@ void main() {
       expect(view1.errorEvents[0].source, 'network');
       expect(view1.errorEvents[0].context![contextKey], expectedContextValue);
     }
+
     expect(view1, becameInactive);
 
     final view2 = session.visits[1];
@@ -202,6 +203,7 @@ void main() {
     expect(view2.errorEvents[0].source, kIsWeb ? 'custom' : 'source');
     expect(view2.errorEvents[0].context![contextKey], expectedContextValue);
     expect(view2.errorEvents[0].context!['custom_attribute'], 'my_attribute');
+    expect(view2.errorEvents[0].fingerprint, 'custom-fingerprint');
 
     // Check all long tasks are over 100 ms (the default) and that one is greater
     // than 200 ms (triggered by the tapping of the button)

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_mapping_test.dart
@@ -24,6 +24,7 @@ void main() {
   //  * actionMapper discards the 'Next Screen' tap
   //  * actionMapper discards 'User Scrolling' events
   //  * resourceMapper and errorMapper rewite the urls to replace 'fake_url' with 'my_url'
+  //  * errorMapper changes 'custom-fingerprint' to 'mapped fingerprint'
   //  * longTask mapper discards all long tasks less than 200 ms
   //  * longTask mapper renames ThirdManualRumView to ThirdView
   testWidgets('test instrumentation with mappers', (WidgetTester tester) async {
@@ -84,6 +85,8 @@ void main() {
           greaterThanOrEqualTo(
               const Duration(milliseconds: 200).inNanoseconds));
     }
+
+    expect(view2.errorEvents[0].fingerprint, 'mapped fingerprint');
 
     final view3 = session.visits[2];
     expect(view3.name, 'ThirdManualRumView');

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -3,6 +3,7 @@
 // Copyright 2016-Present Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:flutter/material.dart';
 
 class LoggingScenario extends StatefulWidget {
@@ -67,6 +68,9 @@ class _LoggingScenarioState extends State<LoggingScenario> {
       'Warning: this error occurred',
       errorMessage: 'Error Message',
       errorStackTrace: st,
+      attributes: {
+        DatadogAttributes.errorFingerprint: 'custom-fingerprint',
+      },
     );
 
     secondLogger.info('Test local attribute override', attributes: {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_error_reporting_scenario.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:flutter/material.dart';
 
 class RumManualErrorReportingScenario extends StatefulWidget {
@@ -36,7 +37,10 @@ class _RumManualErrorReportingScenarioState
         RumErrorSource.source,
         errorType: 'NullThrown',
       );
-      rum.addErrorInfo('Rum error message', RumErrorSource.network);
+      rum.addErrorInfo('Rum error message', RumErrorSource.network,
+          attributes: {
+            DatadogAttributes.errorFingerprint: 'custom-fingerprint',
+          },);
     }
   }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -220,6 +221,7 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
       RumErrorSource.source,
       attributes: {
         'custom_attribute': 'my_attribute',
+        DatadogAttributes.errorFingerprint: 'custom-fingerprint',
       },
     );
     DatadogSdk.instance.rum

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/scenario_runner.dart
@@ -45,6 +45,9 @@ RumErrorEvent? mapRumErrorEvent(RumErrorEvent event) {
     event.error.resource?.url =
         event.error.resource!.url.replaceAll('fake_url', 'my_url');
   }
+  if (event.error.fingerprint == 'custom-fingerprint') {
+    event.error.fingerprint = 'mapped fingerprint';
+  }
 
   return event;
 }
@@ -117,8 +120,11 @@ Future<void> runScenario({
 LogEvent? _mapLogEvent(LogEvent event) {
   event.attributes.remove('logger-attribute2');
 
-  if (event.logger.name == 'second_logger' && event.status == LogStatus.info) {
-    return null;
+  if (event.logger.name == 'second_logger') {
+    if (event.status == LogStatus.info) {
+      return null;
+    }
+    event.error?.fingerprint = 'mapped print';
   }
 
   event.message = event.message.replaceAll('message', 'xxxxxxxx');

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogLogsPlugin.swift
@@ -314,6 +314,10 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
                     let splitTags = tags.split(separator: ",").map { String($0) }
                     event.tags = splitTags
                 }
+                if let error = result["error"] as? [String: Any], 
+                   let fingerprint = error["fingerprint"] as? String {
+                    event.error?.fingerprint = fingerprint
+                }
 
                 // Go through all remaining attributes and add them on to the user
                 // attibutes so long as they aren't reserved

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -647,6 +647,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                 }
 
                 rumErrorEvent.error.stack = encodedError["stack"] as? String
+                rumErrorEvent.error.fingerprint = encodedError["fingerprint"] as? String
             }
 
             if let encodedView = encodedResult["view"] as? [String: Any?] {

--- a/packages/datadog_flutter_plugin/ios/Classes/LogEventEncoder.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/LogEventEncoder.swift
@@ -25,6 +25,7 @@ func logEventToFlutterDictionary(event: LogEvent) -> [String: Any]? {
     nest(property: "error.kind", inDictionary: &encoded)
     nest(property: "error.message", inDictionary: &encoded)
     nest(property: "error.stack", inDictionary: &encoded)
+    nest(property: "error.fingerprint", inDictionary: &encoded)
 
     // Switch "date" to a string (normally an int)
     encoded["date"] = event.date.description

--- a/packages/datadog_flutter_plugin/lib/src/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/attributes.dart
@@ -25,3 +25,10 @@ class DatadogPlatformAttributeKey {
   /// knows how to symbolize it. Expects `String` value.
   static const errorSourceType = '_dd.error.source_type';
 }
+
+/// Attributes that can be added to calls that have special properies in Datadog.
+class DatadogAttributes {
+  /// Add a custom fingerprint to an error.
+  /// The value of this attribute must be a `String`.
+  static const errorFingerprint = '_dd.error.fingerprint';
+}

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlog_event.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlog_event.dart
@@ -71,11 +71,13 @@ class LogEventError {
   final String? kind;
   final String? message;
   final String? stack;
+  String? fingerprint;
 
   LogEventError({
     this.kind,
     this.message,
     this.stack,
+    this.fingerprint,
   });
 
   factory LogEventError.fromJson(Map<dynamic, dynamic> json) =>

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -9,6 +9,7 @@ library ddlogs_flutter_web;
 import 'package:js/js.dart';
 
 import '../../datadog_flutter_plugin.dart';
+import '../../datadog_internal.dart';
 import '../web_helpers.dart';
 import 'ddlogs_platform_interface.dart';
 import 'ddweb_helpers.dart';
@@ -106,6 +107,14 @@ class DdLogsWeb extends DdLogsPlatform {
       error.stack = convertWebStackTrace(errorStackTrace);
       error.message = errorMessage;
       error.name = errorKind ?? 'Error';
+
+      // Move error fingerprint to its proper location
+      final fingerprint = attributes[DatadogAttributes.errorFingerprint];
+      if (fingerprint != null) {
+        attributes = Map.from(attributes)
+          ..remove(DatadogAttributes.errorFingerprint)
+          ..putIfAbsent('error.fingerprint', () => fingerprint);
+      }
     }
     logger?.log(
       message,

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddweb_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddweb_helpers.dart
@@ -17,4 +17,6 @@ extension JSErrorExtension on JSError {
   external String? stack;
   external String? message;
   external String? name;
+  // ignore: non_constant_identifier_names
+  external String? dd_fingerprint;
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
@@ -599,6 +599,7 @@ class RumError {
   final String? sourceType;
   String? stack;
   final String? type;
+  String? fingerprint;
 
   RumError({
     required this.causes,
@@ -612,6 +613,7 @@ class RumError {
     this.sourceType,
     this.stack,
     this.type,
+    this.fingerprint,
   });
 
   factory RumError.fromJson(Map<String, dynamic> json) =>

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -80,6 +80,11 @@ class DdRumWeb extends DdRumPlatform {
     jsError.message = error.toString();
     jsError.name = errorType ?? 'Error';
 
+    final fingerprint = attributes.remove(DatadogAttributes.errorFingerprint);
+    if (fingerprint != null) {
+      jsError.dd_fingerprint = fingerprint;
+    }
+
     _jsAddError(jsError, attributesToJs(attributes, 'attributes'));
   }
 
@@ -95,6 +100,11 @@ class DdRumWeb extends DdRumPlatform {
     jsError.stack = convertWebStackTrace(stackTrace);
     jsError.message = message;
     jsError.name = errorType ?? 'Error';
+
+    final fingerprint = attributes.remove(DatadogAttributes.errorFingerprint);
+    if (fingerprint != null) {
+      jsError.dd_fingerprint = fingerprint;
+    }
 
     _jsAddError(jsError, attributesToJs(attributes, 'attributes'));
   }


### PR DESCRIPTION
### What and why?

This works in a similar way to the Native SDKs where adding the attribute `DatadogAttributes.errorFingerprint` to a log or an `addError*` call in RUM will add the custom fingerprint to the error.

Modify the mappers to allow for modifying custom fingerprints as well.

refs: RUM-3600 #539

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
