### PR TITLE
chore: Constrain gql_link package to pre 2.5.0

### DIFF
--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Constrain compatible datadog_flutter_plugin to <2.5.0
+
 ## 1.0.0
 
 * Initial release of datadog_gql_link

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: '>2.0.0 <2.5.0'
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   uuid: ^4.0.0


### PR DESCRIPTION
### What and why?

Constrain current release of `datadog_gql_link` to require <2.5.0 as changes to support 128-bit trace id's in 2.5.0 may be incompatible.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
