### PR TITLE
fix: Enforce a stricter version in webview plugin

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -131,7 +131,7 @@ workflows:
         - working_dir: "$BITRISE_SOURCE_DIR/tools/third_party_scanner"
   core_build:
     envs:
-    - FLUTTER_VERSION: stable
+    - FLUTTER_VERSION: 3.16.5
     after_run:
     - _setup
     - check_dependencies
@@ -155,7 +155,7 @@ workflows:
         machine_type_id: standard
   integration_android_from_stage:
     envs:
-    - FLUTTER_VERSION: stable
+    - FLUTTER_VERSION: 3.16.5
     after_run:
     - _setup
     - _start_android_emulator
@@ -177,7 +177,7 @@ workflows:
             melos integration_test:ios
   integration_ios_from_stage:
     envs:
-    - FLUTTER_VERSION: stable
+    - FLUTTER_VERSION: 3.16.5
     after_run:
     - _setup
     - _launch_ios_simulator
@@ -215,7 +215,7 @@ workflows:
             melos integration_test:web:main
   integration_web_from_stage:
     envs:
-    - FLUTTER_VERSION: stable
+    - FLUTTER_VERSION: 3.16.5
     after_run:
     - _setup
     - _install_chrome
@@ -227,7 +227,7 @@ workflows:
         machine_type_id: standard
   nightly_android:
     envs:
-    - FLUTTER_VERSION: stable
+    - FLUTTER_VERSION: 3.16.5
     before_run:
     - _setup
     - _start_android_emulator
@@ -245,7 +245,7 @@ workflows:
         machine_type_id: standard
   nightly_ios:
     envs:
-    - FLUTTER_VERSION: stable
+    - FLUTTER_VERSION: 3.16.5
     before_run:
     - _setup
     - _launch_ios_simulator
@@ -288,4 +288,4 @@ app:
     IS_ON_CI: 'true'
   - opts:
       is_expand: false
-    FLUTTER_VERSION: stable
+    FLUTTER_VERSION: 3.16.5

--- a/examples/native-hybrid-app/android/app/build.gradle
+++ b/examples/native-hybrid-app/android/app/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.3.0"
 }
 
 plugins {

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -10,7 +10,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.8.22"
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.3.0"
 
     repositories {
         google()

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.3.0"
 }
 
 def localProperties = new Properties()

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
@@ -16,11 +16,11 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'DatadogCore', '~> 2'
-  s.dependency 'DatadogLogs', '~> 2'
-  s.dependency 'DatadogRUM', '~> 2'
-  s.dependency 'DatadogInternal', '~> 2'
-  s.dependency 'DatadogCrashReporting', '~> 2'
+  s.dependency 'DatadogCore', '2.5.0'
+  s.dependency 'DatadogLogs', '2.5.0'
+  s.dependency 'DatadogRUM', '2.5.0'
+  s.dependency 'DatadogInternal', '2.5.0'
+  s.dependency 'DatadogCrashReporting', '2.5.0'
   s.dependency 'DictionaryCoder', '1.0.8'
   s.platform = :ios, '11.0'
 

--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Re-restrict `datadog_webview_plugin` version.
+
 ## 2.0.1
 
 * Loosen restrictions on native SDK versions to allow `datadog_flutter_plugin` to dictate them.

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.datadog_version = "2+"
+    ext.datadog_version = "(2.0,2.5.1)"
 
     repositories {
         google()

--- a/packages/datadog_webview_tracking/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/datadog_webview_tracking/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.datadog_webview_tracking_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/packages/datadog_webview_tracking/example/android/app/src/profile/AndroidManifest.xml
+++ b/packages/datadog_webview_tracking/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.datadog_webview_tracking_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.


### PR DESCRIPTION
### What and why?

A loose version in the webview plugin is causing a crash because it's pulling down the latest version of Datadog Core while not pulling down the latest version of Datadog RUM, which has a binary incompatibility.

refs: #583

### How?

I'm using a version range, as the webiew package should still be able to use anything in the 2.x line up to 2.7

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
