### PR TITLE
chore: Fix nightly builds.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,6 +271,9 @@ nightly-beta-test:
     - fvm use beta
     - fvm flutter upgrade
     - fvm exec dart pub global activate melos
+    - pod repo update
+    - fvm exec melos melos pub:get
+    - fvm exec melos melos pod_update --no-select
     - fvm exec melos run analyze
     - fvm exec melos run build
     - fvm exec melos run unit_test:all


### PR DESCRIPTION
### What and why?

Nightly builds are failing because they're missing a pod update. Add the pod update step to the nightly.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
