### PR TITLE
chore: Update releaser scripts to generate CHANGELOG.

### DIFF
--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -7,10 +7,15 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:releaser/cocoapod_util.dart';
 import 'package:releaser/command.dart';
 import 'package:releaser/generate_changelog.dart';
+import 'package:releaser/git_actions.dart';
+import 'package:releaser/gradle_util.dart';
 import 'package:releaser/helpers.dart';
+import 'package:releaser/release_validator.dart';
 import 'package:releaser/version_updater.dart';
+import 'package:releaser/yaml_util.dart';
 
 void main(List<String> arguments) async {
   Logger.root.level = Level.INFO;

--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -7,14 +7,10 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
-import 'package:releaser/cocoapod_util.dart';
 import 'package:releaser/command.dart';
-import 'package:releaser/git_actions.dart';
-import 'package:releaser/gradle_util.dart';
+import 'package:releaser/generate_changelog.dart';
 import 'package:releaser/helpers.dart';
-import 'package:releaser/release_validator.dart';
 import 'package:releaser/version_updater.dart';
-import 'package:releaser/yaml_util.dart';
 
 void main(List<String> arguments) async {
   Logger.root.level = Level.INFO;
@@ -107,6 +103,7 @@ void main(List<String> arguments) async {
   final commands = <Command>[
     ValidateReleaseCommand(),
     CreateBranchCommand(choreBranch),
+    GenerateChangelogCommand(),
     UpdateVersionsCommand(),
     CommitChangesCommand(
         'chore: Preparing for release of ${commandArgs.packageName} ${commandArgs.version}.'),

--- a/tools/releaser/lib/command.dart
+++ b/tools/releaser/lib/command.dart
@@ -27,7 +27,7 @@ class CommandArguments {
   // The release of the iOS SDK we want this release to refer to
   String? iOSRelease;
 
-  // The release of the iOS SDK we want this release to refer to
+  // The release of the Android SDK we want this release to refer to
   String? androidRelease;
 
   // Whether we're doing a dry run

--- a/tools/releaser/lib/generate_changelog.dart
+++ b/tools/releaser/lib/generate_changelog.dart
@@ -1,0 +1,155 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+
+import 'command.dart';
+import 'helpers.dart';
+
+class GenerateChangelogCommand extends Command {
+  static const issuesLink = 'https://github.com/DataDog/dd-sdk-flutter/issues/';
+
+  @override
+  Future<bool> run(CommandArguments args, Logger logger) async {
+    final lastReleaseSha = await _findLastReleaseSha(args);
+
+    final commits = await _getCommits(args, '$lastReleaseSha..HEAD');
+
+    final changelogItems = _getChangelogItems(commits);
+    logger.fine(
+        'Found ${changelogItems.length} changelog items for ${args.packageName} version ${args.version}');
+
+    final versionChangelog = changelogItems.map((e) => '* $e').join('\n');
+
+    final file = File(path.join(args.packageRoot, 'CHANGELOG.md'));
+    if (!file.existsSync()) {
+      Logger.root.shout('❌ Could not find file CHANGELOG.md for package.');
+      return false;
+    }
+
+    bool didWriteChangelog = false;
+    await transformFile(file, logger, args.dryRun, (line) {
+      if (didWriteChangelog) return line;
+
+      if (line.startsWith('##')) {
+        String? oldLine = line;
+        if (line == '## Unreleased') {
+          logger
+              .info('ℹ️ ## Unreleased headers are no longer needed. Removing.');
+          oldLine = null;
+        }
+
+        line = '## ${args.version}\n\n$versionChangelog';
+        if (oldLine != null) {
+          line += '\n\n$oldLine';
+        }
+        didWriteChangelog = true;
+      }
+      return line;
+    });
+
+    print(
+        'Verify the CHANGELOG.md changes and add changes from iOS and Android Native SDK updates.');
+    print(
+        'For reference iOS SDK will be updated to ${args.iOSRelease} and Android SDK will be updated to ${args.androidRelease}.');
+    print('Ready to continue? ([Y]es, [N]o): ');
+
+    final input = stdin.readLineSync();
+    if (input != null && input.isNotEmpty) {
+      final firstChar = input[0].toLowerCase();
+      if (firstChar == 'y') {
+        return true;
+      } else if (firstChar == 'n') {
+        logger.shout('😳 Oh, I\'m glad we stopped then!');
+        return false;
+      } else {
+        logger.shout(
+            '❓ Not sure what you meant by that... stopping just in case.');
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  Future<String> _findLastReleaseSha(CommandArguments args) async {
+    final packageTags = await args.gitDir
+        .tags()
+        .where((t) => t.tag.startsWith('${args.packageName}/'))
+        .toList();
+
+    return packageTags.last.objectSha;
+  }
+
+  Future<List<String>> _getCommits(
+      CommandArguments args, String commitRange) async {
+    final result = await args.gitDir.runCommand([
+      '--no-pager',
+      'log',
+      commitRange,
+      '--pretty=format:%H|||%an <%aE>|||%ai|||%B||||',
+      '--',
+      args.packageRoot
+    ]);
+
+    final rawCommits = (result.stdout as String)
+        .split('||||\n')
+        .where((e) => e.trim().isNotEmpty)
+        .toList();
+
+    return rawCommits.map((c) {
+      final parts = c.split('|||');
+      return parts[3].trim();
+    }).toList();
+  }
+}
+
+List<String> _getChangelogItems(List<String> commitMessages) {
+  RegExp conventionalCommitPattern =
+      RegExp(r'(?<type>.*)(\((?<scope>.*)\))?(?<breaking>!)?: (?<rest>.*)');
+  RegExp githubIssueMention = RegExp(r'\#(?<issue_number>\d+)');
+
+  final items = <String>[];
+  for (final commitMessage in commitMessages) {
+    final lines = commitMessage.split('\n');
+    final summaryLine = lines[0];
+    final match = conventionalCommitPattern.firstMatch(summaryLine);
+    if (match != null) {
+      final type = match.namedGroup('type');
+      if (type == 'fix' || type == 'feat') {
+        String changelogItem = '';
+        if (match.namedGroup('scope') case final scope?) {
+          changelogItem += '[$scope] ';
+        }
+
+        changelogItem += match.namedGroup('rest')!;
+        if (!changelogItem.endsWith('.')) {
+          // Commits frequently forget they're sentences.
+          changelogItem += '.';
+        }
+
+        // Check to see if there are any Github issues referenced
+        final refLines = lines.where((l) => l.startsWith('refs:'));
+        var githubRefs = <String>[];
+        for (var refLine in refLines) {
+          for (var match in githubIssueMention.allMatches(refLine)) {
+            githubRefs.add(match.namedGroup('issue_number')!);
+          }
+        }
+        if (githubRefs.isNotEmpty) {
+          final seeStrings = githubRefs
+              .map((r) => '[#$r](${GenerateChangelogCommand.issuesLink}$r)');
+          changelogItem += 'See ${seeStrings.join(' ')}';
+        }
+
+        items.add(changelogItem);
+      }
+    }
+  }
+
+  return items;
+}

--- a/tools/releaser/lib/helpers.dart
+++ b/tools/releaser/lib/helpers.dart
@@ -9,6 +9,11 @@ import 'package:git/git.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
+bool hasNativeDependency(String packageName) {
+  return packageName == 'datadog_flutter_plugin' ||
+      packageName == 'datadog_webview_tracking';
+}
+
 Future<GitDir?> getGitDir() async {
   final currentPath = path.current;
 

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -101,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: git
-      sha256: "65051372cfefcc10926313a1418b04c91807b99be14935ad4cffae433dad029c"
+      sha256: daea03e7471607e7ed942bccd4814cfc7e4fa8ca5d3dd6ad4fb170e44423d1a0
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.0"
   github:
     dependency: "direct main"
     description:
@@ -418,4 +418,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.1 <4.0.0"
+  dart: ">=3.5.0 <4.0.0"

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -4,13 +4,13 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.16.1 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
   args: ^2.3.0
   logging: ^1.0.2
   path: ^1.8.0
-  git: ^2.0.0
+  git: ^2.3.0
   github: ^9.5.0
   version: ^2.0.0
 


### PR DESCRIPTION
### What and why?

Generate the CHANGELOG for a package from [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) messages instead of relying on manually updating the changelog.

This does not satisfy all the requirements of RUM-5667 but eliminates a particularly manual portion of releasing.

refs: RUM-5667

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
