### PR TITLE
feat: Support WASM compilation and new JS interop

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-
+* Bump minimum Dart version to 3.3.0 (Flutter 3.19.0).
+* Add WASM support by removing references to `dart:html` and `package:js`
 
 ## 2.5.0
 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -4,7 +4,7 @@ Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real
 
 Datadog RUM SDK versions < 1.4 support monitoring for Flutter 2.8+.
 Datadog RUM SDK versions >= 1.4 support monitoring for Flutter 3.0+.
-Datadog RUM SDK versions >= 2.6 support monitoring for Flutter 3.19+
+Datadog RUM SDK versions >= 2.6 support monitoring for Flutter 3.19+.
 
 For complete documentation, see the [official Datadog documentation][11].
 

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -4,6 +4,7 @@ Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real
 
 Datadog RUM SDK versions < 1.4 support monitoring for Flutter 2.8+.
 Datadog RUM SDK versions >= 1.4 support monitoring for Flutter 3.0+.
+Datadog RUM SDK versions >= 2.6 support monitoring for Flutter 3.19+
 
 For complete documentation, see the [official Datadog documentation][11].
 

--- a/packages/datadog_flutter_plugin/example/web/index.html
+++ b/packages/datadog_flutter_plugin/example/web/index.html
@@ -27,72 +27,8 @@
   <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
-    if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
-          });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
-      });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
-    }
+    {{flutter_bootstrap_js}}
   </script>
 </body>
 </html>

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -34,7 +34,7 @@ void main() {
     var requestLog = <RequestLog>[];
     var rumLog = <RumEventDecoder>[];
     await recordedSession.pollSessionRequests(
-      const Duration(seconds: 30),
+      const Duration(seconds: 50),
       (requests) {
         requestLog.addAll(requests);
         requests.map((e) => e.data.split('\n')).expand((e) => e).forEach((e) {
@@ -56,7 +56,9 @@ void main() {
     expect(session.visits.length, 1);
 
     final view = session.visits[0];
+    print(view.viewEvents.last.view.errorCount);
     expect(view.viewEvents.last.view.errorCount, 3);
+    print(view.errorEvents.length);
     expect(view.errorEvents.length, 3);
 
     var exceptionError = view.errorEvents[0];

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -56,9 +56,7 @@ void main() {
     expect(session.visits.length, 1);
 
     final view = session.visits[0];
-    print(view.viewEvents.last.view.errorCount);
     expect(view.viewEvents.last.view.errorCount, 3);
-    print(view.errorEvents.length);
     expect(view.errorEvents.length, 3);
 
     var exceptionError = view.errorEvents[0];

--- a/packages/datadog_flutter_plugin/integration_test_app/web/index.html
+++ b/packages/datadog_flutter_plugin/integration_test_app/web/index.html
@@ -30,72 +30,8 @@
   <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
-    var scriptLoaded = false;
-    function loadMainDartJs() {
-      if (scriptLoaded) {
-        return;
-      }
-      scriptLoaded = true;
-      var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
-      scriptTag.type = 'application/javascript';
-      document.body.append(scriptTag);
-    }
-
-    if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'flutter_service_worker.js?v=' + serviceWorkerVersion;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
-                  console.log('Installed new service worker.');
-                  loadMainDartJs();
-                }
-              });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
-              // When the app updates the serviceWorkerVersion changes, so we
-              // need to ask the service worker to update.
-              console.log('New service worker available.');
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
-              console.log('Loading app from service worker.');
-              loadMainDartJs();
-            }
-          });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plaint <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
-      });
-    } else {
-      // Service workers not supported. Just drop the <script> tag.
-      loadMainDartJs();
-    }
+    {{flutter_bootstrap_js}}
   </script>
 </body>
 </html>

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -4,15 +4,10 @@
 
 // ignore_for_file: unused_element
 
-@JS('DD_RUM')
-library ddrum_flutter_web;
-
 import 'dart:async';
-// ignore: unused_import
-import 'dart:html' as html show window;
+import 'dart:js_interop';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'package:js/js.dart';
 
 import 'datadog_flutter_plugin.dart';
 import 'src/datadog_sdk_platform_interface.dart';
