### PR TITLE
chore: Release 2.5.0 compliant packages

### DIFF
--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
 
 * Support 128-bit trace ids in distributed tracing.
 

--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 1.1.0
 
 * Support 128-bit trace ids in distributed tracing.

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -2,7 +2,7 @@ name: datadog_gql_link
 description: A package for tracking GraphQL calls in Datadog compatible with gql_link 
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
-version: 1.1.0
+version: 1.2.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'

--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.1.0
 
 * Support 128-bit trace ids in distributed tracing.
 

--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 1.1.0
 
 * Support 128-bit trace ids in distributed tracing.

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_grpc_interceptor
 description: A plugin for use with the DatadogSdk, used to track performance of gRPC and enable Datadog Distributed Tracing.
-version: 1.1.0
+version: 1.2.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_grpc_interceptor
 description: A plugin for use with the DatadogSdk, used to track performance of gRPC and enable Datadog Distributed Tracing.
-version: 1.0.1
+version: 1.1.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 2.2.0
 
 * Support 128-bit trace ids in distributed tracing.

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.2.0
 
 * Support 128-bit trace ids in distributed tracing.
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 2.2.0
+version: 2.3.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 


### PR DESCRIPTION
### What and why?

Combined PR for release of the following packages that are updated to work with `datadog_flutter_plugin` 2.5.0
* `datadog_tracking_http_client` 2.2.0
* `datadog_gql_link` 1.1.0
* `datadog_grpc_interceptor` 1.1.0

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
