### PR TITLE
chore: Add integration tests for checking `networkInfoEnabled`

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -67,6 +67,15 @@ void main() {
 
     List<LogDecoder> firstLoggerLogs =
         logs.where((l) => l.loggerName != 'second_logger').toList();
+    if (!kIsWeb) {
+      for (final log in firstLoggerLogs) {
+        if (Platform.isAndroid) {
+          expect(log.log['network'], isNotNull);
+        } else if (Platform.isIOS) {
+          expect(log.log['network.client.reachability'], isNotNull);
+        }
+      }
+    }
 
     expect(firstLoggerLogs[0].status, 'debug');
     expect(firstLoggerLogs[0].message, 'debug message');
@@ -140,6 +149,15 @@ void main() {
 
     List<LogDecoder> secondLoggerLogs =
         logs.where((l) => l.loggerName == 'second_logger').toList();
+    if (!kIsWeb) {
+      for (final log in secondLoggerLogs) {
+        if (Platform.isAndroid) {
+          expect(log.log['network'], isNull);
+        } else if (Platform.isIOS) {
+          expect(log.log['network.client.reachability'], isNull);
+        }
+      }
+    }
 
     expect(secondLoggerLogs[0].status, 'info');
     expect(secondLoggerLogs[0].message, 'message on second logger');

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -56,7 +56,10 @@ class _LoggingScenarioState extends State<LoggingScenario> {
           errorMessage: e.toString(), errorStackTrace: st);
     }
 
-    final config = DatadogLoggerConfiguration(name: 'second_logger');
+    final config = DatadogLoggerConfiguration(
+      name: 'second_logger',
+      networkInfoEnabled: false,
+    );
     final secondLogger = DatadogSdk.instance.logs!.createLogger(config);
 
     secondLogger.addAttribute('second-logger-attribute', 'second-value');


### PR DESCRIPTION
### What and why?

Add an integration tests for logging that checks that network properties aren't added if `networkInfoEnabled` is set to `false` on a logger

refs: RUM-7318 #675

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
