### PR TITLE
feat: add ignoreUrlPatterns to TrackingExtensionExisting

### DIFF
--- a/examples/native-hybrid-app/flutter_module/lib/main.dart
+++ b/examples/native-hybrid-app/flutter_module/lib/main.dart
@@ -16,6 +16,7 @@ void main() async {
     reportFlutterPerformance: true,
   )..enableHttpTracking(
       // Using ignoreUrlPatterns is needed if you want to combine HttpClient
+      // tracking and GraphQL tracking through datadog_gql_link
       ignoreUrlPatterns: [
         RegExp('example'),
       ],

--- a/examples/native-hybrid-app/flutter_module/lib/main.dart
+++ b/examples/native-hybrid-app/flutter_module/lib/main.dart
@@ -14,7 +14,12 @@ void main() async {
   final config = DatadogAttachConfiguration(
     detectLongTasks: true,
     reportFlutterPerformance: true,
-  )..enableHttpTracking();
+  )..enableHttpTracking(
+      // Using ignoreUrlPatterns is needed if you want to combine HttpClient
+      ignoreUrlPatterns: [
+        RegExp('example'),
+      ],
+    );
 
   await DatadogSdk.instance.attachToExisting(config);
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
+## 2.2.1
 
+* Add the ability to ignore tracking on specific url patterns with `ignoreUrlPatterns` when using the attach configuration.
 
 ## 2.2.0
 

--- a/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/datadog_tracking_http_client.dart
@@ -57,8 +57,12 @@ extension TrackingExtension on DatadogConfiguration {
 
 extension TrackingExtensionExisting on DatadogAttachConfiguration {
   /// See [TrackingExtension.enableHttpTracking]
-  void enableHttpTracking({DatadogTrackingHttpClientListener? clientListener}) {
-    addPlugin(
-        DdHttpTrackingPluginConfiguration(clientListener: clientListener));
+  void enableHttpTracking(
+      {DatadogTrackingHttpClientListener? clientListener,
+      List<RegExp> ignoreUrlPatterns = const []}) {
+    addPlugin(DdHttpTrackingPluginConfiguration(
+      clientListener: clientListener,
+      ignoreUrlPatterns: ignoreUrlPatterns,
+    ));
   }
 }

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client_plugin.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1268,4 +1269,27 @@ void main() {
       expect(capturedAttributes['extra_parameter'], 1928);
     });
   });
+
+  group(
+    'when is an attach configuration',
+    () {
+      test(
+        'should add ignoreUrlPatterns to DdHttpTrackingPluginConfiguration',
+        () {
+          final ignoreUrlPatterns = [RegExp('teste')];
+
+          final configuration = DatadogAttachConfiguration()
+            ..enableHttpTracking(
+              ignoreUrlPatterns: ignoreUrlPatterns,
+            );
+
+          expect(
+              (configuration.additionalPlugins.first
+                      as DdHttpTrackingPluginConfiguration)
+                  .ignoreUrlPatterns,
+              ignoreUrlPatterns);
+        },
+      );
+    },
+  );
 }

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -9,7 +9,6 @@ import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
-import 'package:datadog_tracking_http_client/src/tracking_http_client.dart';
 import 'package:datadog_tracking_http_client/src/tracking_http_client_plugin.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';


### PR DESCRIPTION
ISSUE: https://github.com/DataDog/dd-sdk-flutter/issues/614
### What and why?

To filter http tracking when using Flutter module.

What changes does this pull request introduce and why is it necessary?

Add ignoreUrlPatterns to TrackingExtensionExisting extension

### How?

Adding in enableHttpTracking the attribute ignoreUrlPatterns.

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
