### PR TITLE
doc: Combined CHANGELOG update

### DIFF
--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Support 128-bit trace ids in distributed tracing.
 
+## 1.0.1
+
+* Constrain compatible datadog_flutter_plugin to <2.5.0
+
 ## 1.0.0
 
 * Initial release of datadog_gql_link

--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 1.0.1
 
-* Constrain compatible datadog_flutter_plugin to <2.5.0
+* Constrain compatible `datadog_flutter_plugin` to <2.5.0
 
 ## 1.0.0
 

--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Support 128-bit trace ids in distributed tracing.
 
+## 1.0.1
+
+* Constrain compatible `datadog_flutter_plugin` to <2.5.0
+
 # 1.0.0
 
 * First official release.

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Support 128-bit trace ids in distributed tracing.
 
+## 2.1.2
+
+* Constrain compatible `datadog_flutter_plugin` to <2.5.0
+
 ## 2.1.1
 
 * Fix `_TypeError` when request URL is matched `ignoreUrlPatterns`. See [#590] (Thanks [@ronnnnn][])


### PR DESCRIPTION
### What and why?

Squash of CHANGELOG updates for releases of:
`datadog_grpc_interceptor 1.0.1`
`datadog_Tracking_http_client 2.1.2`
`datadog_gql_link 1.0.1`

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
