### PR TITLE
fix: Change minimum iOS version to 12.

### DIFF
--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -19,7 +19,7 @@ For complete documentation, see the [official Datadog documentation][11].
 
 ### iOS
 
-Your iOS Podfile must have `use_frameworks!` (which is true by default in Flutter) and target iOS version >= 11.0.
+Your iOS Podfile must have `use_frameworks!` (which is true by default in Flutter) and target iOS version >= 12.0.
 
 ### Android
 

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin.podspec
@@ -22,7 +22,7 @@ A new flutter plugin project.
   s.dependency 'DatadogInternal', '~> 2'
   s.dependency 'DatadogCrashReporting', '~> 2'
   s.dependency 'DictionaryCoder', '1.0.8'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
@@ -17,7 +17,7 @@ A Flutter plugin for use with the Datadog Flutter Plugin to track webviews as pa
   s.dependency 'Flutter'
   s.dependency 'DatadogWebViewTracking', '~> 2'
   s.dependency 'webview_flutter_wkwebview'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
### What and why?

iOS 12 is now a requirement of Apple and the minimum required version in the iOS SDK.

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
