### PR TITLE
fix: Prevent error when using logging from background isolate

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_method_channel.dart
@@ -18,7 +18,9 @@ class DdLogsMethodChannel extends DdLogsPlatform {
   LogEventMapper? _logEventMapper;
 
   DdLogsMethodChannel() {
-    methodChannel.setMethodCallHandler(_handleMethodCall);
+    if (ServicesBinding.rootIsolateToken != null) {
+      methodChannel.setMethodCallHandler(_handleMethodCall);
+    }
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -26,7 +26,9 @@ class DdRumMethodChannel extends DdRumPlatform {
       internalLogger: core.internalLogger,
     );
 
-    methodChannel.setMethodCallHandler(callbackHandler.handleMethodCall);
+    if (ServicesBinding.rootIsolateToken != null) {
+      methodChannel.setMethodCallHandler(callbackHandler.handleMethodCall);
+    }
 
     return methodChannel.invokeMethod('enable', {
       'configuration': configuration.encode(),


### PR DESCRIPTION
### What and why?

When creating a logger from a background isolate, Flutter would throw because WidgetsFlutterBinding wasn't initialized. This is specifically because we were adding a callback handler, which is not supported from background isolates.

Add checks to both logs and RUM and prevent initialization of things we know won't work from background isolates.

This is not full support for background isolates but usable as a work around.

refs: #580

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
