### PR TITLE
chore: Constrain http_client package to pre 2.5.0

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Constrain compatible datadog_flutter_plugin to <2.5.0
+* Constrain compatible `datadog_flutter_plugin` to <2.5.0
 
 ## 2.1.1
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Constrain compatible datadog_flutter_plugin to <2.5.0
 
 ## 2.1.1
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: '>2.0.0 <2.5.0'
   uuid: ^4.0.0
   http: ^1.0.0
 


### PR DESCRIPTION
### What and why?

Changes to trace id's in 2.5.0 may be incompatible with the current version of tracking_http_client

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
