### PR TITLE
feat: Add configurable trace header injection

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Support selective injection of trace contexts with TraceContextInjection configuration item.
 * Bump minimum Dart version to 3.3.0 (Flutter 3.19.0).
 * Add WASM support by removing references to `dart:html` and `package:js`
 

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -105,3 +105,7 @@ class FirstPartyHost {
     return null;
   }
 }
+
+extension DatadogRumInternal on DatadogRum {
+  TraceContextInjection get contextInjectionSetting => traceContextInjection;
+}

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -96,6 +96,16 @@ enum DatadogSite {
   ap1,
 }
 
+/// Defines whether the trace context should be injected into all requests or
+/// only into requests that are sampled in.
+enum TraceContextInjection {
+  /// Injects trace context into all requests regardless of the sampling decision.
+  all,
+
+  /// Injects trace context only into sampled requests.
+  sampled,
+}
+
 class DatadogConfiguration {
   // Either a RUM client token (generated for the RUM Application) or a regular
   // client token for Logging and APM. Obtained on the Datadog website.
@@ -356,14 +366,19 @@ class DatadogAttachConfiguration {
   /// Sets the sampling rate for tracing
   ///
   /// The sampling rate must be a value between `0.0` and `100.0`. A value of
-  /// `0.0` means no resources will include APM tracing, `100.0` resource will
-  /// include APM tracing
+  /// `0.0` means no resources will include APM tracing, while a value of `100.0`
+  /// means all resources will include APM tracing
   ///
   /// This property only affects network requests made from Flutter, and it is
   /// not shared or populated from the existing SDK.
   ///
   /// Defaults to `20.0`.
   double traceSampleRate;
+
+  /// The strategy for injecting trace context into requests. See [TraceContextInjection].
+  ///
+  /// Defaults to [TraceContextInjection.all].
+  TraceContextInjection traceContextInjection = TraceContextInjection.all;
 
   /// Configurations for additional plugins that will be created after Datadog
   /// is initialized.
@@ -376,6 +391,7 @@ class DatadogAttachConfiguration {
     this.reportFlutterPerformance = false,
     List<String>? firstPartyHosts,
     this.firstPartyHostsWithTracingHeaders = const {},
+    this.traceContextInjection = TraceContextInjection.all,
   }) {
     // Attempt a union if both configuration options are present
     if (firstPartyHosts != null) {

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -93,6 +93,9 @@ class DatadogRum {
   /// See [DatadogRumConfiguration.traceSampleRate]
   final double traceSampleRate;
 
+  @internal
+  final TraceContextInjection traceContextInjection;
+
   final _sampleRandom = Random();
   final InternalLogger logger;
 
@@ -112,6 +115,7 @@ class DatadogRum {
   @internal
   DatadogRum.fromExisting(DatadogSdk core, DatadogAttachConfiguration config)
       : traceSampleRate = config.traceSampleRate,
+        traceContextInjection = config.traceContextInjection,
         logger = core.internalLogger {
     _init(
       core: core,
@@ -123,6 +127,7 @@ class DatadogRum {
 
   DatadogRum._(DatadogSdk core, DatadogRumConfiguration configuration)
       : traceSampleRate = configuration.traceSampleRate,
+        traceContextInjection = configuration.traceContextInjection,
         logger = core.internalLogger {
     _init(
       core: core,

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -79,6 +79,11 @@ class DatadogRumConfiguration {
   /// Defaults to `20.0`.
   double traceSampleRate;
 
+  /// The strategy for injecting trace context into requests. See [TraceContextInjection].
+  ///
+  /// Defaults to [TraceContextInjection.all].
+  TraceContextInjection traceContextInjection = TraceContextInjection.all;
+
   /// Enable or disable detection of "long tasks"
   ///
   /// Long task detection attempts to detect when an application is doing too
@@ -158,6 +163,7 @@ class DatadogRumConfiguration {
     required this.applicationId,
     double sessionSamplingRate = 100.0,
     double traceSampleRate = 20.0,
+    this.traceContextInjection = TraceContextInjection.all,
     this.detectLongTasks = true,
     double longTaskThreshold = 0.1,
     this.trackFrustrations = true,

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -225,16 +225,14 @@ Map<String, String> getTracingHeaders(
 
   switch (headersType) {
     case TracingHeaderType.datadog:
-      if (context.sampled) {
+      if (shouldInjectHeaders) {
         headers[DatadogHttpTracingHeaders.traceId] =
             context.traceId.asString(TracingIdRepresentation.lowDecimal);
         headers[DatadogHttpTracingHeaders.tags] =
             '${DatadogHttpTracingHeaders.traceIdTag}=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}';
         headers[DatadogHttpTracingHeaders.parentId] =
             context.spanId.asString(TracingIdRepresentation.decimal);
-      }
-      headers[DatadogHttpTracingHeaders.origin] = 'rum';
-      if (shouldInjectHeaders) {
+        headers[DatadogHttpTracingHeaders.origin] = 'rum';
         headers[DatadogHttpTracingHeaders.samplingPriority] = sampledString;
       }
       break;

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -6,6 +6,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 
+import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
 
 /// The type of tracing header to inject into first party requests.
@@ -213,11 +214,14 @@ Map<String, Object?> generateDatadogAttributes(
 
 Map<String, String> getTracingHeaders(
   TracingContext context,
-  TracingHeaderType headersType,
-) {
+  TracingHeaderType headersType, {
+  TraceContextInjection contextInjection = TraceContextInjection.all,
+}) {
   var headers = <String, String>{};
 
   final sampledString = context.sampled ? '1' : '0';
+  bool shouldInjectHeaders =
+      context.sampled || contextInjection == TraceContextInjection.all;
 
   switch (headersType) {
     case TracingHeaderType.datadog:
@@ -230,7 +234,9 @@ Map<String, String> getTracingHeaders(
             context.spanId.asString(TracingIdRepresentation.decimal);
       }
       headers[DatadogHttpTracingHeaders.origin] = 'rum';
-      headers[DatadogHttpTracingHeaders.samplingPriority] = sampledString;
+      if (shouldInjectHeaders) {
+        headers[DatadogHttpTracingHeaders.samplingPriority] = sampledString;
+      }
       break;
     case TracingHeaderType.b3:
       if (context.sampled) {
@@ -241,12 +247,14 @@ Map<String, String> getTracingHeaders(
           context.parentSpanId?.asString(TracingIdRepresentation.hex16Chars),
         ].whereType<String>().join('-');
         headers[OTelHttpTracingHeaders.singleB3] = headerValue;
-      } else {
+      } else if (contextInjection == TraceContextInjection.all) {
         headers[OTelHttpTracingHeaders.singleB3] = sampledString;
       }
       break;
     case TracingHeaderType.b3multi:
-      headers[OTelHttpTracingHeaders.multipleSampled] = sampledString;
+      if (shouldInjectHeaders) {
+        headers[OTelHttpTracingHeaders.multipleSampled] = sampledString;
+      }
 
       if (context.sampled) {
         headers[OTelHttpTracingHeaders.multipleTraceId] =
@@ -261,21 +269,23 @@ Map<String, String> getTracingHeaders(
       }
       break;
     case TracingHeaderType.tracecontext:
-      final spanString =
-          context.spanId.asString(TracingIdRepresentation.hex16Chars);
-      final parentHeaderValue = [
-        '00', // Version Code
-        context.traceId.asString(TracingIdRepresentation.hex32Chars),
-        spanString,
-        context.sampled ? '01' : '00'
-      ].join('-');
-      final stateHeaderValue = [
-        's:$sampledString',
-        'o:rum',
-        'p:$spanString',
-      ].join(';');
-      headers[W3CTracingHeaders.traceparent] = parentHeaderValue;
-      headers[W3CTracingHeaders.tracestate] = 'dd=$stateHeaderValue';
+      if (shouldInjectHeaders) {
+        final spanString =
+            context.spanId.asString(TracingIdRepresentation.hex16Chars);
+        final parentHeaderValue = [
+          '00', // Version Code
+          context.traceId.asString(TracingIdRepresentation.hex32Chars),
+          spanString,
+          context.sampled ? '01' : '00'
+        ].join('-');
+        final stateHeaderValue = [
+          's:$sampledString',
+          'o:rum',
+          'p:$spanString',
+        ].join(';');
+        headers[W3CTracingHeaders.traceparent] = parentHeaderValue;
+        headers[W3CTracingHeaders.tracestate] = 'dd=$stateHeaderValue';
+      }
       break;
   }
 

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -173,8 +173,12 @@ void main() {
       contextInjection: TraceContextInjection.all,
     );
 
-    expect(headers['x-datadog-trace-id'], isNull);
-    expect(headers['x-datadog-parent-id'], isNull);
+    expect(headers['x-datadog-trace-id'],
+          context.traceId.asString(TracingIdRepresentation.lowDecimal));
+      expect(headers['x-datadog-tags'],
+          '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
+      expect(headers['x-datadog-parent-id'],
+          context.spanId.asString(TracingIdRepresentation.decimal));
     expect(headers['x-datadog-sampling-priority'], '0');
     expect(headers['x-datadog-origin'], 'rum');
   });
@@ -193,7 +197,7 @@ void main() {
     expect(headers['x-datadog-trace-id'], isNull);
     expect(headers['x-datadog-parent-id'], isNull);
     expect(headers['x-datadog-sampling-priority'], isNull);
-    expect(headers['x-datadog-origin'], 'rum');
+    expect(headers['x-datadog-origin'], isNull);
   });
 
   test(

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2023-Present Datadog, Inc.
 
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/src/tracing/tracing_headers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -62,7 +63,7 @@ void main() {
     expect(attributes['_dd.rule_psr'], 0.3);
   });
 
-  test('Sampled context does not generate datadog attributes', () {
+  test('Unsampled context does not generate datadog attributes', () {
     final context = generateTracingContext(false);
 
     final attributes = generateDatadogAttributes(context, 30.0);
@@ -72,25 +73,105 @@ void main() {
     expect(attributes['_dd.rule_psr'], 0.3);
   });
 
-  test('Datadog tracing headers are generated correctly { sampled }', () {
-    final context = generateTracingContext(true);
+  // The TraceContextInjection value shouldn't matter in the sampled cases, so
+  // make sure all tests work the same way for all TraceContextInjection options
+  for (final contextInjection in TraceContextInjection.values) {
+    test(
+        'Datadog tracing headers are generated correctly { $contextInjection, sampled }',
+        () {
+      final context = generateTracingContext(true);
 
-    final headers = getTracingHeaders(context, TracingHeaderType.datadog);
+      final headers = getTracingHeaders(
+        context,
+        TracingHeaderType.datadog,
+        contextInjection: contextInjection,
+      );
 
-    expect(headers['x-datadog-trace-id'],
-        context.traceId.asString(TracingIdRepresentation.lowDecimal));
-    expect(headers['x-datadog-tags'],
-        '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
-    expect(headers['x-datadog-parent-id'],
-        context.spanId.asString(TracingIdRepresentation.decimal));
-    expect(headers['x-datadog-sampling-priority'], '1');
-    expect(headers['x-datadog-origin'], 'rum');
-  });
+      expect(headers['x-datadog-trace-id'],
+          context.traceId.asString(TracingIdRepresentation.lowDecimal));
+      expect(headers['x-datadog-tags'],
+          '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
+      expect(headers['x-datadog-parent-id'],
+          context.spanId.asString(TracingIdRepresentation.decimal));
+      expect(headers['x-datadog-sampling-priority'], '1');
+      expect(headers['x-datadog-origin'], 'rum');
+    });
 
-  test('Datadog tracing headers are generated correctly { unsampled }', () {
+    test(
+        'b3 tracing headers are generated correctly { $contextInjection, sampled }',
+        () {
+      final context = generateTracingContext(true);
+
+      final headers = getTracingHeaders(
+        context,
+        TracingHeaderType.b3,
+        contextInjection: contextInjection,
+      );
+
+      final traceString =
+          context.traceId.asString(TracingIdRepresentation.hex32Chars);
+      final spanString =
+          context.spanId.asString(TracingIdRepresentation.hex16Chars);
+      final expectedHeader = '$traceString-$spanString-1'.toLowerCase();
+
+      expect(headers['b3'], expectedHeader);
+    });
+
+    test(
+        'b3multi tracing headers are generated correctly { $contextInjection, sampled }',
+        () {
+      final context = generateTracingContext(true);
+
+      final headers = getTracingHeaders(
+        context,
+        TracingHeaderType.b3multi,
+        contextInjection: contextInjection,
+      );
+
+      final traceString =
+          context.traceId.asString(TracingIdRepresentation.hex32Chars);
+      final spanString =
+          context.spanId.asString(TracingIdRepresentation.hex16Chars);
+
+      expect(headers['X-B3-TraceId'], traceString.toLowerCase());
+      expect(headers['X-B3-SpanId'], spanString.toLowerCase());
+      expect(headers['X-B3-ParentSpanId'], isNull);
+      expect(headers['X-B3-Sampled'], '1');
+    });
+
+    test(
+        'tracecontext tracing headers are generated correctly { $contextInjection, sampled }',
+        () {
+      final context = generateTracingContext(true);
+
+      final headers = getTracingHeaders(
+        context,
+        TracingHeaderType.tracecontext,
+        contextInjection: contextInjection,
+      );
+
+      final traceString =
+          context.traceId.asString(TracingIdRepresentation.hex32Chars);
+      final spanString =
+          context.spanId.asString(TracingIdRepresentation.hex16Chars);
+      final expectedParentHeader = '00-$traceString-$spanString-01';
+      final expectedStateHeader = 'dd=s:1;o:rum;p:$spanString';
+
+      expect(headers['traceparent'], expectedParentHeader.toLowerCase());
+      expect(headers['tracestate'], expectedStateHeader.toLowerCase());
+    });
+  }
+
+  test(
+      'Datadog tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
+      () {
     final context = generateTracingContext(false);
 
-    final headers = getTracingHeaders(context, TracingHeaderType.datadog);
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.datadog,
+      contextInjection: TraceContextInjection.all,
+    );
 
     expect(headers['x-datadog-trace-id'], isNull);
     expect(headers['x-datadog-parent-id'], isNull);
@@ -98,48 +179,61 @@ void main() {
     expect(headers['x-datadog-origin'], 'rum');
   });
 
-  test('b3 tracing headers are generated correctly { sampled }', () {
-    final context = generateTracingContext(true);
-
-    final headers = getTracingHeaders(context, TracingHeaderType.b3);
-
-    final traceString =
-        context.traceId.asString(TracingIdRepresentation.hex32Chars);
-    final spanString =
-        context.spanId.asString(TracingIdRepresentation.hex16Chars);
-    final expectedHeader = '$traceString-$spanString-1'.toLowerCase();
-
-    expect(headers['b3'], expectedHeader);
-  });
-
-  test('b3 tracing headers are generated correctly { unsampled }', () {
+  test(
+      'Datadog tracing headers are generated correctly { TraceContextInjection.sampled, unsampled }',
+      () {
     final context = generateTracingContext(false);
 
-    final headers = getTracingHeaders(context, TracingHeaderType.b3);
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.datadog,
+      contextInjection: TraceContextInjection.sampled,
+    );
+
+    expect(headers['x-datadog-trace-id'], isNull);
+    expect(headers['x-datadog-parent-id'], isNull);
+    expect(headers['x-datadog-sampling-priority'], isNull);
+    expect(headers['x-datadog-origin'], 'rum');
+  });
+
+  test(
+      'b3 tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
+      () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.b3,
+      contextInjection: TraceContextInjection.all,
+    );
 
     expect(headers['b3'], '0');
   });
 
-  test('b3multi tracing headers are generated correctly { sampled }', () {
-    final context = generateTracingContext(true);
-
-    final headers = getTracingHeaders(context, TracingHeaderType.b3multi);
-
-    final traceString =
-        context.traceId.asString(TracingIdRepresentation.hex32Chars);
-    final spanString =
-        context.spanId.asString(TracingIdRepresentation.hex16Chars);
-
-    expect(headers['X-B3-TraceId'], traceString.toLowerCase());
-    expect(headers['X-B3-SpanId'], spanString.toLowerCase());
-    expect(headers['X-B3-ParentSpanId'], isNull);
-    expect(headers['X-B3-Sampled'], '1');
-  });
-
-  test('b3multi tracing headers are generated correctly { unsampled }', () {
+  test(
+      'b3 tracing headers are generated correctly { TraceContextInjection.sampled, unsampled }',
+      () {
     final context = generateTracingContext(false);
 
-    final headers = getTracingHeaders(context, TracingHeaderType.b3multi);
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.b3,
+      contextInjection: TraceContextInjection.sampled,
+    );
+
+    expect(headers['b3'], isNull);
+  });
+
+  test(
+      'b3multi tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
+      () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.b3multi,
+      contextInjection: TraceContextInjection.all,
+    );
 
     expect(headers['X-B3-TraceId'], isNull);
     expect(headers['X-B3-SpanId'], isNull);
@@ -147,26 +241,33 @@ void main() {
     expect(headers['X-B3-Sampled'], '0');
   });
 
-  test('tracecontext tracing headers are generated correctly { sampled }', () {
-    final context = generateTracingContext(true);
-
-    final headers = getTracingHeaders(context, TracingHeaderType.tracecontext);
-
-    final traceString =
-        context.traceId.asString(TracingIdRepresentation.hex32Chars);
-    final spanString =
-        context.spanId.asString(TracingIdRepresentation.hex16Chars);
-    final expectedParentHeader = '00-$traceString-$spanString-01';
-    final expectedStateHeader = 'dd=s:1;o:rum;p:$spanString';
-
-    expect(headers['traceparent'], expectedParentHeader.toLowerCase());
-    expect(headers['tracestate'], expectedStateHeader.toLowerCase());
-  });
-
-  test('traceparent tracing headers are generated correctly { unsampled }', () {
+  test(
+      'b3multi tracing headers are generated correctly { TraceContextInjection.sampled, unsampled }',
+      () {
     final context = generateTracingContext(false);
 
-    final headers = getTracingHeaders(context, TracingHeaderType.tracecontext);
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.b3multi,
+      contextInjection: TraceContextInjection.sampled,
+    );
+
+    expect(headers['X-B3-TraceId'], isNull);
+    expect(headers['X-B3-SpanId'], isNull);
+    expect(headers['X-B3-ParentSpanId'], isNull);
+    expect(headers['X-B3-Sampled'], isNull);
+  });
+
+  test(
+      'traceparent tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
+      () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.tracecontext,
+      contextInjection: TraceContextInjection.all,
+    );
 
     final traceString =
         context.traceId.asString(TracingIdRepresentation.hex32Chars);
@@ -177,5 +278,20 @@ void main() {
 
     expect(headers['traceparent'], expectedParentHeader.toLowerCase());
     expect(headers['tracestate'], expectedStateHeader.toLowerCase());
+  });
+
+  test(
+      'traceparent tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
+      () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.tracecontext,
+      contextInjection: TraceContextInjection.sampled,
+    );
+
+    expect(headers['traceparent'], isNull);
+    expect(headers['tracestate'], isNull);
   });
 }

--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add support for `TraceContextInjection` configuration.
 
 ## 1.1.1
 

--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -213,7 +213,8 @@ class DatadogGqlLink extends Link {
           final tracingContext = generateTracingContext(shouldSample);
 
           for (final headerType in tracingHeaderTypes) {
-            final newHeaders = getTracingHeaders(tracingContext, headerType);
+            final newHeaders = getTracingHeaders(tracingContext, headerType,
+                contextInjection: rum.contextInjectionSetting);
             for (final entry in newHeaders.entries) {
               // Don't replace exiting headers
               if (!headers.containsKey(entry.key)) {

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.6.0
+  datadog_flutter_plugin: ^2.7.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   uuid: ^4.0.0

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.5.0
+  datadog_flutter_plugin: ^2.6.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   uuid: ^4.0.0

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -947,12 +947,10 @@ void verifyHeaders(
 
   switch (type) {
     case TracingHeaderType.datadog:
-      expect(headers['x-datadog-origin'], 'rum');
-      if (traceContextInjection == TraceContextInjection.all) {
+      if (shouldInjectHeaders) {
+        expect(headers['x-datadog-origin'], 'rum');
         expect(
             headers['x-datadog-sampling-priority'], shouldSample ? '1' : '0');
-      }
-      if (shouldSample) {
         var traceValue = headers['x-datadog-trace-id']!;
         traceInt = BigInt.tryParse(traceValue);
         var spanValue = headers['x-datadog-parent-id']!;
@@ -965,6 +963,12 @@ void verifyHeaders(
         BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
         expect(highTraceInt, isNotNull);
         expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
+      } else {
+        expect(headers['x-datadog-origin'], isNull);
+        expect(headers['x-datadog-sampling-priority'], isNull);
+        expect(headers['x-datadog-trace-id'], isNull);
+        expect(headers['x-datadog-parent-id'], isNull);
+        expect(headers['x-datadog-tags'], isNull);
       }
       break;
     case TracingHeaderType.b3:

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -838,8 +838,12 @@ query UserInfo($id: ID!) {
         }
       });
 
-      test('sets trace headers for first party urls', () {
+      test(
+          'sets trace headers for first party urls { sampled, TraceContextInjection.all }',
+          () {
         when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.all);
         final link =
             DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
         final request = Request(
@@ -853,13 +857,16 @@ query UserInfo($id: ID!) {
         });
 
         final headersEntry = forwardedRequest!.context.entry<HttpLinkHeaders>();
-        verifyHeaders(headersEntry!.headers, headerType, true);
+        verifyHeaders(
+            headersEntry!.headers, headerType, true, TraceContextInjection.all);
       });
 
       test(
-          'sets trave headers for first party urls when should sample is false',
+          'sets trace headers for first party urls { sampled, TraceContextInjection.sampled }',
           () {
-        when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+        when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.sampled);
         final link =
             DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
         final request = Request(
@@ -873,21 +880,78 @@ query UserInfo($id: ID!) {
         });
 
         final headersEntry = forwardedRequest!.context.entry<HttpLinkHeaders>();
-        verifyHeaders(headersEntry!.headers, headerType, false);
+        verifyHeaders(headersEntry!.headers, headerType, true,
+            TraceContextInjection.sampled);
+      });
+
+      test(
+          'sets trace headers for first party urls { unsampled, TraceContextInjection.all }, ',
+          () {
+        when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.all);
+        final link =
+            DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
+        final request = Request(
+            operation: Operation(document: query, operationName: 'UserInfo'));
+
+        // When
+        Request? forwardedRequest;
+        link.request(request, (request) {
+          forwardedRequest = request;
+          return const Stream<Response>.empty();
+        });
+
+        final headersEntry = forwardedRequest!.context.entry<HttpLinkHeaders>();
+        verifyHeaders(headersEntry!.headers, headerType, false,
+            TraceContextInjection.all);
+      });
+
+      test(
+          'does not sets trace headers for first party urls { unsampled, TraceContextInjection.sampled }, ',
+          () {
+        when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.sampled);
+        final link =
+            DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
+        final request = Request(
+            operation: Operation(document: query, operationName: 'UserInfo'));
+
+        // When
+        Request? forwardedRequest;
+        link.request(request, (request) {
+          forwardedRequest = request;
+          return const Stream<Response>.empty();
+        });
+
+        final headersEntry = forwardedRequest!.context.entry<HttpLinkHeaders>();
+        verifyHeaders(headersEntry!.headers, headerType, false,
+            TraceContextInjection.sampled);
       });
     });
   }
 }
 
 void verifyHeaders(
-    Map<String, String> headers, TracingHeaderType type, bool shouldSample) {
+  Map<String, String> headers,
+  TracingHeaderType type,
+  bool shouldSample,
+  TraceContextInjection traceContextInjection,
+) {
   BigInt? traceInt;
   BigInt? spanInt;
+
+  bool shouldInjectHeaders =
+      shouldSample || traceContextInjection == TraceContextInjection.all;
 
   switch (type) {
     case TracingHeaderType.datadog:
       expect(headers['x-datadog-origin'], 'rum');
-      expect(headers['x-datadog-sampling-priority'], shouldSample ? '1' : '0');
+      if (traceContextInjection == TraceContextInjection.all) {
+        expect(
+            headers['x-datadog-sampling-priority'], shouldSample ? '1' : '0');
+      }
       if (shouldSample) {
         var traceValue = headers['x-datadog-trace-id']!;
         traceInt = BigInt.tryParse(traceValue);
@@ -904,38 +968,50 @@ void verifyHeaders(
       }
       break;
     case TracingHeaderType.b3:
-      var singleHeader = headers['b3']!;
+      var singleHeader = headers['b3'];
       if (shouldSample) {
-        var headerParts = singleHeader.split('-');
+        var headerParts = singleHeader!.split('-');
         traceInt = BigInt.tryParse(headerParts[0], radix: 16);
         spanInt = BigInt.tryParse(headerParts[1], radix: 16);
         expect(headerParts[2], shouldSample ? '1' : '0');
-      } else {
+      } else if (shouldInjectHeaders) {
         expect(singleHeader, '0');
+      } else {
+        expect(singleHeader, isNull);
       }
       break;
     case TracingHeaderType.b3multi:
-      expect(headers['X-B3-Sampled'], shouldSample ? '1' : '0');
-      if (shouldSample) {
-        var traceValue = headers['X-B3-TraceId']!;
-        traceInt = BigInt.tryParse(traceValue, radix: 16);
-        var spanValue = headers['X-B3-SpanId']!;
-        spanInt = BigInt.tryParse(spanValue, radix: 16);
+      if (shouldInjectHeaders) {
+        expect(headers['X-B3-Sampled'], shouldSample ? '1' : '0');
+        if (shouldSample) {
+          var traceValue = headers['X-B3-TraceId']!;
+          traceInt = BigInt.tryParse(traceValue, radix: 16);
+          var spanValue = headers['X-B3-SpanId']!;
+          spanInt = BigInt.tryParse(spanValue, radix: 16);
+        }
+      } else {
+        expect(headers['X-B3-Sampled'], isNull);
+        expect(headers['X-B3-TraceId'], isNull);
+        expect(headers['X-B3-SpanId'], isNull);
       }
       break;
     case TracingHeaderType.tracecontext:
-      var header = headers['traceparent']!;
-      var headerParts = header.split('-');
-      expect(headerParts[0], '00');
-      traceInt = BigInt.tryParse(headerParts[1], radix: 16);
-      spanInt = BigInt.tryParse(headerParts[2], radix: 16);
-      expect(headerParts[3], shouldSample ? '01' : '00');
-      final stateHeader = headers['tracestate']!;
+      if (shouldInjectHeaders) {
+        var header = headers['traceparent']!;
+        var headerParts = header.split('-');
+        expect(headerParts[0], '00');
+        traceInt = BigInt.tryParse(headerParts[1], radix: 16);
+        spanInt = BigInt.tryParse(headerParts[2], radix: 16);
+        expect(headerParts[3], shouldSample ? '01' : '00');
+        final stateHeader = headers['tracestate']!;
 
-      final stateParts = getDdTraceState(stateHeader);
-      expect(stateParts['s'], shouldSample ? '1' : '0');
-      expect(stateParts['o'], 'rum');
-      expect(stateParts['p'], headerParts[2]);
+        final stateParts = getDdTraceState(stateHeader);
+        expect(stateParts['s'], shouldSample ? '1' : '0');
+        expect(stateParts['o'], 'rum');
+        expect(stateParts['p'], headerParts[2]);
+      } else {
+        expect(headers['traceparent'], isNull);
+      }
       break;
   }
 

--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add support for `TraceContextInjection` configuration.
 
 ## 1.1.0
 

--- a/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/src/datadog_grpc_interceptor.dart
@@ -73,7 +73,8 @@ class DatadogGrpcInterceptor extends ClientInterceptor {
         }
 
         for (final tracingType in headerTypes) {
-          addedHeaders.addAll(getTracingHeaders(tracingContext, tracingType));
+          addedHeaders.addAll(getTracingHeaders(tracingContext, tracingType,
+              contextInjection: rum.contextInjectionSetting));
         }
       }
 

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.5.0
+  datadog_flutter_plugin: ^2.6.0
   grpc: ^3.0.2
   uuid: ^4.0.0
 

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.6.0
+  datadog_flutter_plugin: ^2.7.0
   grpc: ^3.0.2
   uuid: ^4.0.0
 

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_grpc_interceptor/datadog_grpc_interceptor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:grpc/grpc.dart';
@@ -39,16 +40,25 @@ void main() {
   });
 
   void verifyHeaders(
-      TracingHeaderType type, Map<String, String> metadata, bool sampled) {
+    TracingHeaderType type,
+    Map<String, String> metadata,
+    bool sampled,
+    TraceContextInjection traceContextInjection,
+  ) {
     BigInt? traceInt;
     BigInt? spanInt;
 
+    bool shouldInjectHeaders =
+        sampled || traceContextInjection == TraceContextInjection.all;
+
     switch (type) {
       case TracingHeaderType.datadog:
-        expect(metadata['x-datadog-sampling-priority'], sampled ? '1' : '0');
-        traceInt = BigInt.tryParse(metadata['x-datadog-trace-id'] ?? '');
-        spanInt = BigInt.tryParse(metadata['x-datadog-parent-id'] ?? '');
+        if (traceContextInjection == TraceContextInjection.all) {
+          expect(metadata['x-datadog-sampling-priority'], sampled ? '1' : '0');
+        }
         if (sampled) {
+          traceInt = BigInt.tryParse(metadata['x-datadog-trace-id'] ?? '');
+          spanInt = BigInt.tryParse(metadata['x-datadog-parent-id'] ?? '');
           final tagsHeader = metadata['x-datadog-tags'];
           final parts = tagsHeader?.split('=');
           expect(parts, isNotNull);
@@ -59,34 +69,49 @@ void main() {
         }
         break;
       case TracingHeaderType.b3:
-        var singleHeader = metadata['b3']!;
-        var headerParts = singleHeader.split('-');
+        var singleHeader = metadata['b3'];
         if (sampled) {
+          var headerParts = singleHeader!.split('-');
           traceInt = BigInt.tryParse(headerParts[0], radix: 16);
           spanInt = BigInt.tryParse(headerParts[1], radix: 16);
           expect(headerParts[2], '1');
-        } else {
+        } else if (shouldInjectHeaders) {
           expect(singleHeader, '0');
+        } else {
+          expect(singleHeader, isNull);
         }
         break;
       case TracingHeaderType.b3multi:
-        expect(metadata['x-b3-sampled'], sampled ? '1' : '0');
-        traceInt = BigInt.tryParse(metadata['x-b3-traceid'] ?? '', radix: 16);
-        spanInt = BigInt.tryParse(metadata['x-b3-spanid'] ?? '', radix: 16);
+        if (shouldInjectHeaders) {
+          expect(metadata['x-b3-sampled'], sampled ? '1' : '0');
+          if (sampled) {
+            traceInt =
+                BigInt.tryParse(metadata['x-b3-traceid'] ?? '', radix: 16);
+            spanInt = BigInt.tryParse(metadata['x-b3-spanid'] ?? '', radix: 16);
+          }
+        } else {
+          expect(metadata['X-B3-Sampled'], isNull);
+          expect(metadata['X-B3-TraceId'], isNull);
+          expect(metadata['X-B3-SpanId'], isNull);
+        }
         break;
       case TracingHeaderType.tracecontext:
-        var parentHeader = metadata['traceparent']!;
-        var headerParts = parentHeader.split('-');
-        expect(headerParts[0], '00');
-        traceInt = BigInt.tryParse(headerParts[1], radix: 16);
-        spanInt = BigInt.tryParse(headerParts[2], radix: 16);
-        expect(headerParts[3], sampled ? '01' : '00');
+        if (shouldInjectHeaders) {
+          var parentHeader = metadata['traceparent']!;
+          var headerParts = parentHeader.split('-');
+          expect(headerParts[0], '00');
+          traceInt = BigInt.tryParse(headerParts[1], radix: 16);
+          spanInt = BigInt.tryParse(headerParts[2], radix: 16);
+          expect(headerParts[3], sampled ? '01' : '00');
 
-        final stateHeader = metadata['tracestate']!;
-        final stateParts = getDdTraceState(stateHeader);
-        expect(stateParts['s'], sampled ? '1' : '0');
-        expect(stateParts['o'], 'rum');
-        expect(stateParts['p'], headerParts[2]);
+          final stateHeader = metadata['tracestate']!;
+          final stateParts = getDdTraceState(stateHeader);
+          expect(stateParts['s'], sampled ? '1' : '0');
+          expect(stateParts['o'], 'rum');
+          expect(stateParts['p'], headerParts[2]);
+        } else {
+          expect(metadata['traceparent'], isNull);
+        }
         break;
     }
 
@@ -127,6 +152,8 @@ void main() {
       mockRum = RumMock();
       when(() => mockDatadog.rum).thenReturn(mockRum);
       when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+      when(() => mockRum.contextInjectionSetting)
+          .thenReturn(TraceContextInjection.all);
       when(() => mockRum.traceSampleRate).thenReturn(12);
     });
 
@@ -216,7 +243,11 @@ void main() {
           expect(attributes['_dd.rule_psr'], 0.12);
         });
 
-        test('Interceptor passes on proper metadata', () async {
+        test(
+            'Interceptor passes on proper metadata { sampled, TraceContextInjection.all }',
+            () async {
+          when(() => mockRum.contextInjectionSetting)
+              .thenReturn(TraceContextInjection.all);
           when(() => mockDatadog.headerTypesForHost(any()))
               .thenReturn({tracingType});
 
@@ -231,14 +262,40 @@ void main() {
 
           expect(loggingService.calls.length, 1);
           final call = loggingService.calls[0];
-          verifyHeaders(tracingType, call.clientMetadata!, true);
+          verifyHeaders(tracingType, call.clientMetadata!, true,
+              TraceContextInjection.all);
         });
 
         test(
-            'Interceptor does not send traces metadata when shouldSample returns false',
+            'Interceptor passes on proper metadata { sampled, TraceContextInjection.sampled }',
+            () async {
+          when(() => mockRum.contextInjectionSetting)
+              .thenReturn(TraceContextInjection.sampled);
+          when(() => mockDatadog.headerTypesForHost(any()))
+              .thenReturn({tracingType});
+
+          final interceptor = DatadogGrpcInterceptor(
+            mockDatadog,
+            channel,
+          );
+
+          final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+          await stub.sayHello(HelloRequest(name: 'test'));
+
+          expect(loggingService.calls.length, 1);
+          final call = loggingService.calls[0];
+          verifyHeaders(tracingType, call.clientMetadata!, true,
+              TraceContextInjection.sampled);
+        });
+
+        test(
+            'Interceptor does not send traces metadata returns false { unsampled, TraceContextInjection.all }',
             () async {
           when(() => mockDatadog.headerTypesForHost(any()))
               .thenReturn({tracingType});
+          when(() => mockRum.contextInjectionSetting)
+              .thenReturn(TraceContextInjection.all);
           when(() => mockRum.shouldSampleTrace()).thenReturn(false);
 
           final interceptor = DatadogGrpcInterceptor(
@@ -252,7 +309,32 @@ void main() {
 
           expect(loggingService.calls.length, 1);
           final call = loggingService.calls[0];
-          verifyHeaders(tracingType, call.clientMetadata!, false);
+          verifyHeaders(tracingType, call.clientMetadata!, false,
+              TraceContextInjection.all);
+        });
+
+        test(
+            'Interceptor does not send traces metadata returns false { unsampled, TraceContextInjection.sampled }',
+            () async {
+          when(() => mockDatadog.headerTypesForHost(any()))
+              .thenReturn({tracingType});
+          when(() => mockRum.contextInjectionSetting)
+              .thenReturn(TraceContextInjection.sampled);
+          when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+
+          final interceptor = DatadogGrpcInterceptor(
+            mockDatadog,
+            channel,
+          );
+
+          final stub = GreeterClient(channel, interceptors: [interceptor]);
+
+          await stub.sayHello(HelloRequest(name: 'test'));
+
+          expect(loggingService.calls.length, 1);
+          final call = loggingService.calls[0];
+          verifyHeaders(tracingType, call.clientMetadata!, false,
+              TraceContextInjection.sampled);
         });
       });
     }
@@ -296,6 +378,8 @@ void main() {
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(12);
+    when(() => mockRum.contextInjectionSetting)
+        .thenReturn(TraceContextInjection.all);
     when(() => mockDatadog.headerTypesForHost(any()))
         .thenReturn({TracingHeaderType.datadog});
 
@@ -343,6 +427,8 @@ void main() {
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(12);
+    when(() => mockRum.contextInjectionSetting)
+        .thenReturn(TraceContextInjection.all);
     when(() => mockDatadog.headerTypesForHost(any()))
         .thenReturn({TracingHeaderType.datadog});
 
@@ -385,6 +471,8 @@ void main() {
     when(() => mockDatadog.rum).thenReturn(mockRum);
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(12);
+    when(() => mockRum.contextInjectionSetting)
+        .thenReturn(TraceContextInjection.all);
     when(() => mockDatadog.headerTypesForHost(any()))
         .thenReturn({TracingHeaderType.datadog});
 

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add the ability to ignore tracking on specific url patterns with `ignoreUrlPatterns` when using the attach configuration.
+* Add support for `TraceContextInjection` configuration.
 
 ## 2.2.0
 

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -97,7 +97,12 @@ class DatadogClient extends http.BaseClient {
           var shouldSample = rum.shouldSampleTrace();
           var context = generateTracingContext(shouldSample);
 
-          attributes = _appendRequestHeaders(request, context, tracingHeaders);
+          attributes = _appendRequestHeaders(
+            request,
+            context,
+            tracingHeaders,
+            rum.contextInjectionSetting,
+          );
         }
 
         rumKey = _uuid.v1();
@@ -236,6 +241,7 @@ class DatadogClient extends http.BaseClient {
     http.BaseRequest request,
     TracingContext context,
     Set<TracingHeaderType> tracingHeaderTypes,
+    TraceContextInjection contextInjection,
   ) {
     var attributes = <String, Object?>{};
 
@@ -244,7 +250,11 @@ class DatadogClient extends http.BaseClient {
           context, datadogSdk.rum?.traceSampleRate ?? 0);
 
       for (final headerType in tracingHeaderTypes) {
-        request.headers.addAll(getTracingHeaders(context, headerType));
+        request.headers.addAll(getTracingHeaders(
+          context,
+          headerType,
+          contextInjection: contextInjection,
+        ));
       }
     }
 

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -354,7 +354,11 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
         _tracingContext ??= generateTracingContext(shouldSample);
 
         for (final headerType in tracingHeaderTypes) {
-          final newHeaders = getTracingHeaders(_tracingContext!, headerType);
+          final newHeaders = getTracingHeaders(
+            _tracingContext!,
+            headerType,
+            contextInjection: rum.contextInjectionSetting,
+          );
           for (final entry in newHeaders.entries) {
             // Don't replace exiting headers
             if (headers.value(entry.key) == null) {
@@ -364,6 +368,7 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
         }
       }
     } catch (e, st) {
+      print(e);
       client.datadogSdk.internalLogger.sendToDatadog(
         '$DatadogTrackingHttpClient encountered an error while attempting '
         ' to track an _openUrl call: $e',

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.5.0
+  datadog_flutter_plugin: ^2.6.0
   uuid: ^4.0.0
   http: ^1.0.0
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.6.0
+  datadog_flutter_plugin: ^2.7.0
   uuid: ^4.0.0
   http: ^1.0.0
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -896,38 +896,6 @@ void main() {
     expect(spanInt, contextSpanInt);
   });
 
-  group('when rum is enabled with datadog tracing headers', () {
-    late DatadogTrackingHttpClient client;
-
-    setUp(() {
-      enableRum();
-
-      client = DatadogTrackingHttpClient(
-        mockDatadog,
-        DdHttpTrackingPluginConfiguration(),
-        mockClient,
-      );
-    });
-
-    test('does not set trace headers when should sample returns false',
-        () async {
-      when(() => mockRum.shouldSampleTrace()).thenReturn(false);
-      var url = Uri.parse('https://test_url/path');
-      var completer = setupMockRequest(url);
-      var mockResponse = setupMockClientResponse(200);
-
-      var request = await client.openUrl('get', url);
-      completer.complete(mockResponse);
-
-      var _ = await request.done;
-      final requestHeaders = request.headers;
-
-      verifyNever(() => requestHeaders.add('x-datadog-trace-id', any()));
-      verifyNever(() => requestHeaders.add('x-datadog-parent-id', any()));
-      verify(() => requestHeaders.add('x-datadog-sampling-priority', '0'));
-    });
-  });
-
   group('when rum is enabled with b3 tracing headers', () {
     setUp(() {
       enableRum();

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -78,6 +78,8 @@ void main() {
 
     mockRum = MockDdRum();
     when(() => mockRum.shouldSampleTrace()).thenReturn(true);
+    when(() => mockRum.contextInjectionSetting)
+        .thenReturn(TraceContextInjection.all);
     when(() => mockRum.traceSampleRate).thenReturn(50.0);
 
     mockClient = MockHttpClient();
@@ -658,7 +660,9 @@ void main() {
             capturedAttributes[DatadogRumPlatformAttributeKey.rulePsr], 0.23);
       });
 
-      test('sets trace headers for first party urls', () async {
+      test(
+          'sets trace headers for first party urls { sampled, TraceContextInjection.all }',
+          () async {
         var url = Uri.parse('https://test_url/path');
         var completer = setupMockRequest(url);
         var mockResponse = setupMockClientResponse(200);
@@ -675,7 +679,83 @@ void main() {
         var _ = await request.done;
 
         final requestHeaders = request.headers.toMap();
-        verifyHeaders(requestHeaders, headerType);
+        verifyHeaders(
+            requestHeaders, headerType, true, TraceContextInjection.all);
+      });
+
+      test(
+          'sets trace headers for first party urls { unsampled, TraceContextInjection.all }',
+          () async {
+        when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+        var url = Uri.parse('https://test_url/path');
+        var completer = setupMockRequest(url);
+        var mockResponse = setupMockClientResponse(200);
+
+        final client = DatadogTrackingHttpClient(
+          mockDatadog,
+          DdHttpTrackingPluginConfiguration(),
+          mockClient,
+        );
+
+        var request = await client.openUrl('get', url);
+        completer.complete(mockResponse);
+
+        var _ = await request.done;
+
+        final requestHeaders = request.headers.toMap();
+        verifyHeaders(
+            requestHeaders, headerType, false, TraceContextInjection.all);
+      });
+
+      test(
+          'sets trace headers for first party urls { sampled, TraceContextInjection.sampled }',
+          () async {
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.sampled);
+        var url = Uri.parse('https://test_url/path');
+        var completer = setupMockRequest(url);
+        var mockResponse = setupMockClientResponse(200);
+
+        final client = DatadogTrackingHttpClient(
+          mockDatadog,
+          DdHttpTrackingPluginConfiguration(),
+          mockClient,
+        );
+
+        var request = await client.openUrl('get', url);
+        completer.complete(mockResponse);
+
+        var _ = await request.done;
+
+        final requestHeaders = request.headers.toMap();
+        verifyHeaders(
+            requestHeaders, headerType, true, TraceContextInjection.sampled);
+      });
+
+      test(
+          'sets trace headers for first party urls { unsampled, TraceContextInjection.sampled }',
+          () async {
+        when(() => mockRum.shouldSampleTrace()).thenReturn(false);
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.sampled);
+        var url = Uri.parse('https://test_url/path');
+        var completer = setupMockRequest(url);
+        var mockResponse = setupMockClientResponse(200);
+
+        final client = DatadogTrackingHttpClient(
+          mockDatadog,
+          DdHttpTrackingPluginConfiguration(),
+          mockClient,
+        );
+
+        var request = await client.openUrl('get', url);
+        completer.complete(mockResponse);
+
+        var _ = await request.done;
+
+        final requestHeaders = request.headers.toMap();
+        verifyHeaders(
+            requestHeaders, headerType, false, TraceContextInjection.sampled);
       });
 
       test('does not set trace headers for third party urls', () async {
@@ -737,7 +817,8 @@ void main() {
       var _ = await request.done;
 
       final requestHeaders = request.headers.toMap();
-      verifyHeaders(requestHeaders, headerType);
+      verifyHeaders(
+          requestHeaders, headerType, true, TraceContextInjection.all);
     }
 
     await verifyCall(testUriA, TracingHeaderType.datadog);

--- a/packages/datadog_tracking_http_client/test/test_helpers.dart
+++ b/packages/datadog_tracking_http_client/test/test_helpers.dart
@@ -19,58 +19,92 @@ extension HttpHeadersToMap on HttpHeaders {
   }
 }
 
-void verifyHeaders(Map<String, String> headers, TracingHeaderType type) {
+void verifyHeaders(Map<String, String> headers, TracingHeaderType type,
+    bool sampled, TraceContextInjection traceContextInjection) {
   BigInt? traceInt;
   BigInt? spanInt;
 
+  bool shouldInjectHeaders =
+      sampled || traceContextInjection == TraceContextInjection.all;
+
   switch (type) {
     case TracingHeaderType.datadog:
-      expect(headers['x-datadog-sampling-priority'], '1');
-      traceInt = BigInt.tryParse(headers['x-datadog-trace-id']!);
-      spanInt = BigInt.tryParse(headers['x-datadog-parent-id']!);
-      final tagsHeader = headers['x-datadog-tags'];
-      final parts = tagsHeader?.split('=');
-      expect(parts, isNotNull);
-      expect(parts?[0], '_dd.p.tid');
-      BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
-      expect(highTraceInt, isNotNull);
-      expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
+      if (traceContextInjection == TraceContextInjection.all) {
+        expect(headers['x-datadog-sampling-priority'], sampled ? '1' : '0');
+      }
+      if (sampled) {
+        traceInt = BigInt.tryParse(headers['x-datadog-trace-id']!);
+        spanInt = BigInt.tryParse(headers['x-datadog-parent-id']!);
+        final tagsHeader = headers['x-datadog-tags'];
+        final parts = tagsHeader?.split('=');
+        expect(parts, isNotNull);
+        expect(parts?[0], '_dd.p.tid');
+        BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
+        expect(highTraceInt, isNotNull);
+        expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
+      }
       break;
     case TracingHeaderType.b3:
-      var singleHeader = headers['b3']!;
-      var headerParts = singleHeader.split('-');
-      traceInt = BigInt.tryParse(headerParts[0], radix: 16);
-      spanInt = BigInt.tryParse(headerParts[1], radix: 16);
-      expect(headerParts[2], '1');
+      var singleHeader = headers['b3'];
+      if (sampled) {
+        var headerParts = singleHeader!.split('-');
+        traceInt = BigInt.tryParse(headerParts[0], radix: 16);
+        spanInt = BigInt.tryParse(headerParts[1], radix: 16);
+        expect(headerParts[2], sampled ? '1' : '0');
+      } else if (shouldInjectHeaders) {
+        expect(singleHeader, '0');
+      } else {
+        expect(singleHeader, isNull);
+      }
       break;
     case TracingHeaderType.b3multi:
-      expect(headers['X-B3-Sampled'], '1');
-      traceInt = BigInt.tryParse(headers['X-B3-TraceId']!, radix: 16);
-      spanInt = BigInt.tryParse(headers['X-B3-SpanId']!, radix: 16);
+      if (shouldInjectHeaders) {
+        expect(headers['X-B3-Sampled'], sampled ? '1' : '0');
+        if (sampled) {
+          traceInt = BigInt.tryParse(headers['X-B3-TraceId']!, radix: 16);
+          spanInt = BigInt.tryParse(headers['X-B3-SpanId']!, radix: 16);
+        }
+      } else {
+        expect(headers['X-B3-Sampled'], isNull);
+        expect(headers['X-B3-TraceId'], isNull);
+        expect(headers['X-B3-SpanId'], isNull);
+      }
       break;
     case TracingHeaderType.tracecontext:
-      var header = headers['traceparent']!;
-      var headerParts = header.split('-');
-      expect(headerParts[0], '00');
-      traceInt = BigInt.tryParse(headerParts[1], radix: 16);
-      spanInt = BigInt.tryParse(headerParts[2], radix: 16);
-      expect(headerParts[3], '01');
+      if (shouldInjectHeaders) {
+        var header = headers['traceparent']!;
+        var headerParts = header.split('-');
+        expect(headerParts[0], '00');
+        traceInt = BigInt.tryParse(headerParts[1], radix: 16);
+        spanInt = BigInt.tryParse(headerParts[2], radix: 16);
+        expect(headerParts[3], sampled ? '01' : '00');
 
-      final stateHeader = headers['tracestate']!;
-      final stateParts = getDdTraceState(stateHeader);
-      expect(stateParts['s'], '1');
-      expect(stateParts['o'], 'rum');
-      expect(stateParts['p'], headerParts[2]);
+        final stateHeader = headers['tracestate']!;
+        final stateParts = getDdTraceState(stateHeader);
+        expect(stateParts['s'], sampled ? '1' : '0');
+        expect(stateParts['o'], 'rum');
+        expect(stateParts['p'], headerParts[2]);
+      } else {
+        expect(headers['traceparent'], isNull);
+      }
       break;
   }
 
-  expect(traceInt, isNotNull);
-  if (type == TracingHeaderType.datadog) {
-    expect(traceInt?.bitLength, lessThanOrEqualTo(64));
-  } else {
-    expect(traceInt?.bitLength, lessThanOrEqualTo(128));
+  if (sampled) {
+    expect(traceInt, isNotNull);
+  }
+  if (traceInt != null) {
+    if (type == TracingHeaderType.datadog) {
+      expect(traceInt.bitLength, lessThanOrEqualTo(64));
+    } else {
+      expect(traceInt.bitLength, lessThanOrEqualTo(128));
+    }
   }
 
-  expect(spanInt, isNotNull);
-  expect(spanInt?.bitLength, lessThanOrEqualTo(63));
+  if (sampled) {
+    expect(spanInt, isNotNull);
+  }
+  if (spanInt != null) {
+    expect(spanInt.bitLength, lessThanOrEqualTo(63));
+  }
 }

--- a/packages/datadog_tracking_http_client/test/test_helpers.dart
+++ b/packages/datadog_tracking_http_client/test/test_helpers.dart
@@ -29,10 +29,8 @@ void verifyHeaders(Map<String, String> headers, TracingHeaderType type,
 
   switch (type) {
     case TracingHeaderType.datadog:
-      if (traceContextInjection == TraceContextInjection.all) {
+      if (shouldInjectHeaders) {
         expect(headers['x-datadog-sampling-priority'], sampled ? '1' : '0');
-      }
-      if (sampled) {
         traceInt = BigInt.tryParse(headers['x-datadog-trace-id']!);
         spanInt = BigInt.tryParse(headers['x-datadog-parent-id']!);
         final tagsHeader = headers['x-datadog-tags'];
@@ -42,6 +40,12 @@ void verifyHeaders(Map<String, String> headers, TracingHeaderType type,
         BigInt? highTraceInt = BigInt.tryParse(parts?[1] ?? '', radix: 16);
         expect(highTraceInt, isNotNull);
         expect(highTraceInt?.bitLength, lessThanOrEqualTo(64));
+      } else {
+        expect(headers['x-datadog-origin'], isNull);
+        expect(headers['x-datadog-sampling-priority'], isNull);
+        expect(headers['x-datadog-trace-id'], isNull);
+        expect(headers['x-datadog-parent-id'], isNull);
+        expect(headers['x-datadog-tags'], isNull);
       }
       break;
     case TracingHeaderType.b3:


### PR DESCRIPTION
### What and why?

Currently, the libraries that allow Datadog distributed always inject their sampling decision, which has downstream effects and prevents tail based sampling. Allow header injection to be configured so that only sampled traces inject their tracing headers.

refs: RUM-3538

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
