### PR TITLE
fix: iOS compilation error from Flutter 3.29

### DIFF
--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -342,10 +342,9 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
             // Second, check that the engine hasn't been destroyed, this is the
             // other work around for https://github.com/flutter/flutter/issues/126671
             if let flutterViewController =
-                UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController {
-                if let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
-                    return
-                }
+                UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController,
+                let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
+                return
             }
 
             self.channel.invokeMethod("logCallback", arguments: value)

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -343,8 +343,7 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
             // other work around for https://github.com/flutter/flutter/issues/126671
             if let flutterViewController =
                 UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController {
-                let engine = flutterViewController.engine
-                if engine?.isolateId == nil {
+                if let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
                     return
                 }
             }

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -171,8 +171,11 @@ extension type _JsLoggerConfiguration._(JSObject _) implements JSObject {
   external JSObject get context;
 
   external factory _JsLoggerConfiguration({
+    // ignore: unused_element_parameter
     String? level,
+    // ignore: unused_element_parameter
     String? handler,
+    // ignore: unused_element_parameter
     JSObject context,
   });
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -266,12 +266,15 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
     String? version,
     bool? trackResources,
     bool? trackViewsManually,
+    // ignore: unused_element_parameter
     bool? trackUserInteractions,
     bool? trackFrustrations,
     bool? trackLongTasks,
+    // ignore: unused_element_parameter
     String? defaultPrivacyLevel,
     num? sessionSampleRate,
     num? sessionReplaySampleRate,
+    // ignore: unused_element_parameter
     bool? silentMultipleInit,
     String? proxy,
     JSArray allowedTracingUrls,


### PR DESCRIPTION
### What and why?

Reopen of #709 to fix #708.

Needed to adjust some parameters because of a stricter Dart analyzer in addition to the iOS fix provided.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
