### PR TITLE
fix: Specify android SDK version in datadog_inappwebview_tracking

### DIFF
--- a/packages/datadog_inappwebview_tracking/android/build.gradle
+++ b/packages/datadog_inappwebview_tracking/android/build.gradle
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.8.22"
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.16.0"
 
     repositories {
         google()


### PR DESCRIPTION
### What and why?

This is to bring this version pin to the 1.0.x release train of `datadog_inappwebview_tracking`.  The 1.0.x train and 1.1.x train still need to be separate because of an unreleased fix only in the beta releases of `flutter_inappwebview`.

### How?

Currently this package pulls the latest version, which it shouldn't as that can introduce incompatibilities with the Core package.

(cherry picked from commit 610231223527fe80de6460ad2b1651f3efe16d4a)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
