### PR TITLE
chore: Update all examples to use `flutter.targetSdkVersion`

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
     defaultConfig {
         applicationId "com.datadog.flutter.nightly"
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion flutter.targetSdkVersion
         multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -56,7 +56,7 @@ android {
     defaultConfig {
         applicationId "com.datadoghq.example.flutter"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         applicationId "com.datadoghq.flutter.integrationtestapp"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/datadog_tracking_http_client/example/android/app/build.gradle
+++ b/packages/datadog_tracking_http_client/example/android/app/build.gradle
@@ -49,7 +49,6 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
         minSdkVersion 21
-        targetSdkVersion 31
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/datadog_webview_tracking/example/android/app/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "com.datadoghq.flutter.webview.example"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true


### PR DESCRIPTION
### What and why?

Different examples were using some hard coded android sdk version targets. Switch all of them to use whatever Flutter says to use.

refs: RUM-6930

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
