### PR TITLE
Making siteStringForSite() handle AP1 datadog site to be able to send logs to AP1 orgs

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -21,6 +21,8 @@ String siteStringForSite(DatadogSite? site) {
       return 'datadoghq.eu';
     case DatadogSite.us1Fed:
       return 'ddog-gov.com';
+    case DatadogSite.ap1:
+      return 'ap1.datadoghq.com';
     default:
       return 'datadoghq.com';
   }


### PR DESCRIPTION
This would make the code work with Datadog orgs belonging to AP1 region as well as other region's orgs.

### What and why?

siteStringForSite() currently couldn't handle `DatadogSite.ap1` as `site` argument, which result in defaulted to `datadoghq.com` as return value and failure sending logs to AP1 orgs.

### How?

`siteStringForSite()` would be able to properly return `ap1.datadoghq.com` in case of `DatadogSite.ap1` value is passed as arg.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
