### PR TITLE
feat: Use Flutter timestamps for RUM actions.

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/attributes.dart
@@ -24,6 +24,9 @@ class DatadogPlatformAttributeKey {
   /// language or platform of the RUM error stack trace, so the SCI backend
   /// knows how to symbolize it. Expects `String` value.
   static const errorSourceType = '_dd.error.source_type';
+
+  /// Event timestamp
+  static const timestamp = '_dd.timestamp';
 }
 
 /// Attributes that can be added to calls that have special properies in Datadog.

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -6,13 +6,17 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import '../../datadog_flutter_plugin.dart';
-import '../internal_logger.dart';
+import '../../datadog_internal.dart';
+import '../time_provider.dart';
 import 'ddrum_platform_interface.dart';
 
 class DdRumMethodChannel extends DdRumPlatform {
   @visibleForTesting
   final MethodChannel methodChannel =
       const MethodChannel('datadog_sdk_flutter.rum');
+
+  @visibleForTesting
+  DatadogTimeProvider timeProvider = defaultTimeProvider;
 
   @override
   Future<void> enable(
@@ -56,17 +60,32 @@ class DdRumMethodChannel extends DdRumPlatform {
   @override
   Future<void> startView(
       String key, String name, Map<String, Object?> attributes) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod(
       'startView',
-      {'key': key, 'name': name, 'attributes': attributes},
+      {
+        'key': key,
+        'name': name,
+        'attributes': {
+          ...attributes,
+          DatadogPlatformAttributeKey.timestamp: timestamp,
+        }
+      },
     );
   }
 
   @override
   Future<void> stopView(String key, Map<String, Object?> attributes) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod(
       'stopView',
-      {'key': key, 'attributes': attributes},
+      {
+        'key': key,
+        'attributes': {
+          ...attributes,
+          DatadogPlatformAttributeKey.timestamp: timestamp,
+        }
+      },
     );
   }
 
@@ -77,23 +96,31 @@ class DdRumMethodChannel extends DdRumPlatform {
     String url, [
     Map<String, Object?> attributes = const {},
   ]) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod('startResource', {
       'key': key,
       'httpMethod': httpMethod.toString(),
       'url': url,
-      'attributes': attributes
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      },
     });
   }
 
   @override
   Future<void> stopResource(String key, int? statusCode, RumResourceType kind,
-      [int? size, Map<String, Object?>? attributes = const {}]) {
+      [int? size, Map<String, Object?> attributes = const {}]) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod('stopResource', {
       'key': key,
       'statusCode': statusCode,
       'kind': kind.toString(),
       'size': size,
-      'attributes': attributes
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      },
     });
   }
 
@@ -111,11 +138,15 @@ class DdRumMethodChannel extends DdRumPlatform {
     String type, [
     Map<String, Object?> attributes = const {},
   ]) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod('stopResourceWithError', {
       'key': key,
       'message': message,
       'type': type,
-      'attributes': attributes,
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      },
     });
   }
 
@@ -145,37 +176,59 @@ class DdRumMethodChannel extends DdRumPlatform {
       StackTrace? stackTrace,
       String? errorType,
       Map<String, Object?> attributes) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod('addError', {
       'message': message,
       'source': source.toString(),
       'stackTrace': stackTrace?.toString(),
       'errorType': errorType,
-      'attributes': attributes
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      },
     });
   }
 
   @override
   Future<void> addAction(
       RumActionType type, String? name, Map<String, Object?> attributes) {
+    final timestamp = timeProvider();
     return methodChannel.invokeMethod('addAction', {
       'type': type.toString(),
       'name': name,
-      'attributes': attributes,
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      },
     });
   }
 
   @override
   Future<void> startAction(
       RumActionType type, String name, Map<String, Object?> attributes) {
-    return methodChannel.invokeMethod('startAction',
-        {'type': type.toString(), 'name': name, 'attributes': attributes});
+    final timestamp = timeProvider();
+    return methodChannel.invokeMethod('startAction', {
+      'type': type.toString(),
+      'name': name,
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      },
+    });
   }
 
   @override
   Future<void> stopAction(
       RumActionType type, String name, Map<String, Object?> attributes) {
-    return methodChannel.invokeMethod('stopAction',
-        {'type': type.toString(), 'name': name, 'attributes': attributes});
+    final timestamp = timeProvider();
+    return methodChannel.invokeMethod('stopAction', {
+      'type': type.toString(),
+      'name': name,
+      'attributes': {
+        ...attributes,
+        DatadogPlatformAttributeKey.timestamp: timestamp,
+      }
+    });
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/time_provider.dart
+++ b/packages/datadog_flutter_plugin/lib/src/time_provider.dart
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+/// Internal function to provide the current timestamp for events. Should
+/// return number of milliseconds since unix epoch.
+typedef DatadogTimeProvider = int Function();
+
+/// Default time provider which uses `DateTime` to provide the current timestamp.
+int defaultTimeProvider() {
+  return DateTime.now().millisecondsSinceEpoch;
+}


### PR DESCRIPTION
### What and why?

Instead of using the time reported by the native SDKs when we perform RUM actions, we're going to use the time reported by Dart / Flutter before it is transferred to the native platform. This should be more accurate, as it won't be slowed by the amount of time it takes the method channel to process.

refs: RUM-8246

### How?

Native SDKs already support the `_dd.timestamp` attribute for RUM actions to specify when they occurred. Add this to all calls where a timestamp is needed.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
