### PR TITLE
fix: Do not use singletons for RUM / Logs plugins

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogEventMapper.kt
@@ -1,0 +1,113 @@
+package com.datadoghq.flutter
+
+import android.os.Handler
+import android.os.Looper
+import com.datadog.android.Datadog
+import com.datadog.android.log.LogsConfiguration
+import com.datadog.android.log.model.LogEvent
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * This is a helper class that that simplifies event mapping / scrubbing for Log events.
+ *
+ * Since it is possible for Flutter engines to shut down and be recreated, it is possible that the
+ * object used as the event mapper to be lost. This class is used as a static instance that will
+ * perform mapping and call the Flutter mapping methods using the last provided MethodChannel.
+ */
+internal class DatadogLogEventMapper {
+    private val channels: MutableSet<MethodChannel> = mutableSetOf()
+
+    fun addChannel(channel: MethodChannel) {
+        channels.add(channel)
+    }
+
+    fun removeChannel(channel: MethodChannel) {
+        channels.remove(channel)
+    }
+
+    fun attachMapper(config: LogsConfiguration.Builder): LogsConfiguration.Builder {
+        config.setEventMapper { event -> mapLogEvent(event) }
+
+        return config
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    internal fun mapLogEvent(event: LogEvent): LogEvent? {
+        val jsonEvent = event.toJson().asFlutterMap()
+        var modifiedJson: Map<String, Any?>? = null
+
+        val latch = CountDownLatch(1)
+
+        val handler = Handler(Looper.getMainLooper())
+        handler.post {
+            try {
+                val channel = channels.first()
+                channel.invokeMethod(
+                    "mapLogEvent",
+                    mapOf(
+                        "event" to jsonEvent
+                    ),
+                    object : MethodChannel.Result {
+                        override fun success(result: Any?) {
+                            @Suppress("UNCHECKED_CAST")
+                            modifiedJson = result as? Map<String, Any?>
+                            latch.countDown()
+                        }
+
+                        override fun error(
+                            errorCode: String,
+                            errorMessage: String?,
+                            errorDetails: Any?
+                        ) {
+                            // No telemetry needed, this is likely an issue in user code
+                            latch.countDown()
+                        }
+
+                        override fun notImplemented() {
+                            Datadog._internalProxy()._telemetry.error(
+                                "mapLogEvent returned notImplemented."
+                            )
+                            latch.countDown()
+                        }
+                    }
+                )
+            } catch (e: Exception) {
+                Datadog._internalProxy()._telemetry.error("Attempting call mapLogEvent failed.", e)
+                latch.countDown()
+            }
+        }
+
+        try {
+            // Stalls until the method channel finishes
+            if (!latch.await(1, TimeUnit.SECONDS)) {
+                Datadog._internalProxy()._telemetry.debug("logMapper timed out")
+                return event
+            }
+
+            return modifiedJson?.let {
+                if (!it.containsKey("_dd.mapper_error")) {
+                    val modifiedEvent = LogEvent.fromJsonObject(modifiedJson!!.toJsonObject())
+
+                    event.status = modifiedEvent.status
+                    event.message = modifiedEvent.message
+                    event.ddtags = modifiedEvent.ddtags
+                    event.logger.name = modifiedEvent.logger.name
+                    event.error?.fingerprint = modifiedEvent.error?.fingerprint
+
+                    event.additionalProperties.clear()
+                    event.additionalProperties.putAll(modifiedEvent.additionalProperties)
+                }
+                event
+            }
+        } catch (e: Exception) {
+            Datadog._internalProxy()._telemetry.error(
+                "Attempt to deserialize mapped log event failed, or latch await was interrupted." +
+                    " Returning unmodified event.",
+                e
+            )
+            return event
+        }
+    }
+}

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogEventMapper.kt
@@ -6,6 +6,8 @@ import com.datadog.android.Datadog
 import com.datadog.android.log.LogsConfiguration
 import com.datadog.android.log.model.LogEvent
 import io.flutter.plugin.common.MethodChannel
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -17,7 +19,7 @@ import java.util.concurrent.TimeUnit
  * perform mapping and call the Flutter mapping methods using the last provided MethodChannel.
  */
 internal class DatadogLogEventMapper {
-    private val channels: MutableSet<MethodChannel> = mutableSetOf()
+    private val channels: MutableSet<MethodChannel> = Collections.newSetFromMap(ConcurrentHashMap())
 
     fun addChannel(channel: MethodChannel) {
         channels.add(channel)
@@ -41,9 +43,10 @@ internal class DatadogLogEventMapper {
         val latch = CountDownLatch(1)
 
         val handler = Handler(Looper.getMainLooper())
+        val channel = channels.firstOrNull() ?: return event
+
         handler.post {
             try {
-                val channel = channels.first()
                 channel.invokeMethod(
                     "mapLogEvent",
                     mapOf(

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
@@ -1,0 +1,330 @@
+package com.datadoghq.flutter
+
+import android.os.Handler
+import android.os.Looper
+import com.datadog.android.Datadog
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.LongTaskEvent
+import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.ViewEvent
+import io.flutter.plugin.common.MethodChannel
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.system.measureNanoTime
+
+/**
+ * This is a helper class that that simplifies event mapping / scrubbing for RUM events.
+ *
+ * Since it is possible for Flutter engines to shut down and be recreated, it is possible that the
+ * object used as the event mapper to be lost. This class is used as a static instance that will
+ * perform mapping and call the Flutter mapping methods using the last provided MethodChannel.
+ */
+@Suppress("StringLiteralDuplication")
+internal class DatadogRumEventMapper {
+    private val channels: MutableSet<MethodChannel> = mutableSetOf()
+
+    val mapperPerf = PerformanceTracker()
+    val mapperPerfMainThread = PerformanceTracker()
+    var mapperTimeouts = 0
+
+    fun addChannel(channel: MethodChannel) {
+        channels.add(channel)
+    }
+
+    fun removeChannel(channel: MethodChannel) {
+        channels.remove(channel)
+    }
+
+    fun attachMappers(
+        config: Map<String, Any?>,
+        configBuilder: RumConfiguration.Builder
+    ): RumConfiguration.Builder {
+        fun optionIsSet(key: String): Boolean {
+            return config[key] as? Boolean ?: false
+        }
+
+        if (optionIsSet("attachViewEventMapper")) {
+            configBuilder.setViewEventMapper { event -> mapViewEvent(event) }
+        }
+        if (optionIsSet("attachActionEventMapper")) {
+            configBuilder.setActionEventMapper { event -> mapActionEvent(event) }
+        }
+        if (optionIsSet("attachResourceEventMapper")) {
+            configBuilder.setResourceEventMapper { event -> mapResourceEvent(event) }
+        }
+        if (optionIsSet("attachErrorEventMapper")) {
+            configBuilder.setErrorEventMapper { event -> mapErrorEvent(event) }
+        }
+        if (optionIsSet("attachLongTaskEventMapper")) {
+            configBuilder.setLongTaskEventMapper { event -> mapLongTaskEvent(event) }
+        }
+
+        return configBuilder
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    internal fun mapViewEvent(event: ViewEvent): ViewEvent {
+        var result: ViewEvent
+        val perf = measureNanoTime {
+            var jsonEvent = event.toJson().asFlutterMap()
+            jsonEvent = normalizeExtraUserInfo(jsonEvent)
+
+            result = callEventMapper("mapViewEvent", event, jsonEvent) { encodedResult, event ->
+                (encodedResult?.get("view") as? Map<String, Any?>)?.let {
+                    event.view.name = it["name"] as? String
+                    event.view.referrer = it["referrer"] as? String
+                    event.view.url = it["url"] as String
+                }
+
+                event
+            } ?: event
+        }
+        mapperPerf.addSample(perf)
+
+        return result
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    internal fun mapActionEvent(event: ActionEvent): ActionEvent? {
+        val result: ActionEvent?
+        val perf = measureNanoTime {
+            var jsonEvent = event.toJson().asFlutterMap()
+            jsonEvent = normalizeExtraUserInfo(jsonEvent)
+
+            result = callEventMapper("mapActionEvent", event, jsonEvent) { encodedResult, event ->
+                if (encodedResult == null) {
+                    null
+                } else {
+                    (encodedResult["action"] as? Map<String, Any?>)?.let {
+                        val encodedTarget = it["target"] as? Map<String, Any?>
+                        if (encodedTarget != null) {
+                            event.action.target?.name = encodedTarget["name"] as String
+                        }
+                    }
+
+                    (encodedResult["view"] as? Map<String, Any?>)?.let {
+                        event.view.name = it["name"] as? String
+                        event.view.referrer = it["referrer"] as? String
+                        event.view.url = it["url"] as String
+                    }
+
+                    event
+                }
+            }
+        }
+        mapperPerf.addSample(perf)
+
+        return result
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    internal fun mapResourceEvent(event: ResourceEvent): ResourceEvent? {
+        var result: ResourceEvent?
+        val perf = measureNanoTime {
+            var jsonEvent = event.toJson().asFlutterMap()
+            jsonEvent = normalizeExtraUserInfo(jsonEvent)
+
+            result = callEventMapper("mapResourceEvent", event, jsonEvent) { encodedResult, event ->
+                if (encodedResult == null) {
+                    null
+                } else {
+                    (encodedResult["resource"] as? Map<String, Any?>)?.let {
+                        event.resource.url = it["url"] as String
+                    }
+
+                    (encodedResult["view"] as? Map<String, Any?>)?.let {
+                        event.view.name = it["name"] as? String
+                        event.view.referrer = it["referrer"] as? String
+                        event.view.url = it["url"] as String
+                    }
+
+                    event
+                }
+            }
+        }
+        mapperPerf.addSample(perf)
+
+        return result
+    }
+
+    @Suppress("ComplexMethod", "UNCHECKED_CAST")
+    internal fun mapErrorEvent(event: ErrorEvent): ErrorEvent? {
+        var result: ErrorEvent?
+        val perf = measureNanoTime {
+            var jsonEvent = event.toJson().asFlutterMap()
+            jsonEvent = normalizeExtraUserInfo(jsonEvent)
+
+            result = callEventMapper("mapErrorEvent", event, jsonEvent) { encodedResult, event ->
+                if (encodedResult == null) {
+                    null
+                } else {
+                    (encodedResult["error"] as? Map<String, Any?>)?.let { encodedError ->
+                        val encodedCauses = encodedError["causes"] as? List<Map<String, Any?>>
+                        if (encodedCauses != null) {
+                            event.error.causes?.let { causes ->
+                                if (causes.count() == encodedCauses.count()) {
+                                    causes.forEachIndexed { i, cause ->
+                                        cause.message = encodedCauses[i]["message"] as? String ?: ""
+                                        cause.stack = encodedCauses[i]["stack"] as? String
+                                    }
+                                }
+                            }
+                        } else {
+                            event.error.causes = null
+                        }
+
+                        val encodedResource = encodedError["resource"] as? Map<String, Any?>
+                        if (encodedResource != null) {
+                            event.error.resource?.url = encodedResource["url"] as? String ?: ""
+                        }
+
+                        event.error.stack = encodedError["stack"] as? String
+                        event.error.fingerprint = encodedError["fingerprint"] as? String
+                    }
+
+                    (encodedResult["view"] as? Map<String, Any?>)?.let {
+                        event.view.name = it["name"] as? String
+                        event.view.referrer = it["referrer"] as? String
+                        event.view.url = it["url"] as String
+                    }
+
+                    event
+                }
+            }
+        }
+        mapperPerf.addSample(perf)
+
+        return result
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    internal fun mapLongTaskEvent(event: LongTaskEvent): LongTaskEvent? {
+        var result: LongTaskEvent?
+        val perf = measureNanoTime {
+            var jsonEvent = event.toJson().asFlutterMap()
+            jsonEvent = normalizeExtraUserInfo(jsonEvent)
+
+            result = callEventMapper("mapLongTaskEvent", event, jsonEvent) { encodedResult, event ->
+                if (encodedResult == null) {
+                    null
+                } else {
+                    (encodedResult["view"] as? Map<String, Any?>)?.let {
+                        event.view.name = it["name"] as? String
+                        event.view.referrer = it["referrer"] as? String
+                        event.view.url = it["url"] as String
+                    }
+
+                    event
+                }
+            }
+        }
+        mapperPerf.addSample(perf)
+
+        return result
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun normalizeExtraUserInfo(encodedEvent: Map<String, Any?>): Map<String, Any?> {
+        val reservedKeys = setOf("email", "id", "name")
+        // Pull out user information
+        val mutableEvent = encodedEvent.toMutableMap()
+        (mutableEvent["usr"] as? Map<String, Any?>)?.let { usr ->
+            val mutableUsr = usr.toMutableMap()
+            val extraUserInfo = mutableMapOf<String, Any?>()
+            usr.filter { !reservedKeys.contains(it.key) }.forEach {
+                extraUserInfo[it.key] = it.value
+                mutableUsr.remove(it.key)
+            }
+            mutableUsr["usr_info"] = extraUserInfo
+            mutableEvent["usr"] = mutableUsr
+        }
+
+        return mutableEvent
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    internal fun <T> callEventMapper(
+        mapperName: String,
+        event: T,
+        encodedEvent: Map<String, Any?>,
+        completion: (Map<String, Any?>?, T) -> T?
+    ): T? {
+        var modifiedJson: Map<String, Any?>? = encodedEvent
+        // Any valid channel should do here since they should be connected to the same initialization code,
+        // but calling on multiple could result in weird behavior and performance issues. While "first" may
+        // not be the actual first registered channel, it should be fine for our purposes.
+        val channel = channels.first()
+        val latch = CountDownLatch(1)
+
+        val handler = Handler(Looper.getMainLooper())
+        handler.post {
+            val perf = measureNanoTime {
+                try {
+                    channel.invokeMethod(
+                        mapperName,
+                        mapOf(
+                            "event" to encodedEvent
+                        ),
+                        object : MethodChannel.Result {
+                            @Suppress("UNCHECKED_CAST")
+                            override fun success(result: Any?) {
+                                modifiedJson = (result as? Map<String, Any?>)
+                                latch.countDown()
+                            }
+
+                            override fun error(
+                                errorCode: String,
+                                errorMessage: String?,
+                                errorDetails: Any?
+                            ) {
+                                latch.countDown()
+                            }
+
+                            override fun notImplemented() {
+                                Datadog._internalProxy()._telemetry.error(
+                                    "$mapperName returned notImplemented."
+                                )
+                                latch.countDown()
+                            }
+                        }
+                    )
+                } catch (e: Exception) {
+                    Datadog._internalProxy()._telemetry.error(
+                        "Attempting call $mapperName failed.",
+                        e
+                    )
+                    latch.countDown()
+                }
+            }
+            mapperPerfMainThread.addSample(perf)
+        }
+
+        try {
+            // Stalls until the method channel finishes
+            if (!latch.await(1, TimeUnit.SECONDS)) {
+                Datadog._internalProxy()._telemetry.debug("$mapperName timed out")
+                return event
+            }
+
+            if (modifiedJson?.containsKey("_dd.mapper_error") == true) {
+                return event
+            }
+
+            return completion(modifiedJson, event)
+        } catch (e: InterruptedException) {
+            Datadog._internalProxy()._telemetry.debug(
+                "Latch await was interrupted. Returning unmodified event."
+            )
+        } catch (e: Exception) {
+            Datadog._internalProxy()._telemetry.error(
+                "Unknown exception attempting to deserialize mapped log event." +
+                    " Returning unmodified event.",
+                e
+            )
+        }
+
+        return event
+    }
+}

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
@@ -10,6 +10,8 @@ import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
 import io.flutter.plugin.common.MethodChannel
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.system.measureNanoTime
@@ -23,7 +25,7 @@ import kotlin.system.measureNanoTime
  */
 @Suppress("StringLiteralDuplication")
 internal class DatadogRumEventMapper {
-    private val channels: MutableSet<MethodChannel> = mutableSetOf()
+    private val channels: MutableSet<MethodChannel> = Collections.newSetFromMap(ConcurrentHashMap())
 
     val mapperPerf = PerformanceTracker()
     val mapperPerfMainThread = PerformanceTracker()
@@ -255,7 +257,7 @@ internal class DatadogRumEventMapper {
         // Any valid channel should do here since they should be connected to the same initialization code,
         // but calling on multiple could result in weird behavior and performance issues. While "first" may
         // not be the actual first registered channel, it should be fine for our purposes.
-        val channel = channels.first()
+        val channel = channels.firstOrNull() ?: return event
         val latch = CountDownLatch(1)
 
         val handler = Handler(Looper.getMainLooper())

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -68,7 +68,7 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
     private lateinit var binding: FlutterPlugin.FlutterPluginBinding
 
     var rum: RumMonitor? = null
-        private set
+        internal set
 
     // Might need a better way to deal with this. There's weird shared responsibility for
     // telemetry between the core and RUM.

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -6,10 +6,7 @@
 package com.datadoghq.flutter
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import android.util.Log
-import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.UploadFrequency
@@ -25,12 +22,6 @@ import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
-import com.datadog.android.rum.event.ViewEventMapper
-import com.datadog.android.rum.model.ActionEvent
-import com.datadog.android.rum.model.ErrorEvent
-import com.datadog.android.rum.model.LongTaskEvent
-import com.datadog.android.rum.model.ResourceEvent
-import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -38,14 +29,9 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.Result
 import java.lang.ClassCastException
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import kotlin.system.measureNanoTime
 
-@Suppress("StringLiteralDuplication")
-class DatadogRumPlugin internal constructor(
-    rumInstance: RumMonitor? = null
-) : MethodChannel.MethodCallHandler {
+class DatadogRumPlugin : MethodChannel.MethodCallHandler {
     companion object RumParameterNames {
         const val PARAM_AT = "at"
         const val PARAM_DURATION = "duration"
@@ -69,9 +55,8 @@ class DatadogRumPlugin internal constructor(
         // See DatadogSdkPlugin's description of this same member
         private var previousConfiguration: Map<String, Any?>? = null
 
-        val instance: DatadogRumPlugin by lazy {
-            DatadogRumPlugin()
-        }
+        // Static instance of the event mapper
+        internal val eventMapper: DatadogRumEventMapper = DatadogRumEventMapper()
 
         // For testing purposes only
         internal fun resetConfig() {
@@ -82,12 +67,8 @@ class DatadogRumPlugin internal constructor(
     private lateinit var channel: MethodChannel
     private lateinit var binding: FlutterPlugin.FlutterPluginBinding
 
-    var rum: RumMonitor? = rumInstance
+    var rum: RumMonitor? = null
         private set
-
-    val mapperPerf = PerformanceTracker()
-    val mapperPerfMainThread = PerformanceTracker()
-    var mapperTimeouts = 0
 
     // Might need a better way to deal with this. There's weird shared responsibility for
     // telemetry between the core and RUM.
@@ -96,11 +77,17 @@ class DatadogRumPlugin internal constructor(
     fun attachToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "datadog_sdk_flutter.rum")
         channel.setMethodCallHandler(this)
+        eventMapper.addChannel(channel)
 
         binding = flutterPluginBinding
+
+        if (GlobalRumMonitor.isRegistered()) {
+            rum = GlobalRumMonitor.get()
+        }
     }
 
     fun detachFromEngine() {
+        eventMapper.removeChannel(channel)
         channel.setMethodCallHandler(null)
     }
 
@@ -228,57 +215,7 @@ class DatadogRumPlugin internal constructor(
         config: Map<String, Any?>,
         configBuilder: RumConfiguration.Builder
     ): RumConfiguration.Builder {
-        fun optionIsSet(key: String): Boolean {
-            return config[key] as? Boolean ?: false
-        }
-
-        if (optionIsSet("attachViewEventMapper")) {
-            configBuilder.setViewEventMapper(
-                object : ViewEventMapper {
-                    override fun map(event: ViewEvent): ViewEvent {
-                        return mapViewEvent(event)
-                    }
-                }
-            )
-        }
-        if (optionIsSet("attachActionEventMapper")) {
-            configBuilder.setActionEventMapper(
-                object : EventMapper<ActionEvent> {
-                    override fun map(event: ActionEvent): ActionEvent? {
-                        return mapActionEvent(event)
-                    }
-                }
-            )
-        }
-        if (optionIsSet("attachResourceEventMapper")) {
-            configBuilder.setResourceEventMapper(
-                object : EventMapper<ResourceEvent> {
-                    override fun map(event: ResourceEvent): ResourceEvent? {
-                        return mapResourceEvent(event)
-                    }
-                }
-            )
-        }
-        if (optionIsSet("attachErrorEventMapper")) {
-            configBuilder.setErrorEventMapper(
-                object : EventMapper<ErrorEvent> {
-                    override fun map(event: ErrorEvent): ErrorEvent? {
-                        return mapErrorEvent(event)
-                    }
-                }
-            )
-        }
-        if (optionIsSet("attachLongTaskEventMapper")) {
-            configBuilder.setLongTaskEventMapper(
-                object : EventMapper<LongTaskEvent> {
-                    override fun map(event: LongTaskEvent): LongTaskEvent? {
-                        return mapLongTaskEvent(event)
-                    }
-                }
-            )
-        }
-
-        return configBuilder
+        return eventMapper.attachMappers(config, configBuilder)
     }
 
     private fun startView(call: MethodCall, result: Result) {
@@ -504,266 +441,6 @@ class DatadogRumPlugin internal constructor(
     private fun stopSession(call: MethodCall, result: Result) {
         rum?.stopSession()
         result.success(null)
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    internal fun <T> callEventMapper(
-        mapperName: String,
-        event: T,
-        encodedEvent: Map<String, Any?>,
-        completion: (Map<String, Any?>?, T) -> T?
-    ): T? {
-        var modifiedJson: Map<String, Any?>? = encodedEvent
-        val latch = CountDownLatch(1)
-
-        val handler = Handler(Looper.getMainLooper())
-        handler.post {
-            val perf = measureNanoTime {
-                try {
-                    channel.invokeMethod(
-                        mapperName,
-                        mapOf(
-                            "event" to encodedEvent
-                        ),
-                        object : Result {
-                            @Suppress("UNCHECKED_CAST")
-                            override fun success(result: Any?) {
-                                modifiedJson = (result as? Map<String, Any?>)
-                                latch.countDown()
-                            }
-
-                            override fun error(
-                                errorCode: String,
-                                errorMessage: String?,
-                                errorDetails: Any?
-                            ) {
-                                latch.countDown()
-                            }
-
-                            override fun notImplemented() {
-                                Datadog._internalProxy()._telemetry.error(
-                                    "$mapperName returned notImplemented."
-                                )
-                                latch.countDown()
-                            }
-                        }
-                    )
-                } catch (e: Exception) {
-                    Datadog._internalProxy()._telemetry.error(
-                        "Attempting call $mapperName failed.",
-                        e
-                    )
-                    latch.countDown()
-                }
-            }
-            mapperPerfMainThread.addSample(perf)
-        }
-
-        try {
-            // Stalls until the method channel finishes
-            if (!latch.await(1, TimeUnit.SECONDS)) {
-                Datadog._internalProxy()._telemetry.debug("$mapperName timed out")
-                return event
-            }
-
-            if (modifiedJson?.containsKey("_dd.mapper_error") == true) {
-                return event
-            }
-
-            return completion(modifiedJson, event)
-        } catch (e: InterruptedException) {
-            Datadog._internalProxy()._telemetry.debug(
-                "Latch await was interrupted. Returning unmodified event."
-            )
-        } catch (e: Exception) {
-            Datadog._internalProxy()._telemetry.error(
-                "Unknown exception attempting to deserialize mapped log event." +
-                    " Returning unmodified event.",
-                e
-            )
-        }
-
-        return event
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    internal fun mapViewEvent(event: ViewEvent): ViewEvent {
-        var result: ViewEvent
-        val perf = measureNanoTime {
-            var jsonEvent = event.toJson().asFlutterMap()
-            jsonEvent = normalizeExtraUserInfo(jsonEvent)
-
-            result = callEventMapper("mapViewEvent", event, jsonEvent) { encodedResult, event ->
-                (encodedResult?.get("view") as? Map<String, Any?>)?.let {
-                    event.view.name = it["name"] as? String
-                    event.view.referrer = it["referrer"] as? String
-                    event.view.url = it["url"] as String
-                }
-
-                event
-            } ?: event
-        }
-        mapperPerf.addSample(perf)
-
-        return result
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    internal fun mapActionEvent(event: ActionEvent): ActionEvent? {
-        val result: ActionEvent?
-        val perf = measureNanoTime {
-            var jsonEvent = event.toJson().asFlutterMap()
-            jsonEvent = normalizeExtraUserInfo(jsonEvent)
-
-            result = callEventMapper("mapActionEvent", event, jsonEvent) { encodedResult, event ->
-                if (encodedResult == null) {
-                    null
-                } else {
-                    (encodedResult["action"] as? Map<String, Any?>)?.let {
-                        val encodedTarget = it["target"] as? Map<String, Any?>
-                        if (encodedTarget != null) {
-                            event.action.target?.name = encodedTarget["name"] as String
-                        }
-                    }
-
-                    (encodedResult["view"] as? Map<String, Any?>)?.let {
-                        event.view.name = it["name"] as? String
-                        event.view.referrer = it["referrer"] as? String
-                        event.view.url = it["url"] as String
-                    }
-
-                    event
-                }
-            }
-        }
-        mapperPerf.addSample(perf)
-
-        return result
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    internal fun mapResourceEvent(event: ResourceEvent): ResourceEvent? {
-        var result: ResourceEvent?
-        val perf = measureNanoTime {
-            var jsonEvent = event.toJson().asFlutterMap()
-            jsonEvent = normalizeExtraUserInfo(jsonEvent)
-
-            result = callEventMapper("mapResourceEvent", event, jsonEvent) { encodedResult, event ->
-                if (encodedResult == null) {
-                    null
-                } else {
-                    (encodedResult["resource"] as? Map<String, Any?>)?.let {
-                        event.resource.url = it["url"] as String
-                    }
-
-                    (encodedResult["view"] as? Map<String, Any?>)?.let {
-                        event.view.name = it["name"] as? String
-                        event.view.referrer = it["referrer"] as? String
-                        event.view.url = it["url"] as String
-                    }
-
-                    event
-                }
-            }
-        }
-        mapperPerf.addSample(perf)
-
-        return result
-    }
-
-    @Suppress("ComplexMethod", "UNCHECKED_CAST")
-    internal fun mapErrorEvent(event: ErrorEvent): ErrorEvent? {
-        var result: ErrorEvent?
-        val perf = measureNanoTime {
-            var jsonEvent = event.toJson().asFlutterMap()
-            jsonEvent = normalizeExtraUserInfo(jsonEvent)
-
-            result = callEventMapper("mapErrorEvent", event, jsonEvent) { encodedResult, event ->
-                if (encodedResult == null) {
-                    null
-                } else {
-                    (encodedResult["error"] as? Map<String, Any?>)?.let { encodedError ->
-                        val encodedCauses = encodedError["causes"] as? List<Map<String, Any?>>
-                        if (encodedCauses != null) {
-                            event.error.causes?.let { causes ->
-                                if (causes.count() == encodedCauses.count()) {
-                                    causes.forEachIndexed { i, cause ->
-                                        cause.message = encodedCauses[i]["message"] as? String ?: ""
-                                        cause.stack = encodedCauses[i]["stack"] as? String
-                                    }
-                                }
-                            }
-                        } else {
-                            event.error.causes = null
-                        }
-
-                        val encodedResource = encodedError["resource"] as? Map<String, Any?>
-                        if (encodedResource != null) {
-                            event.error.resource?.url = encodedResource["url"] as? String ?: ""
-                        }
-
-                        event.error.stack = encodedError["stack"] as? String
-                        event.error.fingerprint = encodedError["fingerprint"] as? String
-                    }
-
-                    (encodedResult["view"] as? Map<String, Any?>)?.let {
-                        event.view.name = it["name"] as? String
-                        event.view.referrer = it["referrer"] as? String
-                        event.view.url = it["url"] as String
-                    }
-
-                    event
-                }
-            }
-        }
-        mapperPerf.addSample(perf)
-
-        return result
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    internal fun mapLongTaskEvent(event: LongTaskEvent): LongTaskEvent? {
-        var result: LongTaskEvent?
-        val perf = measureNanoTime {
-            var jsonEvent = event.toJson().asFlutterMap()
-            jsonEvent = normalizeExtraUserInfo(jsonEvent)
-
-            result = callEventMapper("mapLongTaskEvent", event, jsonEvent) { encodedResult, event ->
-                if (encodedResult == null) {
-                    null
-                } else {
-                    (encodedResult["view"] as? Map<String, Any?>)?.let {
-                        event.view.name = it["name"] as? String
-                        event.view.referrer = it["referrer"] as? String
-                        event.view.url = it["url"] as String
-                    }
-
-                    event
-                }
-            }
-        }
-        mapperPerf.addSample(perf)
-
-        return result
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun normalizeExtraUserInfo(encodedEvent: Map<String, Any?>): Map<String, Any?> {
-        val reservedKeys = setOf("email", "id", "name")
-        // Pull out user information
-        val mutableEvent = encodedEvent.toMutableMap()
-        (mutableEvent["usr"] as? Map<String, Any?>)?.let { usr ->
-            val mutableUsr = usr.toMutableMap()
-            val extraUserInfo = mutableMapOf<String, Any?>()
-            usr.filter { !reservedKeys.contains(it.key) }.forEach {
-                extraUserInfo[it.key] = it.value
-                mutableUsr.remove(it.key)
-            }
-            mutableUsr["usr_info"] = extraUserInfo
-            mutableEvent["usr"] = mutableUsr
-        }
-
-        return mutableEvent
     }
 }
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -63,8 +63,8 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         SynchronousQueue()
     )
 
-    private val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin()
-    private val rumPlugin: DatadogRumPlugin = DatadogRumPlugin()
+    internal val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin()
+    internal val rumPlugin: DatadogRumPlugin = DatadogRumPlugin()
 
     override fun onAttachedToEngine(
         flutterPluginBinding: FlutterPlugin.FlutterPluginBinding

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -63,9 +63,8 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
         SynchronousQueue()
     )
 
-    // Because Flutter recreates the plugin, we have to rely on singletons for the contained plugins
-    val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin.instance
-    val rumPlugin: DatadogRumPlugin = DatadogRumPlugin.instance
+    private val logsPlugin: DatadogLogsPlugin = DatadogLogsPlugin()
+    private val rumPlugin: DatadogRumPlugin = DatadogRumPlugin()
 
     override fun onAttachedToEngine(
         flutterPluginBinding: FlutterPlugin.FlutterPluginBinding
@@ -321,16 +320,16 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
             "mapperPerformance" ->
                 mapOf(
                     "total" to mapOf(
-                        "minMs" to rumPlugin.mapperPerf.minInMs,
-                        "maxMs" to rumPlugin.mapperPerf.maxInMs,
-                        "avgMs" to rumPlugin.mapperPerf.avgInMs
+                        "minMs" to DatadogRumPlugin.eventMapper.mapperPerf.minInMs,
+                        "maxMs" to DatadogRumPlugin.eventMapper.mapperPerf.maxInMs,
+                        "avgMs" to DatadogRumPlugin.eventMapper.mapperPerf.avgInMs
                     ),
                     "mainThread" to mapOf(
-                        "minMs" to rumPlugin.mapperPerfMainThread.minInMs,
-                        "maxMs" to rumPlugin.mapperPerfMainThread.maxInMs,
-                        "avgMs" to rumPlugin.mapperPerfMainThread.avgInMs
+                        "minMs" to DatadogRumPlugin.eventMapper.mapperPerfMainThread.minInMs,
+                        "maxMs" to DatadogRumPlugin.eventMapper.mapperPerfMainThread.maxInMs,
+                        "avgMs" to DatadogRumPlugin.eventMapper.mapperPerfMainThread.avgInMs
                     ),
-                    "mapperTimeouts" to rumPlugin.mapperTimeouts
+                    "mapperTimeouts" to DatadogRumPlugin.eventMapper.mapperTimeouts
                 )
             else -> null
         }

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -52,7 +52,8 @@ class DatadogRumPluginTest {
     @BeforeEach
     fun beforeEach() {
         monitorProxy = MockRumMonitor()
-        plugin = DatadogRumPlugin(monitorProxy)
+        plugin = DatadogRumPlugin()
+        plugin.rum = monitorProxy
     }
 
     @AfterEach

--- a/packages/datadog_flutter_plugin/example/lib/main.dart
+++ b/packages/datadog_flutter_plugin/example/lib/main.dart
@@ -27,6 +27,12 @@ void main() async {
             applicationId: applicationId,
             detectLongTasks: true,
             reportFlutterPerformance: true,
+            actionEventMapper: (event) {
+              if (event.action.target?.name == 'Test Action') {
+                event.action.target?.name = 'Replaced';
+              }
+              return event;
+            },
           )
         : null,
   );


### PR DESCRIPTION
### What and why?

Under certain circumstances, Flutter can create two FlutterEngines which each have their own method channels. If this happens, we could end up in a situation where RUM and Logs were not properly attached to a MethodChannel, resulting in error messages and lost calls.

refs: #596 #580 RUM-491 RUM-4438

### How?

We're removing the `DatadogRumPlugin` and `DatadogLogsPlugin` singletons and replacing them with instances to avoid this.  Both plugins will attach to existing Datadog Logs and RUM instances during initialization if they have already been inititalized.

However, this breaks our current mapper implementation. Since Datadog expects the mapper during initialization, and holds it during the life of the application, we have to move the mappers to a companion object of the `*Plugin` classes to avoid issues with multiple or disconnected `MethodChannels`.

This potentially also helps us with multiple isolate tracking, but is just the first step of that.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
