### PR TITLE
fix: iOS compilation error from Flutter 3.29

### DIFF
--- a/packages/datadog_flutter_plugin/example/lib/logging_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/logging_screen.dart
@@ -117,31 +117,6 @@ class _LoggingScreenState extends State<LoggingScreen> {
       ),
     );
   }
-
-  Widget _buildField({String? text, required Widget child}) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.only(top: 6, bottom: 6),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (text != null)
-            Text(
-              text,
-              style: theme.textTheme.titleSmall,
-            ),
-          Container(padding: const EdgeInsets.all(4), child: child),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildSegment(String title) {
-    return Container(
-      padding: const EdgeInsets.all(5),
-      child: Text(title),
-    );
-  }
 }
 
 void sendBackgroundLogs(RootIsolateToken rootIsolateToken) async {

--- a/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
@@ -30,6 +30,7 @@ if (flutterVersionName == null) {
 android {
     namespace "com.datadoghq.flutter.integrationtestapp"
     compileSdkVersion flutter.compileSdkVersion
+    ndkVersion flutter.ndkVersion 
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogSdkPlugin.swift
@@ -342,11 +342,9 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
             // Second, check that the engine hasn't been destroyed, this is the
             // other work around for https://github.com/flutter/flutter/issues/126671
             if let flutterViewController =
-                UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController {
-                let engine = flutterViewController.engine
-                if engine?.isolateId == nil {
-                    return
-                }
+                UIApplication.shared.keyWindow?.rootViewController as? FlutterViewController,
+                let engine = flutterViewController.engine as FlutterEngine?, engine.isolateId == nil {
+                return
             }
 
             self.channel.invokeMethod("logCallback", arguments: value)

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -171,8 +171,11 @@ extension type _JsLoggerConfiguration._(JSObject _) implements JSObject {
   external JSObject get context;
 
   external factory _JsLoggerConfiguration({
+    // ignore: unused_element_parameter
     String? level,
+    // ignore: unused_element_parameter
     String? handler,
+    // ignore: unused_element_parameter
     JSObject context,
   });
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -266,12 +266,15 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
     String? version,
     bool? trackResources,
     bool? trackViewsManually,
+    // ignore: unused_element_parameter
     bool? trackUserInteractions,
     bool? trackFrustrations,
     bool? trackLongTasks,
+    // ignore: unused_element_parameter
     String? defaultPrivacyLevel,
     num? sessionSampleRate,
     num? sessionReplaySampleRate,
+    // ignore: unused_element_parameter
     bool? silentMultipleInit,
     String? proxy,
     JSArray allowedTracingUrls,

--- a/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking.podspec
+++ b/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'DatadogCore',  '~> 2.19.0'
+  s.dependency 'DatadogCore',  '~> 2.19'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   datadog_flutter_plugin: ^2.9.0
   webview_flutter: ^4.0.4
   webview_flutter_android: ^3.8.2
-  webview_flutter_wkwebview: ^3.2.3
+  webview_flutter_wkwebview: '>=3.2.3 <3.18.0'
 
 dev_dependencies:
   flutter_test:

--- a/tools/ci/bin/ci_helpers.dart
+++ b/tools/ci/bin/ci_helpers.dart
@@ -8,7 +8,7 @@ import 'package:ci_helpers/stop_emulators_command.dart';
 import 'package:ci_helpers/web_command.dart';
 
 void main(List<String> arguments) {
-  final runner = CommandRunner(
+  CommandRunner(
       'ci', 'Helper command line utils for CI of the Datadog Flutter SDK')
     ..addCommand(SimulatorCommand())
     ..addCommand(StopEmulatorsCommand())

--- a/tools/ci/lib/android_helpers.dart
+++ b/tools/ci/lib/android_helpers.dart
@@ -149,7 +149,7 @@ Future<Map<String, String>> _getRunningDevices() async {
 Future<bool> _startEmulator(String emulatorName) async {
   print("Starting device");
 
-  var process = await Process.start(
+  var _ = await Process.start(
       emulatorCmd,
       [
         "@$emulatorName",


### PR DESCRIPTION
### What and why?

Backport Flutter 3.29 build fix to 2.10 release.

cherrypicked from f83c71bbdec224c63ee8a8532a1884af167aa7e1

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
