### PR TITLE
fix: iOS compilation error

### DIFF
--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -342,10 +342,9 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
             // Second, check that the engine hasn't been destroyed, this is the
             // other work around for https://github.com/flutter/flutter/issues/126671
             if let flutterViewController =
-                UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController {
-                if let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
-                    return
-                }
+                UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController,
+                let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
+                return
             }
 
             self.channel.invokeMethod("logCallback", arguments: value)

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -343,8 +343,7 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
             // other work around for https://github.com/flutter/flutter/issues/126671
             if let flutterViewController =
                 UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController {
-                let engine = flutterViewController.engine
-                if engine?.isolateId == nil {
+                if let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
                     return
                 }
             }


### PR DESCRIPTION
### What and why?

This pull request fixes the compilation issue described in #708. 

### How?

It seems that in the latest Flutter release 3.29.0, the `engine` parameter on the `FlutterViewController` returns a non-optional type instead of an option type which causes compilation issues when upgrading the Flutter version. By casting the engine to an optional type, the compilation issue is fixed with Flutter 3.29.0 but also remains compatible with older versions of Flutter.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
