### PR TITLE
fix: Fix use of `rootIsolateToken` on Flutter web

### DIFF
--- a/packages/datadog_flutter_plugin/example/lib/logging_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/logging_screen.dart
@@ -5,6 +5,7 @@
 import 'dart:isolate';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -106,10 +107,11 @@ class _LoggingScreenState extends State<LoggingScreen> {
               onPressed: () => _sendErrorWithExceptionLog(),
               child: const Text('Error With Exception Log'),
             ),
-            ElevatedButton(
-              onPressed: () => _sendFromBackgroundIsolate(),
-              child: const Text('Send From Background Isolate'),
-            ),
+            if (!kIsWeb)
+              ElevatedButton(
+                onPressed: () => _sendFromBackgroundIsolate(),
+                child: const Text('Send From Background Isolate'),
+              ),
           ],
         ),
       ),

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -143,7 +143,8 @@ class DatadogRum {
     required double longTaskThreshold,
     required bool reportFlutterPerformance,
   }) {
-    final isBackgroundIsolate = ServicesBinding.rootIsolateToken == null;
+    final isBackgroundIsolate =
+        kIsWeb ? false : ServicesBinding.rootIsolateToken == null;
     // Don't allow initialization of foreground stuff in background isolates
     if (!isBackgroundIsolate) {
       // Never use long task observer on web -- the Browser SDK should


### PR DESCRIPTION
### What and why?

Don't use `rootIsolateToken` on web as isolates are not supported in Flutter web (using this variable crashes web).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
