### PR TITLE
feat: Add configuration option for anonymous user tracking

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -504,6 +504,9 @@ fun RumConfiguration.Builder.withEncoded(encoded: Map<String, Any?>): RumConfigu
     (encoded["trackNonFatalAnrs"] as? Boolean)?.let {
         builder = builder.trackNonFatalAnrs(it)
     }
+    (encoded["trackAnonymousUser"] as? Boolean)?.let {
+        builder = builder.trackAnonymousUser(it)
+    }
     (encoded["initialResourceThreshold"] as? Number)?.let {
         val milliseconds = it.toDouble().seconds.inWholeMilliseconds
         builder = builder.setInitialResourceIdentifier(

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -170,12 +170,14 @@ class DatadogRumPluginTest {
     ) {
         // GIVEN
         val trackNonFatalAnrs = forge.aNullable { forge.aBool() }
+        val trackAnonymousUser = forge.aBool()
         val attributes = forge.exhaustiveAttributes()
         val configArg = mapOf(
             "sessionSampleRate" to sessionSampleRate,
             "longTaskThreshold" to longTaskThreshold,
             "trackFrustrations" to trackFrustration,
             "trackNonFatalAnrs" to trackNonFatalAnrs,
+            "trackAnonymousUser" to trackAnonymousUser,
             "initialResourceThreshold" to initialResourceThreshold,
             "customEndpoint" to endpoint,
             "vitalsUpdateFrequency" to "VitalsFrequency.frequent",
@@ -198,6 +200,7 @@ class DatadogRumPluginTest {
             // If null, default shouldn't be changed. Tests are run on a version that enables ANR tracking by default
             assertThat(featureConfiguration.getPrivate("trackNonFatalAnrs")).isEqualTo(true)
         }
+        assertThat(featureConfiguration.getPrivate("trackAnonymousUser")).isEqualTo(trackAnonymousUser)
         val initialResourceIdentifier = featureConfiguration.getPrivate("initialResourceIdentifier") as? TimeBasedInitialResourceIdentifier
         assertThat(initialResourceIdentifier).isNotNull()
         // The threshold is converted to configured in milliseconds, but held in nanoseconds.

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -195,6 +195,17 @@ class DatadogRumPluginTests: XCTestCase {
         XCTAssertEqual(predicate.threshold, initialResourceThreshold)
     }
 
+    func testRumConfiguration_WithTrackAnonymousUser_IsSetCorrectly() {
+        let trackAnonymousUser = Bool.mockRandom()
+        let encoded: [String: Any?] = [
+            "applicationId": "fake-application-id",
+            "trackAnonymousUser": trackAnonymousUser
+        ]
+
+        let config = RUM.Configuration.init(fromEncoded: encoded)
+        XCTAssertEqual(config?.trackAnonymousUser, trackAnonymousUser)
+    }
+
     func testRepeatEnable_FromMethodChannelSameOptions_DoesNothing() {
         // Uninitialize plugin
         plugin?.inject(rum: nil)

--- a/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/Classes/DatadogRumPlugin.swift
@@ -22,6 +22,7 @@ public extension RUM.Configuration {
         sessionSampleRate = (encoded["sessionSampleRate"] as? NSNumber)?.floatValue ?? 100.0
         longTaskThreshold = (encoded["longTaskThreshold"] as? NSNumber)?.doubleValue ?? 0.1
         trackFrustrations = (encoded["trackFrustrations"] as? NSNumber)?.boolValue ?? true
+        trackAnonymousUser = (encoded["trackAnonymousUser"] as? NSNumber)?.boolValue ?? true
         if let appHangThreshold = (encoded["appHangThreshold"] as? NSNumber)?.doubleValue {
             self.appHangThreshold = appHangThreshold
         }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -156,6 +156,15 @@ class DatadogRumConfiguration {
   /// Defaults to disabled (`null`).
   double? appHangThreshold;
 
+  /// Enables collection of anonymous user id across sessions.
+  ///
+  /// When enabled, the SDK generates a unique, non-personal anonymous user ID that is persisted across
+  /// app launches. This ID will be attached to each RUM Session, allowing you to link sessions
+  /// originating from the same user/device without collecting personal data.
+  ///
+  /// Defaults to `true`.
+  bool trackAnonymousUser = true;
+
   /// The amount of time after a view starts where a Resource should be
   /// considered when calculating Time to Network-Settled (TNS). TNS will be
   /// calculated using all resources that start withing the specified threshold,
@@ -204,6 +213,7 @@ class DatadogRumConfiguration {
     this.reportFlutterPerformance = false,
     this.trackNonFatalAnrs,
     this.appHangThreshold,
+    this.trackAnonymousUser = true,
     this.initialResourceThreshold = 0.1,
     this.customEndpoint,
     this.telemetrySampleRate = 20.0,
@@ -228,6 +238,7 @@ class DatadogRumConfiguration {
       'reportFlutterPerformance': reportFlutterPerformance,
       'trackNonFatalAnrs': trackNonFatalAnrs,
       'appHangThreshold': appHangThreshold,
+      'trackAnonymousUser': trackAnonymousUser,
       'initialResourceThreshold': initialResourceThreshold,
       'customEndpoint': customEndpoint,
       'telemetrySampleRate': telemetrySampleRate,

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -156,7 +156,7 @@ class DatadogRumConfiguration {
   /// Defaults to disabled (`null`).
   double? appHangThreshold;
 
-  /// Enables collection of anonymous user id across sessions.
+  /// Enables collection of anonymous user ID across sessions.
   ///
   /// When enabled, the SDK generates a unique, non-personal anonymous user ID that is persisted across
   /// app launches. This ID will be attached to each RUM Session, allowing you to link sessions

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -98,6 +98,7 @@ void main() {
       vitalUpdateFrequency: vitalUpdateFrequency,
       trackNonFatalAnrs: false,
       appHangThreshold: 0.332,
+      trackAnonymousUser: false,
       initialResourceThreshold: 1.23,
       customEndpoint: customEndpoint,
     );
@@ -110,6 +111,7 @@ void main() {
     expect(encoded['trackFrustrations'], trackFrustrations);
     expect(encoded['vitalsUpdateFrequency'], vitalUpdateFrequency.toString());
     expect(encoded['trackNonFatalAnrs'], false);
+    expect(encoded['trackAnonymousUser'], false);
     expect(encoded['appHangThreshold'], 0.332);
     expect(encoded['customEndpoint'], customEndpoint);
     expect(encoded['initialResourceThreshold'], 1.23);
@@ -456,7 +458,8 @@ void main() {
           (fbcTime.difference(actionTime)).inNanoseconds));
     });
 
-    test('markViewFirstBuildComplete does not set inv attribute if missing', () {
+    test('markViewFirstBuildComplete does not set inv attribute if missing',
+        () {
       // Given
       final startTime = DateTime.now();
       final startTime2 = startTime.add(Duration(seconds: 10));


### PR DESCRIPTION
### What and why?

iOS and Android SDKs added the ability to generate an anonymous user id for tracking. This is enabled by default. Add a configuration option to enable disabling this feature.

refs: RUM-8659

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
