### PR TITLE
feat: Add `addViewLoadingTime` API

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -258,6 +258,7 @@ class RumViewDecoder {
   int get resourceCount => viewData['resource']['count'] as int;
   int get errorCount => viewData['error']['count'] as int;
   int get longTaskCount => viewData['long_task']['count'] as int;
+  int? get loadingTime => viewData['loading_time'] as int?;
 
   Map<String, int> get customTimings =>
       (viewData['custom_timings'] as Map<String, Object?>)

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add `DialogRoute` handling to the `defaultViewInfoExtractor`.
+* Add experimental `addViewLoadingTime` API to RUM.
 
 ## 2.7.0
 

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -51,6 +51,7 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
         const val PARAM_TYPE = "type"
         const val PARAM_BUILD_TIMES = "buildTimes"
         const val PARAM_RASTER_TIMES = "rasterTimes"
+        const val PARAM_OVERWRITE = "overwrite"
 
         // See DatadogSdkPlugin's description of this same member
         private var previousConfiguration: Map<String, Any?>? = null
@@ -107,6 +108,7 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
                 "startView" -> startView(call, result)
                 "stopView" -> stopView(call, result)
                 "addTiming" -> addTiming(call, result)
+                "addViewLoadingTime" -> addViewLoadingTime(call, result)
                 "startResource" -> startResource(call, result)
                 "stopResource" -> stopResource(call, result)
                 "stopResourceWithError" -> stopResourceWithError(call, result)
@@ -245,6 +247,16 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
         val name = call.argument<String>(PARAM_NAME)
         if (name != null) {
             rum?.addTiming(name)
+            result.success(null)
+        } else {
+            result.missingParameter(call.method)
+        }
+    }
+
+    private fun addViewLoadingTime(call: MethodCall, result: Result) {
+        val overwrite = call.argument<Boolean>(PARAM_OVERWRITE)
+        if (overwrite != null) {
+            rum?.addViewLoadingTime(overwrite)
             result.success(null)
         } else {
             result.missingParameter(call.method)

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ContractHelpers.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ContractHelpers.kt
@@ -18,6 +18,7 @@ enum class SupportedContractType {
     LIST,
     INT,
     LONG,
+    BOOL,
     ANY,
 }
 
@@ -61,6 +62,7 @@ data class Contract(
             SupportedContractType.LIST -> emptyList<Any>()
             SupportedContractType.INT -> forge.anInt()
             SupportedContractType.LONG -> forge.aLong()
+            SupportedContractType.BOOL -> forge.aBool()
             SupportedContractType.ANY -> forge.aValueFrom(
                 listOf(
                     forge.aBool(),

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -455,6 +455,25 @@ class DatadogRumPluginTest {
     }
 
     @Test
+    fun `M call monitor addViewLoadingTime W addViewLoadingTime is called`(
+        @BoolForgery overwrite: Boolean
+    ) {
+        // GIVEN
+        val call = MethodCall("addViewLoadingTime", mapOf(
+            "overwrite" to overwrite
+        ))
+        val mockResult = mockk<MethodChannel.Result>()
+        every { mockResult.success(any()) } returns Unit
+
+        // WHEN
+        plugin.onMethodCall(call, mockResult)
+
+        // THEN
+        verify { monitorProxy.mockMonitor.addViewLoadingTime(overwrite) }
+        verify { mockResult.success(null) }
+    }
+
+    @Test
     fun `M call monitor startResource W startResource is called`(
         @StringForgery resourceKey: String,
         @StringForgery url: String,
@@ -718,6 +737,9 @@ class DatadogRumPluginTest {
         )),
         Contract("addTiming", mapOf(
             "name" to ContractParameter.Type(SupportedContractType.STRING),
+        )),
+        Contract("addViewLoadingTime", mapOf(
+            "overwrite" to ContractParameter.Type(SupportedContractType.BOOL),
         )),
         Contract("startResource", mapOf(
             "key" to ContractParameter.Type(SupportedContractType.STRING),

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -119,6 +119,9 @@ class DatadogRumPluginTests: XCTestCase {
         Contract(methodName: "addTiming", requiredParameters: [
             "name": .string
         ]),
+        Contract(methodName: "addViewLoadingTime", requiredParameters: [
+            "overwrite": .bool
+        ]),
         Contract(methodName: "startResource", requiredParameters: [
             "key": .string, "url": .string, "httpMethod": .string, "attributes": .map
         ]),
@@ -282,6 +285,20 @@ class DatadogRumPluginTests: XCTestCase {
         }
 
         XCTAssertEqual(mock.callLog, [ .addTiming(name: "timing name") ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testAddViewLoadingTime_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "addViewLoadingTime", arguments: [
+            "overwrite": true
+        ])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [ .addViewLoadingTime(overwrite: true) ])
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
@@ -576,6 +593,7 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         case startView(key: String, name: String?, attributes: [AttributeKey: AttributeValue])
         case stopView(key: String, attributes: [AttributeKey: AttributeValue])
         case addTiming(name: String)
+        case addViewLoadingTime(overwrite: Bool)
 
         case startResource(key: String, httpMethod: RUMMethod, urlString: String,
                            attributes: [AttributeKey: AttributeValue])
@@ -662,6 +680,10 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
             .addError(message: message, type: type, source: source, stack: stack,
                       attributes: attributes, file: file, line: line)
         )
+    }
+
+    func addViewLoadingTime(overwrite: Bool) {
+        callLog.append(.addViewLoadingTime(overwrite: overwrite))
     }
 
     func addAttribute(forKey key: AttributeKey, value: AttributeValue) {

--- a/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/ContractHelpers.swift
@@ -11,6 +11,7 @@ enum SupportedContractType {
     case string
     case int
     case int64
+    case bool
     case map
     case list
 
@@ -19,6 +20,7 @@ enum SupportedContractType {
         case .string: return "fake string"
         case .int: return 1_234
         case .int64: return 1_223_455_123
+        case .bool: return false
         case .map: return ["key to": "value"]
         case .list: return [] as [Any]
         }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -131,12 +131,18 @@ void main() {
 
     final contentReadyTiming =
         view1.viewEvents.last.view.customTimings['content-ready'];
+    final viewLoadingTiming = view1.viewEvents.last.view.loadingTime;
     final firstInteractionTiming =
         view1.viewEvents.last.view.customTimings['first-interaction'];
     expect(contentReadyTiming, isNotNull);
     expect(contentReadyTiming, greaterThanOrEqualTo(50 * 1000 * 1000));
     // TODO: Figure out why occasionally these have really high values
     // expect(contentReadyTiming, lessThan(200 * 1000 * 100));
+    if (!kIsWeb) {
+      expect(viewLoadingTiming, isNotNull);
+      expect(viewLoadingTiming,
+          closeTo(contentReadyTiming!, 5000000)); // Within 5ms
+    }
     expect(firstInteractionTiming, isNotNull);
     expect(firstInteractionTiming, greaterThanOrEqualTo(contentReadyTiming!));
     // TODO: Figure out why occasionally these have really high values

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -95,6 +95,7 @@ class _RumManualInstrumentationScenarioState
   Future<void> _fakeLoading() async {
     await Future<void>.delayed(const Duration(milliseconds: 50));
     DatadogSdk.instance.rum?.addTiming('content-ready');
+    DatadogSdk.instance.rum?.addViewLoadingTime();
 
     DatadogSdk.instance.setUserInfo(
         id: 'fake-id', name: 'Johnny Silverhand', email: 'fake@datadoghq.com');

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -6,7 +6,7 @@
 import Foundation
 import Flutter
 import DatadogCore
-import DatadogRUM
+@_spi(Experimental) import DatadogRUM
 import DatadogInternal
 import DictionaryCoder
 
@@ -134,6 +134,15 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         case "addTiming":
             if let name = arguments["name"] as? String {
                 rum?.addTiming(name: name)
+                result(nil)
+            } else {
+                result(
+                    FlutterError.missingParameter(methodName: call.method)
+                )
+            }
+        case "addViewLoadingTime":
+            if let overwrite = arguments["overwrite"] as? Bool {
+                rum?.addViewLoadingTime(overwrite: overwrite)
                 result(nil)
             } else {
                 result(

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -225,6 +225,18 @@ class DatadogRum {
     });
   }
 
+  /// Adds view loading time to current RUM view based on the time elapsed since
+  /// the view was started. If this method is called multiple times, only the
+  /// first timing is used, unless [overwrite] is set to [true]. If [overwrite]
+  /// is [true], the new load timing overwrites any previous value.
+  ///
+  /// *Note*: This API is experimental and may change in the future.
+  void addViewLoadingTime({bool override = false}) {
+    wrap('rum.addViewLoadingTime', logger, null, () {
+      return _platform.addViewLoadingTime(override);
+    });
+  }
+
   /// Notifies that the Exception or Error [error] occurred in currently
   /// presented View, with an origin of [source]. You can optionally set
   /// additional [attributes] for this error, an [errorType] and a

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -132,6 +132,13 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
+  Future<void> addViewLoadingTime(bool overwrite) {
+    return methodChannel.invokeMethod('addViewLoadingTime', {
+      'overwrite': overwrite,
+    });
+  }
+
+  @override
   Future<void> addErrorInfo(
       String message,
       RumErrorSource source,

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -43,6 +43,11 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
+  Future<void> addViewLoadingTime(bool overwrite) {
+    return Future.value();
+  }
+
+  @override
   Future<void> addAction(
       RumActionType type, String name, Map<String, Object?> attributes) {
     return Future.value();

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -30,6 +30,7 @@ abstract class DdRumPlatform extends PlatformInterface {
       String key, String name, Map<String, Object?> attributes);
   Future<void> stopView(String key, Map<String, Object?> attributes);
   Future<void> addTiming(String name);
+  Future<void> addViewLoadingTime(bool overwrite);
 
   Future<void> startResource(String key, RumHttpMethod httpMethod, String url,
       Map<String, Object?> attributes);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -114,6 +114,11 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
+  Future<void> addViewLoadingTime(bool overwrite) async {
+    // NOOP - Not supported by the Browser SDK
+  }
+
+  @override
   Future<void> addAction(
       RumActionType type, String name, Map<String, dynamic> attributes) async {
     DD_RUM?.addAction(name, attributesToJs(attributes, 'attributes'));

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -85,6 +85,14 @@ void main() {
     ]);
   });
 
+  test('addViewLoadingTime calls to platform', () async {
+    await ddRumPlatform.addViewLoadingTime(true);
+
+    expect(log, [
+      isMethodCall('addViewLoadingTime', arguments: {'overwrite': true})
+    ]);
+  });
+
   test('startResource calls to platform', () async {
     await ddRumPlatform.startResource('resource_key', RumHttpMethod.get,
         'https://fakeresource.com/url', {'attribute_key': 'attribute_value'});


### PR DESCRIPTION
### What and why?

Add methods to call `addViewLoadingTime` on the native SDKs.

refs: RUM-5841

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
