### PR TITLE
chore: Fix e2e tess

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -169,7 +169,7 @@ scripts:
       cd e2e_test_app
       
       bash -c 'set -euxo pipefail; \
-      flutter test integration_test --machine -d "iPhone"
+      flutter test integration_test --machine -d "iPhone"'
     packageFilters:
       scope: 'datadog_flutter_plugin'
 
@@ -179,7 +179,7 @@ scripts:
       cd e2e_test_app
       
       bash -c 'set -euxo pipefail; \
-      flutter test integration_test --machine -d emulator      
+      flutter test integration_test --machine -d emulator'     
     packageFilters:
       scope: 'datadog_flutter_plugin'
 


### PR DESCRIPTION
### What and why?

Change to remove `tojunit` from e2e tests accidentally left an open quote, which broke e2e tests.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
