### PR TITLE
fix: Remove plan check from integration tests

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -89,15 +89,6 @@ void main() {
       );
     }
 
-    for (var log in rumLog) {
-      if (log.eventType != 'telemetry') {
-        // Web does not use "plan" anymore
-        if (!kIsWeb) {
-          expect(log.dd.plan, 1);
-        }
-      }
-    }
-
     final session = RumSessionDecoder.fromEvents(rumLog);
     expect(session.visits.length, kIsWeb ? 4 : 3);
 


### PR DESCRIPTION
### What and why?

We don't use `plan` anymore and it appears that it is no longer sent in the latest versions of the Android SDK.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
