### PR TITLE
fix: Ensure named dialog routes start views

### DIFF
--- a/examples/simple_example/ios/Podfile.lock
+++ b/examples/simple_example/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - connectivity_plus (0.0.1):
     - Flutter
-    - ReachabilitySwift
+    - FlutterMacOS
   - datadog_flutter_plugin (0.0.1):
     - DatadogCore (~> 2)
     - DatadogCrashReporting (~> 2)
@@ -14,35 +14,35 @@ PODS:
     - DatadogWebViewTracking (~> 2)
     - Flutter
     - webview_flutter_wkwebview
-  - DatadogCore (2.5.1):
-    - DatadogInternal (= 2.5.1)
-  - DatadogCrashReporting (2.5.1):
-    - DatadogInternal (= 2.5.1)
-    - PLCrashReporter (~> 1.11.1)
-  - DatadogInternal (2.5.1)
-  - DatadogLogs (2.5.1):
-    - DatadogInternal (= 2.5.1)
-  - DatadogRUM (2.5.1):
-    - DatadogInternal (= 2.5.1)
-  - DatadogWebViewTracking (2.5.1):
-    - DatadogInternal (= 2.5.1)
+  - DatadogCore (2.16.0):
+    - DatadogInternal (= 2.16.0)
+  - DatadogCrashReporting (2.16.0):
+    - DatadogInternal (= 2.16.0)
+    - PLCrashReporter (~> 1.11.2)
+  - DatadogInternal (2.16.0)
+  - DatadogLogs (2.16.0):
+    - DatadogInternal (= 2.16.0)
+  - DatadogRUM (2.16.0):
+    - DatadogInternal (= 2.16.0)
+  - DatadogWebViewTracking (2.16.0):
+    - DatadogInternal (= 2.16.0)
   - DictionaryCoder (1.0.8)
   - Flutter (1.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - PLCrashReporter (1.11.1)
-  - ReachabilitySwift (5.0.0)
+  - PLCrashReporter (1.11.2)
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
-  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/darwin`)
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_webview_tracking (from `.symlinks/plugins/datadog_webview_tracking/ios`)
   - Flutter (from `Flutter`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
-  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -54,11 +54,10 @@ SPEC REPOS:
     - DatadogWebViewTracking
     - DictionaryCoder
     - PLCrashReporter
-    - ReachabilitySwift
 
 EXTERNAL SOURCES:
   connectivity_plus:
-    :path: ".symlinks/plugins/connectivity_plus/ios"
+    :path: ".symlinks/plugins/connectivity_plus/darwin"
   datadog_flutter_plugin:
     :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
   datadog_webview_tracking:
@@ -68,25 +67,24 @@ EXTERNAL SOURCES:
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   webview_flutter_wkwebview:
-    :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
-  datadog_flutter_plugin: 89d7088ec5cc78c0ff2c24dbe7b7e67e6800a10b
-  datadog_webview_tracking: d46b58a9109c0d29e4d6ffdd4223cb23e4f328a9
-  DatadogCore: 4acbe1aae7f87ed63b1fecdd6cb4264c5fff5de9
-  DatadogCrashReporting: 029e15cfbbacdd278a0d3428dacd3be78b80b3c2
-  DatadogInternal: 8c1de807515237394730e0d0721689adb8f0d7c1
-  DatadogLogs: cd1bbe531cfb56d5aa75ad839c7607ae7b83e3c9
-  DatadogRUM: b800382f479eaa501c99d2e84db8c06deb1409fb
-  DatadogWebViewTracking: 69be2e35bd2ef609853e5d0e1ce3e39a43ce867e
+  connectivity_plus: ddd7f30999e1faaef5967c23d5b6d503d10434db
+  datadog_flutter_plugin: de391eba42569ec1d8282aa1c49b4172603acc90
+  datadog_webview_tracking: 7de2f94cb36dbb00203468d941e89ec7cbc47226
+  DatadogCore: 4cf2a1fe0e60ebcb12a459328f652da6268de140
+  DatadogCrashReporting: 380f559499c2d2171c40ddfbf9d4206f772fdca1
+  DatadogInternal: 67742f9aac1b123f5bda9d6e3bb22ab1773fda0b
+  DatadogLogs: 1278623e6235c5fff7e68d0d4914cee11d828f8d
+  DatadogRUM: 4bac99a16de3c1ebebd9a1c3e6361cf1b13da83c
+  DatadogWebViewTracking: a8cac9ca5d3aa3c2ace3fbe6072dfd77425deae8
   DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
-  PLCrashReporter: 5d2d3967afe0efad61b3048d617e2199a5d1b787
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  PLCrashReporter: 499c53b0104f95c302d94fd723ebb03c56d9bac8
+  webview_flutter_wkwebview: 0982481e3d9c78fd5c6f62a002fcd24fc791f1e4
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/examples/simple_example/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/simple_example/ios/Runner.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				50E793F5A550121A16F6AF72 /* [CP] Embed Pods Frameworks */,
+				C5A6A31AA8D394C2AA220E42 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -267,6 +268,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C5A6A31AA8D394C2AA220E42 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/examples/simple_example/ios/Runner/AppDelegate.swift
+++ b/examples/simple_example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
     var methodChannel: FlutterMethodChannel!
 

--- a/examples/simple_example/lib/main.dart
+++ b/examples/simple_example/lib/main.dart
@@ -8,10 +8,10 @@ import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'app.dart';
+import 'url_strategy_stub.dart' if (dart.library.html) 'url_strategy_web.dart';
 
 const graphQlUrl = 'http://localhost:3000/graphql';
 
@@ -19,7 +19,7 @@ void main() async {
   await dotenv.load();
 
   WidgetsFlutterBinding.ensureInitialized();
-  usePathUrlStrategy();
+  configureUrlStrategy();
 
   DatadogSdk.instance.sdkVerbosity = CoreLoggerLevel.debug;
 

--- a/examples/simple_example/lib/main_screen.dart
+++ b/examples/simple_example/lib/main_screen.dart
@@ -86,6 +86,54 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
+  void _openDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return Container(
+          height: 100,
+          width: 120,
+          color: Colors.white,
+          child: Column(
+            children: [
+              TextButton(
+                child: const Text('CLOSE MODAL'),
+                onPressed: () => {
+                  debugPrint('MODAL REJECTED'),
+                  context.pop(),
+                },
+              ),
+              TextButton(
+                onPressed: () => {
+                  context.pop(),
+                },
+                child: const Text('ACCEPT MODAL'),
+              ),
+              IconButton(
+                key: const Key('REJECT BY ICON'),
+                icon: const Icon(Icons.close),
+                onPressed: () async => {
+                  await Future.delayed(const Duration(seconds: 5), () {
+                    context.pop();
+                  }),
+                },
+              ),
+              IconButton(
+                key: const Key('ACCEPT BY ICON KEY'),
+                icon: const Icon(Icons.done),
+                tooltip: 'MODAL ACCEPT BY ICON',
+                onPressed: () => {
+                  context.pop(),
+                },
+              )
+            ],
+          ),
+        );
+      },
+      routeSettings: RouteSettings(name: 'Download Dialog'),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -106,7 +154,11 @@ class _MyHomePageState extends State<MyHomePage> {
             ElevatedButton(
               onPressed: _goToNamedScreen,
               child: const Text('Named Test'),
-            )
+            ),
+            ElevatedButton(
+              onPressed: () => _openDialog(context),
+              child: const Text('Open Dialog'),
+            ),
           ],
         ),
       ),

--- a/examples/simple_example/lib/url_strategy_stub.dart
+++ b/examples/simple_example/lib/url_strategy_stub.dart
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+void configureUrlStrategy() {
+  // Nothing on most platforms
+}

--- a/examples/simple_example/lib/url_strategy_web.dart
+++ b/examples/simple_example/lib/url_strategy_web.dart
@@ -1,0 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+void configureUrlStrategy() {
+  usePathUrlStrategy();
+}

--- a/examples/simple_example/pubspec.lock
+++ b/examples/simple_example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -53,41 +53,41 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "224a77051d52a11fbad53dd57827594d3bd24f945af28bd70bab376d68d437f0"
+      sha256: "2056db5241f96cdc0126bd94459fc4cdc13876753768fc7a31c425e50a7177d0"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "2.0.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.8"
   datadog_flutter_plugin:
     dependency: "direct main"
     description:
       path: "../../packages/datadog_flutter_plugin"
       relative: true
     source: path
-    version: "2.7.0"
+    version: "2.8.0"
   datadog_gql_link:
     dependency: "direct main"
     description:
@@ -129,10 +129,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.3"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -150,18 +158,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_hooks
-      sha256: "09f64db63fee3b2ab8b9038a1346be7d8986977fae3fec601275bf32455ccfc0"
+      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.4"
+    version: "0.20.5"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -184,18 +192,18 @@ packages:
     dependency: transitive
     description:
       name: gql
-      sha256: f57eb635aa2f134ced585584f3d53006816f1fdd909480bb7626a1d41063ce25
+      sha256: "8ecd3585bb9e40d671aa58f52575d950670f99e5ffab18e2b34a757e071a6693"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-alpha+1704118137418"
+    version: "1.0.1-alpha+1717789143880"
   gql_dedupe_link:
     dependency: transitive
     description:
       name: gql_dedupe_link
-      sha256: d0ba6388a52dab95e7e9a9fa3fec43c11172d3d3feda21bf88df39427c8e282f
+      sha256: "10bee0564d67c24e0c8bd08bd56e0682b64a135e58afabbeed30d85d5e9fea96"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4-alpha+1704118137496"
+    version: "2.0.4-alpha+1715521079596"
   gql_error_link:
     dependency: transitive
     description:
@@ -216,18 +224,18 @@ packages:
     dependency: transitive
     description:
       name: gql_http_link
-      sha256: "1f922eed1b7078fdbfd602187663026f9f659fe9a9499e2207b5d5e01617f658"
+      sha256: ef6ad24d31beb5a30113e9b919eec20876903cc4b0ee0d31550047aaaba7d5dd
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1+1"
+    version: "1.1.0"
   gql_link:
     dependency: transitive
     description:
       name: gql_link
-      sha256: "4cce5019a2ce727023a5e5f9763a9ff85b2770801b10a51738a10472ae779786"
+      sha256: "70fd5b5cbcc50601679f4b9fea3bcc994e583f59cfec7e1fec11113074b1a565"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-alpha+1704118137432"
+    version: "1.0.1-alpha+1717789143896"
   gql_transform_link:
     dependency: transitive
     description:
@@ -240,18 +248,18 @@ packages:
     dependency: transitive
     description:
       name: graphql
-      sha256: d066e53446166c12537458386b507f7426f2b8801ebafc184576aab3cbc64d56
+      sha256: "62f31433ba194eda7b81a812a83c3d9560766cec5ac0210ea4a3e677c91b8df4"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0-beta.7"
+    version: "5.2.0-beta.8"
   graphql_flutter:
     dependency: "direct main"
     description:
       name: graphql_flutter
-      sha256: "39b5e830bc654ab02c5b776c31675841d1a8c95840fdd284efba713b1d47e65d"
+      sha256: "2423b394465e7d83a5e708cd2f5b37b54e7ae9900abfbf0948d512fa46961acb"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.0-beta.6"
+    version: "5.2.0-beta.7"
   hive:
     dependency: transitive
     description:
@@ -264,10 +272,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.2"
   http_parser:
     dependency: transitive
     description:
@@ -276,38 +284,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -320,10 +320,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "4.0.0"
   logging:
     dependency: transitive
     description:
@@ -344,18 +344,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   nm:
     dependency: transitive
     description:
@@ -384,50 +384,50 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "3087813781ab814e4157b172f1a11c46be20179fcc9bea043e0fba36bc0acaa2"
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      sha256: "6f01f8e37ec30b07bc424b4deabac37cacb1bc7e2e515ad74486039918a37eb7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.27"
+    version: "2.2.10"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "916731ccbdce44d545414dd9961f26ba5fbaa74bcbb55237d8e65a623a8c7297"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ffbb8cc9ed2c9ec0e4b7a541e56fd79b138e8f47d2fb86815f15358a349b3b57
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.11"
+    version: "2.2.1"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "1cb68ba4cd3a795033de62ba1b7b4564dace301f952de6bfb3cd91b202b6ee96"
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -440,18 +440,18 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "6a2128648c854906c53fa8e33986fc0247a1116122f9534dd20e3ab9e16a32bc"
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.8"
   rxdart:
     dependency: transitive
     description:
@@ -517,10 +517,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   transparent_image:
     dependency: "direct main"
     description:
@@ -541,10 +541,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: b715b8d3858b6fa9f68f87d20d98830283628014750c2b09b6f516c1da4af2a7
+      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.5.0"
   vector_math:
     dependency: transitive
     description:
@@ -557,10 +557,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -573,50 +581,42 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter
-      sha256: "82f6787d5df55907aa01e49bd9644f4ed1cc82af7a8257dd9947815959d2e755"
+      sha256: ec81f57aa1611f8ebecf1d2259da4ef052281cb5ad624131c93546c79ccc7736
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "4.9.0"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: ddc167c6676f57c8b367d19fcbee267d6dc6adf81bd6c3cb87981d30746e0a6d
+      sha256: "6e64fcb1c19d92024da8f33503aaeeda35825d77142c01d0ea2aa32edc79fdc8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.1"
+    version: "3.16.7"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "6d9213c65f1060116757a7c473247c60f3f7f332cac33dc417c9e362a9a13e4f"
+      sha256: d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.10.0"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: "485af05f2c5f83c7f78c20e236b170ad02df7153b299ae9917345be43871d29f"
+      sha256: "1942a12224ab31e9508cf00c0c6347b931b023b8a4f0811e5dec3b06f94f117d"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: dfdf0136e0aa7a1b474ea133e67cb0154a0acd2599c4f3ada3b49d38d38793ee
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.5"
+    version: "3.15.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: e0b1147eec179d3911f1f19b59206448f78195ca1d20514134e10641b7d7fbff
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:
@@ -634,5 +634,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/examples/simple_example/pubspec.yaml
+++ b/examples/simple_example/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     path: ../../packages/datadog_gql_link
     
   go_router: ^7.0.0
-  path_provider: ^2.0.0
+  path_provider: ^2.1.0
   flutter_dotenv: ^5.1.0
   transparent_image: ^2.0.1
   graphql_flutter: ^5.1.2

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-
+* Add `DialogRoute` handling to the `defaultViewInfoExtractor`.
 
 ## 2.7.0
 

--- a/packages/datadog_flutter_plugin/example/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Runner/AppDelegate.swift
@@ -10,7 +10,7 @@ enum InternalError: Error {
     case pluginError
 }
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
     var methodChannel: FlutterMethodChannel!
 

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
@@ -239,8 +239,8 @@ class DatadogLogsPluginTests: XCTestCase {
         )
         plugin.handle(methodCallA) { _ in }
 
-        var loggedConsoleLines: [String] = []
-        consolePrint = { str, _ in loggedConsoleLines.append(str) }
+        let printMock = PrintFunctionMock()
+        consolePrint = printMock.print
 
         let methodCallB = FlutterMethodCall(
             methodName: "initialize",
@@ -250,9 +250,7 @@ class DatadogLogsPluginTests: XCTestCase {
         )
         plugin.handle(methodCallB) { _ in }
 
-        print(loggedConsoleLines)
-
-        XCTAssertTrue(loggedConsoleLines.isEmpty)
+        XCTAssertTrue(printMock.printedMessages.isEmpty)
     }
 
     func testRepeatEnable_FromMethodChannelDifferentOptions_PrintsError() {
@@ -264,8 +262,8 @@ class DatadogLogsPluginTests: XCTestCase {
         )
         plugin.handle(methodCallA) { _ in }
 
-        var loggedConsoleLines: [String] = []
-        consolePrint = { str, _ in loggedConsoleLines.append(str) }
+        let printMock = PrintFunctionMock()
+        consolePrint = printMock.print
 
         let methodCallB = FlutterMethodCall(
             methodName: "enable",
@@ -277,8 +275,8 @@ class DatadogLogsPluginTests: XCTestCase {
         )
         plugin.handle(methodCallB) { _ in }
 
-        XCTAssertFalse(loggedConsoleLines.isEmpty)
-        XCTAssertTrue(loggedConsoleLines.first?.contains("🔥") == true)
+        XCTAssertFalse(printMock.printedMessages.isEmpty)
+        XCTAssertTrue(printMock.printedMessages.first?.contains("🔥") == true)
     }
 
     func testParseLogLevel_ParsesLevelsCorrectly() {

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -192,8 +192,8 @@ class DatadogRumPluginTests: XCTestCase {
         )
         plugin.handle(methodCallA) { _ in }
 
-        var loggedConsoleLines: [String] = []
-        consolePrint = { str, _ in loggedConsoleLines.append(str) }
+        let printMock = PrintFunctionMock()
+        consolePrint = printMock.print
 
         let methodCallB = FlutterMethodCall(
             methodName: "initialize",
@@ -203,9 +203,7 @@ class DatadogRumPluginTests: XCTestCase {
         )
         plugin.handle(methodCallB) { _ in }
 
-        print(loggedConsoleLines)
-
-        XCTAssertTrue(loggedConsoleLines.isEmpty)
+        XCTAssertTrue(printMock.printedMessages.isEmpty)
     }
 
     func testRepeatEnable_FromMethodChannelDifferentOptions_PrintsError() {
@@ -222,8 +220,8 @@ class DatadogRumPluginTests: XCTestCase {
         )
         plugin.handle(methodCallA) { _ in }
 
-        var loggedConsoleLines: [String] = []
-        consolePrint = { str, _ in loggedConsoleLines.append(str) }
+        let printMock = PrintFunctionMock()
+        consolePrint = printMock.print
 
         let methodCallB = FlutterMethodCall(
             methodName: "enable",
@@ -236,8 +234,8 @@ class DatadogRumPluginTests: XCTestCase {
         )
         plugin.handle(methodCallB) { _ in }
 
-        XCTAssertFalse(loggedConsoleLines.isEmpty)
-        XCTAssertTrue(loggedConsoleLines.first?.contains("🔥") == true)
+        XCTAssertFalse(printMock.printedMessages.isEmpty)
+        XCTAssertTrue(printMock.printedMessages.first?.contains("🔥") == true)
     }
 
     func testStartViewCall_CallsRumMonitor() {

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -98,8 +98,8 @@ class FlutterSdkTests: XCTestCase {
 
         XCTAssertTrue(Datadog.isInitialized())
 
-        var loggedConsoleLines: [String] = []
-        consolePrint = { str, _ in loggedConsoleLines.append(str) }
+        let printMock = PrintFunctionMock()
+        consolePrint = printMock.print
 
         let methodCallB = FlutterMethodCall(
             methodName: "initialize",
@@ -110,9 +110,7 @@ class FlutterSdkTests: XCTestCase {
         )
         plugin.handle(methodCallB) { _ in }
 
-        print(loggedConsoleLines)
-
-        XCTAssertTrue(loggedConsoleLines.isEmpty)
+        XCTAssertTrue(printMock.printedMessages.isEmpty)
     }
 
     func testRepeatInitialization_FromMethodChannelDifferentOptions_PrintsError() {
@@ -131,8 +129,8 @@ class FlutterSdkTests: XCTestCase {
 
         XCTAssertTrue(Datadog.isInitialized())
 
-        var loggedConsoleLines: [String] = []
-        consolePrint = { str, _ in loggedConsoleLines.append(str) }
+        let printMock = PrintFunctionMock()
+        consolePrint = printMock.print
 
         let methodCallB = FlutterMethodCall(
             methodName: "initialize",
@@ -146,8 +144,8 @@ class FlutterSdkTests: XCTestCase {
         )
         plugin.handle(methodCallB) { _ in }
 
-        XCTAssertFalse(loggedConsoleLines.isEmpty)
-        XCTAssertTrue(loggedConsoleLines.first?.contains("🔥") == true)
+        XCTAssertFalse(printMock.printedMessages.isEmpty)
+        XCTAssertTrue(printMock.printedMessages.first?.contains("🔥") == true)
     }
 
 //    func testAttachToExisting_WithNoExisting_PrintsError() {

--- a/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/FoundationMocks.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/FoundationMocks.swift
@@ -5,6 +5,7 @@
  */
 
 import Foundation
+import DatadogInternal
 
 /*
  A collection of mocks for different `Foundation` types. The convention we use is to extend
@@ -817,5 +818,23 @@ private class URLSessionTaskTransactionMetricsMock: URLSessionTaskTransactionMet
         self._responseStartDate = responseStartDate
         self._responseEndDate = responseEndDate
         self._countOfResponseBodyBytesAfterDecoding = countOfResponseBodyBytesAfterDecoding
+    }
+}
+
+public class PrintFunctionMock: @unchecked Sendable {
+    @ReadWriteLock
+    public private(set) var printedMessages: [String] = []
+
+    public var printedMessage: String? { printedMessages.last }
+
+    public init() { }
+
+    @Sendable
+    public func print(message: String, level: CoreLoggerLevel) {
+        printedMessages.append(message)
+    }
+
+    public func reset() {
+        printedMessages = []
     }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -45,6 +45,11 @@ RumViewInfo? defaultViewInfoExtractor(Route<dynamic> route) {
     if (name != null) {
       return RumViewInfo(name: name);
     }
+  } else if (route is DialogRoute) {
+    var name = route.settings.name;
+    if (name != null) {
+      return RumViewInfo(name: name);
+    }
   }
 
   return null;


### PR DESCRIPTION
### What and why?

The `showDialog` method pushes a new route, even when using GoRouter or similar. This stops the current route and causes us to miss any events from the dialog.

Add the ability for users to name dialogs which will start a new view for them.

Also fix some issues with the example app not working on mobile.

refs: RUM-6048

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