@@ -121,9 +116,8 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   }
 }
 
-@JS()
 @anonymous
-class _JsUser {
+extension type _JsUser._(JSObject _) implements JSObject {
   external String? get id;
   external String? get email;
   external String? get name;
@@ -135,5 +129,6 @@ class _JsUser {
   });
 }
 
-@JS('setUser')
+// TODO: Need to fix this
+@JS()
 external void _jsSetUser(_JsUser newUser);

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -5,7 +5,6 @@
 // ignore_for_file: unused_element
 
 import 'dart:async';
-import 'dart:js_interop';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -36,7 +35,7 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   Future<void> setUserInfo(String? id, String? name, String? email,
       Map<String, dynamic> extraInfo) async {
     // TODO: Extra user properties
-    _jsSetUser(_JsUser(
+    DD_RUM?.setUser(JsUser(
       id: id,
       name: name,
       email: email,
@@ -115,20 +114,3 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
     // Not currently supported
   }
 }
-
-@anonymous
-extension type _JsUser._(JSObject _) implements JSObject {
-  external String? get id;
-  external String? get email;
-  external String? get name;
-
-  external factory _JsUser({
-    String? id,
-    String? email,
-    String? name,
-  });
-}
-
-// TODO: Need to fix this
-@JS()
-external void _jsSetUser(_JsUser newUser);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddweb_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddweb_helpers.dart
@@ -2,15 +2,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
-@JS()
-library ddweb_helpers;
-
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('Error')
 @staticInterop
-class JSError {
-  external factory JSError();
+extension type JSError._(JSObject _) implements JSObject {
+  external JSError();
 }
 
 extension JSErrorExtension on JSError {

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -3,10 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 // ignore_for_file: unused_element, library_private_types_in_public_api
 
-@JS('DD_RUM')
-library ddrum_flutter_web;
-
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
@@ -24,7 +21,7 @@ class DdRumWeb extends DdRumPlatform {
     final sanitizedFirstPartyHosts = FirstPartyHost.createSanitized(
         configuration.firstPartyHostsWithTracingHeaders, logger);
 
-    init(_RumInitOptions(
+    DD_RUM.init(_RumInitOptions(
       applicationId: rumConfiguration.applicationId,
       clientToken: configuration.clientToken,
       site: siteStringForSite(configuration.site),
@@ -39,14 +36,14 @@ class DdRumWeb extends DdRumPlatform {
           _TracingUrl(
             match: host.regExp.toJs(),
             propagatorTypes:
-                host.headerTypes.map(_headerTypeToPropagatorType).toList(),
+                host.headerTypes.map(_headerTypeToPropagatorType).toList().toJS,
           )
-      ],
+      ].toJS,
       trackViewsManually: true,
       trackResources: trackResources,
       trackFrustrations: rumConfiguration.trackFrustrations,
       trackLongTasks: rumConfiguration.detectLongTasks,
-      enableExperimentalFeatures: ['feature_flags'],
+      enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
     ));
   }
 
@@ -59,12 +56,12 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<String?> getCurrentSessionId() async {
-    return _jsGetInternalContext()?.session_id;
+    return DD_RUM.getInternalContext()?.session_id;
   }
 
   @override
   Future<void> addAttribute(String key, dynamic value) async {
-    _jsSetGlobalContextProperty(key, valueToJs(value, 'context'));
+    DD_RUM.setGlobalContextProperty(key, valueToJs(value, 'context'));
   }
 
   @override
@@ -85,7 +82,7 @@ class DdRumWeb extends DdRumPlatform {
       jsError.dd_fingerprint = fingerprint;
     }
 
-    _jsAddError(jsError, attributesToJs(attributes, 'attributes'));
+    DD_RUM.addError(jsError, attributesToJs(attributes, 'attributes'));
   }
 
   @override
@@ -106,23 +103,23 @@ class DdRumWeb extends DdRumPlatform {
       jsError.dd_fingerprint = fingerprint;
     }
 
-    _jsAddError(jsError, attributesToJs(attributes, 'attributes'));
+    DD_RUM.addError(jsError, attributesToJs(attributes, 'attributes'));
   }
 
   @override
   Future<void> addTiming(String name) async {
-    _jsAddTiming(name);
+    DD_RUM.addTiming(name);
   }
 
   @override
   Future<void> addAction(
       RumActionType type, String name, Map<String, dynamic> attributes) async {
-    _jsAddAction(name, attributesToJs(attributes, 'attributes'));
+    DD_RUM.addAction(name, attributesToJs(attributes, 'attributes'));
   }
 
   @override
   Future<void> removeAttribute(String key) async {
-    _jsRemoveGlobalContextProperty(key);
+    DD_RUM.removeGlobalContextProperty(key);
   }
 
   @override
@@ -140,7 +137,7 @@ class DdRumWeb extends DdRumPlatform {
   @override
   Future<void> startView(
       String key, String name, Map<String, dynamic> attributes) async {
-    _jsStartView(name);
+    DD_RUM.startView(name);
   }
 
   @override
@@ -173,13 +170,13 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addFeatureFlagEvaluation(String name, Object value) async {
-    _jsAddFeatureFlagEvaluation(name, value);
+  Future<void> addFeatureFlagEvaluation(String name, Object? value) async {
+    DD_RUM.addFeatureFlagEvaluation(name, valueToJs(value, 'value'));
   }
 
   @override
   Future<void> stopSession() async {
-    _jsStopSession();
+    DD_RUM.stopSession();
   }
 
   @override
@@ -194,34 +191,32 @@ class DdRumWeb extends DdRumPlatform {
   }
 }
 
-String _headerTypeToPropagatorType(TracingHeaderType type) {
+JSString _headerTypeToPropagatorType(TracingHeaderType type) {
   switch (type) {
     case TracingHeaderType.datadog:
-      return 'datadog';
+      return 'datadog'.toJS;
     case TracingHeaderType.b3:
-      return 'b3';
+      return 'b3'.toJS;
     case TracingHeaderType.b3multi:
-      return 'b3multi';
+      return 'b3multi'.toJS;
     case TracingHeaderType.tracecontext:
-      return 'tracecontext';
+      return 'tracecontext'.toJS;
   }
 }
 
-@JS()
 @anonymous
-class _TracingUrl {
+extension type _TracingUrl._(JSObject _) implements JSObject {
   external JSRegExp match;
-  external List<String> propagatorTypes;
+  external JSArray propagatorTypes;
 
   external factory _TracingUrl({
     JSRegExp match,
-    List<String> propagatorTypes,
+    JSArray propagatorTypes,
   });
 }
 
-@JS()
 @anonymous
-class _RumInitOptions {
+extension type _RumInitOptions._(JSObject _) implements JSObject {
   external String get applicationId;
   external String get clientToken;
   external String get site;
@@ -237,8 +232,8 @@ class _RumInitOptions {
   external num? get sessionReplaySampleRate;
   external bool? get silentMultipleInit;
   external String? get proxy;
-  external List<dynamic> get allowedTracingUrls;
-  external List<String> get enableExperimentalFeatures;
+  external JSArray get allowedTracingUrls;
+  external JSArray get enableExperimentalFeatures;
 
   external factory _RumInitOptions({
     String applicationId,
@@ -257,8 +252,8 @@ class _RumInitOptions {
     num? sessionReplaySampleRate,
     bool? silentMultipleInit,
     String? proxy,
-    List<dynamic> allowedTracingUrls,
-    List<String> enableExperimentalFeatures,
+    JSArray allowedTracingUrls,
+    JSArray enableExperimentalFeatures,
   });
 }
 
@@ -268,41 +263,26 @@ extension ToJs on RegExp {
   }
 }
 
-@JS()
-@anonymous
-class _RumInternalContext {
+extension type _RumInternalContext._(JSObject _) implements JSObject {
   // ignore: non_constant_identifier_names
   external String? application_id;
   // ignore: non_constant_identifier_names
   external String? session_id;
 }
 
+extension type _DdRum._(JSObject _) implements JSObject {
+  external void init(_RumInitOptions configuration);
+  external _RumInternalContext? getInternalContext();
+  external void startView(String name);
+  external void setGlobalContextProperty(String property, JSAny? context);
+  external void removeGlobalContextProperty(String property);
+  external void addTiming(String name);
+  external void addError(JSObject error, JSAny? context);
+  external void addAction(String action, JSAny? context);
+  external void addFeatureFlagEvaluation(String name, JSAny? value);
+  external void stopSession();
+}
+
 @JS()
-external void init(_RumInitOptions configuration);
-
-@JS('getInternalContext')
-external _RumInternalContext? _jsGetInternalContext();
-
-@JS('startView')
-external void _jsStartView(String name);
-
-@JS('setGlobalContextProperty')
-external void _jsSetGlobalContextProperty(String property, dynamic context);
-
-@JS('removeGlobalContextProperty')
-external void _jsRemoveGlobalContextProperty(String property);
-
-@JS('addTiming')
-external void _jsAddTiming(String name);
-
-@JS('addError')
-external void _jsAddError(dynamic error, dynamic context);
-
-@JS('addAction')
-external void _jsAddAction(String action, dynamic context);
-
-@JS('addFeatureFlagEvaluation')
-external void _jsAddFeatureFlagEvaluation(String name, dynamic value);
-
-@JS('stopSession')
-external void _jsStopSession();
+// ignore: non_constant_identifier_names
+external _DdRum DD_RUM;

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -5,6 +5,8 @@
 
 import 'dart:js_interop';
 
+import 'package:meta/meta.dart';
+
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
 import '../logs/ddweb_helpers.dart';
@@ -21,7 +23,7 @@ class DdRumWeb extends DdRumPlatform {
     final sanitizedFirstPartyHosts = FirstPartyHost.createSanitized(
         configuration.firstPartyHostsWithTracingHeaders, logger);
 
-    DD_RUM.init(_RumInitOptions(
+    DD_RUM?.init(_RumInitOptions(
       applicationId: rumConfiguration.applicationId,
       clientToken: configuration.clientToken,
       site: siteStringForSite(configuration.site),
@@ -56,12 +58,12 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<String?> getCurrentSessionId() async {
-    return DD_RUM.getInternalContext()?.session_id;
+    return DD_RUM?.getInternalContext()?.session_id;
   }
 
   @override
   Future<void> addAttribute(String key, dynamic value) async {
-    DD_RUM.setGlobalContextProperty(key, valueToJs(value, 'context'));
+    DD_RUM?.setGlobalContextProperty(key, valueToJs(value, 'context'));
   }
 
   @override
@@ -82,7 +84,7 @@ class DdRumWeb extends DdRumPlatform {
       jsError.dd_fingerprint = fingerprint;
     }
 
-    DD_RUM.addError(jsError, attributesToJs(attributes, 'attributes'));
+    DD_RUM?.addError(jsError, attributesToJs(attributes, 'attributes'));
   }
 
   @override
@@ -103,23 +105,23 @@ class DdRumWeb extends DdRumPlatform {
       jsError.dd_fingerprint = fingerprint;
     }
 
-    DD_RUM.addError(jsError, attributesToJs(attributes, 'attributes'));
+    DD_RUM?.addError(jsError, attributesToJs(attributes, 'attributes'));
   }
 
   @override
   Future<void> addTiming(String name) async {
-    DD_RUM.addTiming(name);
+    DD_RUM?.addTiming(name);
   }
 
   @override
   Future<void> addAction(
       RumActionType type, String name, Map<String, dynamic> attributes) async {
-    DD_RUM.addAction(name, attributesToJs(attributes, 'attributes'));
+    DD_RUM?.addAction(name, attributesToJs(attributes, 'attributes'));
   }
 
   @override
   Future<void> removeAttribute(String key) async {
-    DD_RUM.removeGlobalContextProperty(key);
+    DD_RUM?.removeGlobalContextProperty(key);
   }
 
   @override
@@ -137,7 +139,7 @@ class DdRumWeb extends DdRumPlatform {
   @override
   Future<void> startView(
       String key, String name, Map<String, dynamic> attributes) async {
-    DD_RUM.startView(name);
+    DD_RUM?.startView(name);
   }
 
   @override
@@ -171,12 +173,12 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> addFeatureFlagEvaluation(String name, Object? value) async {
-    DD_RUM.addFeatureFlagEvaluation(name, valueToJs(value, 'value'));
+    DD_RUM?.addFeatureFlagEvaluation(name, valueToJs(value, 'value'));
   }
 
   @override
   Future<void> stopSession() async {
-    DD_RUM.stopSession();
+    DD_RUM?.stopSession();
   }
 
   @override
@@ -270,6 +272,20 @@ extension type _RumInternalContext._(JSObject _) implements JSObject {
   external String? session_id;
 }
 
+@anonymous
+@internal
+extension type JsUser._(JSObject _) implements JSObject {
+  external String? get id;
+  external String? get email;
+  external String? get name;
+
+  external factory JsUser({
+    String? id,
+    String? email,
+    String? name,
+  });
+}
+
 extension type _DdRum._(JSObject _) implements JSObject {
   external void init(_RumInitOptions configuration);
   external _RumInternalContext? getInternalContext();
@@ -281,8 +297,9 @@ extension type _DdRum._(JSObject _) implements JSObject {
   external void addAction(String action, JSAny? context);
   external void addFeatureFlagEvaluation(String name, JSAny? value);
   external void stopSession();
+  external void setUser(JsUser newUser);
 }
 
 @JS()
 // ignore: non_constant_identifier_names
-external _DdRum DD_RUM;
+external _DdRum? DD_RUM;

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -2,9 +2,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
 import 'package:flutter/foundation.dart';
-import 'package:js/js.dart';
-import 'package:js/js_util.dart' as jsutil;
 
 import '../datadog_flutter_plugin.dart';
 
@@ -29,22 +30,34 @@ dynamic attributesToJs(Map<String, Object?> attributes, String parameterName) {
   return valueToJs(attributes, parameterName);
 }
 
-dynamic valueToJs(Object? value, String parameterName) {
-  if (value == null || value is num || value is bool || value is String) {
-    return value;
+JSAny? valueToJs(Object? value, String parameterName) {
+  if (value == null) {
+    return null;
+  }
+
+  if (value is num) {
+    return value.toJS;
+  }
+
+  if (value is bool) {
+    return value.toJS;
+  }
+
+  if (value is String) {
+    return value.toJS;
   }
 
   if (value is Map) {
-    final jsMap = jsutil.newObject<Map<String, Object?>>();
+    final jsMap = JSObject();
     for (final item in value.entries) {
-      jsutil.setProperty(
-          jsMap, item.key, valueToJs(item.value, '$parameterName.${item.key}'));
+      jsMap.setProperty(
+          item.key, valueToJs(item.value, '$parameterName.${item.key}'));
     }
     return jsMap;
   }
 
   if (value is List) {
-    final jsList = <Object?>[];
+    final jsList = JSArray();
     for (int i = 0; i < value.length; ++i) {
       jsList.add(valueToJs(value[i], '$parameterName[$i]'));
     }
@@ -60,7 +73,7 @@ final _dartLineRegex =
     RegExp(r'(?<file>.+) (?<location>\d+:\d+)\s*(?<function>.+)');
 
 @JS('RegExp')
-class JSRegExp {
+extension type JSRegExp._(JSObject _) implements JSObject {
   external factory JSRegExp([String? pattern, String? flags]);
 }
 

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.6.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.3.0"
 
 dependencies:
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ">=0.6.3 <0.8.0"
   plugin_platform_interface: ^2.0.2
   json_annotation: ^4.7.0
   uuid: ^4.0.0


### PR DESCRIPTION
### What and why?
This makes the necessary changes to support WASM compilation available in Flutter 3.22.

Using the new `js_interop` package requires use of Dart 3.3 (Flutter 3.19+), which is potentially a breaking change, so this needs to be discussed before it enters mainline.

refs: #615

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
