### PR TITLE
feat: Upgrade gson to 2.12.1

### DIFF
--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation "com.datadoghq:dd-sdk-android-ndk:$datadog_version"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.code.gson:gson:2.8.8"
+    implementation "com.google.code.gson:gson:2.12.1"
 
     testImplementation(platform("org.junit:junit-bom:5.8.2"))
     testImplementation "org.junit.jupiter:junit-jupiter"

--- a/packages/datadog_inappwebview_tracking/android/build.gradle
+++ b/packages/datadog_inappwebview_tracking/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
     dependencies {
         implementation "com.datadoghq:dd-sdk-android-webview:$datadog_version"
-        implementation "com.google.code.gson:gson:2.8.8"
+        implementation "com.google.code.gson:gson:2.12.1"
 
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")


### PR DESCRIPTION
### What and why?

Upgrade gson to 2.12.1

refs: #725

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
