### PR TITLE
fix: Constrain to compatible versions of `datadog_flutter_plugin`

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+* Constrain to compatible versions of `datadog_flutter_plugin`
+
 ## 2.0.2
 
 * Re-restrict `datadog_webview_plugin` version.

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_webview_tracking
 description: A package for tracking Datadog sessions in a webview
-version: 2.0.2
+version: 2.0.3
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: '>=2.0.0 <2.6.0'
   webview_flutter: ^4.0.4
   webview_flutter_android: ^3.8.2
   webview_flutter_wkwebview: ^3.2.3


### PR DESCRIPTION
### What and why?

Android 2.10 introduced a binary incompatibility for webview tracking, which was released in datadog_flutter_sdk 2.6.0. Constrain 2.0 versions to using datadog versions below 2.6.0.

We're going to release 2.1.0 shortly which should be compatible with versions >2.6.0

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
