### PR TITLE
chore: Fix nightly tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,6 +233,7 @@ notify-nightly-failed:
 
 .nightly:
   only: [ schedules ]
+  when: always
   tags:
     - macos:sonoma
     - specific:true

--- a/packages/datadog_flutter_plugin/example/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle.properties
@@ -4,7 +4,7 @@
 # Copyright 2016-Present Datadog, Inc.
 #
 
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx12800M
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/packages/datadog_tracking_http_client/example/android/app/build.gradle
+++ b/packages/datadog_tracking_http_client/example/android/app/build.gradle
@@ -30,6 +30,7 @@ if (flutterVersionName == null) {
 
 android {
     compileSdkVersion flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
     namespace "com.example.example"
 
     compileOptions {


### PR DESCRIPTION
### What and why?

The new nightly beta tests were failing because of a lack of memory during the Java compile. Added more memory in the `gradle.properties` to avoid this.

I also made it so that the nightly e2e tests run even if they beta tests fail, as they are independent steps.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
