### PR TITLE
chore: Changes from shipping datadog_grpc_interceptor 1.2.0

### DIFF
--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 1.2.0
 
+* Support grpc 4.x. See [#704](https://github.com/DataDog/dd-sdk-flutter/issues/704).
 * Add support for `TraceContextInjection` configuration.
 
 ## 1.1.0

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_grpc_interceptor
 description: A plugin for use with the DatadogSdk, used to track performance of gRPC and enable Datadog Distributed Tracing.
-version: 1.2.0
+version: 1.3.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

Update from shipping an updated version of the gRPC interceptor package.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
