### PR TITLE
feat: Add custom "Interaction To Next View" metric for Flutter.

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -218,6 +218,11 @@ class RumViewEventDecoder extends RumEventDecoder {
     return null;
   }
 
+  int? get inv {
+    final invValue = rumEvent['view']['interaction_to_next_view_time'];
+    return invValue as int?;
+  }
+
   Performance? get performance {
     final perf = rumEvent['view']['performance'] as Map<String, Object?>?;
     if (perf != null) {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -162,6 +162,7 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
                 configBuilder = configBuilder
                     .disableUserInteractionTracking()
                     .useViewTrackingStrategy(NoOpViewTrackingStrategy)
+                    .setLastInteractionIdentifier(null)
 
                 // Mapper initialization
                 configBuilder = attachEventMappers(encodedConfig, configBuilder)
@@ -455,8 +456,15 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
 
     private fun setInternalViewAttribute(call: MethodCall, result: Result) {
         val key = call.argument<String>(PARAM_KEY)
-        val value = call.argument<Any>(PARAM_VALUE)
+        var value = call.argument<Any>(PARAM_VALUE)
         if (key != null && value != null) {
+            // TODO(RUM-9062): This is a bit of a hack. Flutter will provide int values if the value
+            // fits in 32-bits, but we cast to Long in the Android SDK. We'll fix the issue in the Android
+            // SDK and remove this cast another time.
+            value = when (value) {
+                is Int -> value.toLong()
+                else -> value
+            }
             rum?._getInternal()?.setInternalViewAttribute(key, value)
             result.success(null)
         } else {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -731,7 +731,7 @@ class DatadogRumPluginTest {
         verify { mockResult.success(null) }
     }
 
-    @Test()
+    @Test
     fun `M call internal setInternalViewAttribute W setInternalViewAtttribute is called`(
         forge: Forge,
     ) {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -10,22 +10,17 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import com.datadog.android.Datadog
-import com.datadog.android.log.Logs
-import com.datadog.android.log.LogsConfiguration
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
-import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
-import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -44,7 +39,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 @ExtendWith(ForgeExtension::class)
@@ -737,7 +731,7 @@ class DatadogRumPluginTest {
         verify { mockResult.success(null) }
     }
 
-    @Test
+    @Test()
     fun `M call internal setInternalViewAttribute W setInternalViewAtttribute is called`(
         forge: Forge,
     ) {
@@ -754,18 +748,22 @@ class DatadogRumPluginTest {
                 forge.aList { anAlphabeticalString() },
             ).associateBy { forge.anAlphabeticalString() }
         )
-        val call = MethodCall( "setInternalViewAttribute", mapOf(
-            "key" to key,
-            "value" to value,
-        ))
         val mockResult = mockk<MethodChannel.Result>()
         every { mockResult.success(any()) } returns Unit
 
         // WHEN
+        val call = MethodCall( "setInternalViewAttribute", mapOf(
+            "key" to key,
+            "value" to value,
+        ))
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        verify { monitorProxy.mockInternalProxy.setInternalViewAttribute(key, value) }
+        val expectedValue = when (value) {
+            is Int -> value.toLong()
+            else -> value
+        }
+        verify { monitorProxy.mockInternalProxy.setInternalViewAttribute(key, expectedValue) }
         verify { mockResult.success(null) }
     }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_auto_instrumentation_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_auto_instrumentation_test.dart
@@ -72,6 +72,8 @@ void main() {
       expect(view1.viewEvents.last.flutterBuildTime, isNotNull);
       expect(view1.viewEvents.last.flutterRasterTime, isNotNull);
       expect(view1.viewEvents.last.performance?.fbc, isNotNull);
+      // Should not have INV as no interaction led here
+      expect(view1.viewEvents.last.inv, isNull);
 
       // Web doesn't support action tracking from Flutter
       var actionEvent = view1.actionEvents.last;
@@ -90,8 +92,13 @@ void main() {
       expect(view2.viewEvents.last.flutterRasterTime, isNotNull);
 
       // Second screen build time should delay
-      expect(view2.viewEvents.last.performance?.fbc,
-          greaterThan(const Duration(milliseconds: 10).inNanoseconds));
+      final firstBuildComplete = view2.viewEvents.last.performance?.fbc;
+      final tenMsInNs = const Duration(milliseconds: 10).inNanoseconds;
+      expect(firstBuildComplete, greaterThan(tenMsInNs));
+
+      // INV should be at least 10 milliseconds later, as the tap action also takes up 10 ms
+      expect(view2.viewEvents.last.inv,
+          greaterThan(firstBuildComplete! + tenMsInNs));
 
       // Web doesn't support action tracking from Flutter
       var actionEvent = view2.actionEvents[0];

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_scenario.dart
@@ -28,6 +28,10 @@ class _RumAutoInstrumentationScenarioState
   }
 
   void _onTap(int index) {
+    // Deliberately delay cause a delay
+    final delayEnd = DateTime.now().add(const Duration(milliseconds: 10));
+    while (DateTime.now().isBefore(delayEnd)) {}
+
     switch (index) {
       case 0:
         Navigator.push<void>(

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -350,6 +350,8 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
             if let configArg = configArg,
                var config = RUM.Configuration(fromEncoded: configArg) {
                 attachEventMappers(configArg: configArg, config: &config)
+                // Disable INV as the Flutter calculations for it are different
+                config.nextViewActionPredicate = nil
 
                 RUM.enable(with: config)
                 rum = RUMMonitor.shared()

--- a/packages/datadog_flutter_plugin/lib/src/rum/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/attributes.dart
@@ -19,4 +19,7 @@ class DatadogRumPlatformAttributeKey {
 
   /// Internal attribute that specifies with the first build of a Flutter view is complete.
   static const firstBuildComplete = '_dd.performance.first_build_complete';
+
+  /// Internal view attribute that specifies the "Interaction To Next View" timing.
+  static const customInvValue = '_dd.view.custom_inv_value';
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -14,6 +14,7 @@ import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
 import '../time_provider.dart';
 import 'ddrum_platform_interface.dart';
+import 'inv_metric_provider.dart';
 import 'rum_long_task_observer.dart';
 
 /// HTTP method of the resource
@@ -116,6 +117,8 @@ class DatadogRum {
   // Used for FBC and INV vitals.
   _ViewInfo? _currentViewInfo;
 
+  final InvMetricProvider _invMetricProvider = InvMetricProvider();
+
   static Future<DatadogRum?> enable(
       DatadogSdk core, DatadogRumConfiguration configuration) async {
     DatadogRum? rum;
@@ -215,9 +218,11 @@ class DatadogRum {
   void startView(String key,
       [String? name, Map<String, Object?> attributes = const {}]) {
     name ??= key;
-    _currentViewInfo = _ViewInfo(key, name, timeProvider.now());
+    final currentTime = timeProvider.now();
+    _currentViewInfo = _ViewInfo(key, name, currentTime);
     wrap('rum.startView', logger, attributes, () {
-      return _platform.startView(key, name!, attributes);
+      _invMetricProvider.trackViewStart(key, currentTime);
+      return _platform.startView(currentTime, key, name!, attributes);
     });
   }
 
@@ -228,8 +233,10 @@ class DatadogRum {
   /// The [key] passed here must match the [key] passed to [startView].
   void stopView(String key, [Map<String, Object?> attributes = const {}]) {
     _currentViewInfo = null;
+    final currentTime = timeProvider.now();
     wrap('rum.stopView', logger, attributes, () {
-      return _platform.stopView(key, attributes);
+      _invMetricProvider.trackViewStop(key, currentTime);
+      return _platform.stopView(currentTime, key, attributes);
     });
   }
 
@@ -237,8 +244,9 @@ class DatadogRum {
   /// timing duration will be computed as the number of nanoseconds between the
   /// time the View was started and the time the timing was added.
   void addTiming(String name) {
+    final currentTime = timeProvider.now();
     wrap('rum.addTiming', logger, null, () {
-      return _platform.addTiming(name);
+      return _platform.addTiming(currentTime, name);
     });
   }
 
@@ -274,7 +282,9 @@ class DatadogRum {
       }
     }
     wrap('rum.addError', logger, attributes, () {
-      return _platform.addError(error, source, stackTrace, errorType, {
+      final currentTime = timeProvider.now();
+      return _platform.addError(
+          currentTime, error, source, stackTrace, errorType, {
         DatadogPlatformAttributeKey.errorSourceType: 'flutter',
         ...attributes
       });
@@ -300,7 +310,9 @@ class DatadogRum {
       return;
     }
     wrap('rum.addErrorInfo', logger, attributes, () {
-      return _platform.addErrorInfo(message, source, stackTrace, errorType, {
+      final currentTime = timeProvider.now();
+      return _platform.addErrorInfo(
+          currentTime, message, source, stackTrace, errorType, {
         DatadogPlatformAttributeKey.errorSourceType: 'flutter',
         ...attributes
       });
@@ -336,7 +348,9 @@ class DatadogRum {
   void startResource(String key, RumHttpMethod httpMethod, String url,
       [Map<String, Object?> attributes = const {}]) {
     wrap('rum.startResource', logger, attributes, () {
-      return _platform.startResource(key, httpMethod, url, attributes);
+      final currentTime = timeProvider.now();
+      return _platform.startResource(
+          currentTime, key, httpMethod, url, attributes);
     });
   }
 
@@ -347,7 +361,9 @@ class DatadogRum {
   void stopResource(String key, int? statusCode, RumResourceType kind,
       [int? size, Map<String, Object?> attributes = const {}]) {
     wrap('rum.stopResource', logger, attributes, () {
-      return _platform.stopResource(key, statusCode, kind, size, attributes);
+      final currentTime = timeProvider.now();
+      return _platform.stopResource(
+          currentTime, key, statusCode, kind, size, attributes);
     });
   }
 
@@ -357,7 +373,9 @@ class DatadogRum {
   void stopResourceWithError(String key, Exception error,
       [Map<String, Object?> attributes = const {}]) {
     wrap('rum.stopResourceWithError', logger, attributes, () {
-      return _platform.stopResourceWithError(key, error, attributes);
+      final currentTime = timeProvider.now();
+      return _platform.stopResourceWithError(
+          currentTime, key, error, attributes);
     });
   }
 
@@ -367,8 +385,9 @@ class DatadogRum {
   void stopResourceWithErrorInfo(String key, String message, String type,
       [Map<String, Object?> attributes = const {}]) {
     wrap('rum.stopResourceWithErrorInfo', logger, attributes, () {
+      final currentTime = timeProvider.now();
       return _platform.stopResourceWithErrorInfo(
-          key, message, type, attributes);
+          currentTime, key, message, type, attributes);
     });
   }
 
@@ -380,7 +399,12 @@ class DatadogRum {
   void addAction(RumActionType type, String name,
       [Map<String, Object?> attributes = const {}]) {
     wrap('rum.addAction', logger, attributes, () {
-      return _platform.addAction(type, name, attributes);
+      final currentTime = timeProvider.now();
+      if (_currentViewInfo != null) {
+        _invMetricProvider.trackAction(
+            _currentViewInfo!.viewKey, currentTime, type);
+      }
+      return _platform.addAction(currentTime, type, name, attributes);
     });
   }
 
@@ -392,7 +416,8 @@ class DatadogRum {
   void startAction(RumActionType type, String name,
       [Map<String, Object?> attributes = const {}]) {
     wrap('rum.startAction', logger, attributes, () {
-      return _platform.startAction(type, name, attributes);
+      final currentTime = timeProvider.now();
+      return _platform.startAction(currentTime, type, name, attributes);
     });
   }
 
@@ -402,7 +427,8 @@ class DatadogRum {
   void stopAction(RumActionType type, String name,
       [Map<String, Object?> attributes = const {}]) {
     wrap('rum.stopAction', logger, attributes, () {
-      return _platform.stopAction(type, name, attributes);
+      final currentTime = timeProvider.now();
+      return _platform.stopAction(currentTime, type, name, attributes);
     });
   }
 
@@ -471,12 +497,19 @@ class DatadogRum {
   void markViewFirstBuildComplete(String viewKey) {
     if (_currentViewInfo case final currentViewInfo?) {
       if (viewKey == currentViewInfo.viewKey) {
+        final currentTime = timeProvider.now();
         final fbcTime =
-            (timeProvider.now().difference(currentViewInfo.viewStart))
-                .inNanoseconds;
+            (currentTime.difference(currentViewInfo.viewStart)).inNanoseconds;
         wrap('rum.setInternalViewAttribute', logger, null, () {
           _platform.setInternalViewAttribute(
               DatadogRumPlatformAttributeKey.firstBuildComplete, fbcTime);
+          _invMetricProvider.trackViewFirstBuildComplete(viewKey, currentTime);
+
+          final invValue = _invMetricProvider.valueForView(viewKey);
+          if (invValue != null) {
+            _platform.setInternalViewAttribute(
+                DatadogRumPlatformAttributeKey.customInvValue, invValue);
+          }
         });
       }
     }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -46,7 +46,7 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> addTiming(DateTime timeStamp, String name) {
+  Future<void> addTiming(DateTime timestamp, String name) {
     return methodChannel.invokeMethod(
       'addTiming',
       {'name': name},
@@ -54,9 +54,9 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> startView(DateTime timeStamp, String key, String name,
+  Future<void> startView(DateTime timestamp, String key, String name,
       Map<String, Object?> attributes) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod(
       'startView',
       {
@@ -72,8 +72,8 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> stopView(
-      DateTime timeStamp, String key, Map<String, Object?> attributes) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+      DateTime timestamp, String key, Map<String, Object?> attributes) {
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod(
       'stopView',
       {
@@ -88,13 +88,13 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> startResource(
-    DateTime timeStamp,
+    DateTime timestamp,
     String key,
     RumHttpMethod httpMethod,
     String url, [
     Map<String, Object?> attributes = const {},
   ]) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('startResource', {
       'key': key,
       'httpMethod': httpMethod.toString(),
@@ -108,9 +108,9 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> stopResource(
-      DateTime timeStamp, String key, int? statusCode, RumResourceType kind,
+      DateTime timestamp, String key, int? statusCode, RumResourceType kind,
       [int? size, Map<String, Object?> attributes = const {}]) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('stopResource', {
       'key': key,
       'statusCode': statusCode,
@@ -125,21 +125,21 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> stopResourceWithError(
-      DateTime timeStamp, String key, Exception error,
+      DateTime timestamp, String key, Exception error,
       [Map<String, Object?> attributes = const {}]) {
-    return stopResourceWithErrorInfo(timeStamp, key, error.toString(),
+    return stopResourceWithErrorInfo(timestamp, key, error.toString(),
         error.runtimeType.toString(), attributes);
   }
 
   @override
   Future<void> stopResourceWithErrorInfo(
-    DateTime timeStamp,
+    DateTime timestamp,
     String key,
     String message,
     String type, [
     Map<String, Object?> attributes = const {},
   ]) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('stopResourceWithError', {
       'key': key,
       'message': message,
@@ -153,7 +153,7 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> addError(
-    DateTime timeStamp,
+    DateTime timestamp,
     Object error,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -161,7 +161,7 @@ class DdRumMethodChannel extends DdRumPlatform {
     Map<String, Object?> attributes,
   ) {
     return addErrorInfo(
-        timeStamp, error.toString(), source, stackTrace, errorType, attributes);
+        timestamp, error.toString(), source, stackTrace, errorType, attributes);
   }
 
   @override
@@ -173,13 +173,13 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> addErrorInfo(
-      DateTime timeStamp,
+      DateTime timestamp,
       String message,
       RumErrorSource source,
       StackTrace? stackTrace,
       String? errorType,
       Map<String, Object?> attributes) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('addError', {
       'message': message,
       'source': source.toString(),
@@ -193,9 +193,9 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(DateTime timeStamp, RumActionType type, String? name,
+  Future<void> addAction(DateTime timestamp, RumActionType type, String? name,
       Map<String, Object?> attributes) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('addAction', {
       'type': type.toString(),
       'name': name,
@@ -207,9 +207,9 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('startAction', {
       'type': type.toString(),
       'name': name,
@@ -221,9 +221,9 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes) {
-    final timestampMs = timeStamp.millisecondsSinceEpoch;
+    final timestampMs = timestamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('stopAction', {
       'type': type.toString(),
       'name': name,

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -7,16 +7,12 @@ import 'package:flutter/services.dart';
 
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
-import '../time_provider.dart';
 import 'ddrum_platform_interface.dart';
 
 class DdRumMethodChannel extends DdRumPlatform {
   @visibleForTesting
   final MethodChannel methodChannel =
       const MethodChannel('datadog_sdk_flutter.rum');
-
-  @visibleForTesting
-  DatadogTimeProvider timeProvider = DefaultTimeProvider();
 
   @override
   Future<void> enable(
@@ -50,7 +46,7 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> addTiming(String name) {
+  Future<void> addTiming(DateTime timeStamp, String name) {
     return methodChannel.invokeMethod(
       'addTiming',
       {'name': name},
@@ -58,9 +54,9 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> startView(
-      String key, String name, Map<String, Object?> attributes) {
-    final timestamp = timeProvider.nowMs();
+  Future<void> startView(DateTime timeStamp, String key, String name,
+      Map<String, Object?> attributes) {
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod(
       'startView',
       {
@@ -68,22 +64,23 @@ class DdRumMethodChannel extends DdRumPlatform {
         'name': name,
         'attributes': {
           ...attributes,
-          DatadogPlatformAttributeKey.timestamp: timestamp,
+          DatadogPlatformAttributeKey.timestamp: timestampMs,
         }
       },
     );
   }
 
   @override
-  Future<void> stopView(String key, Map<String, Object?> attributes) {
-    final timestamp = timeProvider.nowMs();
+  Future<void> stopView(
+      DateTime timeStamp, String key, Map<String, Object?> attributes) {
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod(
       'stopView',
       {
         'key': key,
         'attributes': {
           ...attributes,
-          DatadogPlatformAttributeKey.timestamp: timestamp,
+          DatadogPlatformAttributeKey.timestamp: timestampMs,
         }
       },
     );
@@ -91,27 +88,29 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> startResource(
+    DateTime timeStamp,
     String key,
     RumHttpMethod httpMethod,
     String url, [
     Map<String, Object?> attributes = const {},
   ]) {
-    final timestamp = timeProvider.nowMs();
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('startResource', {
       'key': key,
       'httpMethod': httpMethod.toString(),
       'url': url,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       },
     });
   }
 
   @override
-  Future<void> stopResource(String key, int? statusCode, RumResourceType kind,
+  Future<void> stopResource(
+      DateTime timeStamp, String key, int? statusCode, RumResourceType kind,
       [int? size, Map<String, Object?> attributes = const {}]) {
-    final timestamp = timeProvider.nowMs();
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('stopResource', {
       'key': key,
       'statusCode': statusCode,
@@ -119,39 +118,42 @@ class DdRumMethodChannel extends DdRumPlatform {
       'size': size,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       },
     });
   }
 
   @override
-  Future<void> stopResourceWithError(String key, Exception error,
+  Future<void> stopResourceWithError(
+      DateTime timeStamp, String key, Exception error,
       [Map<String, Object?> attributes = const {}]) {
-    return stopResourceWithErrorInfo(
-        key, error.toString(), error.runtimeType.toString(), attributes);
+    return stopResourceWithErrorInfo(timeStamp, key, error.toString(),
+        error.runtimeType.toString(), attributes);
   }
 
   @override
   Future<void> stopResourceWithErrorInfo(
+    DateTime timeStamp,
     String key,
     String message,
     String type, [
     Map<String, Object?> attributes = const {},
   ]) {
-    final timestamp = timeProvider.nowMs();
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('stopResourceWithError', {
       'key': key,
       'message': message,
       'type': type,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       },
     });
   }
 
   @override
   Future<void> addError(
+    DateTime timeStamp,
     Object error,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -159,7 +161,7 @@ class DdRumMethodChannel extends DdRumPlatform {
     Map<String, Object?> attributes,
   ) {
     return addErrorInfo(
-        error.toString(), source, stackTrace, errorType, attributes);
+        timeStamp, error.toString(), source, stackTrace, errorType, attributes);
   }
 
   @override
@@ -171,12 +173,13 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> addErrorInfo(
+      DateTime timeStamp,
       String message,
       RumErrorSource source,
       StackTrace? stackTrace,
       String? errorType,
       Map<String, Object?> attributes) {
-    final timestamp = timeProvider.nowMs();
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('addError', {
       'message': message,
       'source': source.toString(),
@@ -184,49 +187,49 @@ class DdRumMethodChannel extends DdRumPlatform {
       'errorType': errorType,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       },
     });
   }
 
   @override
-  Future<void> addAction(
-      RumActionType type, String? name, Map<String, Object?> attributes) {
-    final timestamp = timeProvider.nowMs();
+  Future<void> addAction(DateTime timeStamp, RumActionType type, String? name,
+      Map<String, Object?> attributes) {
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('addAction', {
       'type': type.toString(),
       'name': name,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       },
     });
   }
 
   @override
-  Future<void> startAction(
-      RumActionType type, String name, Map<String, Object?> attributes) {
-    final timestamp = timeProvider.nowMs();
+  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes) {
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('startAction', {
       'type': type.toString(),
       'name': name,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       },
     });
   }
 
   @override
-  Future<void> stopAction(
-      RumActionType type, String name, Map<String, Object?> attributes) {
-    final timestamp = timeProvider.nowMs();
+  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes) {
+    final timestampMs = timeStamp.millisecondsSinceEpoch;
     return methodChannel.invokeMethod('stopAction', {
       'type': type.toString(),
       'name': name,
       'attributes': {
         ...attributes,
-        DatadogPlatformAttributeKey.timestamp: timestamp,
+        DatadogPlatformAttributeKey.timestamp: timestampMs,
       }
     });
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -17,6 +17,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
 
   @override
   Future<void> addError(
+      DateTime timeStamp,
       Object error,
       RumErrorSource source,
       StackTrace? stackTrace,
@@ -27,6 +28,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
 
   @override
   Future<void> addErrorInfo(
+      DateTime timeStamp,
       String message,
       RumErrorSource source,
       StackTrace? stackTrace,
@@ -41,7 +43,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> addTiming(String name) {
+  Future<void> addTiming(DateTime timeStamp, String name) {
     return Future.value();
   }
 
@@ -51,8 +53,8 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(
-      RumActionType type, String name, Map<String, Object?> attributes) {
+  Future<void> addAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes) {
     return Future.value();
   }
 
@@ -75,38 +77,38 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> startResource(String key, RumHttpMethod httpMethod, String url,
+  Future<void> startResource(DateTime timeStamp, String key,
+      RumHttpMethod httpMethod, String url, Map<String, Object?> attributes) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
       Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> startAction(
-      RumActionType type, String name, Map<String, Object?> attributes) {
+  Future<void> startView(DateTime timeStamp, String key, String name,
+      Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> startView(
-      String key, String name, Map<String, Object?> attributes) {
+  Future<void> stopResource(DateTime timeStamp, String key, int? statusCode,
+      RumResourceType kind, int? size, Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResource(String key, int? statusCode, RumResourceType kind,
-      int? size, Map<String, Object?> attributes) {
+  Future<void> stopResourceWithError(DateTime timeStamp, String key,
+      Exception error, Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResourceWithError(
-      String key, Exception error, Map<String, Object?> attributes) {
-    return Future.value();
-  }
-
-  @override
-  Future<void> stopResourceWithErrorInfo(String key, String message,
-      String type, Map<String, Object?> attributes) {
+  Future<void> stopResourceWithErrorInfo(DateTime timeStamp, String key,
+      String message, String type, Map<String, Object?> attributes) {
     return Future.value();
   }
 
@@ -114,13 +116,14 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   Future<void> stopSession() => Future.value();
 
   @override
-  Future<void> stopAction(
-      RumActionType type, String name, Map<String, Object?> attributes) {
+  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> stopView(String key, Map<String, Object?> attributes) {
+  Future<void> stopView(
+      DateTime timeStamp, String key, Map<String, Object?> attributes) {
     return Future.value();
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -17,7 +17,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
 
   @override
   Future<void> addError(
-      DateTime timeStamp,
+      DateTime timestamp,
       Object error,
       RumErrorSource source,
       StackTrace? stackTrace,
@@ -28,7 +28,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
 
   @override
   Future<void> addErrorInfo(
-      DateTime timeStamp,
+      DateTime timestamp,
       String message,
       RumErrorSource source,
       StackTrace? stackTrace,
@@ -43,7 +43,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> addTiming(DateTime timeStamp, String name) {
+  Future<void> addTiming(DateTime timestamp, String name) {
     return Future.value();
   }
 
@@ -53,7 +53,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> addAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes) {
     return Future.value();
   }
@@ -77,37 +77,37 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> startResource(DateTime timeStamp, String key,
+  Future<void> startResource(DateTime timestamp, String key,
       RumHttpMethod httpMethod, String url, Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> startView(DateTime timeStamp, String key, String name,
+  Future<void> startView(DateTime timestamp, String key, String name,
       Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResource(DateTime timeStamp, String key, int? statusCode,
+  Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
       RumResourceType kind, int? size, Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResourceWithError(DateTime timeStamp, String key,
+  Future<void> stopResourceWithError(DateTime timestamp, String key,
       Exception error, Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResourceWithErrorInfo(DateTime timeStamp, String key,
+  Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
       String message, String type, Map<String, Object?> attributes) {
     return Future.value();
   }
@@ -116,14 +116,14 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   Future<void> stopSession() => Future.value();
 
   @override
-  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes) {
     return Future.value();
   }
 
   @override
   Future<void> stopView(
-      DateTime timeStamp, String key, Map<String, Object?> attributes) {
+      DateTime timestamp, String key, Map<String, Object?> attributes) {
     return Future.value();
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -26,24 +26,24 @@ abstract class DdRumPlatform extends PlatformInterface {
 
   Future<String?> getCurrentSessionId();
 
-  Future<void> startView(DateTime timeStamp, String key, String name,
+  Future<void> startView(DateTime timestamp, String key, String name,
       Map<String, Object?> attributes);
   Future<void> stopView(
-      DateTime timeStamp, String key, Map<String, Object?> attributes);
-  Future<void> addTiming(DateTime timeStamp, String name);
+      DateTime timestamp, String key, Map<String, Object?> attributes);
+  Future<void> addTiming(DateTime timestamp, String name);
   Future<void> addViewLoadingTime(bool overwrite);
 
-  Future<void> startResource(DateTime timeStamp, String key,
+  Future<void> startResource(DateTime timestamp, String key,
       RumHttpMethod httpMethod, String url, Map<String, Object?> attributes);
-  Future<void> stopResource(DateTime timeStamp, String key, int? statusCode,
+  Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
       RumResourceType kind, int? size, Map<String, Object?> attributes);
-  Future<void> stopResourceWithError(DateTime timeStamp, String key,
+  Future<void> stopResourceWithError(DateTime timestamp, String key,
       Exception error, Map<String, Object?> attributes);
-  Future<void> stopResourceWithErrorInfo(DateTime timeStamp, String key,
+  Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
       String message, String type, Map<String, Object?> attributes);
 
   Future<void> addError(
-    DateTime timeStamp,
+    DateTime timestamp,
     Object error,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -51,7 +51,7 @@ abstract class DdRumPlatform extends PlatformInterface {
     Map<String, Object?> attributes,
   );
   Future<void> addErrorInfo(
-    DateTime timeStamp,
+    DateTime timestamp,
     String message,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -59,11 +59,11 @@ abstract class DdRumPlatform extends PlatformInterface {
     Map<String, Object?> attributes,
   );
 
-  Future<void> addAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> addAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes);
-  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes);
-  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
       Map<String, Object?> attributes);
 
   Future<void> addAttribute(String key, dynamic value);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -26,22 +26,24 @@ abstract class DdRumPlatform extends PlatformInterface {
 
   Future<String?> getCurrentSessionId();
 
-  Future<void> startView(
-      String key, String name, Map<String, Object?> attributes);
-  Future<void> stopView(String key, Map<String, Object?> attributes);
-  Future<void> addTiming(String name);
+  Future<void> startView(DateTime timeStamp, String key, String name,
+      Map<String, Object?> attributes);
+  Future<void> stopView(
+      DateTime timeStamp, String key, Map<String, Object?> attributes);
+  Future<void> addTiming(DateTime timeStamp, String name);
   Future<void> addViewLoadingTime(bool overwrite);
 
-  Future<void> startResource(String key, RumHttpMethod httpMethod, String url,
-      Map<String, Object?> attributes);
-  Future<void> stopResource(String key, int? statusCode, RumResourceType kind,
-      int? size, Map<String, Object?> attributes);
-  Future<void> stopResourceWithError(
-      String key, Exception error, Map<String, Object?> attributes);
-  Future<void> stopResourceWithErrorInfo(
-      String key, String message, String type, Map<String, Object?> attributes);
+  Future<void> startResource(DateTime timeStamp, String key,
+      RumHttpMethod httpMethod, String url, Map<String, Object?> attributes);
+  Future<void> stopResource(DateTime timeStamp, String key, int? statusCode,
+      RumResourceType kind, int? size, Map<String, Object?> attributes);
+  Future<void> stopResourceWithError(DateTime timeStamp, String key,
+      Exception error, Map<String, Object?> attributes);
+  Future<void> stopResourceWithErrorInfo(DateTime timeStamp, String key,
+      String message, String type, Map<String, Object?> attributes);
 
   Future<void> addError(
+    DateTime timeStamp,
     Object error,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -49,6 +51,7 @@ abstract class DdRumPlatform extends PlatformInterface {
     Map<String, Object?> attributes,
   );
   Future<void> addErrorInfo(
+    DateTime timeStamp,
     String message,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -56,12 +59,12 @@ abstract class DdRumPlatform extends PlatformInterface {
     Map<String, Object?> attributes,
   );
 
-  Future<void> addAction(
-      RumActionType type, String name, Map<String, Object?> attributes);
-  Future<void> startAction(
-      RumActionType type, String name, Map<String, Object?> attributes);
-  Future<void> stopAction(
-      RumActionType type, String name, Map<String, Object?> attributes);
+  Future<void> addAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes);
+  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes);
+  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, Object?> attributes);
 
   Future<void> addAttribute(String key, dynamic value);
   Future<void> removeAttribute(String key);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -79,6 +79,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> addError(
+    DateTime timeStamp,
     Object error,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -100,6 +101,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> addErrorInfo(
+    DateTime timeStamp,
     String message,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -120,7 +122,7 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addTiming(String name) async {
+  Future<void> addTiming(DateTime timeStamp, String name) async {
     DD_RUM?.addTiming(name);
   }
 
@@ -130,8 +132,8 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(
-      RumActionType type, String name, Map<String, dynamic> attributes) async {
+  Future<void> addAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, dynamic> attributes) async {
     DD_RUM?.addAction(name, attributesToJs(attributes, 'attributes'));
   }
 
@@ -141,49 +143,54 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> startResource(String key, RumHttpMethod httpMethod, String url,
+  Future<void> startResource(
+      DateTime timeStamp,
+      String key,
+      RumHttpMethod httpMethod,
+      String url,
       Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> startAction(
-      RumActionType type, String name, Map<String, dynamic> attributes) async {
+  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> startView(
-      String key, String name, Map<String, dynamic> attributes) async {
+  Future<void> startView(DateTime timeStamp, String key, String name,
+      Map<String, dynamic> attributes) async {
     DD_RUM?.startView(name);
   }
 
   @override
-  Future<void> stopResource(String key, int? statusCode, RumResourceType kind,
-      int? size, Map<String, dynamic> attributes) async {
+  Future<void> stopResource(DateTime timeStamp, String key, int? statusCode,
+      RumResourceType kind, int? size, Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopResourceWithError(
-      String key, Exception error, Map<String, dynamic> attributes) async {
+  Future<void> stopResourceWithError(DateTime timeStamp, String key,
+      Exception error, Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopResourceWithErrorInfo(String key, String message,
-      String type, Map<String, dynamic> attributes) async {
+  Future<void> stopResourceWithErrorInfo(DateTime timeStamp, String key,
+      String message, String type, Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopAction(
-      RumActionType type, String name, Map<String, dynamic> attributes) async {
+  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+      Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopView(String key, Map<String, dynamic> attributes) async {
+  Future<void> stopView(
+      DateTime timeStamp, String key, Map<String, dynamic> attributes) async {
     // NOOP
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -79,7 +79,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> addError(
-    DateTime timeStamp,
+    DateTime timestamp,
     Object error,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -101,7 +101,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> addErrorInfo(
-    DateTime timeStamp,
+    DateTime timestamp,
     String message,
     RumErrorSource source,
     StackTrace? stackTrace,
@@ -122,7 +122,7 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addTiming(DateTime timeStamp, String name) async {
+  Future<void> addTiming(DateTime timestamp, String name) async {
     DD_RUM?.addTiming(name);
   }
 
@@ -132,7 +132,7 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> addAction(DateTime timestamp, RumActionType type, String name,
       Map<String, dynamic> attributes) async {
     DD_RUM?.addAction(name, attributesToJs(attributes, 'attributes'));
   }
@@ -144,7 +144,7 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> startResource(
-      DateTime timeStamp,
+      DateTime timestamp,
       String key,
       RumHttpMethod httpMethod,
       String url,
@@ -153,44 +153,44 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> startAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
       Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> startView(DateTime timeStamp, String key, String name,
+  Future<void> startView(DateTime timestamp, String key, String name,
       Map<String, dynamic> attributes) async {
     DD_RUM?.startView(name);
   }
 
   @override
-  Future<void> stopResource(DateTime timeStamp, String key, int? statusCode,
+  Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
       RumResourceType kind, int? size, Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopResourceWithError(DateTime timeStamp, String key,
+  Future<void> stopResourceWithError(DateTime timestamp, String key,
       Exception error, Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopResourceWithErrorInfo(DateTime timeStamp, String key,
+  Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
       String message, String type, Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
-  Future<void> stopAction(DateTime timeStamp, RumActionType type, String name,
+  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
       Map<String, dynamic> attributes) async {
     // NOOP
   }
 
   @override
   Future<void> stopView(
-      DateTime timeStamp, String key, Map<String, dynamic> attributes) async {
+      DateTime timestamp, String key, Map<String, dynamic> attributes) async {
     // NOOP
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/inv_metric_provider.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/inv_metric_provider.dart
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:meta/meta.dart';
+
+import '../../datadog_flutter_plugin.dart';
+import '../../datadog_internal.dart';
+
+// Max time in seconds
+const double defaultMaxTimeToNextView = 3.0;
+
+/// Tracks actions in views in order to provide a custom Interaction To Next View (INV)
+/// value. INV in Flutter is calculated as the time from when a user takes an action
+/// until the "First Build Complete" on a new view.
+class InvMetricProvider {
+  final Map<String, _InvViewInfo> _views = {};
+  // _curentView can hold a stopped view, so should not be used to see what the
+  // current active view is.
+  _InvViewInfo? _currentView;
+
+  void trackViewStart(String viewKey, DateTime timestamp) {
+    final newView = _InvViewInfo(viewKey, _currentView?.viewKey, timestamp);
+    if (_currentView case final currentView?) {
+      trackViewStop(currentView.viewKey, timestamp);
+    }
+    _currentView = newView;
+    _views[viewKey] = newView;
+  }
+
+  void trackViewStop(String viewKey, DateTime timestamp) {
+    final view = _views[viewKey];
+    if (view != null) {
+      view.endTime = timestamp;
+      if (view.previousViewKey case final previousViewKey?) {
+        // The view before this shouldn't be required anymore.
+        _views.remove(previousViewKey);
+      }
+    }
+  }
+
+  void trackAction(
+      String viewKey, DateTime startTime, RumActionType actionType) {
+    final view = _views[viewKey];
+    if (view == null) return;
+
+    view.actionLog.add(_AcitonInfo(startTime, actionType));
+  }
+
+  void trackViewFirstBuildComplete(String viewKey, DateTime timestamp) {
+    final view = _views[viewKey];
+    if (view == null) return;
+
+    view.firstBuildCompleteTime = timestamp;
+  }
+
+  /// Time in nanoseconds from the last interaction on the previous view to the moment the current view was finished building.
+  int? valueForView(String viewKey) {
+    final view = _views[viewKey];
+    if (view == null) return null;
+    if (view.previousViewKey == null) return null;
+    if (view.firstBuildCompleteTime == null) return null;
+
+    final previousView = _views[view.previousViewKey];
+    if (previousView == null) return null;
+
+    final lastAction = _findLastValidActionBefore(
+      view.firstBuildCompleteTime!,
+      previousView.actionLog,
+      defaultMaxTimeToNextView,
+    );
+    if (lastAction == null) return null;
+
+    final duration =
+        view.firstBuildCompleteTime!.difference(lastAction.startTime);
+
+    return duration.inNanoseconds;
+  }
+
+  // Max is in total seconds
+  _AcitonInfo? _findLastValidActionBefore(
+      DateTime time, List<_AcitonInfo> actions, double max) {
+    final maxDuration =
+        Duration(microseconds: (max * Duration.microsecondsPerSecond).toInt());
+    for (final action in actions.reversed) {
+      final duration = time.difference(action.startTime);
+      if (duration.isNegative) continue;
+
+      // Stuff from here back will be even older
+      if (duration > maxDuration) return null;
+
+      if (action.actionType == RumActionType.tap ||
+          action.actionType == RumActionType.swipe) {
+        return action;
+      }
+    }
+    return null;
+  }
+}
+
+class _InvViewInfo {
+  final String viewKey;
+  final String? previousViewKey;
+  final DateTime startTime;
+  DateTime? firstBuildCompleteTime;
+  DateTime? endTime;
+  double? invTime;
+
+  final List<_AcitonInfo> actionLog = [];
+
+  _InvViewInfo(this.viewKey, this.previousViewKey, this.startTime);
+}
+
+@immutable
+class _AcitonInfo {
+  final DateTime startTime;
+  final RumActionType actionType;
+
+  const _AcitonInfo(this.startTime, this.actionType);
+}

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -222,8 +222,8 @@ void main() {
 
     final targetLogCount = 1000 * (sampleRate / 100);
     // Should be target count with a 10% margin of error
-    expect(logCount, greaterThan(targetLogCount * .9));
-    expect(logCount, lessThan(targetLogCount * 1.1));
+    expect(logCount, greaterThan(targetLogCount * .8));
+    expect(logCount, lessThan(targetLogCount * 1.2));
   });
 
   group('threshold tests', () {

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -30,17 +30,15 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late DdRumMethodChannel ddRumPlatform;
-  MockTimeProvider timeProvider = MockTimeProvider();
   final List<MethodCall> log = [];
 
   final random = Random();
-  int randomizeTimestampMs() {
-    return random.nextInt(1 << 32);
+  DateTime randomTimestamp() {
+    return DateTime.fromMillisecondsSinceEpoch(random.nextInt(1 << 32));
   }
 
   setUp(() {
     ddRumPlatform = DdRumMethodChannel();
-    ddRumPlatform.timeProvider = timeProvider;
     ambiguate(TestDefaultBinaryMessengerBinding.instance)
         ?.defaultBinaryMessenger
         .setMockMethodCallHandler(ddRumPlatform.methodChannel, (message) {
@@ -66,9 +64,9 @@ void main() {
   });
 
   test('startView calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.startView('my_key', 'my_name', {'attribute': 'value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform
+        .startView(timestamp, 'my_key', 'my_name', {'attribute': 'value'});
 
     expect(log, [
       isMethodCall('startView', arguments: {
@@ -76,30 +74,31 @@ void main() {
         'name': 'my_name',
         'attributes': {
           'attribute': 'value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('stopView calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.stopView('my_key', {'stop_attribute': 'my_value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform
+        .stopView(timestamp, 'my_key', {'stop_attribute': 'my_value'});
 
     expect(log, [
       isMethodCall('stopView', arguments: {
         'key': 'my_key',
         'attributes': {
           'stop_attribute': 'my_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('addTiming calls to platform', () async {
-    await ddRumPlatform.addTiming('my timing name');
+    final timestamp = randomTimestamp();
+    await ddRumPlatform.addTiming(timestamp, 'my timing name');
 
     expect(log, [
       isMethodCall('addTiming', arguments: {'name': 'my timing name'})
@@ -115,10 +114,13 @@ void main() {
   });
 
   test('startResource calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.startResource('resource_key', RumHttpMethod.get,
-        'https://fakeresource.com/url', {'attribute_key': 'attribute_value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform.startResource(
+        timestamp,
+        'resource_key',
+        RumHttpMethod.get,
+        'https://fakeresource.com/url',
+        {'attribute_key': 'attribute_value'});
 
     expect(log, [
       isMethodCall('startResource', arguments: {
@@ -127,17 +129,16 @@ void main() {
         'url': 'https://fakeresource.com/url',
         'attributes': {
           'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('stopResource calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.stopResource('resource_key', 202, RumResourceType.image,
-        41123, {'attribute_key': 'attribute_value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform.stopResource(timestamp, 'resource_key', 202,
+        RumResourceType.image, 41123, {'attribute_key': 'attribute_value'});
 
     expect(log, [
       isMethodCall('stopResource', arguments: {
@@ -147,19 +148,18 @@ void main() {
         'size': 41123,
         'attributes': {
           'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('stopResourceWithError calls to platform with info', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
+    final timestamp = randomTimestamp();
     final exception = TimeoutException(
         'Timeout retrieving resource', const Duration(seconds: 5));
-    await ddRumPlatform.stopResourceWithError(
-        'resource_key', exception, {'attribute_key': 'attribute_value'});
+    await ddRumPlatform.stopResourceWithError(timestamp, 'resource_key',
+        exception, {'attribute_key': 'attribute_value'});
 
     expect(log, [
       isMethodCall('stopResourceWithError', arguments: {
@@ -168,16 +168,16 @@ void main() {
         'type': exception.runtimeType.toString(),
         'attributes': {
           'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('stopResourceWithErrorInfo calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
+    final timestamp = randomTimestamp();
     await ddRumPlatform.stopResourceWithErrorInfo(
+        timestamp,
         'resource_key',
         'Exception message',
         'Exception type',
@@ -190,19 +190,18 @@ void main() {
         'type': 'Exception type',
         'attributes': {
           'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('addError calls to platform with info', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
+    final timestamp = randomTimestamp();
     final exception = TimeoutException(
         'Timeout retrieving resource', const Duration(seconds: 5));
-    await ddRumPlatform.addError(exception, RumErrorSource.source, null,
-        'error_type', {'attribute_key': 'attribute_value'});
+    await ddRumPlatform.addError(timestamp, exception, RumErrorSource.source,
+        null, 'error_type', {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -213,15 +212,19 @@ void main() {
     expect(call.arguments['errorType'], 'error_type');
     expect(call.arguments['attributes'], {
       'attribute_key': 'attribute_value',
-      '_dd.timestamp': timestamp,
+      '_dd.timestamp': timestamp.millisecondsSinceEpoch,
     });
   });
 
   test('addErrorInfo calls to platform with info', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.addErrorInfo('Exception message', RumErrorSource.source,
-        null, 'error_type', {'attribute_key': 'attribute_value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform.addErrorInfo(
+        timestamp,
+        'Exception message',
+        RumErrorSource.source,
+        null,
+        'error_type',
+        {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -232,18 +235,17 @@ void main() {
     expect(call.arguments['errorType'], 'error_type');
     expect(call.arguments['attributes'], {
       'attribute_key': 'attribute_value',
-      '_dd.timestamp': timestamp,
+      '_dd.timestamp': timestamp.millisecondsSinceEpoch,
     });
   });
 
   test('addError passes stack trace string', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
+    final timestamp = randomTimestamp();
     final stackTrace = StackTrace.current;
     final exception = TimeoutException(
         'Timeout retrieving resource', const Duration(seconds: 5));
-    await ddRumPlatform.addError(exception, RumErrorSource.source, stackTrace,
-        null, {'attribute_key': 'attribute_value'});
+    await ddRumPlatform.addError(timestamp, exception, RumErrorSource.source,
+        stackTrace, null, {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -254,16 +256,20 @@ void main() {
     expect(call.arguments['errorType'], isNull);
     expect(call.arguments['attributes'], {
       'attribute_key': 'attribute_value',
-      '_dd.timestamp': timestamp,
+      '_dd.timestamp': timestamp.millisecondsSinceEpoch,
     });
   });
 
   test('addErrorInfo passes stack trace string', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
+    final timestamp = randomTimestamp();
     final stackTrace = StackTrace.current;
-    await ddRumPlatform.addErrorInfo('Exception message', RumErrorSource.source,
-        stackTrace, 'error_type', {'attribute_key': 'attribute_value'});
+    await ddRumPlatform.addErrorInfo(
+        timestamp,
+        'Exception message',
+        RumErrorSource.source,
+        stackTrace,
+        'error_type',
+        {'attribute_key': 'attribute_value'});
 
     expect(log.length, 1);
     final call = log.first;
@@ -274,14 +280,14 @@ void main() {
     expect(call.arguments['errorType'], 'error_type');
     expect(call.arguments['attributes'], {
       'attribute_key': 'attribute_value',
-      '_dd.timestamp': timestamp,
+      '_dd.timestamp': timestamp.millisecondsSinceEpoch,
     });
   });
 
   test('addAction calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.addAction(RumActionType.tap, 'fake_user_action', {
+    final timestamp = randomTimestamp();
+    await ddRumPlatform
+        .addAction(timestamp, RumActionType.tap, 'fake_user_action', {
       'attribute_name': 'attribute_value',
     });
 
@@ -291,17 +297,16 @@ void main() {
         'name': 'fake_user_action',
         'attributes': {
           'attribute_name': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('startAction calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.startAction(RumActionType.scroll, 'user_action_scroll',
-        {'attribute_name': 'attribute_value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform.startAction(timestamp, RumActionType.scroll,
+        'user_action_scroll', {'attribute_name': 'attribute_value'});
 
     expect(log, [
       isMethodCall('startAction', arguments: {
@@ -309,17 +314,16 @@ void main() {
         'name': 'user_action_scroll',
         'attributes': {
           'attribute_name': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);
   });
 
   test('stopAction calls to platform', () async {
-    final timestamp = randomizeTimestampMs();
-    when(() => timeProvider.nowMs()).thenReturn(timestamp);
-    await ddRumPlatform.stopAction(RumActionType.swipe, 'user_action_swipe',
-        {'attribute_name': 'attribute_value'});
+    final timestamp = randomTimestamp();
+    await ddRumPlatform.stopAction(timestamp, RumActionType.swipe,
+        'user_action_swipe', {'attribute_name': 'attribute_value'});
 
     expect(log, [
       isMethodCall('stopAction', arguments: {
@@ -327,7 +331,7 @@ void main() {
         'name': 'user_action_swipe',
         'attributes': {
           'attribute_name': 'attribute_value',
-          '_dd.timestamp': timestamp,
+          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
         }
       })
     ]);

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -5,7 +5,8 @@
 import 'dart:io';
 import 'dart:math';
 
-import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_common_test/datadog_common_test.dart'
+    hide DurationHelpers;
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_noop_platform.dart';
@@ -341,9 +342,9 @@ void main() {
 
       when(() => mockRumPlatform.enable(any(), any()))
           .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.startView(any(), any(), any()))
+      when(() => mockRumPlatform.startView(any(), any(), any(), any()))
           .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.stopView(any(), any()))
+      when(() => mockRumPlatform.stopView(any(), any(), any()))
           .thenAnswer((_) => Future.value());
       when(() => mockRumPlatform.addAttribute(any(), any()))
           .thenAnswer((_) => Future.value());
@@ -395,6 +396,87 @@ void main() {
 
       verifyNever(() => mockRumPlatform.setInternalViewAttribute(
           '_dd.performance.first_build_complete', any()));
+    });
+  });
+
+  group('interaction to next view', () {
+    late DatadogRum rum;
+    final random = Random();
+    final mockTimeProvider = MockTimeProvider();
+
+    setUp(() async {
+      DdRumPlatform.instance = mockRumPlatform;
+      final rumConfiguration = DatadogRumConfiguration(
+        applicationId: 'applicationId',
+        traceSampleRate: 23,
+        detectLongTasks: false,
+      );
+
+      registerFallbackValue(RumActionType.custom);
+
+      when(() => mockRumPlatform.enable(any(), any()))
+          .thenAnswer((_) => Future.value());
+      when(() => mockRumPlatform.startView(any(), any(), any(), any()))
+          .thenAnswer((_) => Future.value());
+      when(() => mockRumPlatform.stopView(any(), any(), any()))
+          .thenAnswer((_) => Future.value());
+      when(() => mockRumPlatform.addAction(any(), any(), any(), any()))
+          .thenAnswer((_) => Future.value());
+      when(() => mockRumPlatform.addAttribute(any(), any()))
+          .thenAnswer((_) => Future.value());
+
+      rum = (await DatadogRum.enable(mockDatadogSdk, rumConfiguration))!;
+      rum.timeProvider = mockTimeProvider;
+    });
+
+    test('markFirstBuildComplete sets inv attribute', () {
+      // Given
+      final startTime = DateTime.now();
+      final actionTime = startTime.add(Duration(seconds: 1));
+      final startTime2 = actionTime.add(Duration(milliseconds: 10));
+      final fbcTime =
+          startTime2.add(Duration(microseconds: random.nextInt(1 << 8)));
+      final timeAnswers = [
+        startTime,
+        actionTime,
+        startTime2,
+        fbcTime,
+      ];
+      when(() => mockTimeProvider.now())
+          .thenAnswer((_) => timeAnswers.removeAt(0));
+
+      // When
+      rum.startView('test_view');
+      rum.addAction(RumActionType.tap, 'Test Action');
+      rum.startView('test_view_2');
+      rum.markViewFirstBuildComplete('test_view_2');
+
+      verify(() => mockRumPlatform.setInternalViewAttribute(
+          '_dd.view.custom_inv_value',
+          (fbcTime.difference(actionTime)).inNanoseconds));
+    });
+
+    test('markFirstBuildComplete does not set inv attribute if missing', () {
+      // Given
+      final startTime = DateTime.now();
+      final startTime2 = startTime.add(Duration(seconds: 10));
+      final fbcTime =
+          startTime2.add(Duration(microseconds: random.nextInt(1 << 8)));
+      final timeAnswers = [
+        startTime,
+        startTime2,
+        fbcTime,
+      ];
+      when(() => mockTimeProvider.now())
+          .thenAnswer((_) => timeAnswers.removeAt(0));
+
+      // When
+      rum.startView('test_view');
+      rum.startView('test_view_2');
+      rum.markViewFirstBuildComplete('test_view_2');
+
+      verifyNever(() => mockRumPlatform.setInternalViewAttribute(
+          '_dd.view.custom_inv_value', any()));
     });
   });
 }

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -429,7 +429,7 @@ void main() {
       rum.timeProvider = mockTimeProvider;
     });
 
-    test('markFirstBuildComplete sets inv attribute', () {
+    test('markViewFirstBuildComplete sets inv attribute', () {
       // Given
       final startTime = DateTime.now();
       final actionTime = startTime.add(Duration(seconds: 1));
@@ -456,7 +456,7 @@ void main() {
           (fbcTime.difference(actionTime)).inNanoseconds));
     });
 
-    test('markFirstBuildComplete does not set inv attribute if missing', () {
+    test('markViewFirstBuildComplete does not set inv attribute if missing', () {
       // Given
       final startTime = DateTime.now();
       final startTime2 = startTime.add(Duration(seconds: 10));

--- a/packages/datadog_flutter_plugin/test/rum/inv_metric_provider_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/inv_metric_provider_test.dart
@@ -1,0 +1,172 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
+import 'package:datadog_flutter_plugin/src/rum/inv_metric_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const defaultFirstBuildTime = Duration(milliseconds: 38);
+
+void main() {
+  final baseStartTime = DateTime.now();
+
+  group('inv metric provider', () {
+    test('null value for unknown view', () {
+      // Given
+      final provider = InvMetricProvider();
+
+      // When
+      final value = provider.valueForView('unknown');
+
+      // Then
+      expect(value, isNull);
+    });
+
+    test('null value for view with no previous view', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+
+      // When
+      final value = provider.valueForView('view1');
+
+      // Then
+      expect(value, isNull);
+    });
+
+    test('null value for view with previous view with no actions', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final secondViewStart =
+          baseStartTime.add(Duration(minutes: 1, seconds: 10));
+      startView(provider, 'view2', secondViewStart);
+
+      // When
+      final value = provider.valueForView('view2');
+
+      // Then
+      expect(value, isNull);
+    });
+
+    test('provides value for inv when action on previous view', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final actionTime = baseStartTime.add(Duration(seconds: 4));
+      final nextViewTime = actionTime.add(Duration(milliseconds: 10));
+      provider.trackAction('view1', actionTime, RumActionType.tap);
+      startView(provider, 'view2', nextViewTime);
+
+      // When
+      final value = provider.valueForView('view2');
+
+      // Then
+      final expectedValue =
+          Duration(milliseconds: 10 + defaultFirstBuildTime.inMilliseconds)
+              .inNanoseconds;
+      expect(value, expectedValue);
+    });
+
+    test('null value when lacking FBC', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final actionTime = baseStartTime.add(Duration(seconds: 4));
+      final nextViewTime = actionTime.add(Duration(milliseconds: 10));
+      provider.trackAction('view1', actionTime, RumActionType.tap);
+      provider.trackViewStart('view2', nextViewTime);
+
+      // When
+      final value = provider.valueForView('view2');
+
+      // Then
+      expect(value, isNull);
+    });
+
+    test('provides value for last action on previous view', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final actionTime = baseStartTime.add(Duration(seconds: 4));
+      final stopTime = actionTime.add(Duration(milliseconds: 10));
+      final nextViewTime = stopTime.add(Duration(milliseconds: 10));
+      provider.trackAction('view1', actionTime, RumActionType.tap);
+      provider.trackViewStop('view1', stopTime);
+      startView(provider, 'view2', nextViewTime);
+
+      // When
+      final value = provider.valueForView('view2');
+
+      // Then
+      final expectedValue =
+          Duration(milliseconds: 20 + defaultFirstBuildTime.inMilliseconds)
+              .inNanoseconds;
+      expect(value, expectedValue);
+    });
+
+    test('null value when action is older than tolerance', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final actionTime = baseStartTime.add(Duration(seconds: 5));
+      final nextViewTime = actionTime
+          .add(Duration(seconds: (defaultMaxTimeToNextView + 1).toInt()));
+      provider.trackAction('view1', actionTime, RumActionType.tap);
+      startView(provider, 'view2', nextViewTime);
+
+      // When
+      final value = provider.valueForView('view2');
+
+      // Then
+      expect(value, isNull);
+    });
+
+    test('provides value when previous view manually stopped', () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final actionTime = baseStartTime.add(Duration(seconds: 5));
+      final nextViewTime = actionTime
+          .add(Duration(seconds: (defaultMaxTimeToNextView + 1).toInt()));
+      provider.trackAction('view1', actionTime, RumActionType.tap);
+      startView(provider, 'view2', nextViewTime);
+
+      // When
+      final value = provider.valueForView('view2');
+
+      // Then
+      expect(value, isNull);
+    });
+
+    test('null value when previous view has no actions {older view exists}',
+        () {
+      // Given
+      final provider = InvMetricProvider();
+      startView(provider, 'view1', baseStartTime);
+      final actionTime = baseStartTime.add(Duration(seconds: 5));
+      final secondViewTime = actionTime
+          .add(Duration(seconds: (defaultMaxTimeToNextView + 1).toInt()));
+      provider.trackAction('view1', actionTime, RumActionType.tap);
+      startView(provider, 'view2', secondViewTime);
+      final thirdViewTime = secondViewTime.add(Duration(seconds: 1));
+      startView(provider, 'view3', thirdViewTime);
+
+      // When
+      final value = provider.valueForView('view3');
+
+      // Then
+      expect(value, isNull);
+    });
+  });
+}
+
+// Helper methods
+void startView(InvMetricProvider provider, String viewKey, DateTime startTime,
+    {Duration firstBuildCompleteTime = defaultFirstBuildTime}) {
+  provider.trackViewStart(viewKey, startTime);
+  final firstBuildComplete = startTime.add(firstBuildCompleteTime);
+  provider.trackViewFirstBuildComplete(viewKey, firstBuildComplete);
+}


### PR DESCRIPTION
### What and why?

Interaction To Next View measures the time from a user action, like a tap, until the next view is visible. On native platforms, this is timed until `startView` is called. However, in Flutter `startView` is called as soon as a route changes, before the view is visible to the user.

So, instead, Flutter measures the time from a user interaction until the completion of a view's "first build" (the FBC metric) and sets this as a `custom INV` value.

Because this calculation is so different from the native platforms, Flutter disables native INV calculations.

refs: RUM-8227

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
