### PR TITLE
chore: Fix creation of changelog in releaser script

### DIFF
--- a/tools/releaser/lib/generate_changelog.dart
+++ b/tools/releaser/lib/generate_changelog.dart
@@ -45,7 +45,7 @@ class GenerateChangelogCommand extends Command {
 
         line = '## ${args.version}\n\n$versionChangelog';
         if (oldLine != null) {
-          line += '\n\n$oldLine';
+          line += '\n$oldLine';
         }
         didWriteChangelog = true;
       }

--- a/tools/releaser/lib/helpers.dart
+++ b/tools/releaser/lib/helpers.dart
@@ -50,7 +50,9 @@ Future<void> transformFile(
   logger.finest(' ------- NEW  $filename CONTENTS ------');
   logger.finest(newFileBuffer.toString());
   if (!dryRun) {
-    file.openWrite().write(newFileBuffer);
+    final sync = file.openWrite();
+    sync.write(newFileBuffer);
+    await sync.flush();
     logger.info(' ✏️ Wrote ${file.path}');
   }
 }

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -27,8 +27,7 @@ class UpdateVersionsCommand extends Command {
       }
     }
 
-    return _updateChangelogUnreleasedChanges(
-        args.packageRoot, args.version, logger, args.dryRun);
+    return true;
   }
 }
 
@@ -61,9 +60,7 @@ class BumpVersionCommand extends Command {
         }
         break;
     }
-    logger.info('🔀 Adding "Unreleased" back into CHANGELOG');
-    await _updateChangelogAddUnreleased(args.packageRoot, logger, args.dryRun);
-
+    
     logger.info('🔀 Bumping version to $newVersion');
     return updateVersions(
         args.packageRoot, newVersion.toString(), logger, args.dryRun);
@@ -118,43 +115,6 @@ Future<bool> _updateVersionDartFile(
     if (element.startsWith('const ddPackageVersion')) {
       element = "const ddPackageVersion = '$version';";
     }
-    return element;
-  });
-
-  return true;
-}
-
-Future<bool> _updateChangelogUnreleasedChanges(
-    String packageRoot, String version, Logger logger, bool dryRun) async {
-  final changelogFile = File(path.join(packageRoot, 'CHANGELOG.md'));
-  if (!changelogFile.existsSync()) {
-    logger.shout('⁉️ Could not find CHANGELOG.md at ${changelogFile.path}');
-    return false;
-  }
-
-  await transformFile(changelogFile, logger, dryRun, (element) {
-    if (element.startsWith('## Unreleased')) {
-      element = '## $version';
-    }
-    return element;
-  });
-
-  return true;
-}
-
-Future<bool> _updateChangelogAddUnreleased(
-    String packageRoot, Logger logger, bool dryRun) async {
-  final changelogFile = File(path.join(packageRoot, 'CHANGELOG.md'));
-  if (!changelogFile.existsSync()) {
-    logger.shout('⁉️ Could not find CHANGELOG.md at ${changelogFile.path}');
-    return false;
-  }
-
-  await transformFile(changelogFile, logger, dryRun, (element) {
-    if (element.startsWith('# Changelog')) {
-      element += '\n\n## Unreleased\n\n';
-    }
-
     return element;
   });
 


### PR DESCRIPTION
### What and why?

Either the CHANGELOG is now at a size where it's not flushing fast enough, or something changed in Dart where flushing the IOSink is now necessary, otherwise a blank changelog gets written.

Also remove changes that were specifically looking for Unreleased headers now that we are generating changelogs based on git history.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
