### PR TITLE
fix: Fix exception when encoding variables in gql_link

### DIFF
--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Fix an exception when attempting to `jsonEncode` unencodable variables.
 
 ## 1.1.0
 

--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -158,7 +158,22 @@ class DatadogGqlLink extends Link {
       attributes[_GraphQLAttributes.operationName] = operationName;
     }
 
-    attributes[_GraphQLAttributes.variables] = jsonEncode(request.variables);
+    try {
+      attributes[_GraphQLAttributes.variables] = jsonEncode(
+        request.variables,
+        toEncodable: (nonEncodable) {
+          // Non-encodable variables should just use their string representations
+          return nonEncodable.toString();
+        },
+      );
+    } catch (e, st) {
+      datadogSdk.internalLogger.error('Error encodeing GraphQL variables: $e.');
+      datadogSdk.internalLogger.sendToDatadog(
+        '$DatadogGqlLink encountered an error while attempting to encode variables: $e',
+        st,
+        e.runtimeType.toString(),
+      );
+    }
 
     return attributes;
   }


### PR DESCRIPTION
### What and why?

The gql_link encodes variables to JSON for display in the Datadog UI. However, there are situations when those variables are not encodable (such as when sending a file using `MultipartFile`.  In these situations, we'll take the `toString` of the variable instead.

To avoid this issue in the future, wrap the `jsonEncode` in a try / catch and send encoding issues to both the developer and to telemetry.

refs: #618

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
