### PR TITLE
chore: Ship datadog_flutter_plugin 2.7.0

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.7.0
 
 * Support selective injection of trace contexts with TraceContextInjection configuration item.
 * Bump minimum Dart version to 3.3.0 (Flutter 3.19.0).

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -9,6 +9,14 @@
 * Upgrade Android to `compileSdkVersion` 34 to prevent issues with Flutter 3.24. See [#639].
 * Add an option to support detection of non-fatal ANRs on Android.
 * Add an option for detecting non-fatal app hangs within a givin threshold on iOS.
+* Update iOS SDK to 2.15.0. For a full list of changes, see the [iOS Changelog](https://github.com/DataDog/dd-sdk-ios/blob/develop/CHANGELOG.md#2150--25-07-2024)
+  * Send memory warnings as RUM errors
+  * Inject backtrace reporter into Logs feature.
+  * Use `#fileID` over `#filePath` as the default argument in errors.
+* Update Android SDK to 2.12.1
+  * InternalMetrics: Add sampling rate to internal metrics.
+  * Core: Increase retry delay on DNS error.
+  * Reduce Method Call Sample Rate and limit total telemetry events sent per session
 
 ## 2.6.0
 

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+
+
 ## 2.7.0
 
 * Support selective injection of trace contexts with TraceContextInjection configuration item.

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -14,7 +14,7 @@ For complete documentation, see the [official Datadog documentation][11].
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
-| 2.13.0 | 2.11.0 | 5.x.x |
+| 2.15.0 | 2.12.1 | 5.x.x |
 
 [//]: # (End SDK Table)
 

--- a/packages/datadog_flutter_plugin/lib/src/version.dart
+++ b/packages/datadog_flutter_plugin/lib/src/version.dart
@@ -2,4 +2,4 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
-const ddPackageVersion = '2.7.0';
+const ddPackageVersion = '2.8.0';

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_flutter_plugin
 description: Flutter bindings and tools for utilizing Datadog Mobile SDks
-version: 2.7.0
+version: 2.8.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:


### PR DESCRIPTION
### What and why?

Changes related to shipping `datadog_flutter_plugin` 2.7.0

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
