### PR TITLE
fix: Update constraints on compatible versions of android webview package

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+## 2.0.3
 
+* Constrain to compatible versions of `datadog_flutter_plugin`
+
+## 2.0.2
+
+* Re-restrict `datadog_webview_plugin` version.
 
 ## 2.0.1
 

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.8.22'
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.15.1"
 
     repositories {
         google()

--- a/packages/datadog_webview_tracking/example/pubspec.yaml
+++ b/packages/datadog_webview_tracking/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  datadog_flutter_plugin: ^1.3.0
+  datadog_flutter_plugin: ^2.9.0
   datadog_webview_tracking:
     path: ../
   webview_flutter: ^4.0.4

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.0.0
+  datadog_flutter_plugin: ^2.9.0
   webview_flutter: ^4.0.4
   webview_flutter_android: ^3.8.2
   webview_flutter_wkwebview: ^3.2.3


### PR DESCRIPTION
### What and why?

dd-sdk-android-webview introduced an incompatibility in 2.10 and (which was released in Flutter SDK 2.6.0). This updates constraints to be compatible.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
