### PR TITLE
chore: Update develop with changes from release of 2.5.0

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -11,7 +11,6 @@
   * Start sending data immediately after SDK is initialized.
 * Update Android to 2.9.0. For a full list of changes see the [Android Changelog](https://github.com/DataDog/dd-sdk-android/blob/develop/CHANGELOG.md#290--2024-05-02)
   * Call RUM's `errorEventMapper` for crashes.
-  * Support calling log event mapper for crashes.
   * Start sending batches immediately after feature is initialized.
 
 ## 2.4.0

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.5.0
 
 * Support 128-bit trace ids in distributed tracing.
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 2.5.0
 
 * Support 128-bit trace ids in distributed tracing.

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 2.5.0
 
 * Support 128-bit trace ids in distributed tracing.
+* Update iOS to 2.11.0. For a full list of changes see the [iOS Changelog](https://github.com/DataDog/dd-sdk-ios/blob/develop/CHANGELOG.md#2110--08-05-2024)
+  * Add Fatal App hang tracking in RUM.
+  * Solve false-positive Privacy Manifest warnings on Required Reason API usage.
+  * Call RUM's `errorEventMapper` for crashes.
+  * Support calling log event mapper for crashes
+  * Start sending data immediately after SDK is initialized.
+* Update Android to 2.9.0. For a full list of changes see the [Android Changelog](https://github.com/DataDog/dd-sdk-android/blob/develop/CHANGELOG.md#290--2024-05-02)
+  * Call RUM's `errorEventMapper` for crashes.
+  * Support calling log event mapper for crashes
+  * Start sending batches immediately after feature is initialized.
 
 ## 2.4.0
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,15 +3,15 @@
 ## 2.5.0
 
 * Support 128-bit trace ids in distributed tracing.
-* Update iOS to 2.11.0. For a full list of changes see the [iOS Changelog](https://github.com/DataDog/dd-sdk-ios/blob/develop/CHANGELOG.md#2110--08-05-2024)
-  * Add Fatal App hang tracking in RUM.
-  * Solve false-positive Privacy Manifest warnings on Required Reason API usage.
+* Update iOS to 2.11.0. For a full list of changes, see the [iOS changelog](https://github.com/DataDog/dd-sdk-ios/blob/develop/CHANGELOG.md#2110--08-05-2024).
+  * Add fatal app hang tracking in RUM.
+  * Solve false-positive privacy manifest warnings on Required Reason API usage.
   * Call RUM's `errorEventMapper` for crashes.
-  * Support calling log event mapper for crashes
+  * Support calling log event mapper for crashes.
   * Start sending data immediately after SDK is initialized.
 * Update Android to 2.9.0. For a full list of changes see the [Android Changelog](https://github.com/DataDog/dd-sdk-android/blob/develop/CHANGELOG.md#290--2024-05-02)
   * Call RUM's `errorEventMapper` for crashes.
-  * Support calling log event mapper for crashes
+  * Support calling log event mapper for crashes.
   * Start sending batches immediately after feature is initialized.
 
 ## 2.4.0

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -13,7 +13,7 @@ For complete documentation, see the [official Datadog documentation][11].
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 2.8.1 | 2.7.0 | 5.x.x |
+| 2.11.0 | 2.9.0 | 5.x.x |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/lib/src/version.dart
+++ b/packages/datadog_flutter_plugin/lib/src/version.dart
@@ -2,4 +2,4 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
-const ddPackageVersion = '2.5.0';
+const ddPackageVersion = '2.6.0';

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_flutter_plugin
 description: Flutter bindings and tools for utilizing Datadog Mobile SDks
-version: 2.5.0
+version: 2.6.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:


### PR DESCRIPTION
### What and why?

Changes related to releasing `datadog_flutter_plugin` 2.5.0

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
