### PR TITLE
fix: throw original error when ignore url is matched

### DIFF
--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -10,7 +10,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.8.22"
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.5.0"
 
     repositories {
         google()

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.5.0"
 }
 
 def localProperties = new Properties()

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
@@ -16,11 +16,11 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.static_framework = true
   s.dependency 'Flutter'
-  s.dependency 'DatadogCore', '~> 2'
-  s.dependency 'DatadogLogs', '~> 2'
-  s.dependency 'DatadogRUM', '~> 2'
-  s.dependency 'DatadogInternal', '~> 2'
-  s.dependency 'DatadogCrashReporting', '~> 2'
+  s.dependency 'DatadogCore', '~> 2.6.0'
+  s.dependency 'DatadogLogs', '~> 2.6.0'
+  s.dependency 'DatadogRUM', '~> 2.6.0'
+  s.dependency 'DatadogInternal', '~> 2.6.0'
+  s.dependency 'DatadogCrashReporting', '~> 2.6.0'
   s.dependency 'DictionaryCoder', '1.0.8'
   s.platform = :ios, '11.0'
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix _TypeError when request URL is matched ignoreUrlPatterns. See [#590] (Thanks [@ronnnnn][])
+
 ## 2.1.0
 
 * Add the ability to ignore tracking on specific url patterns with `ignoreUrlPatterns`.
@@ -72,3 +76,5 @@
 
 [#355]: https://github.com/DataDog/dd-sdk-flutter/issues/355
 [#424]: https://github.com/DataDog/dd-sdk-flutter/issues/424
+[#590]: https://github.com/DataDog/dd-sdk-flutter/pull/590
+[@ronnnnn]: https://github.com/ronnnnn

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fix _TypeError when request URL is matched ignoreUrlPatterns. See [#590] (Thanks [@ronnnnn][])
+* Fix `_TypeError` when request URL is matched `ignoreUrlPatterns`. See [#590] (Thanks [@ronnnnn][])
 
 ## 2.1.0
 

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -137,9 +137,9 @@ class DatadogTrackingHttpClient implements HttpClient {
             userAttributes: userAttributes);
       }
     } catch (e) {
-      if (rum != null) {
+      if (rum != null && rumKey != null) {
         rum.stopResourceWithErrorInfo(
-            rumKey!, e.toString(), e.runtimeType.toString(), userAttributes);
+            rumKey, e.toString(), e.runtimeType.toString(), userAttributes);
       }
       rethrow;
     }

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -547,6 +547,27 @@ void main() {
       verifyNoMoreInteractions(mockRum);
     });
 
+    test('ignoreUrlPatterns does not perform tracking on matching url even though innerClient throw error', () async {
+      const error = SocketException('Mock socket exception');
+      when(() => mockClient.openUrl(any(), any())).thenThrow(error);
+      final client = DatadogTrackingHttpClient(
+        mockDatadog,
+        DdHttpTrackingPluginConfiguration(
+          ignoreUrlPatterns: [
+            RegExp('test_url/path'),
+          ]
+        ),
+        mockClient,
+      );
+
+      var url = Uri.parse('https://test_url/path');
+
+      await expectLater(() async => await client.openUrl('get', url),
+          throwsA(predicate((e) => e == error)));
+
+      verifyNoMoreInteractions(mockRum);
+    });
+
     test('error on openUrl stops resource with error', () async {
       const error = SocketException('Mock socket exception');
       when(() => mockClient.openUrl(any(), any())).thenThrow(error);

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.5.0"
 
     repositories {
         google()

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
@@ -15,7 +15,7 @@ A Flutter plugin for use with the Datadog Flutter Plugin to track webviews as pa
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'DatadogWebViewTracking', '~> 2'
+  s.dependency 'DatadogWebViewTracking', '~> 2.6.0'
   s.dependency 'webview_flutter_wkwebview'
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
### What and why?

This should be in a patch release on 2.1.0. 

(cherry picked from commit 666a551268e5dc968d1846b7eb602ae8f7d1fbf4)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
