### PR TITLE
Changes related to releasing 2.1.0 of datadog_webview_tracking

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 2.1.0
+
+* Update constraints on compatible versions of `datadog-sdk-android-webview`.
 
 ## 2.0.3
 

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_webview_tracking
 description: A package for tracking Datadog sessions in a webview
-version: 2.1.0
+version: 2.2.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

Changes related to releasing 2.1.0 of datadog_webview_tracking.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
