### PR TITLE
chore: Changes related to releasing datadog_inappwebview_tracking 1.1.0-beta.1

### DIFF
--- a/packages/datadog_inappwebview_tracking/CHANGELOG.md
+++ b/packages/datadog_inappwebview_tracking/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0-beta.1
+
+* Update flutter_inappwebview support to 6.2.0-beta.2
+
 ## 1.0.1
 
 * Loosen the version constraint in `inappwebiview_tracking`.

--- a/packages/datadog_inappwebview_tracking/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_inappwebview_tracking
 description: "A package for tracking Datadog sessions in webviews create with flutter_inappwebview"
-version: 1.1.0-beta.1
+version: 1.1.0-beta.2
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

We're releasing `datadog_inappwebview_tracking` 1.1.0 in beta to line up with `flutter_inappwebview` 6.2 which is currently in beta. We need an early release because of a bug in 6.1.x regarding how communication is handled in InAppBrowser on Android that is fixed in 6.2.0.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
