### PR TITLE
fix: Untracked URLs could throw an exception with a clientListener

### DIFF
--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -130,9 +130,9 @@ class DatadogTrackingHttpClient implements HttpClient {
       request = await innerClient.openUrl(method, url);
       request =
           _DatadogTrackingHttpRequest(this, request, rumKey, userAttributes);
-      if (rum != null) {
+      if (rum != null && rumKey != null) {
         configuration.clientListener?.requestStarted(
-            resourceKey: rumKey!,
+            resourceKey: rumKey,
             request: request,
             userAttributes: userAttributes);
       }
@@ -367,7 +367,7 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
           }
         }
       }
-    } catch (e, st) {      
+    } catch (e, st) {
       client.datadogSdk.internalLogger.sendToDatadog(
         '$DatadogTrackingHttpClient encountered an error while attempting '
         ' to track an _openUrl call: $e',

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -1316,6 +1316,32 @@ void main() {
       expect(capturedAttributes['other_parameter'], 123);
       expect(capturedAttributes['extra_parameter'], 1928);
     });
+
+    test('ignorUrlPatterns does not call client listener on matching url',
+        () async {
+      var url = Uri.parse('https://test_url/path');
+      final completer = setupMockRequest(url);
+      final mockListener = MockTrackingHttpClientListener();
+
+      final client = DatadogTrackingHttpClient(
+        mockDatadog,
+        DdHttpTrackingPluginConfiguration(
+            ignoreUrlPatterns: [RegExp('test_url/path')],
+            clientListener: mockListener),
+        mockClient,
+      );
+      final request = await client.openUrl('get', url);
+
+      final mockResponse = setupMockClientResponse(200);
+      completer.complete(mockResponse);
+      var response = await request.done;
+
+      // Listen / close the response
+      response.listen((event) {});
+      await mockResponse.streamController.close();
+
+      verifyNoMoreInteractions(mockListener);
+    });
   });
 
   group(


### PR DESCRIPTION
### What and why?

Calls into the `clientListener` expected all calls to be tracked, and didn't correctly account for untracked URLs not having a RUM Key.  These ignored urls shouldn't call into the client listener at all.

Fix the null reference exception and add a test to verify.

refs: #716

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
