### PR TITLE
chore: Remove bitrise triggers

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -2,15 +2,7 @@
 format_version: '11'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: flutter
-trigger_map:
-- push_branch: main
-  pipeline: primary
-- push_branch: develop
-  pipeline: primary
-- push_branch: release/*
-  pipeline: primary
-- pull_request_source_branch: "*"
-  pipeline: pull_request
+trigger_map: []
 pipelines:
   primary:
     stages:


### PR DESCRIPTION
### What and why?

Remove bitrise triggers as we're using gitlab across the board at this point, and it's more stable.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
