### PR TITLE
fix: Loosen the version constraint in inappwebiview_tracking

### DIFF
--- a/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking.podspec
+++ b/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'DatadogCore',  '~> 2.19.0'
+  s.dependency 'DatadogCore',  '~> 2.20'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
### What and why?

The main version constraint for Datadog Core is held in the main package, and unless this package is a little bit more loose with its restrictions, any mismatch between the main package and this one will cause `pod install` to faile.

Loosen the restriction to allow any iOS Core version in this package to be 2.x.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
