### PR TITLE
fix: Add additional timeout for mappers

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -6,6 +6,21 @@ import 'dart:io';
 
 import '../../datadog_common_test.dart';
 
+class RumUser {
+  String? email;
+  String? id;
+  String? name;
+
+  RumUser(this.email, this.id, this.name);
+
+  static RumUser fromJson(Map<String, dynamic> json) {
+    final email = json['email'] is String ? json['email'] as String : null;
+    final id = json['id'] is String ? json['id'] as String : null;
+    final name = json['name'] is String ? json['name'] as String : null;
+    return RumUser(email, id, name);
+  }
+}
+
 class RumSessionDecoder {
   final List<RumViewVisit> visits;
 
@@ -115,6 +130,12 @@ class RumEventDecoder {
       if (Platform.isIOS) return rumEvent['service'];
     }
     return rumEvent['service'];
+  }
+
+  RumUser? get user {
+    final usr = rumEvent['usr'];
+    if (usr == null) return null;
+    return RumUser.fromJson(usr);
   }
 
   int get date => rumEvent['date'] as int;

--- a/packages/datadog_flutter_plugin/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -129,3 +129,11 @@ void verifyCommonTags(
     expect(request.tags['variant'], variant);
   }
 }
+
+void verifyUser(RumEventDecoder decoder) {
+  final user = decoder.user;
+  expect(user, isNotNull);
+  expect(user?.email, 'fake@datadoghq.com');
+  expect(user?.id, 'fake-id');
+  expect(user?.name, 'Johnny Silverhand');
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -163,6 +163,20 @@ void main() {
       expect(view1.errorEvents[0].context![contextKey], expectedContextValue);
     }
 
+    // Verify user in all events, except for the first view event
+    for (final viewEvent in view1.viewEvents.sublist(1)) {
+      verifyUser(viewEvent);
+    }
+    for (final actionEvent in view1.actionEvents) {
+      verifyUser(actionEvent);
+    }
+    for (final resourceEvent in view1.resourceEvents) {
+      verifyUser(resourceEvent);
+    }
+    for (final errorEvent in view1.errorEvents) {
+      verifyUser(errorEvent);
+    }
+
     expect(view1, becameInactive);
 
     final view2 = session.visits[1];

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -95,6 +95,9 @@ class _RumManualInstrumentationScenarioState
   Future<void> _fakeLoading() async {
     await Future<void>.delayed(const Duration(milliseconds: 50));
     DatadogSdk.instance.rum?.addTiming('content-ready');
+
+    DatadogSdk.instance.setUserInfo(
+        id: 'fake-id', name: 'Johnny Silverhand', email: 'fake@datadoghq.com');
   }
 
   void _simulateResourceDownload() async {

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -401,6 +401,13 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                     encodedResult = nil
                 } else if let result = result as? [String: Any] {
                     encodedResult = result
+                } else if (result as? NSObject) == FlutterMethodNotImplemented {
+                    Datadog._internal.telemetry.error(
+                        id: "event_mapper_not_implemented",
+                        message: "\(mapperName) returned notImplemented.",
+                        kind: nil,
+                        stack: nil
+                    )
                 }
 
                 semaphore.signal()


### PR DESCRIPTION
### What and why?

We're getting reports that event mappers still time out, even with 1s of available time. This is likely because of a sudden influx of calls on the method channel, which is hopefully temporary and can be resolved within the new timeout (5s).
 
Additionally, we're seeing reports of `notImplemented` errors when calling mappers.  This appears to be caused by users or third party libraries creating multiple Flutter engines (some of which don't initialize Datadog) or some weird (and very difficult to reproduce cases) where it appears that Flutter does not unregister the plugin.   To fix this, we'll attempt to call other mappers if the first one returns `NotImplemented`, and remove the offending method channel from the list.

Add formerly missing mapper "not implemented" telemetry to iOS.

Add an integration test for user information.

refs: RUM-6457 #652

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
