### PR TITLE
feat: Support 128-bit trace ids

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Support 128-bit trace ids in distributed tracing.
 
 ## 2.4.0
 

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -87,15 +87,15 @@ class TracingId {
   const TracingId(this.value);
 
   static TracingId fromString(
-      String? uuid, TracingIdRepresentation representation) {
-    if (uuid == null) {
+      String? id, TracingIdRepresentation representation) {
+    if (id == null) {
       return TracingId(BigInt.zero);
     }
 
     switch (representation) {
       case TracingIdRepresentation.lowDecimal:
       case TracingIdRepresentation.decimal:
-        final value = BigInt.tryParse(uuid);
+        final value = BigInt.tryParse(id);
         if (value != null) {
           return TracingId(value);
         }
@@ -103,17 +103,17 @@ class TracingId {
       case TracingIdRepresentation.hex:
       case TracingIdRepresentation.hex16Chars:
       case TracingIdRepresentation.hex32Chars:
-        final value = BigInt.tryParse(uuid, radix: 16);
+        final value = BigInt.tryParse(id, radix: 16);
         if (value != null) {
           return TracingId(value);
         }
         break;
       case TracingIdRepresentation.highHex16Chars:
         // Take only the last 16 chars
-        if (uuid.length > 16) {
-          uuid = uuid.substring(uuid.length - 16);
+        if (id.length > 16) {
+          id = id.substring(id.length - 16);
         }
-        final value = BigInt.tryParse(uuid, radix: 16);
+        final value = BigInt.tryParse(id, radix: 16);
         if (value != null) {
           return TracingId(value);
         }

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -5,7 +5,6 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 
 import '../../datadog_internal.dart';
 
@@ -27,9 +26,11 @@ enum TracingHeaderType {
 class DatadogHttpTracingHeaders {
   static const traceId = 'x-datadog-trace-id';
   static const parentId = 'x-datadog-parent-id';
-
+  static const tags = 'x-datadog-tags';
   static const samplingPriority = 'x-datadog-sampling-priority';
   static const origin = 'x-datadog-origin';
+
+  static const traceIdTag = '_dd.p.tid';
 }
 
 class OTelHttpTracingHeaders {
@@ -46,66 +47,140 @@ class W3CTracingHeaders {
   static const tracestate = 'tracestate';
 }
 
-enum TraceIdRepresentation {
+/// Controls how we print a TracingId
+enum TracingIdRepresentation {
+  /// Decimal string representation of the tracing id
   decimal,
+
+  /// The low 64-bits of rhe tracing id as a decimal
+  lowDecimal,
+
+  /// Hexadecimal string representation of the full tracing id
   hex,
+
+  /// Hexadecimal string representation of the low 64-bits of the tracing id
   hex16Chars,
+
+  /// Hexadecimal string representation of the high 64-bits of the tracing id
+  highHex16Chars,
+
+  /// Hexadecimal string representation of the full 128-bits of the tracing id
   hex32Chars,
 }
 
+/// Type alias for [TracingIdRepresentation] to ensure backwards
+/// compatibility with other packages
+@Deprecated('Use [TracingIdRepresentation] instead.')
+typedef TraceIdRepresentation = TracingIdRepresentation;
+
+// A value to mask the high 64-bits from a 128-bit trace id.
+@visibleForTesting
+final lowTraceMask = (BigInt.from(0xffffffff) << 32) + BigInt.from(0xffffffff);
+
+/// [TracingId] is used as both a unsigned 64-bit "Span Id" and unsigned 128-bit "Trace Id"
 @immutable
-class TracingUUID {
-  // Because TraceIDs are unsigned and Dart ints are signed, we store the trace id as a BigInt.
-  // Also this will make it easier to switch to 128-bit trace ids at a later date.
+class TracingId {
+  // Because Span Ids are unsigned and Dart ints are signed, we have to store the id as a BigInt
+  // to be able to store all 64-bits properly.
   final BigInt value;
 
-  const TracingUUID(this.value);
+  const TracingId(this.value);
 
-  static TracingUUID fromString(
-      String? uuid, TraceIdRepresentation representation) {
+  static TracingId fromString(
+      String? uuid, TracingIdRepresentation representation) {
     if (uuid == null) {
-      return TracingUUID(BigInt.zero);
+      return TracingId(BigInt.zero);
     }
 
     switch (representation) {
-      case TraceIdRepresentation.decimal:
+      case TracingIdRepresentation.lowDecimal:
+      case TracingIdRepresentation.decimal:
         final value = BigInt.tryParse(uuid);
         if (value != null) {
-          return TracingUUID(value);
+          return TracingId(value);
         }
         break;
-      case TraceIdRepresentation.hex:
-      case TraceIdRepresentation.hex16Chars:
-      case TraceIdRepresentation.hex32Chars:
+      case TracingIdRepresentation.hex:
+      case TracingIdRepresentation.hex16Chars:
+      case TracingIdRepresentation.hex32Chars:
         final value = BigInt.tryParse(uuid, radix: 16);
         if (value != null) {
-          return TracingUUID(value);
+          return TracingId(value);
+        }
+        break;
+      case TracingIdRepresentation.highHex16Chars:
+        // Take only the last 16 chars
+        if (uuid.length > 16) {
+          uuid = uuid.substring(uuid.length - 16);
+        }
+        final value = BigInt.tryParse(uuid, radix: 16);
+        if (value != null) {
+          return TracingId(value);
         }
         break;
     }
 
-    return TracingUUID(BigInt.zero);
+    return TracingId(BigInt.zero);
   }
 
-  String asString(TraceIdRepresentation representation) {
+  String asString(TracingIdRepresentation representation) {
     switch (representation) {
-      case TraceIdRepresentation.decimal:
+      case TracingIdRepresentation.decimal:
         return value.toString();
-      case TraceIdRepresentation.hex:
+      case TracingIdRepresentation.lowDecimal:
+        return (value & lowTraceMask).toString();
+      case TracingIdRepresentation.hex:
         return value.toRadixString(16);
-      case TraceIdRepresentation.hex16Chars:
-        return value.toRadixString(16).padLeft(16, '0');
-      case TraceIdRepresentation.hex32Chars:
+      case TracingIdRepresentation.hex16Chars:
+        return (value & lowTraceMask).toRadixString(16).padLeft(16, '0');
+      case TracingIdRepresentation.highHex16Chars:
+        return (value >> 64).toRadixString(16).padLeft(16, '0');
+      case TracingIdRepresentation.hex32Chars:
         return value.toRadixString(16).padLeft(32, '0');
     }
+  }
+
+  TracingId.traceId() : value = _generateTraceId();
+
+  TracingId.spanId() : value = _generateSpanId();
+
+  /// Generate a 128-bit Trace Id.
+  ///
+  /// The trace is generated within the range:
+  /// <32-bit unix seconds> <32-bits of zero> <64-bits random>
+  static BigInt _generateTraceId() {
+    final time = (DateTime.now().millisecondsSinceEpoch ~/ 1000);
+
+    final highBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+    final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+
+    var traceId = BigInt.from(time) << 96;
+    traceId += (highBits << 32);
+    traceId += lowBits;
+
+    return traceId;
+  }
+
+  /// Generate a 64-bit Span Id
+  static BigInt _generateSpanId() {
+    // Though Span Ids is an unsigned 64-bit int, for compatibility
+    // we assume it needs to be a positive signed 64-bit int, so only
+    // use 63-bits.
+    final highBits = _traceRandom.nextInt(1 << 31);
+    final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+
+    var spanId = BigInt.from(highBits) << 32;
+    spanId += lowBits;
+
+    return spanId;
   }
 }
 
 @immutable
 class TracingContext {
-  final TracingUUID traceId;
-  final TracingUUID spanId;
-  final TracingUUID? parentSpanId;
+  final TracingId traceId;
+  final TracingId spanId;
+  final TracingId? parentSpanId;
   final bool sampled;
 
   const TracingContext(
@@ -114,22 +189,9 @@ class TracingContext {
 
 final Random _traceRandom = Random();
 
-TracingUUID _generateTraceId() {
-  // Though traceId is an unsigned 64-bit int, for compatibility
-  // we assume it needs to be a positive signed 64-bit int, so only
-  // use 63-bits.
-  final highBits = _traceRandom.nextInt(1 << 31);
-  final lowBits = BigInt.from(_traceRandom.nextInt(pow(2, 32).toInt()));
-
-  var traceId = BigInt.from(highBits) << 32;
-  traceId += lowBits;
-
-  return TracingUUID(traceId);
-}
-
 /// Generate a tracing context
 TracingContext generateTracingContext(bool sampled) {
-  return TracingContext(_generateTraceId(), _generateTraceId(), null, sampled);
+  return TracingContext(TracingId.traceId(), TracingId.spanId(), null, sampled);
 }
 
 Map<String, Object?> generateDatadogAttributes(
@@ -140,9 +202,9 @@ Map<String, Object?> generateDatadogAttributes(
     attributes[DatadogRumPlatformAttributeKey.rulePsr] = samplingRate / 100.0;
     if (context.sampled) {
       attributes[DatadogRumPlatformAttributeKey.traceID] =
-          context.traceId.asString(TraceIdRepresentation.decimal);
+          context.traceId.asString(TracingIdRepresentation.hex32Chars);
       attributes[DatadogRumPlatformAttributeKey.spanID] =
-          context.spanId.asString(TraceIdRepresentation.decimal);
+          context.spanId.asString(TracingIdRepresentation.decimal);
     }
   }
 
@@ -161,9 +223,11 @@ Map<String, String> getTracingHeaders(
     case TracingHeaderType.datadog:
       if (context.sampled) {
         headers[DatadogHttpTracingHeaders.traceId] =
-            context.traceId.asString(TraceIdRepresentation.decimal);
+            context.traceId.asString(TracingIdRepresentation.lowDecimal);
+        headers[DatadogHttpTracingHeaders.tags] =
+            '${DatadogHttpTracingHeaders.traceIdTag}=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}';
         headers[DatadogHttpTracingHeaders.parentId] =
-            context.spanId.asString(TraceIdRepresentation.decimal);
+            context.spanId.asString(TracingIdRepresentation.decimal);
       }
       headers[DatadogHttpTracingHeaders.origin] = 'rum';
       headers[DatadogHttpTracingHeaders.samplingPriority] = sampledString;
@@ -171,10 +235,10 @@ Map<String, String> getTracingHeaders(
     case TracingHeaderType.b3:
       if (context.sampled) {
         final headerValue = [
-          context.traceId.asString(TraceIdRepresentation.hex32Chars),
-          context.spanId.asString(TraceIdRepresentation.hex16Chars),
+          context.traceId.asString(TracingIdRepresentation.hex32Chars),
+          context.spanId.asString(TracingIdRepresentation.hex16Chars),
           sampledString,
-          context.parentSpanId?.asString(TraceIdRepresentation.hex16Chars),
+          context.parentSpanId?.asString(TracingIdRepresentation.hex16Chars),
         ].whereType<String>().join('-');
         headers[OTelHttpTracingHeaders.singleB3] = headerValue;
       } else {
@@ -186,21 +250,22 @@ Map<String, String> getTracingHeaders(
 
       if (context.sampled) {
         headers[OTelHttpTracingHeaders.multipleTraceId] =
-            context.traceId.asString(TraceIdRepresentation.hex32Chars);
+            context.traceId.asString(TracingIdRepresentation.hex32Chars);
         headers[OTelHttpTracingHeaders.multipleSpanId] =
-            context.spanId.asString(TraceIdRepresentation.hex16Chars);
+            context.spanId.asString(TracingIdRepresentation.hex16Chars);
         if (context.parentSpanId != null) {
-          headers[OTelHttpTracingHeaders.multipleParentId] =
-              context.parentSpanId!.asString(TraceIdRepresentation.hex16Chars);
+          headers[OTelHttpTracingHeaders.multipleParentId] = context
+              .parentSpanId!
+              .asString(TracingIdRepresentation.hex16Chars);
         }
       }
       break;
     case TracingHeaderType.tracecontext:
       final spanString =
-          context.spanId.asString(TraceIdRepresentation.hex16Chars);
+          context.spanId.asString(TracingIdRepresentation.hex16Chars);
       final parentHeaderValue = [
         '00', // Version Code
-        context.traceId.asString(TraceIdRepresentation.hex32Chars),
+        context.traceId.asString(TracingIdRepresentation.hex32Chars),
         spanString,
         context.sampled ? '01' : '00'
       ].join('-');

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -31,10 +31,21 @@ void main() {
         '91303371895026875');
   });
 
+  test('traceId generates proper values', () {
+    final nowSeconds = (DateTime.now().millisecondsSinceEpoch ~/ 1000);
+    final traceId = TracingId.traceId();
+
+    final traceIdString = traceId.asString(TracingIdRepresentation.hex);
+    int traceSeconds = int.parse(traceIdString.substring(0, 8), radix: 16);
+    expect(traceSeconds, closeTo(nowSeconds, 1));
+    expect('00000000', traceIdString.substring(8, 16));
+    expect(traceIdString.substring(16), isNot('0000000000000000'));
+  });
+
   test('generateTracingContext generates proper bit values', () {
     final context = generateTracingContext(true);
 
-    expect(context.traceId.value.bitLength, lessThanOrEqualTo(127));
+    expect(context.traceId.value.bitLength, lessThanOrEqualTo(128));
     expect(context.spanId.value.bitLength, lessThanOrEqualTo(63));
     expect(context.sampled, true);
   });

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -34,7 +34,7 @@ void main() {
   test('generateTracingContext generates proper bit values', () {
     final context = generateTracingContext(true);
 
-    expect(context.traceId.value.bitLength, lessThanOrEqualTo(128));
+    expect(context.traceId.value.bitLength, lessThanOrEqualTo(127));
     expect(context.spanId.value.bitLength, lessThanOrEqualTo(63));
     expect(context.sampled, true);
   });

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -6,10 +6,35 @@ import 'package:datadog_flutter_plugin/src/tracing/tracing_headers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('generateTracingContext generates 64-bit values', () {
+  test('TracingIdRepresentation generates proper values', () {
+    // Create a value in 128-bit hex that has leading zeros on both
+    // the low and high 64-bits, and ensure we get the proper values
+    const low = 0x01445feed89934bb;
+    const high = 0x01222f00d89934ba;
+
+    var combined = BigInt.from(high);
+    combined = (combined << 64) + BigInt.from(low);
+
+    final tracingId = TracingId(combined);
+
+    expect(tracingId.asString(TracingIdRepresentation.hex),
+        '1222f00d89934ba01445feed89934bb');
+    expect(tracingId.asString(TracingIdRepresentation.hex32Chars),
+        '01222f00d89934ba01445feed89934bb');
+    expect(tracingId.asString(TracingIdRepresentation.hex16Chars),
+        '01445feed89934bb');
+    expect(tracingId.asString(TracingIdRepresentation.highHex16Chars),
+        '01222f00d89934ba');
+    expect(tracingId.asString(TracingIdRepresentation.decimal),
+        '1506719429260448406838152867989763259');
+    expect(tracingId.asString(TracingIdRepresentation.lowDecimal),
+        '91303371895026875');
+  });
+
+  test('generateTracingContext generates proper bit values', () {
     final context = generateTracingContext(true);
 
-    expect(context.traceId.value.bitLength, lessThanOrEqualTo(63));
+    expect(context.traceId.value.bitLength, lessThanOrEqualTo(128));
     expect(context.spanId.value.bitLength, lessThanOrEqualTo(63));
     expect(context.sampled, true);
   });
@@ -20,9 +45,9 @@ void main() {
     final attributes = generateDatadogAttributes(context, 30.0);
 
     expect(attributes['_dd.trace_id'],
-        context.traceId.asString(TraceIdRepresentation.decimal));
+        context.traceId.asString(TracingIdRepresentation.hex32Chars));
     expect(attributes['_dd.span_id'],
-        context.spanId.asString(TraceIdRepresentation.decimal));
+        context.spanId.asString(TracingIdRepresentation.decimal));
     expect(attributes['_dd.rule_psr'], 0.3);
   });
 
@@ -42,9 +67,11 @@ void main() {
     final headers = getTracingHeaders(context, TracingHeaderType.datadog);
 
     expect(headers['x-datadog-trace-id'],
-        context.traceId.asString(TraceIdRepresentation.decimal));
+        context.traceId.asString(TracingIdRepresentation.lowDecimal));
+    expect(headers['x-datadog-tags'],
+        '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
     expect(headers['x-datadog-parent-id'],
-        context.spanId.asString(TraceIdRepresentation.decimal));
+        context.spanId.asString(TracingIdRepresentation.decimal));
     expect(headers['x-datadog-sampling-priority'], '1');
     expect(headers['x-datadog-origin'], 'rum');
   });
@@ -66,9 +93,9 @@ void main() {
     final headers = getTracingHeaders(context, TracingHeaderType.b3);
 
     final traceString =
-        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+        context.traceId.asString(TracingIdRepresentation.hex32Chars);
     final spanString =
-        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+        context.spanId.asString(TracingIdRepresentation.hex16Chars);
     final expectedHeader = '$traceString-$spanString-1'.toLowerCase();
 
     expect(headers['b3'], expectedHeader);
@@ -88,9 +115,9 @@ void main() {
     final headers = getTracingHeaders(context, TracingHeaderType.b3multi);
 
     final traceString =
-        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+        context.traceId.asString(TracingIdRepresentation.hex32Chars);
     final spanString =
-        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+        context.spanId.asString(TracingIdRepresentation.hex16Chars);
 
     expect(headers['X-B3-TraceId'], traceString.toLowerCase());
     expect(headers['X-B3-SpanId'], spanString.toLowerCase());
@@ -115,9 +142,9 @@ void main() {
     final headers = getTracingHeaders(context, TracingHeaderType.tracecontext);
 
     final traceString =
-        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+        context.traceId.asString(TracingIdRepresentation.hex32Chars);
     final spanString =
-        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+        context.spanId.asString(TracingIdRepresentation.hex16Chars);
     final expectedParentHeader = '00-$traceString-$spanString-01';
     final expectedStateHeader = 'dd=s:1;o:rum;p:$spanString';
 
@@ -131,9 +158,9 @@ void main() {
     final headers = getTracingHeaders(context, TracingHeaderType.tracecontext);
 
     final traceString =
-        context.traceId.asString(TraceIdRepresentation.hex32Chars);
+        context.traceId.asString(TracingIdRepresentation.hex32Chars);
     final spanString =
-        context.spanId.asString(TraceIdRepresentation.hex16Chars);
+        context.spanId.asString(TracingIdRepresentation.hex16Chars);
     final expectedParentHeader = '00-$traceString-$spanString-00';
     final expectedStateHeader = 'dd=s:0;o:rum;p:$spanString';
 

--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Support 128-bit trace ids in distributed tracing.
 
 ## 1.0.0
 

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: ^2.5.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   uuid: ^4.0.0

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -732,7 +732,7 @@ query UserInfo($id: ID!) {
             capturedAttrs[DatadogRumPlatformAttributeKey.traceID],
             radix: 16);
         expect(traceId, isNotNull);
-        expect(traceId.bitLength, lessThanOrEqualTo(127));
+        expect(traceId.bitLength, lessThanOrEqualTo(128));
 
         var spanId =
             BigInt.parse(capturedAttrs[DatadogRumPlatformAttributeKey.spanID]);
@@ -880,7 +880,7 @@ void verifyHeaders(
     if (type == TracingHeaderType.datadog) {
       expect(traceInt.bitLength, lessThanOrEqualTo(64));
     } else {
-      expect(traceInt.bitLength, lessThanOrEqualTo(127));
+      expect(traceInt.bitLength, lessThanOrEqualTo(128));
     }
   }
 

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -728,10 +728,11 @@ query UserInfo($id: ID!) {
         final capturedAttrs = verify(
                 () => mockRum.startResource(any(), any(), any(), captureAny()))
             .captured[0] as Map<String, dynamic>;
-        var traceId =
-            BigInt.parse(capturedAttrs[DatadogRumPlatformAttributeKey.traceID]);
+        var traceId = BigInt.parse(
+            capturedAttrs[DatadogRumPlatformAttributeKey.traceID],
+            radix: 16);
         expect(traceId, isNotNull);
-        expect(traceId.bitLength, lessThanOrEqualTo(63));
+        expect(traceId.bitLength, lessThanOrEqualTo(127));
 
         var spanId =
             BigInt.parse(capturedAttrs[DatadogRumPlatformAttributeKey.spanID]);
@@ -826,6 +827,14 @@ void verifyHeaders(
         traceInt = BigInt.tryParse(traceValue);
         var spanValue = headers['x-datadog-parent-id']!;
         spanInt = BigInt.tryParse(spanValue);
+        var tagsHeader = headers['x-datadog-tags'];
+        expect(tagsHeader, isNotNull);
+        final parts = tagsHeader?.split('=');
+        expect(parts, isNotNull);
+        expect(parts?[0], '_dd.p.tid');
+        BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
+        expect(highTraceInt, isNotNull);
+        expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
       }
       break;
     case TracingHeaderType.b3:
@@ -868,7 +877,11 @@ void verifyHeaders(
     expect(traceInt, isNotNull);
   }
   if (traceInt != null) {
-    expect(traceInt.bitLength, lessThanOrEqualTo(63));
+    if (type == TracingHeaderType.datadog) {
+      expect(traceInt.bitLength, lessThanOrEqualTo(64));
+    } else {
+      expect(traceInt.bitLength, lessThanOrEqualTo(127));
+    }
   }
 
   if (shouldSample) {

--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
+* Support 128-bit trace ids in distributed tracing.
 
-
+# 1.0.0
 
 * First official release.
 * Update to v2.0 of Datadog SDKs.

--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -67,9 +67,9 @@ class DatadogGrpcInterceptor extends ClientInterceptor {
             rum.traceSampleRate / 100.0;
         if (tracingContext.sampled) {
           attributes[DatadogRumPlatformAttributeKey.traceID] =
-              tracingContext.traceId.asString(TraceIdRepresentation.decimal);
+              tracingContext.traceId.asString(TracingIdRepresentation.hex);
           attributes[DatadogRumPlatformAttributeKey.spanID] =
-              tracingContext.spanId.asString(TraceIdRepresentation.decimal);
+              tracingContext.spanId.asString(TracingIdRepresentation.decimal);
         }
 
         for (final tracingType in headerTypes) {

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: ^2.5.0
   grpc: ^3.0.2
   uuid: ^4.0.0
 

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -96,7 +96,7 @@ void main() {
         expect(traceInt?.bitLength, lessThanOrEqualTo(64));
       } else {
         expect(traceInt, isNotNull);
-        expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+        expect(traceInt?.bitLength, lessThanOrEqualTo(128));
       }
 
       expect(spanInt, isNotNull);

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -48,6 +48,15 @@ void main() {
         expect(metadata['x-datadog-sampling-priority'], sampled ? '1' : '0');
         traceInt = BigInt.tryParse(metadata['x-datadog-trace-id'] ?? '');
         spanInt = BigInt.tryParse(metadata['x-datadog-parent-id'] ?? '');
+        if (sampled) {
+          final tagsHeader = metadata['x-datadog-tags'];
+          final parts = tagsHeader?.split('=');
+          expect(parts, isNotNull);
+          expect(parts?[0], '_dd.p.tid');
+          BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
+          expect(highTraceInt, isNotNull);
+          expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
+        }
         break;
       case TracingHeaderType.b3:
         var singleHeader = metadata['b3']!;
@@ -82,8 +91,13 @@ void main() {
     }
 
     if (sampled) {
-      expect(traceInt, isNotNull);
-      expect(traceInt?.bitLength, lessThanOrEqualTo(63));
+      if (type == TracingHeaderType.datadog) {
+        expect(traceInt, isNotNull);
+        expect(traceInt?.bitLength, lessThanOrEqualTo(64));
+      } else {
+        expect(traceInt, isNotNull);
+        expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+      }
 
       expect(spanInt, isNotNull);
       expect(spanInt?.bitLength, lessThanOrEqualTo(63));
@@ -167,7 +181,8 @@ void main() {
           final attributes = captures[1] as Map<String, Object?>;
           expect(attributes['_dd.trace_id'], isNotNull);
           expect(
-              BigInt.tryParse(attributes['_dd.trace_id'] as String), isNotNull);
+              BigInt.tryParse(attributes['_dd.trace_id'] as String, radix: 16),
+              isNotNull);
           expect(attributes['_dd.span_id'], isNotNull);
           expect(
               BigInt.tryParse(attributes['_dd.span_id'] as String), isNotNull);

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support 128-bit trace ids in distributed tracing.
+
 ## 2.1.1
 
 * Fix `_TypeError` when request URL is matched `ignoreUrlPatterns`. See [#590] (Thanks [@ronnnnn][])

--- a/packages/datadog_tracking_http_client/example/integration_test/tracing_id_helpers.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracing_id_helpers.dart
@@ -1,0 +1,34 @@
+BigInt? extractDatadogTraceId(Map<String, List<String>> headers) {
+  final traceIdHeader = headers['x-datadog-trace-id']?.first;
+  if (traceIdHeader == null) {
+    return null;
+  }
+
+  final lowPart = BigInt.tryParse(traceIdHeader);
+  if (lowPart == null) {
+    return null;
+  }
+
+  final tagsHeader = headers['x-datadog-tags']?.first;
+  if (tagsHeader == null) {
+    return lowPart;
+  }
+
+  final tags = tagsHeader.split(',');
+  Map<String, String> tagMap = {};
+  for (var tag in tags) {
+    final parts = tag.split('=');
+    tagMap[parts[0]] = parts[1];
+  }
+
+  final highPartString = tagMap['_dd.p.tid'];
+  if (highPartString == null) {
+    return lowPart;
+  }
+  final highPart = BigInt.tryParse(highPartString, radix: 16);
+  if (highPart == null) {
+    return lowPart;
+  }
+
+  return (highPart << 64) + lowPart;
+}

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_test.dart
@@ -11,6 +11,8 @@ import 'package:datadog_tracking_http_client_example/scenario_config.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
+import 'tracing_id_helpers.dart';
+
 Future<void> performRumUserFlow(WidgetTester tester) async {
   var scenario = find.text('http.Client Override');
   await tester.tap(scenario);
@@ -109,19 +111,17 @@ void main() async {
     }
 
     final getEvent = view2.resourceEvents[0];
-    final getTraceId =
-        testRequests[0].requestHeaders['x-datadog-trace-id']?.first;
+    final getTraceId = extractDatadogTraceId(testRequests[0].requestHeaders);
     final getSpanId =
         testRequests[0].requestHeaders['x-datadog-parent-id']?.first;
     expect(getEvent.url, scenarioConfig.firstPartyGetUrl);
     expect(getEvent.statusCode, 200);
     expect(getEvent.method, 'GET');
     expect(getEvent.duration, greaterThan(0));
-    expect(getEvent.dd.traceId, getTraceId!);
+    expect(getEvent.dd.traceId, getTraceId?.toRadixString(16));
     expect(getEvent.dd.spanId, getSpanId!);
 
-    final postTraceId =
-        testRequests[1].requestHeaders['x-datadog-trace-id']?.first;
+    final postTraceId = extractDatadogTraceId(testRequests[1].requestHeaders);
     final postSpanId =
         testRequests[1].requestHeaders['x-datadog-parent-id']?.first;
     final postEvent = view2.resourceEvents[1];
@@ -129,7 +129,7 @@ void main() async {
     expect(postEvent.statusCode, 200);
     expect(postEvent.method, 'POST');
     expect(postEvent.duration, greaterThan(0));
-    expect(postEvent.dd.traceId, postTraceId!);
+    expect(postEvent.dd.traceId, postTraceId?.toRadixString(16));
     expect(postEvent.dd.spanId, postSpanId!);
 
     // Third party requests

--- a/packages/datadog_tracking_http_client/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_tracking_http_client/example/ios/Runner.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				C647780C1977D629D8167989 /* [CP] Embed Pods Frameworks */,
+				AD699EB7BA153AC3CE8CB290 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -155,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -249,6 +250,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		AD699EB7BA153AC3CE8CB290 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		C647780C1977D629D8167989 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/datadog_tracking_http_client/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/datadog_tracking_http_client/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: ^2.5.0
   uuid: ^4.0.0
   http: ^1.0.0
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
@@ -13,6 +12,8 @@ import 'package:datadog_tracking_http_client/src/tracking_http.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
+
+import 'test_helpers.dart';
 
 class MockDatadogSdk extends Mock implements DatadogSdk {}
 
@@ -65,51 +66,6 @@ void main() {
     when(() => mockClient.send(any()))
         .thenAnswer((_) => Future.value(mockResponse));
   });
-
-  void verifyHeaders(Map<String, String> headers, TracingHeaderType type) {
-    BigInt? traceInt;
-    BigInt? spanInt;
-
-    switch (type) {
-      case TracingHeaderType.datadog:
-        expect(headers['x-datadog-sampling-priority'], '1');
-        traceInt = BigInt.tryParse(headers['x-datadog-trace-id']!);
-        spanInt = BigInt.tryParse(headers['x-datadog-parent-id']!);
-        break;
-      case TracingHeaderType.b3:
-        var singleHeader = headers['b3']!;
-        var headerParts = singleHeader.split('-');
-        traceInt = BigInt.tryParse(headerParts[0], radix: 16);
-        spanInt = BigInt.tryParse(headerParts[1], radix: 16);
-        expect(headerParts[2], '1');
-        break;
-      case TracingHeaderType.b3multi:
-        expect(headers['X-B3-Sampled'], '1');
-        traceInt = BigInt.tryParse(headers['X-B3-TraceId']!, radix: 16);
-        spanInt = BigInt.tryParse(headers['X-B3-SpanId']!, radix: 16);
-        break;
-      case TracingHeaderType.tracecontext:
-        var header = headers['traceparent']!;
-        var headerParts = header.split('-');
-        expect(headerParts[0], '00');
-        traceInt = BigInt.tryParse(headerParts[1], radix: 16);
-        spanInt = BigInt.tryParse(headerParts[2], radix: 16);
-        expect(headerParts[3], '01');
-
-        final stateHeader = headers['tracestate']!;
-        final stateParts = getDdTraceState(stateHeader);
-        expect(stateParts['s'], '1');
-        expect(stateParts['o'], 'rum');
-        expect(stateParts['p'], headerParts[2]);
-        break;
-    }
-
-    expect(traceInt, isNotNull);
-    expect(traceInt?.bitLength, lessThanOrEqualTo(63));
-
-    expect(spanInt, isNotNull);
-    expect(spanInt?.bitLength, lessThanOrEqualTo(63));
-  }
 
   group('when rum is disabled', () {
     setUp(() {
@@ -473,10 +429,11 @@ void main() {
               .captured[0] as Map<String, Object?>;
 
           final traceValue = callAttributes['_dd.trace_id'] as String?;
-          final traceInt =
-              traceValue != null ? BigInt.tryParse(traceValue) : null;
+          final traceInt = traceValue != null
+              ? BigInt.tryParse(traceValue, radix: 16)
+              : null;
           expect(traceInt, isNotNull);
-          expect(traceInt?.bitLength, lessThanOrEqualTo(63));
+          expect(traceInt?.bitLength, lessThanOrEqualTo(127));
 
           final spanValue = callAttributes['_dd.span_id'] as String?;
           final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;
@@ -543,9 +500,9 @@ void main() {
 
         final traceValue = callAttributes['_dd.trace_id'] as String?;
         final traceInt =
-            traceValue != null ? BigInt.tryParse(traceValue) : null;
+            traceValue != null ? BigInt.tryParse(traceValue, radix: 16) : null;
         expect(traceInt, isNotNull);
-        expect(traceInt?.bitLength, lessThanOrEqualTo(63));
+        expect(traceInt?.bitLength, lessThanOrEqualTo(127));
 
         final spanValue = callAttributes['_dd.span_id'] as String?;
         final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;
@@ -588,9 +545,10 @@ void main() {
           .captured[0] as Map<String, Object?>;
 
       final traceValue = callAttributes['_dd.trace_id'] as String?;
-      final traceInt = traceValue != null ? BigInt.tryParse(traceValue) : null;
+      final traceInt =
+          traceValue != null ? BigInt.tryParse(traceValue, radix: 16) : null;
       expect(traceInt, isNotNull);
-      expect(traceInt?.bitLength, lessThanOrEqualTo(63));
+      expect(traceInt?.bitLength, lessThanOrEqualTo(127));
 
       final spanValue = callAttributes['_dd.span_id'] as String?;
       final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;
@@ -600,9 +558,15 @@ void main() {
       final captured = verify(() => mockClient.send(captureAny())).captured[0]
           as http.BaseRequest;
 
-      final datadogTraceInt =
+      var datadogTraceInt =
           BigInt.tryParse(captured.headers['x-datadog-trace-id']!);
+      final parts = captured.headers['x-datadog-tags']?.split('=');
+      expect(parts?[0], '_dd.p.tid');
+      BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
+      expect(highTraceInt, isNotNull);
+      datadogTraceInt = (highTraceInt! << 64) + datadogTraceInt!;
       expect(traceInt, datadogTraceInt);
+
       final datadogSpanInt =
           BigInt.tryParse(captured.headers['x-datadog-parent-id']!);
       expect(spanInt, datadogSpanInt);

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -433,7 +433,7 @@ void main() {
               ? BigInt.tryParse(traceValue, radix: 16)
               : null;
           expect(traceInt, isNotNull);
-          expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+          expect(traceInt?.bitLength, lessThanOrEqualTo(128));
 
           final spanValue = callAttributes['_dd.span_id'] as String?;
           final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;
@@ -502,7 +502,7 @@ void main() {
         final traceInt =
             traceValue != null ? BigInt.tryParse(traceValue, radix: 16) : null;
         expect(traceInt, isNotNull);
-        expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+        expect(traceInt?.bitLength, lessThanOrEqualTo(128));
 
         final spanValue = callAttributes['_dd.span_id'] as String?;
         final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;
@@ -548,7 +548,7 @@ void main() {
       final traceInt =
           traceValue != null ? BigInt.tryParse(traceValue, radix: 16) : null;
       expect(traceInt, isNotNull);
-      expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+      expect(traceInt?.bitLength, lessThanOrEqualTo(128));
 
       final spanValue = callAttributes['_dd.span_id'] as String?;
       final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -647,7 +647,7 @@ void main() {
             capturedAttributes[DatadogRumPlatformAttributeKey.traceID],
             radix: 16);
         expect(traceInt, isNotNull);
-        expect(traceInt.bitLength, lessThanOrEqualTo(127));
+        expect(traceInt.bitLength, lessThanOrEqualTo(128));
 
         var spanInt = BigInt.parse(
             capturedAttributes[DatadogRumPlatformAttributeKey.spanID]);
@@ -777,7 +777,7 @@ void main() {
     final traceInt =
         traceValue != null ? BigInt.tryParse(traceValue, radix: 16) : null;
     expect(traceInt, isNotNull);
-    expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+    expect(traceInt?.bitLength, lessThanOrEqualTo(128));
 
     final spanValue = callAttributes['_dd.span_id'] as String?;
     final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
@@ -13,6 +12,8 @@ import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client_plugin.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import 'test_helpers.dart';
 
 class MockDatadogSdk extends Mock implements DatadogSdk {}
 
@@ -130,64 +131,6 @@ void main() {
     when(() => mockResponse.contentLength).thenReturn(size);
 
     return mockResponse;
-  }
-
-  void verifyHeaders(HttpHeaders headers, TracingHeaderType type) {
-    BigInt? traceInt;
-    BigInt? spanInt;
-
-    switch (type) {
-      case TracingHeaderType.datadog:
-        verify(() => headers.add('x-datadog-sampling-priority', '1'));
-        var traceValue =
-            verify(() => headers.add('x-datadog-trace-id', captureAny()))
-                .captured[0] as String;
-        traceInt = BigInt.tryParse(traceValue);
-        var spanValue =
-            verify(() => headers.add('x-datadog-parent-id', captureAny()))
-                .captured[0] as String;
-        spanInt = BigInt.tryParse(spanValue);
-        break;
-      case TracingHeaderType.b3:
-        var singleHeader =
-            verify(() => headers.add('b3', captureAny())).captured[0] as String;
-        var headerParts = singleHeader.split('-');
-        traceInt = BigInt.tryParse(headerParts[0], radix: 16);
-        spanInt = BigInt.tryParse(headerParts[1], radix: 16);
-        expect(headerParts[2], '1');
-        break;
-      case TracingHeaderType.b3multi:
-        verify(() => headers.add('X-B3-Sampled', '1'));
-        var traceValue = verify(() => headers.add('X-B3-TraceId', captureAny()))
-            .captured[0] as String;
-        traceInt = BigInt.tryParse(traceValue, radix: 16);
-        var spanValue = verify(() => headers.add('X-B3-SpanId', captureAny()))
-            .captured[0] as String;
-        spanInt = BigInt.tryParse(spanValue, radix: 16);
-        break;
-      case TracingHeaderType.tracecontext:
-        var header = verify(() => headers.add('traceparent', captureAny()))
-            .captured[0] as String;
-        var headerParts = header.split('-');
-        expect(headerParts[0], '00');
-        traceInt = BigInt.tryParse(headerParts[1], radix: 16);
-        spanInt = BigInt.tryParse(headerParts[2], radix: 16);
-        expect(headerParts[3], '01');
-        final stateHeader =
-            verify(() => headers.add('tracestate', captureAny())).captured[0]
-                as String;
-        final stateParts = getDdTraceState(stateHeader);
-        expect(stateParts['s'], '1');
-        expect(stateParts['o'], 'rum');
-        expect(stateParts['p'], headerParts[2]);
-        break;
-    }
-
-    expect(traceInt, isNotNull);
-    expect(traceInt?.bitLength, lessThanOrEqualTo(63));
-
-    expect(spanInt, isNotNull);
-    expect(spanInt?.bitLength, lessThanOrEqualTo(63));
   }
 
   group('when rum is disabled', () {
@@ -548,16 +491,16 @@ void main() {
       verifyNoMoreInteractions(mockRum);
     });
 
-    test('ignoreUrlPatterns does not perform tracking on matching url even though innerClient throw error', () async {
+    test(
+        'ignoreUrlPatterns does not perform tracking on matching url even though innerClient throw error',
+        () async {
       const error = SocketException('Mock socket exception');
       when(() => mockClient.openUrl(any(), any())).thenThrow(error);
       final client = DatadogTrackingHttpClient(
         mockDatadog,
-        DdHttpTrackingPluginConfiguration(
-          ignoreUrlPatterns: [
-            RegExp('test_url/path'),
-          ]
-        ),
+        DdHttpTrackingPluginConfiguration(ignoreUrlPatterns: [
+          RegExp('test_url/path'),
+        ]),
         mockClient,
       );
 
@@ -701,9 +644,10 @@ void main() {
         final capturedAttributes = capturedEndArgs[0] as Map<String, dynamic>;
 
         var traceInt = BigInt.parse(
-            capturedAttributes[DatadogRumPlatformAttributeKey.traceID]);
+            capturedAttributes[DatadogRumPlatformAttributeKey.traceID],
+            radix: 16);
         expect(traceInt, isNotNull);
-        expect(traceInt.bitLength, lessThanOrEqualTo(63));
+        expect(traceInt.bitLength, lessThanOrEqualTo(127));
 
         var spanInt = BigInt.parse(
             capturedAttributes[DatadogRumPlatformAttributeKey.spanID]);
@@ -730,7 +674,7 @@ void main() {
 
         var _ = await request.done;
 
-        final requestHeaders = request.headers;
+        final requestHeaders = request.headers.toMap();
         verifyHeaders(requestHeaders, headerType);
       });
 
@@ -792,7 +736,7 @@ void main() {
 
       var _ = await request.done;
 
-      final requestHeaders = request.headers;
+      final requestHeaders = request.headers.toMap();
       verifyHeaders(requestHeaders, headerType);
     }
 
@@ -830,9 +774,10 @@ void main() {
         .captured[0] as Map<String, Object?>;
 
     final traceValue = callAttributes['_dd.trace_id'] as String?;
-    final traceInt = traceValue != null ? BigInt.tryParse(traceValue) : null;
+    final traceInt =
+        traceValue != null ? BigInt.tryParse(traceValue, radix: 16) : null;
     expect(traceInt, isNotNull);
-    expect(traceInt?.bitLength, lessThanOrEqualTo(63));
+    expect(traceInt?.bitLength, lessThanOrEqualTo(127));
 
     final spanValue = callAttributes['_dd.span_id'] as String?;
     final spanInt = spanValue != null ? BigInt.tryParse(spanValue) : null;
@@ -844,7 +789,16 @@ void main() {
         verify(() => headers.add('x-datadog-trace-id', captureAny()))
             .captured[0];
     final datadogTraceInt = BigInt.tryParse(datadogTraceString);
-    expect(traceInt, datadogTraceInt);
+    expect(traceInt! & lowTraceMask, datadogTraceInt);
+    final datadogTagString =
+        verify(() => headers.add('x-datadog-tags', captureAny())).captured[0]
+            as String?;
+    final parts = datadogTagString?.split('=');
+    expect(parts?[0], '_dd.p.tid');
+    BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
+    expect(highTraceInt, isNotNull);
+    expect(highTraceInt, traceInt >> 64);
+
     final datadogSpanString =
         verify(() => headers.add('x-datadog-parent-id', captureAny()))
             .captured[0];

--- a/packages/datadog_tracking_http_client/test/test_helpers.dart
+++ b/packages/datadog_tracking_http_client/test/test_helpers.dart
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+extension HttpHeadersToMap on HttpHeaders {
+  Map<String, String> toMap() {
+    Map<String, String> map = {};
+    forEach((name, values) {
+      map[name] = values.join(',');
+    });
+
+    return map;
+  }
+}
+
+void verifyHeaders(Map<String, String> headers, TracingHeaderType type) {
+  BigInt? traceInt;
+  BigInt? spanInt;
+
+  switch (type) {
+    case TracingHeaderType.datadog:
+      expect(headers['x-datadog-sampling-priority'], '1');
+      traceInt = BigInt.tryParse(headers['x-datadog-trace-id']!);
+      spanInt = BigInt.tryParse(headers['x-datadog-parent-id']!);
+      final tagsHeader = headers['x-datadog-tags'];
+      final parts = tagsHeader?.split('=');
+      expect(parts, isNotNull);
+      expect(parts?[0], '_dd.p.tid');
+      BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
+      expect(highTraceInt, isNotNull);
+      expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
+      break;
+    case TracingHeaderType.b3:
+      var singleHeader = headers['b3']!;
+      var headerParts = singleHeader.split('-');
+      traceInt = BigInt.tryParse(headerParts[0], radix: 16);
+      spanInt = BigInt.tryParse(headerParts[1], radix: 16);
+      expect(headerParts[2], '1');
+      break;
+    case TracingHeaderType.b3multi:
+      expect(headers['X-B3-Sampled'], '1');
+      traceInt = BigInt.tryParse(headers['X-B3-TraceId']!, radix: 16);
+      spanInt = BigInt.tryParse(headers['X-B3-SpanId']!, radix: 16);
+      break;
+    case TracingHeaderType.tracecontext:
+      var header = headers['traceparent']!;
+      var headerParts = header.split('-');
+      expect(headerParts[0], '00');
+      traceInt = BigInt.tryParse(headerParts[1], radix: 16);
+      spanInt = BigInt.tryParse(headerParts[2], radix: 16);
+      expect(headerParts[3], '01');
+
+      final stateHeader = headers['tracestate']!;
+      final stateParts = getDdTraceState(stateHeader);
+      expect(stateParts['s'], '1');
+      expect(stateParts['o'], 'rum');
+      expect(stateParts['p'], headerParts[2]);
+      break;
+  }
+
+  expect(traceInt, isNotNull);
+  if (type == TracingHeaderType.datadog) {
+    expect(traceInt?.bitLength, lessThanOrEqualTo(64));
+  } else {
+    expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+  }
+
+  expect(spanInt, isNotNull);
+  expect(spanInt?.bitLength, lessThanOrEqualTo(63));
+}

--- a/packages/datadog_tracking_http_client/test/test_helpers.dart
+++ b/packages/datadog_tracking_http_client/test/test_helpers.dart
@@ -68,7 +68,7 @@ void verifyHeaders(Map<String, String> headers, TracingHeaderType type) {
   if (type == TracingHeaderType.datadog) {
     expect(traceInt?.bitLength, lessThanOrEqualTo(64));
   } else {
-    expect(traceInt?.bitLength, lessThanOrEqualTo(127));
+    expect(traceInt?.bitLength, lessThanOrEqualTo(128));
   }
 
   expect(spanInt, isNotNull);


### PR DESCRIPTION
### What and why?

Adding 128-bit trace id support for distributed tracing.

`datadog_tracking_http_client` and `datadog_grpc_interceptor` didn't change code (though their tests changed) But to be safe I'm changing them to require 2.5.0 in future releases. I'll also be releasing a point release of both packages to restrict them to <2.5.0.

refs: RUM-1831

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
