### PR TITLE
Changes from shipping datadog_tracking_http_client 2.3.0

### DIFF
--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.0
 
-* Fix ignored URLs throwing an exception with a clientListener. See [#716](https://github.com/DataDog/dd-sdk-flutter/issues/716)
+* Fix ignored URLs throwing an exception with a `clientListener`. See [#716](https://github.com/DataDog/dd-sdk-flutter/issues/716)
 * Fix distributed tracing for Web.
 * Upgrade Android build to SDK 34. See [#639](https://github.com/DataDog/dd-sdk-flutter/issues/639)
 * Add the ability to ignore tracking on specific url patterns with `ignoreUrlPatterns` when using the attach configuration.

--- a/packages/datadog_tracking_http_client/CHANGELOG.md
+++ b/packages/datadog_tracking_http_client/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## Unreleased
+## 2.3.0
 
+* Fix ignored URLs throwing an exception with a clientListener. See [#716](https://github.com/DataDog/dd-sdk-flutter/issues/716)
+* Fix distributed tracing for Web.
+* Upgrade Android build to SDK 34. See [#639](https://github.com/DataDog/dd-sdk-flutter/issues/639)
 * Add the ability to ignore tracking on specific url patterns with `ignoreUrlPatterns` when using the attach configuration.
 * Add support for `TraceContextInjection` configuration.
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_tracking_http_client
 description: A wrapping implementation of HttpClient for tracking resources with Datadog
-version: 2.3.0
+version: 2.4.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 


### PR DESCRIPTION
### What and why?

Changes from shipping `datadog_tracking_http_client` 2.3.0.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
