### PR TITLE
chore: Constrain grpc package to pre 2.5.0

### DIFF
--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Constrain compatible datadog_flutter_plugin to <2.5.0
+* Constrain compatible `datadog_flutter_plugin` to <2.5.0
 
 ## 1.0.0
 

--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Constrain compatible datadog_flutter_plugin to <2.5.0
+
 ## 1.0.0
 
 * First official release.

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: '>2.0.0 <2.5.0'
   grpc: ^3.0.2
   uuid: ^4.0.0
 


### PR DESCRIPTION
### What and why?

Changes to trace id's in 2.5.0 may be incompatible with 1.0.0 of the grpc interceptor

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
