### PR TITLE
fix: Fix an issue where nested gesture detectors would always use the topmost.

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -34,9 +34,15 @@ class _ElementDescription {
   }
 
   bool betterThan(_ElementDescription? other) {
-    // Literally anything is better than GestureDetector
-    if (element.widget is GestureDetector && other != null) {
-      return false;
+    if (other == null) {
+      // Something is always better than nothing
+      return true;
+    }
+
+    // Literally anything is better than GestureDetector...
+    if (element.widget is GestureDetector) {
+      // ... except another GestureDetector
+      return other.element.widget is GestureDetector;
     }
 
     return true;

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -221,6 +221,44 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
+  testWidgets('nested tap gesture detector uses lowest in tree',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final firstAnnotation = randomString();
+    final firstButtonText = randomString();
+    final secondButtonText = randomString();
+    final secondAnnotation = randomString();
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      RumUserActionAnnotation(
+        description: firstAnnotation,
+        child: GestureDetector(
+          onTap: () {},
+          child: Column(children: [
+            Text(firstButtonText),
+            RumUserActionAnnotation(
+              description: secondAnnotation,
+              child: GestureDetector(
+                onTap: () {},
+                child: Text(secondButtonText),
+              ),
+            ),
+          ]),
+        ),
+      ),
+    ));
+
+    final text = find.byWidgetPredicate(
+        (widget) => widget is Text && widget.data == secondButtonText);
+    await tester.tap(text);
+
+    verify(() => mockRum.addAction(
+        RumActionType.tap, 'GestureDetector($secondAnnotation)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
   testWidgets('tap button with annotation reports annotation over text',
       (tester) async {
     final mockRum = MockDdRum();


### PR DESCRIPTION
### What and why?

`betterThan` always assumed that the currently held element was better if it was comparing to a `GestureDetector`, but this is incorrect if it was comparing itself to another `GestureDetector`. In that case, the detector lower down the tree should take precedence.

refs: #738

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
