### PR TITLE
chore: Fix the name of the gitlab notify step

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ stages:
   - build
   - integration-test
   - e2e-test
-  - notify
+  - post
 
 # Prebuild - install necessary tools
 
@@ -178,7 +178,7 @@ web-integration-test:
 
 notify-publish-develop-failure:
   extends: .slack-notifier-base
-  stage: notify
+  stage: post
   when: on_failure
   only:
     - develop
@@ -188,8 +188,7 @@ notify-publish-develop-failure:
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
 notify-pipeline-succeeded:
-  extends: .slack-notifier-base
-  stage: notify
+  stage: post
   tags: [ "arch:amd64" ]
   image: "$BUILDENV_REGISTRY/images/docker:24.0.4-gbi-focal"
   when: on_success

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/MockRumMonitor.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/MockRumMonitor.kt
@@ -1,5 +1,6 @@
 package com.datadoghq.flutter
 
+import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
@@ -60,6 +61,11 @@ class MockRumMonitor : RumMonitor {
 
     override fun addTiming(name: String) {
         mockMonitor.addTiming(name)
+    }
+
+    @ExperimentalRumApi
+    override fun addViewLoadingTime(overwrite: Boolean) {
+        mockMonitor.addViewLoadingTime(overwrite)
     }
 
     override fun clearAttributes() {


### PR DESCRIPTION
### What and why?

Apparently the name 'notify' doesn't get synced from GitLab to GitHub. Fix the name so that the stage syncs properly

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
