### PR TITLE
chore: Cherrypick changelog changes from point releases

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.10.2
+
+* Add missing `AP1` support to Flutter Web.
+
+## 2.10.1
+
+* Fix iOS compilation for Flutter 3.29
+
 ## 2.10.0
 
 * Support for `datadog_inappwebview_tracking`. See [#624](https://github.com/DataDog/dd-sdk-flutter/issues/624).


### PR DESCRIPTION
### What and why?

Adding changelog changes from 2.10.2 and 2.10.1 point releases to the main changelog.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
