### PR TITLE
chore: Remove unneeded / deprecated package from e2e tests

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/e2e_test_app/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_webview_plugin: ^0.4.0
   cupertino_icons: ^1.0.2
   datadog_flutter_plugin:
     path: ../

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -610,6 +610,8 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         case stopAction(type: RUMActionType, name: String?, attributes: [AttributeKey: AttributeValue])
         case addAttribute(forKey: AttributeKey, value: AttributeValue)
         case removeAttribute(forKey: AttributeKey)
+        case addAttributes(attributes: [AttributeKey : any AttributeValue])
+        case removeAttributes(forKeys: [AttributeKey])
     }
 
     var callLog: [MethodCall] = []
@@ -692,6 +694,14 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
 
     func removeAttribute(forKey key: AttributeKey) {
         callLog.append(.removeAttribute(forKey: key))
+    }
+
+    func addAttributes(_ attributes: [AttributeKey : any AttributeValue]) {
+        callLog.append(.addAttributes(attributes: attributes))
+    }
+
+    func removeAttributes(forKeys keys: [AttributeKey]) {
+        callLog.append(.removeAttributes(forKeys: keys))
     }
 
     func addAction(type: RUMActionType, name: String,

--- a/packages/datadog_webview_tracking/example/ios/Podfile.lock
+++ b/packages/datadog_webview_tracking/example/ios/Podfile.lock
@@ -11,25 +11,26 @@ PODS:
     - DatadogWebViewTracking (~> 2)
     - Flutter
     - webview_flutter_wkwebview
-  - DatadogCore (2.6.0):
-    - DatadogInternal (= 2.6.0)
-  - DatadogCrashReporting (2.6.0):
-    - DatadogInternal (= 2.6.0)
-    - PLCrashReporter (~> 1.11.1)
-  - DatadogInternal (2.6.0)
-  - DatadogLogs (2.6.0):
-    - DatadogInternal (= 2.6.0)
-  - DatadogRUM (2.6.0):
-    - DatadogInternal (= 2.6.0)
-  - DatadogWebViewTracking (2.6.0):
-    - DatadogInternal (= 2.6.0)
+  - DatadogCore (2.22.0):
+    - DatadogInternal (= 2.22.0)
+  - DatadogCrashReporting (2.22.0):
+    - DatadogInternal (= 2.22.0)
+    - PLCrashReporter (~> 1.11.2)
+  - DatadogInternal (2.22.0)
+  - DatadogLogs (2.22.0):
+    - DatadogInternal (= 2.22.0)
+  - DatadogRUM (2.22.0):
+    - DatadogInternal (= 2.22.0)
+  - DatadogWebViewTracking (2.22.0):
+    - DatadogInternal (= 2.22.0)
   - DictionaryCoder (1.0.8)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - PLCrashReporter (1.11.1)
+  - PLCrashReporter (1.11.2)
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
@@ -42,7 +43,7 @@ DEPENDENCIES:
   - DatadogWebViewTracking (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
-  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -77,43 +78,43 @@ EXTERNAL SOURCES:
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
   webview_flutter_wkwebview:
-    :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 CHECKOUT OPTIONS:
   DatadogCore:
-    :commit: 36862590661791e1ac6a0d61fbaf863c94cea97d
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogCrashReporting:
-    :commit: 36862590661791e1ac6a0d61fbaf863c94cea97d
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogInternal:
-    :commit: 36862590661791e1ac6a0d61fbaf863c94cea97d
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogLogs:
-    :commit: 36862590661791e1ac6a0d61fbaf863c94cea97d
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogRUM:
-    :commit: 36862590661791e1ac6a0d61fbaf863c94cea97d
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogWebViewTracking:
-    :commit: 36862590661791e1ac6a0d61fbaf863c94cea97d
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: 89d7088ec5cc78c0ff2c24dbe7b7e67e6800a10b
-  datadog_webview_tracking: d46b58a9109c0d29e4d6ffdd4223cb23e4f328a9
-  DatadogCore: 2b9cae7b3706ec29c6329f5b2e350bd70395bfb6
-  DatadogCrashReporting: 0ebc16ea7f226805c19a7efa6dab47f3743c6d2c
-  DatadogInternal: 6febbce547fac204638f2ef5fe53cea49d05215b
-  DatadogLogs: 23905c3f91c8c3c9ab3bd0f00ec5c070fccafa36
-  DatadogRUM: 691819a9d5fc1924f783af6ad6eb609e5ab35e72
-  DatadogWebViewTracking: d1c6e9b349444d8996380dd0545bdb3abd620302
+  datadog_flutter_plugin: de391eba42569ec1d8282aa1c49b4172603acc90
+  datadog_webview_tracking: 7de2f94cb36dbb00203468d941e89ec7cbc47226
+  DatadogCore: ac232fee1427f4082895d73479aadc39bf143789
+  DatadogCrashReporting: f6f56f405f8f2ab9478be290a1e561861a18578f
+  DatadogInternal: 2c9770cd4bb66636f2c1578f4cfbc5984e032e2d
+  DatadogLogs: 397a79884d4dff82cf3d1a35b3e61e9ab4b03cf4
+  DatadogRUM: 9f23460eb44e2bd2f2fe5e4db9d205dcdd0ef865
+  DatadogWebViewTracking: 2191682c6af12d86c093ceb3a20a886708bfeb4f
   DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 13825b8a9334a850581300559b8839134b124670
-  PLCrashReporter: 5d2d3967afe0efad61b3048d617e2199a5d1b787
-  webview_flutter_wkwebview: 2e2d318f21a5e036e2c3f26171342e95908bd60a
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  PLCrashReporter: 499c53b0104f95c302d94fd723ebb03c56d9bac8
+  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
 
 PODFILE CHECKSUM: 572ca5e96f49c59ed4f5f02e3a147e09cc70e717
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				33000F1A259CC4105C882AC4 /* [CP] Embed Pods Frameworks */,
+				756F814F6C6D0A86032D5E08 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -344,6 +345,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		756F814F6C6D0A86032D5E08 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {

--- a/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
@@ -34,7 +34,7 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
         if call.method == "initWebView" {
             if let number = arguments["webViewIdentifier"] as? NSNumber,
                let allowedHosts = arguments["allowedHosts"] as? [String] {
-                let webViewIdentifier = number.intValue
+                let webViewIdentifier = number.int64Value
 
                 // swiftlint:disable:next todo
                 // TODO: Add to app scenario, search for a FlutterViewController to get the
@@ -42,7 +42,7 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                 if let pluginRegistry = UIApplication.shared.delegate as? FlutterPluginRegistry,
                    let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(
                         forIdentifier: webViewIdentifier,
-                        with: pluginRegistry) {
+                        withPluginRegistry: pluginRegistry) {
                     WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
                 }
                 result(nil)

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   datadog_flutter_plugin: ^2.9.0
   webview_flutter: ^4.0.4
   webview_flutter_android: ^3.8.2
-  webview_flutter_wkwebview: ^3.2.3
+  webview_flutter_wkwebview: ^3.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What and why?

An old version of flutter_webivew_plugin was hanging out in the e2e test application. This package was deprecated a long time ago and was breaking builds in the e2e app.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
