### PR TITLE
chore: Remove `tojunit` from e2e builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,6 +107,8 @@ android-integration-test:
     - specific:true
   script:
     - !reference [.pre, script]
+    # Kill all active emulators
+    - pushd tools/ci && dart pub get && dart run ci_helpers stop_emu && popd
     - melos pub:get
     - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0" "platform-tools" "platforms;android-34" || true
     - yes | flutter doctor --android-licenses || true
@@ -187,7 +189,8 @@ nightly-android:
   script:
     - !reference [.nightly-vars, script]
     - !reference [.pre, script]
-    - pod repo update
+    # Kill all active emulators
+    - pushd tools/ci && dart pub get && dart run ci_helpers stop_emu && popd
     - melos pub:get
     - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;33.0.3" "platform-tools" "platforms;android-34" || true
     - yes | flutter doctor --android-licenses || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ stages:
 
 .pre:
   script:
+    - ulimit -S -n 2048
     - export PATH=$PATH:$HOME/.pub-cache/bin
     - flutter upgrade
     - flutter --version

--- a/melos.yaml
+++ b/melos.yaml
@@ -169,8 +169,7 @@ scripts:
       cd e2e_test_app
       
       bash -c 'set -euxo pipefail; \
-      flutter test integration_test --machine -d "iPhone" \
-      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_ios_e2e.xml"'
+      flutter test integration_test --machine -d "iPhone"
     packageFilters:
       scope: 'datadog_flutter_plugin'
 
@@ -180,8 +179,7 @@ scripts:
       cd e2e_test_app
       
       bash -c 'set -euxo pipefail; \
-      flutter test integration_test --machine -d emulator \
-      | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_android_e2e.xml"'
+      flutter test integration_test --machine -d emulator      
     packageFilters:
       scope: 'datadog_flutter_plugin'
 

--- a/tools/ci/bin/ci_helpers.dart
+++ b/tools/ci/bin/ci_helpers.dart
@@ -4,10 +4,12 @@
 
 import 'package:args/command_runner.dart';
 import 'package:ci_helpers/simulator_command.dart';
+import 'package:ci_helpers/stop_emulators_command.dart';
 
 void main(List<String> arguments) {
   final runner = CommandRunner(
       'ci', 'Helper command line utils for CI of the Datadog Flutter SDK')
     ..addCommand(SimulatorCommand())
+    ..addCommand(StopEmulatorsCommand())
     ..run(arguments);
 }

--- a/tools/ci/lib/stop_emulators_command.dart
+++ b/tools/ci/lib/stop_emulators_command.dart
@@ -1,0 +1,15 @@
+import 'package:args/command_runner.dart';
+import 'package:ci_helpers/android_helpers.dart';
+
+class StopEmulatorsCommand extends Command {
+  @override
+  String get name => 'stop_emu';
+
+  @override
+  String get description => 'Stop all android simulators';
+
+  @override
+  Future<void> run() async {
+    await killAllEmulators();
+  }
+}


### PR DESCRIPTION
### What and why?

Remove `tojunit` from the e2e test builds.  e2e tests don't run actual tests so tojunit isn't useful. Remove it to get more app and flutter output.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
