### PR TITLE
feat: Support configuration of TNS.

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -259,6 +259,7 @@ class RumViewDecoder {
   int get errorCount => viewData['error']['count'] as int;
   int get longTaskCount => viewData['long_task']['count'] as int;
   int? get loadingTime => viewData['loading_time'] as int?;
+  int? get networkSettledTime => viewData['network_settled_time'] as int?;
 
   Map<String, int> get customTimings =>
       (viewData['custom_timings'] as Map<String, Object?>)

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -31,7 +31,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.Result
 import java.lang.ClassCastException
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
 class DatadogRumPlugin : MethodChannel.MethodCallHandler {
@@ -469,6 +468,7 @@ object NoOpViewTrackingStrategy : ViewTrackingStrategy {
     }
 }
 
+@Suppress("ComplexMethod")
 fun RumConfiguration.Builder.withEncoded(encoded: Map<String, Any?>): RumConfiguration.Builder {
     var builder = this
 
@@ -486,7 +486,9 @@ fun RumConfiguration.Builder.withEncoded(encoded: Map<String, Any?>): RumConfigu
     }
     (encoded["initialResourceThreshold"] as? Number)?.let {
         val milliseconds = it.toDouble().seconds.inWholeMilliseconds
-        builder = builder.setInitialResourceIdentifier(TimeBasedInitialResourceIdentifier(milliseconds))
+        builder = builder.setInitialResourceIdentifier(
+            TimeBasedInitialResourceIdentifier(milliseconds)
+        )
     }
     (encoded["customEndpoint"] as? String)?.let {
         builder = builder.useCustomEndpoint(it)

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -22,6 +22,7 @@ import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -30,6 +31,8 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.Result
 import java.lang.ClassCastException
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DatadogRumPlugin : MethodChannel.MethodCallHandler {
     companion object RumParameterNames {
@@ -480,6 +483,10 @@ fun RumConfiguration.Builder.withEncoded(encoded: Map<String, Any?>): RumConfigu
     }
     (encoded["trackNonFatalAnrs"] as? Boolean)?.let {
         builder = builder.trackNonFatalAnrs(it)
+    }
+    (encoded["initialResourceThreshold"] as? Number)?.let {
+        val milliseconds = it.toDouble().seconds.inWholeMilliseconds
+        builder = builder.setInitialResourceIdentifier(TimeBasedInitialResourceIdentifier(milliseconds))
     }
     (encoded["customEndpoint"] as? String)?.let {
         builder = builder.useCustomEndpoint(it)

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -179,6 +179,18 @@ class DatadogRumPluginTests: XCTestCase {
         XCTAssertEqual(config?.appHangThreshold, appHangThreshold)
     }
 
+    func testRumConfiguration_WithInitialResourceThreshold_IsSetCorrectly() throws {
+        let initialResourceThreshold = Double.mockRandom()
+        let encoded: [String: Any?] = [
+            "applicationId": "fake-application-id",
+            "initialResourceThreshold": initialResourceThreshold
+        ]
+
+        let config = RUM.Configuration.init(fromEncoded: encoded)
+        let predicate = try XCTUnwrap(config?.networkSettledResourcePredicate as? TimeBasedTNSResourcePredicate)
+        XCTAssertEqual(predicate.threshold, initialResourceThreshold)
+    }
+
     func testRepeatEnable_FromMethodChannelSameOptions_DoesNothing() {
         // Uninitialize plugin
         plugin?.inject(rum: nil)
@@ -610,6 +622,8 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         case stopAction(type: RUMActionType, name: String?, attributes: [AttributeKey: AttributeValue])
         case addAttribute(forKey: AttributeKey, value: AttributeValue)
         case removeAttribute(forKey: AttributeKey)
+        case addAttributes(attributes: [DatadogInternal.AttributeKey: any DatadogInternal.AttributeValue])
+        case removeAttributes(forKeys: [AttributeKey])
     }
 
     var callLog: [MethodCall] = []
@@ -692,6 +706,14 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
 
     func removeAttribute(forKey key: AttributeKey) {
         callLog.append(.removeAttribute(forKey: key))
+    }
+
+    func addAttributes(_ attributes: [AttributeKey: any AttributeValue]) {
+        callLog.append(.addAttributes(attributes: attributes))
+    }
+
+    func removeAttributes(forKeys keys: [AttributeKey]) {
+        callLog.append(.removeAttributes(forKeys: keys))
     }
 
     func addAction(type: RUMActionType, name: String,

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -622,7 +622,7 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         case stopAction(type: RUMActionType, name: String?, attributes: [AttributeKey: AttributeValue])
         case addAttribute(forKey: AttributeKey, value: AttributeValue)
         case removeAttribute(forKey: AttributeKey)
-        case addAttributes(attributes: [AttributeKey : any AttributeValue])
+        case addAttributes(attributes: [AttributeKey: any AttributeValue])
         case removeAttributes(forKeys: [AttributeKey])
     }
 
@@ -687,7 +687,7 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         )
     }
 
-    // swiftlint:ignore function_parameter_count
+    // swiftlint:disable:next function_parameter_count
     func addError(message: String, type: String?, stack: String?, source: RUMErrorSource,
                   attributes: [AttributeKey: AttributeValue], file: StaticString?, line: UInt?) {
         callLog.append(
@@ -709,7 +709,6 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
     }
 
     func addAttributes(_ attributes: [AttributeKey: any AttributeValue]) {
-    func addAttributes(_ attributes: [AttributeKey : any AttributeValue]) {
         callLog.append(.addAttributes(attributes: attributes))
     }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -153,13 +153,11 @@ void main() {
       expect(view1.resourceEvents[0].url, 'https://fake_url/resource/1');
       expect(view1.resourceEvents[0].statusCode, 200);
       expect(view1.resourceEvents[0].resourceType, 'image');
-      expect(view1.resourceEvents[0].duration,
-          greaterThan((90 * 1000 * 1000) - 1)); // 90ms
-      // TODO: Figure out why occasionally these have really high values
-      // expect(view1.resourceEvents[0].duration,
-      //     lessThan(10 * 1000 * 1000 * 1000)); // 10s
-      expect(
-          view1.resourceEvents[0].context![contextKey], expectedContextValue);
+      final resourceDuration = view1.resourceEvents[0].duration;
+      expect(resourceDuration,
+          greaterThan(const Duration(milliseconds: 90).inNanoseconds - 1));
+      expect(resourceDuration,
+          lessThan(const Duration(seconds: 10).inNanoseconds));
 
       expect(view1.errorEvents.length, 1);
       expect(view1.errorEvents[0].resourceUrl, 'https://fake_url/resource/2');
@@ -200,7 +198,7 @@ void main() {
     expect(view2.viewEvents.last.view.longTaskCount, greaterThanOrEqualTo(1));
     if (!kIsWeb) {
       // Web can download extra resources
-      expect(view2.viewEvents.last.view.resourceCount, 0);
+      expect(view2.viewEvents.last.view.resourceCount, 1);
     }
     if (!kIsWeb) {
       // The removal of this key happens at a weird point for web, so
@@ -209,6 +207,27 @@ void main() {
     }
     expect(view2.viewEvents.last.featureFlags?['mock_flag_a'], false);
     expect(view2.viewEvents.last.featureFlags?['mock_flag_b'], 'mock_value');
+
+    // Manual resource loading calls are ignored on Web.
+    if (!kIsWeb) {
+      final viewStart = view2.viewEvents.first.date;
+      final resourceStart = view2.resourceEvents[0].date;
+
+      expect(view2.resourceEvents[0].url, 'https://fake_url/tns-resource/1');
+      expect(view2.resourceEvents[0].statusCode, 200);
+      expect(view2.resourceEvents[0].resourceType, 'image');
+      final resourceDuration = view1.resourceEvents[0].duration;
+      expect(resourceDuration,
+          greaterThan(const Duration(milliseconds: 90).inNanoseconds - 1));
+      expect(resourceDuration,
+          lessThan(const Duration(seconds: 10).inNanoseconds));
+
+      final tns =
+          Duration(milliseconds: resourceStart - viewStart).inNanoseconds +
+              resourceDuration!;
+      expect(view2.viewEvents.last.view.networkSettledTime,
+          closeTo(tns, const Duration(milliseconds: 10).inNanoseconds));
+    }
 
     expect(view2.errorEvents[0].message, 'Simulated view error');
     expect(view2.errorEvents[0].source, kIsWeb ? 'custom' : 'source');

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -226,7 +226,7 @@ void main() {
           Duration(milliseconds: resourceStart - viewStart).inNanoseconds +
               resourceDuration!;
       expect(view2.viewEvents.last.view.networkSettledTime,
-          closeTo(tns, const Duration(milliseconds: 10).inNanoseconds));
+          closeTo(tns, const Duration(milliseconds: 100).inNanoseconds));
     }
 
     expect(view2.errorEvents[0].message, 'Simulated view error');

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -185,6 +185,8 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
   void didPush() {
     DatadogSdk.instance.rum?.startView(_viewKey, _viewName);
 
+    _simulateResourceDownload();
+
     DatadogSdk.instance.rum?.addFeatureFlagEvaluation('mock_flag_a', false);
     DatadogSdk.instance.rum
         ?.addFeatureFlagEvaluation('mock_flag_b', 'mock_value');
@@ -216,6 +218,18 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
         ),
       ),
     );
+  }
+
+  void _simulateResourceDownload() async {
+    final rum = DatadogSdk.instance.rum;
+
+    var simulatedResourceKey1 = '/tns-resource/1';
+
+    rum?.startResource(simulatedResourceKey1, RumHttpMethod.get,
+        '$fakeRootUrl$simulatedResourceKey1');
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    rum?.stopResource(simulatedResourceKey1, 200, RumResourceType.image);
   }
 
   Future<void> _simulateActions() async {

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -36,6 +36,10 @@ public extension RUM.Configuration {
 
         telemetrySampleRate = (encoded["telemetrySampleRate"] as? NSNumber)?.floatValue ?? 20.0
 
+        if let initialResourceThreshold = (encoded["initialResourceThreshold"] as? NSNumber)?.doubleValue {
+            self.networkSettledResourcePredicate = TimeBasedTNSResourcePredicate(threshold: initialResourceThreshold)
+        }
+
         if let additionalConfig = encoded["additionalConfig"] as? [String: Any?] {
             if let sampleRateArg = (additionalConfig["_dd.telemetry.configuration_sample_rate"] as? NSNumber) {
                 self._internal_mutation({

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -156,6 +156,14 @@ class DatadogRumConfiguration {
   /// Defaults to disabled (`null`).
   double? appHangThreshold;
 
+  /// The amount of time after a view starts where a Resource should be
+  /// considered when calculating Time to Network-Settled (TNS).  TNS will be
+  /// calculated using all resources that start withing the specified threshold,
+  /// in seconds.
+  ///
+  /// Defaults to 0.1 seconds.
+  double initialResourceThreshold;
+
   /// Use a custom endpoint for sending RUM data.
   String? customEndpoint;
 
@@ -196,6 +204,7 @@ class DatadogRumConfiguration {
     this.reportFlutterPerformance = false,
     this.trackNonFatalAnrs,
     this.appHangThreshold,
+    this.initialResourceThreshold = 0.1,
     this.customEndpoint,
     this.telemetrySampleRate = 20.0,
     this.viewEventMapper,
@@ -219,6 +228,7 @@ class DatadogRumConfiguration {
       'reportFlutterPerformance': reportFlutterPerformance,
       'trackNonFatalAnrs': trackNonFatalAnrs,
       'appHangThreshold': appHangThreshold,
+      'initialResourceThreshold': initialResourceThreshold,
       'customEndpoint': customEndpoint,
       'telemetrySampleRate': telemetrySampleRate,
       'attachViewEventMapper': viewEventMapper != null,

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -157,7 +157,7 @@ class DatadogRumConfiguration {
   double? appHangThreshold;
 
   /// The amount of time after a view starts where a Resource should be
-  /// considered when calculating Time to Network-Settled (TNS).  TNS will be
+  /// considered when calculating Time to Network-Settled (TNS). TNS will be
   /// calculated using all resources that start withing the specified threshold,
   /// in seconds.
   ///

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -92,6 +92,7 @@ void main() {
       vitalUpdateFrequency: vitalUpdateFrequency,
       trackNonFatalAnrs: false,
       appHangThreshold: 0.332,
+      initialResourceThreshold: 1.23,
       customEndpoint: customEndpoint,
     );
 
@@ -105,6 +106,7 @@ void main() {
     expect(encoded['trackNonFatalAnrs'], false);
     expect(encoded['appHangThreshold'], 0.332);
     expect(encoded['customEndpoint'], customEndpoint);
+    expect(encoded['initialResourceThreshold'], 1.23);
   });
 
   test('configuration with mapper sets attach*Mapper', () {

--- a/packages/datadog_inappwebview_tracking/example/ios/Podfile
+++ b/packages/datadog_inappwebview_tracking/example/ios/Podfile
@@ -32,6 +32,16 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  # Datadog Pod Overrides
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  # End Datadog Pod Overrides
+  
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/packages/datadog_inappwebview_tracking/example/ios/Podfile.lock
+++ b/packages/datadog_inappwebview_tracking/example/ios/Podfile.lock
@@ -8,18 +8,20 @@ PODS:
     - DictionaryCoder (= 1.0.8)
     - Flutter
   - datadog_inappwebview_tracking (0.0.1):
-    - DatadogCore (~> 2.19.0)
+    - DatadogCore (~> 2.20)
     - Flutter
-  - DatadogCore (2.19.0):
-    - DatadogInternal (= 2.19.0)
-  - DatadogCrashReporting (2.19.0):
-    - DatadogInternal (= 2.19.0)
+  - DatadogCore (2.22.0):
+    - DatadogInternal (= 2.22.0)
+  - DatadogCrashReporting (2.22.0):
+    - DatadogInternal (= 2.22.0)
     - PLCrashReporter (~> 1.11.2)
-  - DatadogInternal (2.19.0)
-  - DatadogLogs (2.19.0):
-    - DatadogInternal (= 2.19.0)
-  - DatadogRUM (2.19.0):
-    - DatadogInternal (= 2.19.0)
+  - DatadogInternal (2.22.0)
+  - DatadogLogs (2.22.0):
+    - DatadogInternal (= 2.22.0)
+  - DatadogRUM (2.22.0):
+    - DatadogInternal (= 2.22.0)
+  - DatadogWebViewTracking (2.22.0):
+    - DatadogInternal (= 2.22.0)
   - DictionaryCoder (1.0.8)
   - Flutter (1.0.0)
   - flutter_inappwebview_ios (0.0.1):
@@ -37,17 +39,18 @@ PODS:
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_inappwebview_tracking (from `.symlinks/plugins/datadog_inappwebview_tracking/ios`)
+  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogWebViewTracking (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
 
 SPEC REPOS:
   trunk:
-    - DatadogCore
-    - DatadogCrashReporting
-    - DatadogInternal
-    - DatadogLogs
-    - DatadogRUM
     - DictionaryCoder
     - OrderedSet
     - PLCrashReporter
@@ -57,6 +60,24 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
   datadog_inappwebview_tracking:
     :path: ".symlinks/plugins/datadog_inappwebview_tracking/ios"
+  DatadogCore:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogCrashReporting:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogInternal:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogLogs:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogRUM:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogWebViewTracking:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
   Flutter:
     :path: Flutter
   flutter_inappwebview_ios:
@@ -64,14 +85,35 @@ EXTERNAL SOURCES:
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
 
+CHECKOUT OPTIONS:
+  DatadogCore:
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogCrashReporting:
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogInternal:
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogLogs:
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogRUM:
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogWebViewTracking:
+    :commit: 23d2fcf19d0aca4374599f027e575d507652130e
+    :git: https://github.com/DataDog/dd-sdk-ios
+
 SPEC CHECKSUMS:
   datadog_flutter_plugin: de391eba42569ec1d8282aa1c49b4172603acc90
-  datadog_inappwebview_tracking: 167f16984472229a07f15574737059a892fcf8e6
-  DatadogCore: 3619e45f7939494cd6747dfba037162ffbf397c6
-  DatadogCrashReporting: 89f88b4f0b8a544ab8b5f56c62d6397d60b4e367
-  DatadogInternal: bf6779b4c19606151801fa75e88152fe3f0b40bc
-  DatadogLogs: 7a2dea1adfb9a24690c24caf54dbcb5cd0912c4a
-  DatadogRUM: c76d759c4dff89ba60dbf77abadcef99960ed1fa
+  datadog_inappwebview_tracking: 32fbbfd207e0a271d2ac13e788f5dc7080f8454d
+  DatadogCore: ac232fee1427f4082895d73479aadc39bf143789
+  DatadogCrashReporting: f6f56f405f8f2ab9478be290a1e561861a18578f
+  DatadogInternal: 2c9770cd4bb66636f2c1578f4cfbc5984e032e2d
+  DatadogLogs: 397a79884d4dff82cf3d1a35b3e61e9ab4b03cf4
+  DatadogRUM: 9f23460eb44e2bd2f2fe5e4db9d205dcdd0ef865
+  DatadogWebViewTracking: 2191682c6af12d86c093ceb3a20a886708bfeb4f
   DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
@@ -79,6 +121,6 @@ SPEC CHECKSUMS:
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   PLCrashReporter: 499c53b0104f95c302d94fd723ebb03c56d9bac8
 
-PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+PODFILE CHECKSUM: 2de31ad0c7f6a0956af60ce23d6037f7422e8be2
 
 COCOAPODS: 1.15.2

--- a/packages/datadog_tracking_http_client/example/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_tracking_http_client/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/project.pbxproj
@@ -220,7 +220,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					4942FF7829AE546000D8F9BE = {

--- a/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/datadog_webview_tracking/example/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_webview_tracking/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,


### PR DESCRIPTION
### What and why?

This adds support to allow clients to customize how long since the start of a view that a resource should be considered for the "Time to Network Settled" metric.

It also adds an integration tests to check if TNS is being reported properly.

refs: RUM-8226

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
