### PR TITLE
feat: Update flutter_inappwebview support to 6.2.0-beta.2

### DIFF
--- a/packages/datadog_inappwebview_tracking/example/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
   flutter_dotenv: ^5.2.1
-  flutter_inappwebview: ^6.1.5
+  flutter_inappwebview: ^6.2.0-beta
   go_router: ^14.5.0
   datadog_flutter_plugin: ^2.10.0
   datadog_inappwebview_tracking:

--- a/packages/datadog_inappwebview_tracking/lib/src/datadog_inappwebview_user_script.dart
+++ b/packages/datadog_inappwebview_tracking/lib/src/datadog_inappwebview_user_script.dart
@@ -76,9 +76,9 @@ extension DatadogInAppWebViewControllerExtension on InAppWebViewController {
   void trackDatadogEvents(DatadogSdk datadog, {double logSampleRate = 100.0}) {
     addJavaScriptHandler(
       handlerName: handlerName,
-      callback: (data) {
-        if (data.isNotEmpty) {
-          final message = data[0];
+      callback: (JavaScriptHandlerFunctionData data) {
+        if (data.args.isNotEmpty) {
+          final message = data.args.first;
           if (message is String) {
             // ignore: invalid_use_of_internal_member
             wrap('handleWebMessage', datadog.internalLogger, {}, () {

--- a/packages/datadog_inappwebview_tracking/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_inappwebview_tracking
 description: "A package for tracking Datadog sessions in webviews create with flutter_inappwebview"
-version: 1.1.0
+version: 1.1.0-beta.1
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   datadog_flutter_plugin: ^2.10.0
   plugin_platform_interface: ^2.0.2
-  flutter_inappwebview: ^6.1.0
+  flutter_inappwebview: ^6.2.0-beta
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What and why?

Supporting InAppBrowser on Android API 33+ requires 6.2.0+, which is currently in beta. We will support it as a beta as well for the time being.

Adjust one of our callbacks to use a non-deprecated API. 

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
