### PR TITLE
fix: throw original error when ignore url is matched

### DIFF
--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -137,9 +137,9 @@ class DatadogTrackingHttpClient implements HttpClient {
             userAttributes: userAttributes);
       }
     } catch (e) {
-      if (rum != null) {
+      if (rum != null && rumKey != null) {
         rum.stopResourceWithErrorInfo(
-            rumKey!, e.toString(), e.runtimeType.toString(), userAttributes);
+            rumKey, e.toString(), e.runtimeType.toString(), userAttributes);
       }
       rethrow;
     }

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -548,6 +548,27 @@ void main() {
       verifyNoMoreInteractions(mockRum);
     });
 
+    test('ignoreUrlPatterns does not perform tracking on matching url even though innerClient throw error', () async {
+      const error = SocketException('Mock socket exception');
+      when(() => mockClient.openUrl(any(), any())).thenThrow(error);
+      final client = DatadogTrackingHttpClient(
+        mockDatadog,
+        DdHttpTrackingPluginConfiguration(
+          ignoreUrlPatterns: [
+            RegExp('test_url/path'),
+          ]
+        ),
+        mockClient,
+      );
+
+      var url = Uri.parse('https://test_url/path');
+
+      await expectLater(() async => await client.openUrl('get', url),
+          throwsA(predicate((e) => e == error)));
+
+      verifyNoMoreInteractions(mockRum);
+    });
+
     test('error on openUrl stops resource with error', () async {
       const error = SocketException('Mock socket exception');
       when(() => mockClient.openUrl(any(), any())).thenThrow(error);


### PR DESCRIPTION
### What and why?

Fixes #589
Related PR #517

`DatadogTrackingHttpClient` throws original errors even if request URL is matched to ignoreUrlPatterns.

### How?

Not call `stopResourceWithErrorInfo` when rumKey is null because rumKey is always null when request URL is matched to `ignoreUrlPatterns`.
`DatadogClient` already does but `DatadogTrackingHttpClient` doesn't.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
