### PR TITLE
chore: Fix web integration tests.

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -55,9 +55,9 @@ void main() {
             .whereType<List<dynamic>>()
             .expand<dynamic>((e) => e)
             .whereType<Map<String, Object?>>()
-            // Ignore RUM sessions and telemetry
+            // Only include logs, ignore telemetry
             .where((e) {
-              return !(e).containsKey('session') && e['type'] != 'telemetry';
+              return e['message'] != null && e['type'] != 'telemetry';
             })
             .forEach((e) => logs.add(LogDecoder(e)));
         return logs.length >= 8;


### PR DESCRIPTION
### What and why?

A change to the Browser SDK has started sending a "session" object in logs, which was how we were filtering out RUM events.  Switch to checking for the presence of `message` instead.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
