### PR TITLE
fix: Specify android SDK version in datadog_inappwebview_tracking

### DIFF
--- a/packages/datadog_inappwebview_tracking/android/build.gradle
+++ b/packages/datadog_inappwebview_tracking/android/build.gradle
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.8.22"
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.16.0"
 
     repositories {
         google()


### PR DESCRIPTION
### What and why?

Currently this package pulls the latest version, which it shouldn't as that can introduce incompatibilities with the Core package.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
