### PR TITLE
chore: Add Slack notifications for build failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ variables:
   IOS_SIMULATOR: "iPhone 15"
   VAULT_ADDR: "https://vault.us1.ddbuild.io"
   IS_ON_CI: $CI
+  SLACK_CHANNEL: "#mobile-sdk-ops"
 
   KUBERNETES_MEMORY_REQUEST: "8Gi"
   KUBERNETES_MEMORY_LIMIT: "16Gi"
@@ -20,6 +21,7 @@ stages:
   - build
   - integration-test
   - e2e-test
+  - notify
 
 # Prebuild - install necessary tools
 
@@ -148,6 +150,19 @@ ios-integration-test:
 #   stage: integration-test
 #   script:
 #     - melos run integration_test:web
+
+# Notify
+
+notify:publish-develop-failure:
+  extends: .slack-notifier-base
+  stage: notify
+  when: on_failure
+  only:
+    - develop
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":status_alert: $CI_PROJECT_NAME $CI_COMMIT_TAG develop pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
+    - postmessage "$SLACK_CHANNEL" "$MESSAGE_TEXT"
 
 # Nightly
 


### PR DESCRIPTION
### What and why?

Add notifications of build failures on develop.

Posting failures on `only: develop` should also cover nightly / e2e tests.

refs: RUM-5574

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
