### PR TITLE
chore: Add a nightly build step to run tests against Flutter betas

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,10 @@ stages:
   - ci-image
   - build
   - integration-test
-  - e2e-test
+  - beta-test
+  - e2e-test  
   - post
+  - post-nightly
 
 # Prebuild - install necessary tools
 
@@ -43,6 +45,16 @@ stages:
     - xcodebuild -runFirstLaunch
     - xcodebuild -downloadPlatform iOS
 
+.pre-android:
+  script:
+    # Kill all active emulators
+    - pushd tools/ci && dart pub get && dart run ci_helpers stop_emu && popd
+    - melos pub:get
+    - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0" "platform-tools" "platforms;android-34" || true
+    - yes | flutter doctor --android-licenses || true
+    - flutter doctor
+
+  
 ci-image:
   when: manual
   stage: ci-image
@@ -124,12 +136,7 @@ android-integration-test:
     - specific:true
   script:
     - !reference [.pre, script]
-    # Kill all active emulators
-    - pushd tools/ci && dart pub get && dart run ci_helpers stop_emu && popd
-    - melos pub:get
-    - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0" "platform-tools" "platforms;android-34" || true
-    - yes | flutter doctor --android-licenses || true
-    - flutter doctor
+    - !reference [.pre-android, script]
     - cd tools/ci && dart pub get && dart run ci_helpers start_sim --platform android --sdk "33"
     - melos run integration_test:android
   artifacts:
@@ -204,6 +211,18 @@ notify-pipeline-succeeded:
   script:
     - echo "Pipeline did succeed"
 
+notify-nightly-failed:
+  extends: .slack-notifier-base
+  stage: post-nightly
+  when: on_failure
+  only:
+    - develop
+    - schedules
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":status_alert: $CI_PROJECT_NAME $CI_COMMIT_TAG Nightly develop pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
+    - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
+
 # Nightly
 
 .nightly-vars:
@@ -214,7 +233,6 @@ notify-pipeline-succeeded:
 
 .nightly:
   only: [ schedules ]
-  stage: e2e-test
   tags:
     - macos:sonoma
     - specific:true
@@ -226,12 +244,35 @@ nightly-ios:
     - !reference [.nightly-vars, script]
     - !reference [.pre, script]
     - !reference [.pre-ios, script]
-    
     - pod repo update
     - melos pub:get
     - cd tools/ci && dart pub get && dart run ci_helpers start_sim --platform ios --sdk "iOS-17" --device "iPhone 15"
     - melos pod_update --no-select
     - melos run e2e_tests:ios
+  artifacts:
+    when: always
+    expire_in: "30 days"
+    reports:
+      junit: $CI_PROJECT_DIR/.build/test-results/*.xml
+
+nightly-beta-test:
+  extends: .nightly
+  stage: beta-test
+  tags:
+    - macos:sonoma
+    - specific:true
+  script:
+    - !reference [.pre, script]
+    - !reference [.pre-ios, script]
+    - brew tap leoafarias/fvm
+    - brew install fvm
+    - fvm install beta
+    - fvm use beta
+    - fvm flutter upgrade
+    - fvm exec dart pub global activate melos
+    - fvm exec melos run analyze
+    - fvm exec melos run build
+    - fvm exec melos run unit_test
   artifacts:
     when: always
     expire_in: "30 days"
@@ -244,12 +285,7 @@ nightly-android:
   script:
     - !reference [.nightly-vars, script]
     - !reference [.pre, script]
-    # Kill all active emulators
-    - pushd tools/ci && dart pub get && dart run ci_helpers stop_emu && popd
-    - melos pub:get
-    - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;33.0.3" "platform-tools" "platforms;android-34" || true
-    - yes | flutter doctor --android-licenses || true
-    - flutter doctor
+    - !reference [.pre-android, script]
     - cd tools/ci && dart pub get && dart run ci_helpers start_sim --platform android --sdk "34"
     - melos run e2e_tests:android
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -272,7 +272,7 @@ nightly-beta-test:
     - fvm exec dart pub global activate melos
     - fvm exec melos run analyze
     - fvm exec melos run build
-    - fvm exec melos run unit_test
+    - fvm exec melos run unit_test:all
   artifacts:
     when: always
     expire_in: "30 days"

--- a/melos.yaml
+++ b/melos.yaml
@@ -20,7 +20,7 @@ scripts:
   build:android:
     exec:
       concurrency: 1
-    run: cd example && flutter build apk --release --verbose
+    run: cd example && flutter build apk --release
     packageFilters:
       dirExists: example/android
 

--- a/packages/datadog_flutter_plugin/example/lib/rum_user_actions_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_user_actions_screen.dart
@@ -69,7 +69,7 @@ class _RumUserActionsScreenState extends State<RumUserActionsScreen> {
         // and the attribute 'custom_attribute'.
         RumUserActionAnnotation(
           description: 'Alternative Button A',
-          attributes: {'custom_attribute': 'can be added too'},
+          attributes: const {'custom_attribute': 'can be added too'},
           child: ElevatedButton(
             onPressed: () => _buttonPressed('Button A'),
             child: const Text('Button A'),
@@ -86,7 +86,7 @@ class _RumUserActionsScreenState extends State<RumUserActionsScreen> {
         // and the attribute 'custom_attribute'.
         CustomButton(
           debugActionLabel: 'Custom Button A',
-          attributes: {'custom_attribute': 'can be added too'},
+          attributes: const {'custom_attribute': 'can be added too'},
           text: 'Button A',
           onPressed: () => _buttonPressed('Button A'),
         ),
@@ -147,7 +147,7 @@ class _RumUserActionsScreenState extends State<RumUserActionsScreen> {
       rum: DatadogSdk.instance.rum,
       customGestureDetector: (widget) {
         if (widget is CustomButton) {
-          return RumGestureDetectorInfo('CustomButton');
+          return const RumGestureDetectorInfo('CustomButton');
         }
         return null;
       },


### PR DESCRIPTION
### What and why?

We occasionally get caught off guard because of breaking changes made in Flutter betas. To combat this, I want to run our builds and unit tests against the Flutter beta channel nightly. It is possible integration tests will follow.

### How?

Install and use Flutter Version Manager to switch to the Flutter beta channel and run our build and unit tests for all platforms. This is done in a single step instead of the multiple in the main builds as parallelization of builds is not as important here.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
