### PR TITLE
chore: Add back e2e logger config tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ ios-integration-test:
 
 # Notify
 
-notify:publish-develop-failure:
+notify-publish-develop-failure:
   extends: .slack-notifier-base
   stage: notify
   when: on_failure
@@ -162,7 +162,19 @@ notify:publish-develop-failure:
   script:
     - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
     - 'MESSAGE_TEXT=":status_alert: $CI_PROJECT_NAME $CI_COMMIT_TAG develop pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
-    - postmessage "$SLACK_CHANNEL" "$MESSAGE_TEXT"
+    - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
+
+notify-pipeline-succeeded:
+  extends: .slack-notifier-base
+  stage: notify
+  tags: [ "arch:amd64" ]
+  image: "$BUILDENV_REGISTRY/images/docker:24.0.4-gbi-focal"
+  when: on_success
+  except:
+    - schedules
+    - develop
+  script:
+    - echo "Pipeline did succeed"
 
 # Nightly
 

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/logs/logger_config_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/logs/logger_config_test.dart
@@ -42,4 +42,32 @@ void main() {
 
     sendRandomLog(logger, tester);
   });
+
+  /// - data monitor:
+  /// ```logs(ios, android)
+  /// $monitor_id = ${{feature}}_set_network_info_enabled_${{variant}}
+  /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of logs is below expected value"
+  /// $monitor_query = "logs(\"service:${{service}} @test_method_name:\\\"${{test_description}}\\\" @operating_system:${{variant}}\" \"@network.client.reachability:*\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
+  /// ```
+  testWidgets('logger config - send network info enabled', (tester) async {
+    await initializeDatadog();
+    var logger = datadog.logs
+        ?.createLogger(DatadogLoggerConfiguration(networkInfoEnabled: true));
+
+    sendRandomLog(logger, tester);
+  });
+
+  /// - data monitor:
+  /// ```logs(ios, android)
+  /// $monitor_id = ${{feature}}_set_bundle_with_rum_enabled_${{variant}}
+  /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of logs is below expected value"
+  /// $monitor_query = "logs(\"service:${{service}} @test_method_name:\\\"${{test_description}}\\\" @operating_system:${{variant}}\" \"@application_id:*\" \"@session_id:*\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
+  /// ```
+  testWidgets('logger config - send network info enabled', (tester) async {
+    await initializeDatadog();
+    var logger = datadog.logs
+        ?.createLogger(DatadogLoggerConfiguration(bundleWithRumEnabled: true));
+
+    sendRandomLog(logger, tester);
+  });
 }

--- a/packages/datadog_flutter_plugin/e2e_test_app/integration_test/logs/logger_config_test.dart
+++ b/packages/datadog_flutter_plugin/e2e_test_app/integration_test/logs/logger_config_test.dart
@@ -63,7 +63,7 @@ void main() {
   /// $monitor_name = "${{monitor_name_prefix}} - ${{test_description}}: number of logs is below expected value"
   /// $monitor_query = "logs(\"service:${{service}} @test_method_name:\\\"${{test_description}}\\\" @operating_system:${{variant}}\" \"@application_id:*\" \"@session_id:*\").index(\"*\").rollup(\"count\").last(\"1d\") < 1"
   /// ```
-  testWidgets('logger config - send network info enabled', (tester) async {
+  testWidgets('logger config - bundle with RUM enabled', (tester) async {
     await initializeDatadog();
     var logger = datadog.logs
         ?.createLogger(DatadogLoggerConfiguration(bundleWithRumEnabled: true));

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Runner.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				00C98267BBB268930213463E /* [CP] Embed Pods Frameworks */,
+				95D66AF34BB19B5B94AEEBD9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -156,7 +157,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -230,6 +231,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		95D66AF34BB19B5B94AEEBD9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,


### PR DESCRIPTION
### What and why?
Some e2e monitors are failing because the tests that check for certain configuration setups were removed during the v2 refactor. This should add those checks back in.

This also add a meta-reporting step to the flutter pipeline to block merges on PR build failure.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
