### PR TITLE
feat: Add iOS overhead for SessionReplayFeature

### DIFF
--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -1,0 +1,70 @@
+PODS:
+  - datadog_flutter_plugin (0.0.1):
+    - DatadogCore (= 2.25.0)
+    - DatadogCrashReporting (= 2.25.0)
+    - DatadogInternal (= 2.25.0)
+    - DatadogLogs (= 2.25.0)
+    - DatadogRUM (= 2.25.0)
+    - DictionaryCoder (= 1.0.8)
+    - Flutter
+  - datadog_session_replay (0.0.1):
+    - DatadogCore (~> 2)
+    - Flutter
+  - DatadogCore (2.25.0):
+    - DatadogInternal (= 2.25.0)
+  - DatadogCrashReporting (2.25.0):
+    - DatadogInternal (= 2.25.0)
+    - PLCrashReporter (~> 1.12.0)
+  - DatadogInternal (2.25.0)
+  - DatadogLogs (2.25.0):
+    - DatadogInternal (= 2.25.0)
+  - DatadogRUM (2.25.0):
+    - DatadogInternal (= 2.25.0)
+  - DictionaryCoder (1.0.8)
+  - Flutter (1.0.0)
+  - integration_test (0.0.1):
+    - Flutter
+  - PLCrashReporter (1.12.0)
+
+DEPENDENCIES:
+  - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
+  - datadog_session_replay (from `.symlinks/plugins/datadog_session_replay/ios`)
+  - Flutter (from `Flutter`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
+
+SPEC REPOS:
+  trunk:
+    - DatadogCore
+    - DatadogCrashReporting
+    - DatadogInternal
+    - DatadogLogs
+    - DatadogRUM
+    - DictionaryCoder
+    - PLCrashReporter
+
+EXTERNAL SOURCES:
+  datadog_flutter_plugin:
+    :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
+  datadog_session_replay:
+    :path: ".symlinks/plugins/datadog_session_replay/ios"
+  Flutter:
+    :path: Flutter
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
+
+SPEC CHECKSUMS:
+  datadog_flutter_plugin: 0536db97da04dda6e0198a732efb599a179cd316
+  datadog_session_replay: 50aac665d5a87dc45b9cb2df38c779e6cf43f9b0
+  DatadogCore: a068d264191f687d00125aafa8042110cf886cd7
+  DatadogCrashReporting: b19d80a98b1eb51bdb3ec5b1a7f339769fb70b95
+  DatadogInternal: e9b6cef84448ee32f73bc9b37646708a65c1b8ae
+  DatadogLogs: 623d89158ef3a4a7545a8fbce9afa4cedc576324
+  DatadogRUM: ff0661b42124d90c9ff2538c3cc1b806ddf7620c
+  DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
+
+PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
+
+COCOAPODS: 1.16.2

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,13 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		494123582DC129660071423F /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494123572DC129630071423F /* RequestBuilderTests.swift */; };
+		495A027A2DCE433800869BEA /* ResultStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A02782DCE433800869BEA /* ResultStatus.swift */; };
+		495A02822DCE433B00869BEA /* DatadogContextMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A027B2DCE433B00869BEA /* DatadogContextMock.swift */; };
+		495A02832DCE433B00869BEA /* DatadogCoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A027C2DCE433B00869BEA /* DatadogCoreMock.swift */; };
+		495A02842DCE433B00869BEA /* FileWriterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A027D2DCE433B00869BEA /* FileWriterMock.swift */; };
+		495A02852DCE433B00869BEA /* FlutterMethodChannelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A027E2DCE433B00869BEA /* FlutterMethodChannelMock.swift */; };
+		495A02862DCE433B00869BEA /* FoundationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A027F2DCE433B00869BEA /* FoundationMocks.swift */; };
+		495A02872DCE433B00869BEA /* MultipartBuilderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */; };
 		49C3AB392DB985A7000D8F6E /* FlutterSessionReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0E33B2DB97BC7007B7DA1 /* FlutterSessionReplayTests.swift */; };
 		49C3AB492DBBC546000D8F6E /* DatadogSessionReplayPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C3AB482DBBC534000D8F6E /* DatadogSessionReplayPluginTests.swift */; };
 		49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */; };
@@ -54,6 +61,13 @@
 		38C1E02D31D6D70F9A6DF3EB /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		494123572DC129630071423F /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
+		495A02782DCE433800869BEA /* ResultStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultStatus.swift; sourceTree = "<group>"; };
+		495A027B2DCE433B00869BEA /* DatadogContextMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogContextMock.swift; sourceTree = "<group>"; };
+		495A027C2DCE433B00869BEA /* DatadogCoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogCoreMock.swift; sourceTree = "<group>"; };
+		495A027D2DCE433B00869BEA /* FileWriterMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWriterMock.swift; sourceTree = "<group>"; };
+		495A027E2DCE433B00869BEA /* FlutterMethodChannelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterMethodChannelMock.swift; sourceTree = "<group>"; };
+		495A027F2DCE433B00869BEA /* FoundationMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundationMocks.swift; sourceTree = "<group>"; };
+		495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartBuilderSpy.swift; sourceTree = "<group>"; };
 		49C3AB482DBBC534000D8F6E /* DatadogSessionReplayPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogSessionReplayPluginTests.swift; sourceTree = "<group>"; };
 		49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayFeatureTests.swift; sourceTree = "<group>"; };
 		49F0E33B2DB97BC7007B7DA1 /* FlutterSessionReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayTests.swift; sourceTree = "<group>"; };
@@ -72,19 +86,6 @@
 		D327F0021DD9C18C84836E84 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		F5E3BBC8740D961C9BCAB645 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		49C3AB3E2DBBBF68000D8F6E /* Mocks */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Mocks;
-			sourceTree = "<group>";
-		};
-		49C3AB4A2DBBC79D000D8F6E /* Helpers */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = Helpers;
-			sourceTree = "<group>";
-		};
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
@@ -126,10 +127,31 @@
 				49C3AB482DBBC534000D8F6E /* DatadogSessionReplayPluginTests.swift */,
 				49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */,
 				49F0E33B2DB97BC7007B7DA1 /* FlutterSessionReplayTests.swift */,
-				49C3AB4A2DBBC79D000D8F6E /* Helpers */,
-				49C3AB3E2DBBBF68000D8F6E /* Mocks */,
+				495A02792DCE433800869BEA /* Helpers */,
+				495A02812DCE433B00869BEA /* Mocks */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		495A02792DCE433800869BEA /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				495A02782DCE433800869BEA /* ResultStatus.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+		495A02812DCE433B00869BEA /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				495A027B2DCE433B00869BEA /* DatadogContextMock.swift */,
+				495A027C2DCE433B00869BEA /* DatadogCoreMock.swift */,
+				495A027D2DCE433B00869BEA /* FileWriterMock.swift */,
+				495A027E2DCE433B00869BEA /* FlutterMethodChannelMock.swift */,
+				495A027F2DCE433B00869BEA /* FoundationMocks.swift */,
+				495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		76CABD408CF658ABADE57D5E /* Frameworks */ = {
@@ -205,10 +227,6 @@
 			dependencies = (
 				331C8086294A63A400263BE5 /* PBXTargetDependency */,
 			);
-			fileSystemSynchronizedGroups = (
-				49C3AB3E2DBBBF68000D8F6E /* Mocks */,
-				49C3AB4A2DBBC79D000D8F6E /* Helpers */,
-			);
 			name = RunnerTests;
 			productName = RunnerTests;
 			productReference = 331C8081294A63A400263BE5 /* RunnerTests.xctest */;
@@ -265,6 +283,7 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -415,6 +434,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				49C3AB392DB985A7000D8F6E /* FlutterSessionReplayTests.swift in Sources */,
+				495A02822DCE433B00869BEA /* DatadogContextMock.swift in Sources */,
+				495A02832DCE433B00869BEA /* DatadogCoreMock.swift in Sources */,
+				495A02842DCE433B00869BEA /* FileWriterMock.swift in Sources */,
+				495A02852DCE433B00869BEA /* FlutterMethodChannelMock.swift in Sources */,
+				495A02862DCE433B00869BEA /* FoundationMocks.swift in Sources */,
+				495A02872DCE433B00869BEA /* MultipartBuilderSpy.swift in Sources */,
+				495A027A2DCE433800869BEA /* ResultStatus.swift in Sources */,
 				494123582DC129660071423F /* RequestBuilderTests.swift in Sources */,
 				49C3AB492DBBC546000D8F6E /* DatadogSessionReplayPluginTests.swift in Sources */,
 				49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */,

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,16 +3,22 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		494123582DC129660071423F /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494123572DC129630071423F /* RequestBuilderTests.swift */; };
+		49C3AB392DB985A7000D8F6E /* FlutterSessionReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F0E33B2DB97BC7007B7DA1 /* FlutterSessionReplayTests.swift */; };
+		49C3AB492DBBC546000D8F6E /* DatadogSessionReplayPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C3AB482DBBC534000D8F6E /* DatadogSessionReplayPluginTests.swift */; };
+		49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		9F293130235B212EE1AE4E5B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38C1E02D31D6D70F9A6DF3EB /* Pods_RunnerTests.framework */; };
+		A0D62814D39A1A1BA42E6637 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52DEE038B4A35E8180AB59CE /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,10 +45,19 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		041F02A43357916B8D140259 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		0CE0EE836C4443BF8846D6AD /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		0EF22621A2187FC8842491D8 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		38C1E02D31D6D70F9A6DF3EB /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		494123572DC129630071423F /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
+		49C3AB482DBBC534000D8F6E /* DatadogSessionReplayPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogSessionReplayPluginTests.swift; sourceTree = "<group>"; };
+		49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayFeatureTests.swift; sourceTree = "<group>"; };
+		49F0E33B2DB97BC7007B7DA1 /* FlutterSessionReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayTests.swift; sourceTree = "<group>"; };
+		52DEE038B4A35E8180AB59CE /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -53,24 +68,77 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ABB51620DF3550231B6AF683 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		D327F0021DD9C18C84836E84 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F5E3BBC8740D961C9BCAB645 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		49C3AB3E2DBBBF68000D8F6E /* Mocks */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		49C3AB4A2DBBC79D000D8F6E /* Helpers */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Helpers;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A0D62814D39A1A1BA42E6637 /* Pods_Runner.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A7D59CBE4A3F7A47600FDEF9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9F293130235B212EE1AE4E5B /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0BB2D78FFBA055BE1B719106 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0CE0EE836C4443BF8846D6AD /* Pods-Runner.debug.xcconfig */,
+				041F02A43357916B8D140259 /* Pods-Runner.release.xcconfig */,
+				F5E3BBC8740D961C9BCAB645 /* Pods-Runner.profile.xcconfig */,
+				D327F0021DD9C18C84836E84 /* Pods-RunnerTests.debug.xcconfig */,
+				0EF22621A2187FC8842491D8 /* Pods-RunnerTests.release.xcconfig */,
+				ABB51620DF3550231B6AF683 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
+				494123572DC129630071423F /* RequestBuilderTests.swift */,
+				49C3AB482DBBC534000D8F6E /* DatadogSessionReplayPluginTests.swift */,
+				49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */,
+				49F0E33B2DB97BC7007B7DA1 /* FlutterSessionReplayTests.swift */,
+				49C3AB4A2DBBC79D000D8F6E /* Helpers */,
+				49C3AB3E2DBBBF68000D8F6E /* Mocks */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		76CABD408CF658ABADE57D5E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				52DEE038B4A35E8180AB59CE /* Pods_Runner.framework */,
+				38C1E02D31D6D70F9A6DF3EB /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -91,6 +159,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				76CABD408CF658ABADE57D5E /* Frameworks */,
+				0BB2D78FFBA055BE1B719106 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -125,13 +195,19 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				2FEA49C49781AF00E86B6C49 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				A7D59CBE4A3F7A47600FDEF9 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				331C8086294A63A400263BE5 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				49C3AB3E2DBBBF68000D8F6E /* Mocks */,
+				49C3AB4A2DBBC79D000D8F6E /* Helpers */,
 			);
 			name = RunnerTests;
 			productName = RunnerTests;
@@ -142,12 +218,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				B7C647B03E9A8E5FB1B1DBBC /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				78590287FF3336717242F794 /* [CP] Embed Pods Frameworks */,
+				1A1D7C3A162A7CF6E48DC625 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -179,7 +258,6 @@
 				};
 			};
 			buildConfigurationList = 97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */;
-			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -187,6 +265,7 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -219,6 +298,45 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1A1D7C3A162A7CF6E48DC625 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2FEA49C49781AF00E86B6C49 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -235,6 +353,23 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		78590287FF3336717242F794 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -250,6 +385,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
+		B7C647B03E9A8E5FB1B1DBBC /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -257,6 +414,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49C3AB392DB985A7000D8F6E /* FlutterSessionReplayTests.swift in Sources */,
+				494123582DC129660071423F /* RequestBuilderTests.swift in Sources */,
+				49C3AB492DBBC546000D8F6E /* DatadogSessionReplayPluginTests.swift in Sources */,
+				49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -375,6 +536,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D327F0021DD9C18C84836E84 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -392,6 +554,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0EF22621A2187FC8842491D8 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -407,6 +570,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ABB51620DF3550231B6AF683 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/packages/datadog_session_replay/example/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/packages/datadog_session_replay/example/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -1,0 +1,218 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import Testing
+import Flutter
+import DatadogInternal
+
+@testable import datadog_session_replay
+
+extension FlutterError: EquatableInTests {
+
+}
+
+func checkResult(_ result: ResultStatus, expectedError: NSObject) {
+    switch result {
+    case .called(let value):
+        #expect((value as? NSObject) === expectedError)
+    default:
+        #expect(Bool(false), "Unexpected result: \(result)")
+    }
+}
+
+func checkResult(_ result: ResultStatus, errorCode: String, errorMessage: String) throws {
+    switch result {
+    case .called(let value):
+        let error = value as? FlutterError
+        try #require(error != nil, "Unexpected error type: \(type(of: value))")
+        #expect(error?.code == errorCode)
+        #expect(error?.message == errorMessage)
+    default:
+        #expect(Bool(false), "Unexpected result: \(result)")
+    }
+}
+
+@Suite(.serialized)
+class SessionReplayPluginTests {
+    let mockCore = PassthroughCoreMock()
+    let mockChannel = FlutterMethodChannel()
+
+    init() {
+        CoreRegistry.register(default: mockCore)
+    }
+
+    deinit {
+        CoreRegistry.unregisterDefault()
+    }
+
+    @Test
+    func returnNotImplemented_WhenUnknownMethod() throws {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let arguments: [String: Any] = [:]
+        let methodCall = FlutterMethodCall(methodName: "unknown", arguments: arguments)
+
+        // When
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        checkResult(status, expectedError: FlutterMethodNotImplemented)
+    }
+
+    @Test
+    func returnInvalidOperation_WhenBadArguments() throws {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let methodCall = FlutterMethodCall(methodName: "unknown", arguments: 22)
+
+        // When
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        try checkResult(status, errorCode: "DatadogSdk:InvalidOperation", errorMessage: "No arguments in call to unknown")
+    }
+
+    @Test
+    func enablesFeature_WhenEnableMethodCall() {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let arguments: [String: Any] = [
+            "configuration": [String: Any]()
+        ]
+        let methodCall = FlutterMethodCall(methodName: "enable", arguments: arguments)
+
+        // When
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        #expect(status == .called(value: nil))
+        #expect(mockCore.get(feature: FlutterSessionReplayFeature.self) != nil)
+    }
+
+    @Test
+    func returnsError_WhenEnableMethodCall_MissingConfiguration() throws {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let arguments: [String: Any] = [:]
+        let methodCall = FlutterMethodCall(methodName: "enable", arguments: arguments)
+
+        // When
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        try checkResult(status, errorCode: "DatadogSdk:ContractViolation", errorMessage: "Missing parameter in call to enable")
+    }
+
+    @Test
+    func setsContext_WhenSetHasReplayMethodCall() throws {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let expectedValue: Bool = .mockRandom()
+        let arguments: [String: Any] = [
+            "hasReplay": expectedValue
+        ]
+        let methodCall = FlutterMethodCall(methodName: "setHasReplay", arguments: arguments)
+
+        // When
+        plugin.enable(configuration: .init())
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        #expect(status == .called(value: nil))
+        let value = try mockCore.context.baggages["sr_has_replay"]?.encode() as? Bool
+        #expect(value == expectedValue)
+    }
+
+    @Test
+    func returnsError_WhenSetHasReplayMethodCall_InvalidParameter() throws {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let arguments: [String: Any] = [
+            "hasReplay": "true"
+        ]
+        let methodCall = FlutterMethodCall(methodName: "setHasReplay", arguments: arguments)
+
+        // When
+        plugin.enable(configuration: .init())
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        try checkResult(status, errorCode: "DatadogSdk:ContractViolation", errorMessage: "Missing parameter in call to setHasReplay")
+    }
+
+    @Test
+    func setsContext_WhenSetRecordCountMethodCall() throws {
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let expectedValue: Int = .mockRandom()
+        let expectedViewId: String = .mockRandom()
+        let arguments: [String: Any] = [
+            "viewId": expectedViewId,
+            "count": expectedValue
+        ]
+        let methodCall = FlutterMethodCall(methodName: "setRecordCount", arguments: arguments)
+
+        // When
+        plugin.enable(configuration: .init())
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        #expect(status == .called(value: nil))
+        let value = try mockCore.context.baggages["sr_records_count_by_view_id"]?.encode() as? [String: Any]
+        #expect(value?.count == 1)
+        #expect(value?[expectedViewId] as? Int == expectedValue)
+    }
+
+    @Test
+    func broadcastsRumContext_WhenContextChanges() throws {
+        // Given
+        let methodChannelMock = FlutterMethodChannelMock()
+        let plugin = DatadogSessionReplayPlugin(channel: methodChannelMock)
+        plugin.enable(configuration: .init())
+
+        // When
+        let expectedRumContext: RUMContext = .mockRandom()
+        let datadogContext: DatadogContext = .mockRandom(
+            withBaggages: [
+                RUMContext.key: .init(expectedRumContext)]
+        )
+        mockCore.send(message: .context(datadogContext), else: {})
+
+        // Then
+        // Push to the back of the main queue, as method channel must send
+        // callbacks on the main queue
+        try DispatchQueue.main.sync {
+            try #require(methodChannelMock.invocations.count == 1)
+            let argument = methodChannelMock.invocations[0].arguments as? [String: Any?]
+            try #require(argument != nil)
+            if let argument = argument {
+                #expect(argument["applicationId"] as? String == expectedRumContext.applicationID)
+                #expect(argument["sessionId"] as? String == expectedRumContext.sessionID)
+                #expect(argument["viewId"] as? String == expectedRumContext.viewID)
+                #expect(argument["viewServerTimeOffset"] as? TimeInterval == expectedRumContext.viewServerTimeOffset)
+            }
+        }
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -162,6 +162,7 @@ class SessionReplayPluginTests {
 
     @Test
     func setsContext_WhenSetRecordCountMethodCall() throws {
+        // Given
         let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
         let expectedValue: Int = .mockRandom()
         let expectedViewId: String = .mockRandom()
@@ -214,5 +215,29 @@ class SessionReplayPluginTests {
                 #expect(argument["viewServerTimeOffset"] as? TimeInterval == expectedRumContext.viewServerTimeOffset)
             }
         }
+    }
+
+    @Test
+    func writesSegment_WhenWriteSegment() throws {
+        // Given
+        let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
+        let segment: String = .mockRandom(length: 100)
+        let arguments: [String: Any] = [
+            "segment": segment
+        ]
+        let methodCall = FlutterMethodCall(methodName: "writeSegment", arguments: arguments)
+
+        // When
+        plugin.enable(configuration: .init())
+        var status: ResultStatus = .notCalled
+        plugin.handle(methodCall) { result in
+            status = .called(value: result)
+        }
+
+        // Then
+        #expect(status == .called(value: nil))
+        #expect(mockCore.writer.events.count == 1)
+        let recordEvent = try #require(mockCore.writer.events[0] as? RecordWrapper)
+        #expect(recordEvent.recordJson == segment)
     }
 }

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayFeatureTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayFeatureTests.swift
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import Testing
+
+@testable import datadog_session_replay
+
+@Test
+func setsReplayBaggage_WhenSetHasReplay() throws {
+    // Given
+    let core = PassthroughCoreMock()
+    let config = FlutterSessionReplay.Configuration()
+    let feature = try FlutterSessionReplayFeature(core: core, configuration: config)
+
+    // When
+    let expectedValue: Bool = .mockRandom()
+    feature.setHasReplay(expectedValue)
+
+    // Then
+    let value = try core.context.baggages["sr_has_replay"]?.encode() as? Bool
+    #expect(value == expectedValue)
+}
+
+@Test
+func setsBackage_WhenSetRecordCount() throws {
+    // Given
+    let core = PassthroughCoreMock()
+    let config = FlutterSessionReplay.Configuration()
+    let feature = try FlutterSessionReplayFeature(core: core, configuration: config)
+
+    // When
+    let viewId: String = .mockRandom()
+    let expectedCount: Int = .mockRandom()
+    feature.setRecordCount(for: viewId, count: expectedCount)
+
+    // Then
+    let baggage = try core.context.baggages["sr_records_count_by_view_id"]?.encode() as? [String: Any]
+    let value = baggage?[viewId] as? Int
+    #expect(value == expectedCount)
+}
+
+@Test
+func setsBackage_WhenSetRecordCount_MultipleViews() throws {
+    // Given
+    let core = PassthroughCoreMock()
+    let config = FlutterSessionReplay.Configuration()
+    let feature = try FlutterSessionReplayFeature(core: core, configuration: config)
+
+    // When
+    let viewIdA: String = .mockRandom()
+    let viewIdB: String = .mockRandom()
+    let expectedCountA: Int = .mockRandom()
+    let expectedCountB: Int = .mockRandom()
+    feature.setRecordCount(for: viewIdA, count: expectedCountA)
+    feature.setRecordCount(for: viewIdB, count: expectedCountB)
+
+    // Then
+    let baggage = try core.context.baggages["sr_records_count_by_view_id"]?.encode() as? [String: Any]
+    let valueA = baggage?[viewIdA] as? Int
+    #expect(valueA == expectedCountA)
+    let valueB = baggage?[viewIdB] as? Int
+    #expect(valueB == expectedCountB)
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayTests.swift
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import Foundation
+import Testing
+import DatadogInternal
+
+@testable import datadog_session_replay
+
+@Test
+func decodeConfigurationCorrectly() {
+    // Given
+    let encodedConfiguration = [
+        "customEndpoint": "https://example.com"
+    ]
+
+    // When
+    let configuration = FlutterSessionReplay.Configuration(fromEncoded: encodedConfiguration)
+
+    // Then
+    #expect(configuration?.customEndpoint == URL(string: "https://example.com"))
+}
+
+@Test
+func enableRegistersToCore() {
+    // Given
+    let config: FlutterSessionReplay.Configuration = .init()
+    let mockCore = PassthroughCoreMock()
+
+    // When
+    let createdFeature = FlutterSessionReplay.enable(with: config, in: mockCore)
+
+    // Then
+    let feature = mockCore.get(feature: FlutterSessionReplayFeature.self)
+    #expect(feature != nil)
+    #expect(feature === createdFeature)
+}
+
+@Test
+func writeSegmentWritesWrappedSegmentToCore() {
+    // Given
+    let config: FlutterSessionReplay.Configuration = .init()
+    let mockCore = PassthroughCoreMock()
+    let createdFetaure = FlutterSessionReplay.enable(with: config, in: mockCore)
+
+    // When
+    let mockSegment = "{}"
+    createdFetaure?.writeSegment(segment: mockSegment)
+
+    // Then
+    let events: [RecordWrapper] = mockCore.events()
+    #expect(events.count == 1)
+    #expect(events[0].recordJson == mockSegment)
+}
+
+@Test
+func changeInRumContextCallOnContextChanged() throws {
+    // Given
+    var config: FlutterSessionReplay.Configuration = .init()
+    var recievedContext: RUMContext?
+    config.onContextChanged = { context in
+        recievedContext = context
+    }
+    let mockCore = PassthroughCoreMock()
+    _ = FlutterSessionReplay.enable(with: config, in: mockCore)
+
+    // When
+    let expectedRumContext: RUMContext = .mockRandom()
+    let datadogContext: DatadogContext = .mockRandom(
+        withBaggages: [
+            RUMContext.key: .init(expectedRumContext)]
+    )
+    mockCore.send(message: .context(datadogContext), else: {})
+
+    // Then
+    #expect(recievedContext != nil)
+    #expect(recievedContext == expectedRumContext)
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Helpers/ResultStatus.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Helpers/ResultStatus.swift
@@ -1,0 +1,84 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+
+enum ResultStatus: EquatableInTests {
+    case notCalled
+    case called(value: Any?)
+}
+
+/// Utility protocol adding `Equatable` conformance to any arbitrary type.
+/// The equatability is determined based on comparing type mirrors and values.
+protocol EquatableInTests: Equatable {}
+
+extension EquatableInTests {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return equals(lhs: lhs, rhs: rhs)
+    }
+}
+
+private func equals<T>(lhs: T, rhs: T) -> Bool {
+    return equalsAny(lhs: lhs, rhs: rhs)
+}
+
+// swiftlint:disable:next cyclomatic_complexity
+private func equalsAny(lhs: Any, rhs: Any) -> Bool {
+    let lhsMirror = Mirror(reflecting: lhs)
+    let rhsMirror = Mirror(reflecting: rhs)
+
+    if lhsMirror.displayStyle != rhsMirror.displayStyle {
+        return false // different types
+    }
+
+    if lhsMirror.children.count != rhsMirror.children.count {
+        return false // different number of children
+    }
+
+    if lhsMirror.children.isEmpty, rhsMirror.children.isEmpty {
+        return String(describing: lhs) == String(describing: rhs) // plain values, compare debug strings
+    }
+
+    switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
+    case (.dictionary?, .dictionary?): // two dictionaries
+        let lhsDictionary = lhs as! [String: Any]
+        let rhsDictionary = rhs as! [String: Any]
+
+        if lhsDictionary.keys.count != rhsDictionary.keys.count {
+            return false // difference on number of keys
+        }
+
+        for (lhsKey, lhsValue) in lhsDictionary {
+            if let rhsValue = rhsDictionary[lhsKey] {
+                if !equalsAny(lhs: lhsValue, rhs: rhsValue) {
+                    return false // difference on key values
+                }
+            } else {
+                return false // difference on key names
+            }
+        }
+
+        return true // dictionaries are equal
+    case (.set?, .set?): // two sets
+        let lhsSet = lhs as! Set<AnyHashable>
+        let rhsSet = rhs as! Set<AnyHashable>
+
+        let setsEqual = lhsSet == rhsSet // if sets are equal
+        return setsEqual
+    default:
+        break // other than dictionary or set, continue...
+    }
+
+    let lhsChildren = lhsMirror.children.map { $0.value }
+    let rhsChildren = rhsMirror.children.map { $0.value }
+
+    for (lhsChild, rhsChild) in zip(lhsChildren, rhsChildren) { // compare each child
+        // swiftlint:disable:next for_where
+        if !equalsAny(lhs: lhsChild, rhs: rhsChild) {
+            return false // childs are different
+        }
+    }
+
+    return true
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
@@ -1,0 +1,390 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+
+@testable import datadog_session_replay
+
+extension DatadogContext {
+    public static func mockAny() -> DatadogContext { mockWith() }
+
+    public static func mockWith(
+        site: DatadogSite = .mockAny(),
+        clientToken: String = .mockAny(),
+        service: String = .mockAny(),
+        env: String = .mockAny(),
+        version: String = .mockAny(),
+        buildNumber: String = .mockAny(),
+        buildId: String? = nil,
+        variant: String? = nil,
+        source: String = .mockAny(),
+        sdkVersion: String = .mockAny(),
+        ciAppOrigin: String? = .mockAny(),
+        serverTimeOffset: TimeInterval = .zero,
+        applicationName: String = .mockAny(),
+        applicationBundleIdentifier: String = .mockAny(),
+        applicationBundleType: BundleType = .mockAny(),
+        sdkInitDate: Date = Date(),
+        nativeSourceOverride: String? = nil,
+        device: DeviceInfo = .mockAny(),
+        userInfo: UserInfo = .mockAny(),
+        trackingConsent: TrackingConsent = .pending,
+        launchTime: LaunchTime = .mockAny(),
+        applicationStateHistory: AppStateHistory = .mockAny(),
+        networkConnectionInfo: NetworkConnectionInfo? = .mockWith(reachability: .yes),
+        carrierInfo: CarrierInfo? = .mockAny(),
+        batteryStatus: BatteryStatus? = .mockAny(),
+        isLowPowerModeEnabled: Bool = false,
+        baggages: [String: FeatureBaggage] = [:]
+    ) -> DatadogContext {
+        .init(
+            site: site,
+            clientToken: clientToken,
+            service: service,
+            env: env,
+            version: version,
+            buildNumber: buildNumber,
+            buildId: buildId,
+            variant: variant,
+            source: source,
+            sdkVersion: sdkVersion,
+            ciAppOrigin: ciAppOrigin,
+            serverTimeOffset: serverTimeOffset,
+            applicationName: applicationName,
+            applicationBundleIdentifier: applicationBundleIdentifier,
+            applicationBundleType: applicationBundleType,
+            sdkInitDate: sdkInitDate,
+            device: device,
+            nativeSourceOverride: nativeSourceOverride,
+            userInfo: userInfo,
+            trackingConsent: trackingConsent,
+            launchTime: launchTime,
+            applicationStateHistory: applicationStateHistory,
+            networkConnectionInfo: networkConnectionInfo,
+            carrierInfo: carrierInfo,
+            batteryStatus: batteryStatus,
+            isLowPowerModeEnabled: isLowPowerModeEnabled,
+            baggages: baggages
+        )
+    }
+
+    public static func mockRandom(withBaggages: [String: FeatureBaggage] = [:]) -> DatadogContext {
+        .init(
+            site: .mockRandom(),
+            clientToken: .mockRandom(),
+            service: .mockRandom(),
+            env: .mockRandom(),
+            version: .mockRandom(),
+            buildNumber: .mockRandom(),
+            buildId: .mockRandom(),
+            variant: .mockRandom(),
+            source: .mockAnySource(),
+            sdkVersion: .mockRandom(),
+            ciAppOrigin: .mockRandom(),
+            serverTimeOffset: .mockRandomInThePast(),
+            applicationName: .mockRandom(),
+            applicationBundleIdentifier: .mockRandom(),
+            applicationBundleType: .mockRandom(),
+            sdkInitDate: .mockRandomInThePast(),
+            device: .mockRandom(),
+            userInfo: .mockRandom(),
+            trackingConsent: .mockRandom(),
+            launchTime: .mockRandom(),
+            applicationStateHistory: .mockRandom(),
+            networkConnectionInfo: .mockRandom(),
+            carrierInfo: .mockRandom(),
+            batteryStatus: nil,
+            isLowPowerModeEnabled: .mockRandom(),
+            baggages: withBaggages
+        )
+    }
+}
+
+extension RUMContext {
+    public static func mockRandom() -> Self {
+        return RUMContext.init(
+            applicationID: .mockRandom(),
+            sessionID: .mockRandom(),
+            viewID: .mockRandom(),
+            viewServerTimeOffset: nil
+        )
+    }
+}
+
+extension DatadogSite {
+    public static func mockAny() -> Self {
+        return .us1
+    }
+
+    public static func mockRandom() -> Self {
+        return [.us1, .us3, .us5, .eu1, .ap1, .us1_fed].randomElement()!
+    }
+}
+
+extension BundleType {
+    public static func mockAny() -> Self {
+        return .iOSApp
+    }
+
+    public static func mockRandom() -> Self {
+        return [.iOSApp, .iOSAppExtension].randomElement()!
+    }
+}
+
+extension DeviceInfo {
+    public static func mockAny() -> DeviceInfo {
+        return .mockWith()
+    }
+
+    public static func mockWith(
+        name: String = "iPhone",
+        model: String = "iPhone10,1",
+        osName: String = "iOS",
+        osVersion: String = "15.4.1",
+        osBuildNumber: String = "13D20",
+        architecture: String = "arm64e",
+        isSimulator: Bool = true,
+        vendorId: String? = "xyz",
+        isDebugging: Bool = false,
+        systemBootTime: TimeInterval = Date.timeIntervalSinceReferenceDate
+    ) -> DeviceInfo {
+        return .init(
+            name: name,
+            model: model,
+            osName: osName,
+            osVersion: osVersion,
+            osBuildNumber: osBuildNumber,
+            architecture: architecture,
+            isSimulator: isSimulator,
+            vendorId: vendorId,
+            isDebugging: isDebugging,
+            systemBootTime: systemBootTime
+        )
+    }
+
+    public static func mockRandom() -> DeviceInfo {
+        return .init(
+            name: .mockRandom(),
+            model: .mockRandom(),
+            osName: .mockRandom(),
+            osVersion: .mockRandom(),
+            osBuildNumber: .mockRandom(),
+            architecture: .mockRandom(),
+            isSimulator: .mockRandom(),
+            vendorId: .mockRandom(),
+            isDebugging: .mockRandom(),
+            systemBootTime: .mockRandom()
+        )
+    }
+}
+
+extension UserInfo {
+    public static func mockAny() -> UserInfo {
+        return mockEmpty()
+    }
+
+    public static func mockEmpty() -> UserInfo {
+        return UserInfo(id: nil, name: nil, email: nil, extraInfo: [:])
+    }
+
+    public static func mockRandom() -> UserInfo {
+        return .init(
+            id: .mockRandom(),
+            name: .mockRandom(),
+            email: .mockRandom(),
+            extraInfo: [:]
+        )
+    }
+}
+
+extension LaunchTime {
+    public static func mockAny() -> LaunchTime {
+        .init(
+            launchTime: .mockAny(),
+            launchDate: .mockAny(),
+            isActivePrewarm: .mockAny()
+        )
+    }
+
+    public static func mockWith(
+        launchTime: TimeInterval? = 1,
+        launchDate: Date = Date(),
+        isActivePrewarm: Bool = false
+    ) -> LaunchTime {
+        .init(
+            launchTime: launchTime,
+            launchDate: launchDate,
+            isActivePrewarm: isActivePrewarm
+        )
+    }
+
+    public static func mockRandom() -> LaunchTime {
+        return .init(
+            launchTime: .mockRandom(),
+            launchDate: .mockRandom(),
+            isActivePrewarm: .mockRandom()
+        )
+    }
+}
+
+extension AppState {
+    public static func mockAny() -> AppState {
+        return .active
+    }
+
+    public static func mockRandom() -> AppState {
+        return [.active, .inactive, .background].randomElement()!
+    }
+
+    public static func mockRandom(runningInForeground: Bool) -> AppState {
+        return runningInForeground ? [.active, .inactive].randomElement()! : .background
+    }
+}
+
+extension AppStateHistory {
+    public static func mockAny() -> Self {
+        return mockAppInForeground(since: .mockDecember15th2019At10AMUTC())
+    }
+
+    public static func mockAppInForeground(since date: Date = Date()) -> Self {
+        return .init(initialSnapshot: .init(state: .active, date: date), recentDate: date)
+    }
+
+    public static func mockAppInBackground(since date: Date = Date()) -> Self {
+        return .init(initialSnapshot: .init(state: .background, date: date), recentDate: date)
+    }
+
+    public static func mockRandom(since date: Date = Date()) -> Self {
+        return Bool.random() ? mockAppInForeground(since: date) : mockAppInBackground(since: date)
+    }
+}
+
+extension NetworkConnectionInfo {
+    public static func mockAny() -> NetworkConnectionInfo {
+        return mockWith()
+    }
+
+    public static func mockWith(
+        reachability: NetworkConnectionInfo.Reachability = .mockAny(),
+        availableInterfaces: [NetworkConnectionInfo.Interface] = [.wifi],
+        supportsIPv4: Bool = true,
+        supportsIPv6: Bool = true,
+        isExpensive: Bool = true,
+        isConstrained: Bool = true
+    ) -> NetworkConnectionInfo {
+        return NetworkConnectionInfo(
+            reachability: reachability,
+            availableInterfaces: availableInterfaces,
+            supportsIPv4: supportsIPv4,
+            supportsIPv6: supportsIPv6,
+            isExpensive: isExpensive,
+            isConstrained: isConstrained
+        )
+    }
+
+    public static func mockRandom() -> NetworkConnectionInfo {
+        return NetworkConnectionInfo(
+            reachability: .mockRandom(),
+            availableInterfaces: [],
+            supportsIPv4: .random(),
+            supportsIPv6: .random(),
+            isExpensive: .random(),
+            isConstrained: .random()
+        )
+    }
+}
+
+extension NetworkConnectionInfo.Interface {
+    public static func mockRandom() -> NetworkConnectionInfo.Interface {
+        return allCases.randomElement()!
+    }
+}
+
+extension CarrierInfo {
+    public static func mockAny() -> CarrierInfo {
+        return mockWith()
+    }
+
+    public static func mockWith(
+        carrierName: String? = .mockAny(),
+        carrierISOCountryCode: String? = .mockAny(),
+        carrierAllowsVOIP: Bool = .mockAny(),
+        radioAccessTechnology: CarrierInfo.RadioAccessTechnology = .mockAny()
+    ) -> CarrierInfo {
+        return CarrierInfo(
+            carrierName: carrierName,
+            carrierISOCountryCode: carrierISOCountryCode,
+            carrierAllowsVOIP: carrierAllowsVOIP,
+            radioAccessTechnology: radioAccessTechnology
+        )
+    }
+
+    public static func mockRandom() -> CarrierInfo {
+        return CarrierInfo(
+            carrierName: .mockRandom(),
+            carrierISOCountryCode: .mockRandom(),
+            carrierAllowsVOIP: .random(),
+            radioAccessTechnology: .mockRandom()
+        )
+    }
+}
+
+extension CarrierInfo.RadioAccessTechnology {
+    public static func mockAny() -> CarrierInfo.RadioAccessTechnology { .LTE }
+
+    public static func mockRandom() -> CarrierInfo.RadioAccessTechnology {
+        return allCases.randomElement()!
+    }
+}
+
+extension BatteryStatus {
+    public static func mockAny() -> BatteryStatus {
+        return mockWith()
+    }
+
+    public static func mockWith(
+        state: State = .charging,
+        level: Float = 0.5
+    ) -> BatteryStatus {
+        return BatteryStatus(state: state, level: level)
+    }
+}
+
+extension TrackingConsent {
+    public static func mockRandom() -> TrackingConsent {
+        return [.granted, .notGranted, .pending].randomElement()!
+    }
+
+    public static func mockRandom(otherThan consent: TrackingConsent? = nil) -> TrackingConsent {
+        while true {
+            let randomConsent: TrackingConsent = .mockRandom()
+            if randomConsent != consent {
+                return randomConsent
+            }
+        }
+    }
+}
+
+extension String {
+    public static func mockAnySource() -> String {
+        return ["ios", "android", "browser", "ios", "react-native", "flutter", "unity", "kotlin-multiplatform"].randomElement()!
+    }
+
+    public static func mockAnySourceType() -> String {
+        return ["ios", "android", "browser", "react-native", "flutter", "roku", "ndk", "ios+il2cpp", "ndk+il2cpp"].randomElement()!
+    }
+}
+
+extension NetworkConnectionInfo.Reachability {
+    public static func mockAny() -> NetworkConnectionInfo.Reachability {
+        return .maybe
+    }
+
+    public static func mockRandom(
+        within cases: [NetworkConnectionInfo.Reachability] = [.yes, .no, .maybe]
+    ) -> NetworkConnectionInfo.Reachability {
+        return cases.randomElement()!
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogCoreMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogCoreMock.swift
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+
+/// Passthrough core mocks feature-scope allowing recording events in **sync**.
+///
+/// This mock it will always provide a `FeatureScope` for any registered feature with the current
+/// context and a `writer` that will store all events in the `events` property.
+///
+/// Usage:
+///
+///     let core = PassthroughCoreMock()
+///     try core.register(CustomFeature.self)
+///     core.scope(for: CustomFeature.self)?.eventWriteContext { context, writer in
+///         // will always open a scope
+///     }
+///
+open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Sendable {
+    /// Counts references to `PassthroughCoreMock` instances, so we can prevent memory
+    /// leaks of SDK core in `DatadogTestsObserver`.
+    public private(set) static var referenceCount = 0
+
+    public internal(set) var registeredFeatures: [DatadogFeature] = []
+
+    /// Current context that will be passed to feature-scopes.
+    @ReadWriteLock
+    public var context: DatadogContext {
+        didSet { send(message: .context(context)) }
+    }
+
+    let writer = FileWriterMock()
+
+    /// Callback called when `eventWriteContext` closure is executed.
+    public var onEventWriteContext: ((Bool) -> Void)?
+
+    /// Creates a Passthrough core mock.
+    ///
+    /// - Parameters:
+    ///   - context: The testing context.
+
+    public required init(
+        context: DatadogContext = .mockAny(),
+        dataStore: DataStore = NOPDataStore(),
+        messageReceiver: FeatureMessageReceiver = NOPFeatureMessageReceiver()
+    ) {
+        self.context = context
+        self.dataStore = dataStore
+
+        messageReceiver.receive(message: .context(context), from: self)
+
+        PassthroughCoreMock.referenceCount += 1
+    }
+
+    deinit {
+        PassthroughCoreMock.referenceCount -= 1
+    }
+
+    /// no-op
+    public func register<T>(feature: T) throws where T: DatadogFeature {
+        registeredFeatures.append(feature)
+    }
+    /// no-op
+    public func feature<T>(named name: String, type: T.Type) -> T? {
+        return registeredFeatures.first(where: { $0 is T}) as? T
+    }
+
+    /// Always returns a feature-scope.
+    public func scope<T>(for featureType: T.Type) -> FeatureScope where T: DatadogFeature {
+        self
+    }
+
+    public func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
+        context.baggages[key] = baggage()
+    }
+
+    public func send(message: FeatureMessage, else fallback: () -> Void) {
+        for feature in registeredFeatures {
+            if !feature.messageReceiver.receive(message: message, from: self) {
+                fallback()
+            }
+        }
+    }
+
+    /// no-op
+    public func set(anonymousId: String?) { }
+
+    /// Execute `block` with the current context and a `writer` to record events.
+    ///
+    /// - Parameter block: The block to execute.
+    public func eventWriteContext(bypassConsent: Bool, _ block: @escaping (DatadogContext, Writer) -> Void) {
+        block(context, writer)
+        onEventWriteContext?(bypassConsent)
+    }
+
+    public func context(_ block: @escaping (DatadogContext) -> Void) {
+        block(context)
+    }
+
+    public var dataStore: DataStore
+
+    /// Recorded events from feature scopes.
+    ///
+    /// Invoking the `writer` from the `eventWriteContext` will add
+    /// events to this stack.
+    public var events: [Encodable] { writer.events }
+
+    /// Returns all events of the given type.
+    ///
+    /// - Parameter type: The event type to retrieve.
+    /// - Returns: A list of event of the give type.
+    public func events<T>(ofType type: T.Type = T.self) -> [T] where T: Encodable {
+        writer.events(ofType: type)
+    }
+
+    public func mostRecentModifiedFileAt(before: Date) throws -> Date? {
+        return nil
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/FileWriterMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/FileWriterMock.swift
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+
+public class FileWriterMock: Writer {
+    public init() { }
+
+    /// Recorded events.
+    public private(set) var events: [Encodable] = []
+
+    /// Adds an `Encodable` event to the events stack.
+    ///
+    /// - Parameter value: The event value to record.
+    public func write<T: Encodable, M: Encodable>(value: T, metadata: M) {
+        events.append(value)
+    }
+
+    /// Returns all events of the given type.
+    ///
+    /// - Parameter type: The event type to retrieve.
+    /// - Returns: A list of event of the give type.
+    public func events<T>(ofType type: T.Type = T.self) -> [T] where T: Encodable {
+        events.compactMap { $0 as? T }
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/FlutterMethodChannelMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/FlutterMethodChannelMock.swift
@@ -1,0 +1,38 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import Flutter
+
+class FlutterMethodChannelMock: FlutterMethodChannel {
+    struct MockInvocation {
+        let method: String
+        let arguments: Any?
+    }
+
+    public var invocations: [MockInvocation] = []
+
+    override func invokeMethod(_ method: String, arguments: Any?) {
+        invocations.append(
+            .init(method: method, arguments: arguments)
+        )
+    }
+
+    override func invokeMethod(_ method: String, arguments: Any?, result callback: FlutterResult? = nil) {
+        invocations.append(
+            .init(method: method, arguments: arguments)
+        )
+        if let callback = callback {
+            callback(nil)
+        }
+    }
+
+    override func setMethodCallHandler(_ handler: FlutterMethodCallHandler?) {
+        // NOOP
+    }
+
+    override func resizeBuffer(_ bufferSize: Int) {
+        // NOOP
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/FoundationMocks.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/FoundationMocks.swift
@@ -1,0 +1,141 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+
+extension FixedWidthInteger {
+    public static func mockRandom() -> Self {
+        return .random(in: min...max)
+    }
+
+    public static func mockRandom(min: Self = .min, max: Self = .max, otherThan values: Set<Self> = []) -> Self {
+        var random: Self = .random(in: min...max)
+        while values.contains(random) { random = .random(in: min...max) }
+        return random
+    }
+}
+
+extension Bool {
+    public static func mockRandom() -> Bool {
+        return .random()
+    }
+
+    public static func mockAny() -> Bool {
+        return false
+    }
+}
+
+extension TimeInterval {
+    public static let distantFuture = TimeInterval(integerLiteral: .max)
+
+    public static func mockRandomInThePast() -> TimeInterval {
+        return random(in: 0..<Date().timeIntervalSinceReferenceDate)
+    }
+}
+
+extension Double {
+    public static func mockAny() -> Double {
+        return 0
+    }
+
+    public static func mockRandom() -> Double {
+        return mockRandom(min: 0, max: .greatestFiniteMagnitude)
+    }
+
+    public static func mockRandom(min: Double, max: Double) -> Double {
+        return .random(in: min...max)
+    }
+}
+
+extension Date {
+    public static func mockAny() -> Date {
+        return Date(timeIntervalSinceReferenceDate: 1)
+    }
+
+    public static func mockRandom() -> Date {
+        let randomTimeInterval = TimeInterval.random(in: 0..<Date().timeIntervalSince1970)
+        return Date(timeIntervalSince1970: randomTimeInterval)
+    }
+
+    public static func mockRandomInThePast() -> Date {
+        return Date(timeIntervalSinceReferenceDate: TimeInterval.mockRandomInThePast())
+    }
+
+    public static func mockSpecificUTCGregorianDate(year: Int, month: Int, day: Int, hour: Int, minute: Int = 0, second: Int = 0) -> Date {
+        var dateComponents = DateComponents()
+        dateComponents.year = year
+        dateComponents.month = month
+        dateComponents.day = day
+        dateComponents.hour = hour
+        dateComponents.minute = minute
+        dateComponents.second = second
+        dateComponents.timeZone = TimeZone(abbreviation: "UTC")!
+        dateComponents.calendar = Calendar(identifier: .gregorian)
+        return dateComponents.date!
+    }
+
+    public static func mockDecember15th2019At10AMUTC(addingTimeInterval timeInterval: TimeInterval = 0) -> Date {
+        return mockSpecificUTCGregorianDate(year: 2_019, month: 12, day: 15, hour: 10)
+            .addingTimeInterval(timeInterval)
+    }
+}
+
+extension String {
+    public static func mockAny() -> String {
+        return "abc"
+    }
+
+    public static func mockRandom() -> String {
+        return mockRandom(length: 10)
+    }
+
+    public static func mockRandom<Length: BinaryInteger>(length: Length) -> String {
+        return mockRandom(among: .alphanumericsAndWhitespace, length: Int(length))
+    }
+
+    public static func mockRandom(among characters: RandomStringCharacterSet, length: Int = 10) -> String {
+        return characters.random(ofLength: length)
+    }
+
+    public static func mockRandom(otherThan values: Set<String> = []) -> String {
+        var random: String = .mockRandom()
+        while values.contains(random) { random = .mockRandom() }
+        return random
+    }
+
+    public static func mockRepeating(character: Character, times: Int) -> String {
+        let characters = (0..<times).map { _ in character }
+        return String(characters)
+    }
+
+    public enum RandomStringCharacterSet {
+        private static let alphanumericCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        private static let decimalDigitCharacters = "0123456789"
+
+        /// Only letters and numbers (lower and upper cased).
+        case alphanumerics
+        /// Letters, numbers and whitespace (lower and upper cased).
+        case alphanumericsAndWhitespace
+        /// Only numbers.
+        case decimalDigits
+        /// Custom characters.
+        case custom(characters: String)
+
+        func random(ofLength length: Int) -> String {
+            var characters: String
+            switch self {
+            case .alphanumerics:
+                characters = RandomStringCharacterSet.alphanumericCharacters
+            case .alphanumericsAndWhitespace:
+                characters = RandomStringCharacterSet.alphanumericCharacters + " "
+            case .decimalDigits:
+                characters = RandomStringCharacterSet.decimalDigitCharacters
+            case .custom(let customCharacters):
+                characters = customCharacters
+            }
+
+            return String((0..<length).map { _ in characters.randomElement()! })
+        }
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/MultipartBuilderSpy.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/MultipartBuilderSpy.swift
@@ -1,0 +1,24 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+#if os(iOS)
+import Foundation
+@testable import datadog_session_replay
+
+class MultipartBuilderSpy: MultipartFormDataBuilder {
+    var formFields: [String: String] = [:]
+    var formFiles: [(filename: String, data: Data, mimeType: String)] = []
+    var returnedData: Data = Data()
+
+    let boundary: String = UUID().uuidString
+
+    func addFormField(name: String, value: String) { formFields[name] = value }
+
+    func addFormData(name: String, filename: String, data: Data, mimeType: String) {
+        formFiles.append((filename: filename, data: data, mimeType: mimeType))
+    }
+
+    func build() -> Data { returnedData }
+}
+#endif

--- a/packages/datadog_session_replay/example/ios/RunnerTests/RequestBuilderTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/RequestBuilderTests.swift
@@ -1,0 +1,291 @@
+//// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+import Testing
+import Compression
+
+@testable import datadog_session_replay
+
+// Records are encoded by Flutter, so the models aren't in
+// the Flutter SR feature for flutter, so we encode JSON manually.
+func createEnrichedRecordJson(context: RUMContext, records: [String] = []) -> String {
+    let viewId = context.viewID ?? "null"
+    let recordsString = "[\(records.joined(separator: ","))]"
+    return """
+{
+    "applicationID": "\(context.applicationID)",
+    "sessionID": "\(context.sessionID)",
+    "viewID": "\(viewId)",
+    "records": \(recordsString)
+}
+"""
+}
+
+func mockRecord() -> String {
+    // Return a full snapshot record always for now.
+    return """
+{
+    "timestamp": \(Int.mockRandom()),
+    "data": {
+        "wireframes": []
+    }
+}
+"""
+}
+
+func createEvents(_ records: [RecordWrapper]) throws -> [Event] {
+    let encoder = JSONEncoder()
+    return try records.map({
+        Event(data: try encoder.encode($0), metadata: nil)
+    })
+}
+
+@Test
+func requestBuildsURLRequest_WithCorrectHeaders() throws {
+    // Given
+    let mockCore = PassthroughCoreMock()
+    let rumContext = RUMContext.mockRandom()
+    let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry)
+    let events = try createEvents([
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(context: rumContext)
+        )
+    ])
+
+    // When
+    let context: DatadogContext = .mockRandom(
+        withBaggages: [RUMContext.key: .init(rumContext)]
+    )
+    let request = try requestBuilder.request(
+        for: events,
+        with: context,
+        execution: DatadogInternal.ExecutionContext(previousResponseCode: nil, attempt: 0)
+    )
+
+    // Then
+    // .mockAny defaults to us1
+    #expect(request.url?.absoluteString.hasSuffix("api/v2/replay") ?? false)
+    #expect(request.httpMethod == "POST")
+    #expect(request.value(forHTTPHeaderField: "Content-Type") == "multipart/form-data; boundary=\(requestBuilder.multipartBuilder.boundary)")
+    let expectedUserAgent = "\(context.applicationName)/\(context.version) CFNetwork (\(context.device.name); \(context.device.osName)/\(context.device.osVersion))"
+    #expect(request.value(forHTTPHeaderField: "User-Agent") == expectedUserAgent)
+    #expect(request.value(forHTTPHeaderField: "DD-API-KEY") == context.clientToken)
+    #expect(request.value(forHTTPHeaderField: "DD-EVP-ORIGIN") == context.source)
+    #expect(request.value(forHTTPHeaderField: "DD-EVP-ORIGIN-VERSION") == context.sdkVersion)
+    #expect(UUID(uuidString: request.value(forHTTPHeaderField: "DD-REQUEST-ID")!) != nil)
+}
+
+@Test
+func requestBuilder_BuildsFormData_WithMultipartBuilder() throws {
+    // Given
+    let mockCore = PassthroughCoreMock()
+    let rumContext = RUMContext.mockRandom()
+    let multipartSpy = MultipartBuilderSpy()
+    let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry, multipartBuilder: multipartSpy)
+    let events = try createEvents([
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(context: rumContext)
+        )
+    ])
+
+    // When
+    let context: DatadogContext = .mockRandom(
+        withBaggages: [RUMContext.key: .init(rumContext)]
+    )
+    _ = try requestBuilder.request(
+        for: events,
+        with: context,
+        execution: DatadogInternal.ExecutionContext(previousResponseCode: nil, attempt: 0)
+    )
+
+    // Then
+    let decoder = JSONDecoder()
+    try #require(multipartSpy.formFiles.count == 2)
+    let file = multipartSpy.formFiles[0]
+    #expect(file.filename == "file0")
+    #expect(file.mimeType == "application/octet-stream")
+
+    let segmentData = try #require(try zlibDecode(file.data))
+    let segment = try #require(try JSONSerialization.jsonObject(with: segmentData) as? [String: Any])
+    #expect((segment["application"] as! JSONObject)["id"] as? String == rumContext.applicationID)
+    #expect((segment["session"] as! JSONObject)["id"] as? String == rumContext.sessionID)
+    #expect((segment["view"] as! JSONObject)["id"] as? String == rumContext.viewID)
+    #expect(segment["source"] as? String == context.source)
+    #expect(segment["records_count"] as? Int == 0)
+
+    let metadataFile = multipartSpy.formFiles[1]
+    #expect(metadataFile.filename == "blob")
+    #expect(metadataFile.mimeType == "application/json")
+
+    let metadata = try decoder.decode([Metadata].self, from: metadataFile.data)
+    try #require(metadata.count == 1)
+    #expect(metadata[0].application.id == rumContext.applicationID)
+    #expect(metadata[0].session.id == rumContext.sessionID)
+    #expect(metadata[0].view.id == rumContext.viewID)
+    #expect(metadata[0].rawSegmentSize >= metadata[0].compressedSegmentSize)
+}
+
+@Test
+func requestBuilder_BuildsFormDataWithRecords_WithMultipartBuilder() throws {
+    // Given
+    let mockCore = PassthroughCoreMock()
+    let rumContext = RUMContext.mockRandom()
+    let multipartSpy = MultipartBuilderSpy()
+    let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry, multipartBuilder: multipartSpy)
+    let events = try createEvents([
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(
+                context: rumContext,
+                records: [ mockRecord(), mockRecord(), mockRecord() ]
+            )
+        )
+    ])
+
+    // When
+    let context: DatadogContext = .mockRandom(
+        withBaggages: [RUMContext.key: .init(rumContext)]
+    )
+    _ = try requestBuilder.request(
+        for: events,
+        with: context,
+        execution: DatadogInternal.ExecutionContext(previousResponseCode: nil, attempt: 0)
+    )
+
+    // Then
+    let decoder = JSONDecoder()
+    try #require(multipartSpy.formFiles.count == 2)
+    let file = multipartSpy.formFiles[0]
+    #expect(file.filename == "file0")
+    #expect(file.mimeType == "application/octet-stream")
+
+    let segmentData = try #require(try zlibDecode(file.data))
+    let segment = try #require(try JSONSerialization.jsonObject(with: segmentData) as? [String: Any])
+    #expect(segment["records_count"] as? Int == 3)
+
+    let metadataFile = multipartSpy.formFiles[1]
+    #expect(metadataFile.filename == "blob")
+    #expect(metadataFile.mimeType == "application/json")
+
+    let metadata = try decoder.decode([Metadata].self, from: metadataFile.data)
+    try #require(metadata.count == 1)
+    #expect(metadata[0].application.id == rumContext.applicationID)
+    #expect(metadata[0].session.id == rumContext.sessionID)
+    #expect(metadata[0].view.id == rumContext.viewID)
+    #expect(metadata[0].rawSegmentSize >= metadata[0].compressedSegmentSize)
+}
+
+@Test
+func requestBuilder_BuildsFormDataWithMultipleContexts_WithMultipartBuilder() throws {
+    // Given
+    let mockCore = PassthroughCoreMock()
+    let context0 = RUMContext.mockRandom()
+    let context1 = RUMContext.mockRandom()
+    let multipartSpy = MultipartBuilderSpy()
+    let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry, multipartBuilder: multipartSpy)
+    let events = try createEvents([
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(
+                context: context0,
+                records: [ mockRecord(), mockRecord(), mockRecord() ]
+            )
+        ),
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(
+                context: context0,
+                records: [ mockRecord() ]
+            )
+        ),
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(
+                context: context1,
+                records: [ mockRecord(), mockRecord(), mockRecord() ]
+            )
+        ),
+        RecordWrapper(
+            recordJson: createEnrichedRecordJson(
+                context: context1,
+                records: [ mockRecord(), mockRecord() ]
+            )
+        )
+    ])
+
+    // When
+    let context: DatadogContext = .mockRandom(
+        withBaggages: [RUMContext.key: .init(context0)]
+    )
+    _ = try requestBuilder.request(
+        for: events,
+        with: context,
+        execution: DatadogInternal.ExecutionContext(previousResponseCode: nil, attempt: 0)
+    )
+
+    // Then
+    let decoder = JSONDecoder()
+    try #require(multipartSpy.formFiles.count == 3)
+    let file0 = multipartSpy.formFiles[0]
+    #expect(file0.filename == "file0")
+    #expect(file0.mimeType == "application/octet-stream")
+
+    let segmentData0 = try #require(try zlibDecode(file0.data))
+    let segment0 = try #require(try JSONSerialization.jsonObject(with: segmentData0) as? [String: Any])
+    #expect((segment0["application"] as! JSONObject)["id"] as? String == context0.applicationID)
+    #expect((segment0["session"] as! JSONObject)["id"] as? String == context0.sessionID)
+    #expect((segment0["view"] as! JSONObject)["id"] as? String == context0.viewID)
+    #expect(segment0["source"] as? String == context.source)
+    #expect(segment0["records_count"] as? Int == 4)
+
+    let file1 = multipartSpy.formFiles[1]
+    #expect(file1.filename == "file1")
+    #expect(file1.mimeType == "application/octet-stream")
+
+    let segmentData1 = try #require(try zlibDecode(file1.data))
+    let segment1 = try #require(try JSONSerialization.jsonObject(with: segmentData1) as? [String: Any])
+    #expect((segment1["application"] as! JSONObject)["id"] as? String == context1.applicationID)
+    #expect((segment1["session"] as! JSONObject)["id"] as? String == context1.sessionID)
+    #expect((segment1["view"] as! JSONObject)["id"] as? String == context1.viewID)
+    #expect(segment1["source"] as? String == context.source)
+    #expect(segment1["records_count"] as? Int == 5)
+
+    let metadataFile = multipartSpy.formFiles[2]
+    #expect(metadataFile.filename == "blob")
+    #expect(metadataFile.mimeType == "application/json")
+
+    let metadata = try decoder.decode([Metadata].self, from: metadataFile.data)
+    try #require(metadata.count == 2)
+    #expect(metadata[0].application.id == context0.applicationID)
+    #expect(metadata[0].session.id == context0.sessionID)
+    #expect(metadata[0].view.id == context0.viewID)
+    #expect(metadata[0].rawSegmentSize >= metadata[0].compressedSegmentSize)
+
+    #expect(metadata[1].application.id == context1.applicationID)
+    #expect(metadata[1].session.id == context1.sessionID)
+    #expect(metadata[1].view.id == context1.viewID)
+    #expect(metadata[1].rawSegmentSize >= metadata[0].compressedSegmentSize)
+}
+
+func zlibDecode(_ data: Data, capacity: Int = 1_000_000) -> Data? {
+    // Skip `deflate` header (2 bytes) and checksum (4 bytes)
+    // validations and inflate raw deflated data.
+    let range = 2..<data.count - 4
+    let subdata = data.subdata(in: range)
+
+    return subdata.withUnsafeBytes {
+        guard let ptr = $0.bindMemory(to: UInt8.self).baseAddress else {
+            return nil
+        }
+
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+        defer { buffer.deallocate() }
+
+        // Returns the number of bytes written to the destination buffer after
+        // decompressing the input. If there is not enough space in the destination
+        // buffer to hold the entire decompressed output, the function writes the
+        // first dst_size bytes to the buffer and returns dst_size. Note that this
+        // behavior differs from that of `compression_encode_buffer(_:_:_:_:_:_:)`.
+        let size = compression_decode_buffer(buffer, capacity, ptr, data.count, nil, COMPRESSION_ZLIB)
+        return Data(bytes: buffer, count: size)
+    }
+}

--- a/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
@@ -5,13 +5,108 @@ import Flutter
 import UIKit
 
 public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "datadog_session_replay", binaryMessenger: registrar.messenger())
-    let instance = DatadogSessionReplayPlugin()
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "datadog_session_replay", binaryMessenger: registrar.messenger())
+        let instance = DatadogSessionReplayPlugin(channel: channel)
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
 
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    
-  }
+    let channel: FlutterMethodChannel
+    var feature: FlutterSessionReplayFeature?
+
+    init(channel: FlutterMethodChannel) {
+        self.channel = channel
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let arguments = call.arguments as? [String: Any?] else {
+            result(
+                FlutterError.invalidOperation(message: "No arguments in call to \(call.method)")
+            )
+            return
+        }
+
+        switch call.method {
+        case "enable":
+            enableSessionReplay(argumnets: arguments, result: result)
+        case "setHasReplay":
+            setHasReplay(arguments: arguments, result: result)
+        case "setRecordCount":
+            setRecordCount(arguments: arguments, result: result)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func enableSessionReplay(argumnets: [String: Any?], result: @escaping FlutterResult) {
+        guard let configurationJson = argumnets["configuration"] as? [String: Any?],
+              let configuration = FlutterSessionReplay.Configuration(fromEncoded: configurationJson) else {
+            result(FlutterError.missingParameter(methodName: "enable"))
+            return
+        }
+
+        enable(configuration: configuration)
+
+        result(nil)
+    }
+
+    // Visible for testing
+    internal func enable(configuration: FlutterSessionReplay.Configuration) {
+        var configuration = configuration
+        configuration.onContextChanged = { context in
+            self.onContextChanged(rumContext: context)
+        }
+        feature = FlutterSessionReplay.enable(with: configuration)
+    }
+
+    private func setHasReplay(arguments: [String: Any?], result: @escaping FlutterResult) {
+        guard let hasReplay = arguments["hasReplay"] as? Bool else {
+            result(FlutterError.missingParameter(methodName: "setHasReplay"))
+            return
+        }
+
+        feature?.setHasReplay(hasReplay)
+
+        result(nil)
+
+    }
+
+    func setRecordCount(arguments: [String: Any?], result: @escaping FlutterResult) {
+        guard let viewId = arguments["viewId"] as? String,
+              let count = arguments["count"] as? Int else {
+            result(FlutterError.missingParameter(methodName: "setRecordCount"))
+            return
+        }
+
+        feature?.setRecordCount(for: viewId, count: count)
+
+        result(nil)
+    }
+
+    private func onContextChanged(rumContext: RUMContext?) {
+        if let dictionary = rumContext?.encodedForFlutter() {
+            DispatchQueue.main.async {
+                self.channel.invokeMethod("onContextChanged", arguments: dictionary)
+            }
+        }
+    }
+}
+
+extension FlutterError {
+    public enum DdErrorCodes {
+        static let contractViolation = "DatadogSdk:ContractViolation"
+        static let invalidOperation = "DatadogSdk:InvalidOperation"
+    }
+
+    static func missingParameter(methodName: String) -> FlutterError {
+        return FlutterError(code: DdErrorCodes.contractViolation,
+                            message: "Missing parameter in call to \(methodName)",
+                            details: nil)
+    }
+
+    static func invalidOperation(message: String) -> FlutterError {
+        return FlutterError(code: DdErrorCodes.invalidOperation,
+                            message: message,
+                            details: nil)
+    }
 }

--- a/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
@@ -33,6 +33,8 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
             setHasReplay(arguments: arguments, result: result)
         case "setRecordCount":
             setRecordCount(arguments: arguments, result: result)
+        case "writeSegment":
+            writeSegment(arguments: arguments, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -68,7 +70,6 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
         feature?.setHasReplay(hasReplay)
 
         result(nil)
-
     }
 
     func setRecordCount(arguments: [String: Any?], result: @escaping FlutterResult) {
@@ -79,6 +80,17 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
         }
 
         feature?.setRecordCount(for: viewId, count: count)
+
+        result(nil)
+    }
+
+    func writeSegment(arguments: [String: Any?], result: @escaping FlutterResult) {
+        guard let segmentJson = arguments["segment"] as? String else {
+            result(FlutterError.missingParameter(methodName: "writeSegment"))
+            return
+        }
+
+        feature?.writeSegment(segment: segmentJson)
 
         result(nil)
     }

--- a/packages/datadog_session_replay/ios/Classes/Feature/Baggages.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/Baggages.swift
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import Foundation
+
+/// Defines dependency between Session Replay (SR) and RUM modules.
+/// It aims at centralizing documentation of contracts between both products.
+internal enum RUMDependency {
+    // MARK: Contract from SR to RUM (mirror of `SessionReplayDependency` in RUM):
+
+    /// The key referencing a `Bool` value that indicates if replay is being recorded.
+    static let hasReplay = "sr_has_replay"
+
+    /// They key referencing a `[String: Int64]` dictionary of viewIDs and associated records count.
+    static let recordsCountByViewID = "sr_records_count_by_view_id"
+}
+
+/// The RUM context received from `DatadogCore`.
+internal struct RUMContext: Codable, Equatable {
+    static let key = "rum"
+
+    enum CodingKeys: String, CodingKey {
+        case applicationID = "application.id"
+        case sessionID = "session.id"
+        case viewID = "view.id"
+        case viewServerTimeOffset = "server_time_offset"
+    }
+
+    /// Current RUM application ID - standard UUID string, lowecased.
+    let applicationID: String
+    /// Current RUM session ID - standard UUID string, lowecased.
+    let sessionID: String
+    /// Current RUM view ID - standard UUID string, lowecased. It can be empty when view is being loaded.
+    let viewID: String?
+    /// Current view related server time offset
+    let viewServerTimeOffset: TimeInterval?
+}
+
+extension RUMContext {
+    func encodedForFlutter() -> [String: Any?] {
+        return [
+            "applicationId": applicationID,
+            "sessionId": sessionID,
+            "viewId": viewID,
+            "viewServerTimeOffset": viewServerTimeOffset
+        ]
+    }
+}

--- a/packages/datadog_session_replay/ios/Classes/Feature/FlutterSeasionReplayFeature.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/FlutterSeasionReplayFeature.swift
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-2020 Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+
+class FlutterSessionReplayFeature: DatadogRemoteFeature {
+    static var name: String = "session-replay"
+
+    let requestBuilder: DatadogInternal.FeatureRequestBuilder
+    let messageReceiver: DatadogInternal.FeatureMessageReceiver
+
+    private weak var core: DatadogCoreProtocol?
+
+    private var recordCountByViewId: [String: Int] = [:]
+
+    init(
+        core: DatadogCoreProtocol,
+        configuration: FlutterSessionReplay.Configuration
+    ) throws {
+        self.core = core
+
+        self.requestBuilder = RequestBuilder(
+            customUploadURL: configuration.customEndpoint,
+            telemetry: core.telemetry
+        )
+
+        self.core = core
+        let contextReciever = RUMContextReceiver()
+        if let onContextChanged = configuration.onContextChanged {
+            contextReciever.observe(notify: { context in
+                onContextChanged(context)
+            })
+        }
+        self.messageReceiver = contextReciever
+    }
+
+    func setHasReplay(_ hasReplay: Bool) {
+        core?.set(baggage: hasReplay, forKey: RUMDependency.hasReplay)
+    }
+
+    func setRecordCount(for viewId: String, count: Int) {
+        recordCountByViewId[viewId] = count
+        core?.set(baggage: recordCountByViewId, forKey: RUMDependency.recordsCountByViewID)
+    }
+
+    func writeSegment(segment: String) {
+        let wrapper = RecordWrapper(recordJson: segment)
+        core?.scope(for: FlutterSessionReplayFeature.self).eventWriteContext(bypassConsent: true) { _, writer in
+            writer.write(value: wrapper)
+        }
+    }
+}

--- a/packages/datadog_session_replay/ios/Classes/Feature/FlutterSeasionReplayFeature.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/FlutterSeasionReplayFeature.swift
@@ -11,7 +11,8 @@ class FlutterSessionReplayFeature: DatadogRemoteFeature {
     let requestBuilder: DatadogInternal.FeatureRequestBuilder
     let messageReceiver: DatadogInternal.FeatureMessageReceiver
 
-    private weak var core: DatadogCoreProtocol?
+    private var core: DatadogCoreProtocol?
+    private var featureScope: FeatureScope?
 
     private var recordCountByViewId: [String: Int] = [:]
 
@@ -20,13 +21,13 @@ class FlutterSessionReplayFeature: DatadogRemoteFeature {
         configuration: FlutterSessionReplay.Configuration
     ) throws {
         self.core = core
+        self.featureScope = core.scope(for: FlutterSessionReplayFeature.self)
 
         self.requestBuilder = RequestBuilder(
             customUploadURL: configuration.customEndpoint,
             telemetry: core.telemetry
         )
 
-        self.core = core
         let contextReciever = RUMContextReceiver()
         if let onContextChanged = configuration.onContextChanged {
             contextReciever.observe(notify: { context in
@@ -47,7 +48,7 @@ class FlutterSessionReplayFeature: DatadogRemoteFeature {
 
     func writeSegment(segment: String) {
         let wrapper = RecordWrapper(recordJson: segment)
-        core?.scope(for: FlutterSessionReplayFeature.self).eventWriteContext(bypassConsent: true) { _, writer in
+        featureScope?.eventWriteContext(bypassConsent: true) { _, writer in
             writer.write(value: wrapper)
         }
     }

--- a/packages/datadog_session_replay/ios/Classes/Feature/RUMContextReceiver.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RUMContextReceiver.swift
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+import Foundation
+import DatadogInternal
+
+/// An observer notifying on`RUMContext` changes.
+internal protocol RUMContextObserver {
+    /// Starts notifying on distinct changes to `RUMContext`.
+    ///
+    /// - Parameters:
+    ///   - queue: a queue to call `notify` block on
+    ///   - notify: a closure receiving new `RUMContext` or `nil` if current RUM session is not sampled
+    func observe(notify: @escaping (RUMContext?) -> Void)
+}
+
+/// Receives RUM context from `DatadogCore` and notifies it through `RUMContextObserver` interface.
+internal class RUMContextReceiver: FeatureMessageReceiver, RUMContextObserver {
+    /// Notifies new `RUMContext` or `nil` if current RUM session is not sampled.
+    private var onNew: ((RUMContext?) -> Void)?
+    private var previous: RUMContext?
+
+    // MARK: - FeatureMessageReceiver
+
+    func receive(message: FeatureMessage, from core: DatadogCoreProtocol) -> Bool {
+        guard case let .context(context) = message else {
+            return false
+        }
+
+        var new: RUMContext?
+
+        do {
+            // Extract the `RUMContext` or `nil` if RUM session is not sampled:
+            new = try context.baggages[RUMContext.key].map { try $0.decode() }
+        } catch {
+            core.telemetry
+                .error("Fails to decode RUM context from Session Replay", error: error)
+        }
+
+        // Notify only if it has changed:
+        if new != previous {
+            onNew?(new)
+            previous = new
+        }
+
+        return true
+    }
+
+    func observe(notify: @escaping (RUMContext?) -> Void) {
+        onNew = { new in
+            notify(new)
+        }
+    }
+}

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/EnrichedRecordJSON.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/EnrichedRecordJSON.swift
@@ -9,7 +9,7 @@ internal typealias JSONObject = [String: Any?]
 
 internal struct RecordWrapper: Codable {
     enum CodingKeys: String, CodingKey {
-        case recordJson = "recordJson"
+        case recordJson
     }
 
     let recordJson: String
@@ -78,8 +78,11 @@ private func read<T>(codingKey: EnrichedRecordJSON.CodingKeys, from object: JSON
 }
 
 /// An exception thrown by the SDK.
-/// It is always handled by SDK (keeps it functional) and never passed to the user unless SDK verbosity is configured (then it might be printed in debugger console).
-/// `InternalError` might be thrown due to programmer error (API misuse) or SDK internal inconsistency or external issues (e.g.  I/O errors).
+///
+/// It is always handled by SDK (keeps it functional) and never passed to the user unless SDK verbosity is configured
+/// (then it might be printed in debugger console). `InternalError` might be thrown due to programmer error (API misuse)
+/// or SDK internal inconsistency or external issues (e.g.  I/O errors).
+///
 /// The SDK should always recover from these failures (if it can not, `FatalError` should be used).
 internal struct InternalError: Error, CustomStringConvertible {
     let description: String

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/EnrichedRecordJSON.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/EnrichedRecordJSON.swift
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+#if os(iOS)
+import Foundation
+
+internal typealias JSONObject = [String: Any?]
+
+internal struct RecordWrapper: Codable {
+    enum CodingKeys: String, CodingKey {
+        case recordJson = "recordJson"
+    }
+
+    let recordJson: String
+
+    func extractEnrichedRecord() throws -> EnrichedRecordJSON {
+        if let data = recordJson.data(using: .utf8) {
+            let record = try EnrichedRecordJSON(jsonObjectData: data)
+            return record
+        }
+        throw InternalError(description: "Failed to convert jsonString")
+    }
+}
+
+// NOTE: This code is pulled from dd-sdk-ios
+
+/// A mirror of `EnrichedRecord` but providing decoding capability. Unlike encodable `EnrichedRecord`
+/// it can be both encoded and decoded with `Foundation.JSONSerialization`.
+///
+/// `EnrichedRecordJSON` values are decoded from batched events (`[Data]`) upon request from `DatadogCore`.
+/// They are mapped into one or many `SegmentJSONs`. Segments are then encoded in multipart-body of `URLRequests`
+/// and sent by core on behalf of Session Replay.
+///
+/// Except containing original records created by `Processor` (in `records: [JSONObject]`), `EnrichedRecordJSON`
+/// offers a typed meta information that facilitates grouping records into segments.
+internal struct EnrichedRecordJSON {
+    enum CodingKeys: String, CodingKey {
+        case records
+        case applicationID
+        case sessionID
+        case viewID
+    }
+
+    /// Records enriched with further information.
+    let records: [JSONObject]
+
+    /// The RUM application ID common to all records.
+    let applicationID: String
+    /// The RUM session ID common to all records.
+    let sessionID: String
+    /// The RUM view ID common to all records.
+    let viewID: String
+    /// If there is a Full Snapshot among records.
+
+    init(jsonObjectData: Data) throws {
+        let jsonObject: JSONObject = try decode(jsonObjectData)
+
+        self.records = try read(codingKey: .records, from: jsonObject)
+        self.applicationID = try read(codingKey: .applicationID, from: jsonObject)
+        self.sessionID = try read(codingKey: .sessionID, from: jsonObject)
+        self.viewID = try read(codingKey: .viewID, from: jsonObject)
+    }
+}
+
+internal func decode<T>(_ data: Data) throws -> T {
+    guard let value = try JSONSerialization.jsonObject(with: data) as? T else {
+        throw InternalError(description: "Failed to decode \(type(of: T.self))")
+    }
+    return value
+}
+
+private func read<T>(codingKey: EnrichedRecordJSON.CodingKeys, from object: JSONObject) throws -> T {
+    guard let value = object[codingKey.stringValue] as? T else {
+        throw InternalError(description: "Failed to read attribute at key path '\(codingKey.stringValue)'")
+    }
+    return value
+}
+
+/// An exception thrown by the SDK.
+/// It is always handled by SDK (keeps it functional) and never passed to the user unless SDK verbosity is configured (then it might be printed in debugger console).
+/// `InternalError` might be thrown due to programmer error (API misuse) or SDK internal inconsistency or external issues (e.g.  I/O errors).
+/// The SDK should always recover from these failures (if it can not, `FatalError` should be used).
+internal struct InternalError: Error, CustomStringConvertible {
+    let description: String
+
+    init(description: String, fileID: StaticString = #fileID, line: UInt = #line) {
+        self.description = "\(description) (\(fileID):\(line))"
+    }
+}
+
+#endif

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/MultipartFormData.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/MultipartFormData.swift
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+#if os(iOS)
+import Foundation
+
+internal protocol MultipartFormDataBuilder {
+    /// The boundary UUID of this multipart form.
+    var boundary: String { get }
+    /// Adds a field.
+    mutating func addFormField(name: String, value: String)
+    /// Adds a file.
+    mutating func addFormData(name: String, filename: String, data: Data, mimeType: String)
+    /// Returns the entire multipart body data (as it should be applied to request).
+    mutating func build() -> Data
+}
+
+/// A helper facilitating creation of `multipart/form-data` body.
+internal struct MultipartFormData: MultipartFormDataBuilder {
+    private(set) var boundary: String
+    private var body = Data()
+
+    init() {
+        self.boundary = UUID().uuidString
+    }
+
+    mutating func addFormField(name: String, value: String) {
+        body.append(string: "--\(boundary)\r\n")
+        body.append(string: "Content-Disposition: form-data; name=\"\(name)\"\r\n")
+        body.append(string: "\r\n")
+        body.append(string: value)
+        body.append(string: "\r\n")
+    }
+
+    mutating func addFormData(name: String, filename: String, data: Data, mimeType: String) {
+        body.append(string: "--\(boundary)\r\n")
+        body.append(string: "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        body.append(string: "Content-Type: \(mimeType)\r\n")
+        body.append(string: "\r\n")
+        body.append(data)
+        body.append(string: "\r\n")
+    }
+
+    mutating func build() -> Data {
+        defer {
+            // reset builder
+            body = Data()
+            boundary = UUID().uuidString
+        }
+
+        body.append(string: "--\(boundary)--")
+        return body
+    }
+}
+
+private extension Data {
+    mutating func append(string: String) {
+        guard let data = string.data(using: .utf8) else {
+            return
+        }
+        self.append(data)
+    }
+}
+#endif

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
@@ -24,20 +24,15 @@ internal struct RequestBuilder: FeatureRequestBuilder {
 
         // If we can't decode `events: [Data]` there is no way to recover, so we throw an
         // error to let the core delete the batch:
-        do {
-            let decoder = JSONDecoder()
-            let wrappers: [RecordWrapper] = try events.compactMap {
-                try decoder.decode(RecordWrapper.self, from: $0.data)
-            }
-            let segments = try wrappers.map { try $0.extractEnrichedRecord() }
-                .map { try SegmentJSON($0, source: source) }
-                .merge()
-
-            return try createRequest(segments: segments, context: context)
-        } catch let error {
-            print("Error \(error)")
-            throw error
+        let decoder = JSONDecoder()
+        let wrappers: [RecordWrapper] = try events.compactMap {
+            try decoder.decode(RecordWrapper.self, from: $0.data)
         }
+        let segments = try wrappers.map { try $0.extractEnrichedRecord() }
+            .map { try SegmentJSON($0, source: source) }
+            .merge()
+
+        return try createRequest(segments: segments, context: context)        
     }
 
     private func createRequest(segments: [SegmentJSON], context: DatadogContext) throws -> URLRequest {

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+
+internal struct RequestBuilder: FeatureRequestBuilder {
+    private static let newlineByte = "\n".data(using: .utf8)! // swiftlint:disable:this force_unwrapping
+
+    /// Custom URL for uploading data to.
+    let customUploadURL: URL?
+    /// Sends telemetry through sdk core.
+    let telemetry: Telemetry
+    /// Builds multipart form for request's body.
+    var multipartBuilder: MultipartFormDataBuilder = MultipartFormData()
+
+    func request(for events: [Event], with context: DatadogContext, execution: DatadogInternal.ExecutionContext) throws -> URLRequest {
+        let source = context.source
+
+        // If we can't decode `events: [Data]` there is no way to recover, so we throw an
+        // error to let the core delete the batch:
+        do {
+            let decoder = JSONDecoder()
+            let wrappers: [RecordWrapper] = try events.compactMap {
+                try decoder.decode(RecordWrapper.self, from: $0.data)
+            }
+            let segments = try wrappers.map { try $0.extractEnrichedRecord() }
+                .map { try SegmentJSON($0, source: source) }
+                .merge()
+
+            return try createRequest(segments: segments, context: context)
+        } catch let error {
+            print("Error \(error)")
+            throw error
+        }
+    }
+
+    private func createRequest(segments: [SegmentJSON], context: DatadogContext) throws -> URLRequest {
+        var multipart = multipartBuilder
+
+        let builder = URLRequestBuilder(
+            url: url(with: context),
+            queryItems: [],
+            headers: [
+                .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
+                .userAgentHeader(appName: context.applicationName, appVersion: context.version, device: context.device),
+                .ddAPIKeyHeader(clientToken: context.clientToken),
+                .ddEVPOriginHeader(source: context.source),
+                .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),
+                .ddRequestIDHeader()
+            ],
+            telemetry: telemetry
+        )
+
+        let jsonEncoder = JSONEncoder()
+
+        let metadata = try segments.enumerated().map { index, segment in
+            let json = segment.toJSONObject()
+            // Session Replay BE accepts compressed segment data followed by newline character (before compression):
+            let data = try JSONSerialization.data(withJSONObject: json) + RequestBuilder.newlineByte
+            let compressedData = try SRCompression.compress(data: data)
+            // Compressed segment is sent within multipart form data - with some of segment (metadata)
+            // attributes listed as form fields:
+            multipart.addFormData(
+                name: "segment",
+                filename: "file\(index)",
+                data: compressedData,
+                mimeType: "application/octet-stream"
+            )
+            return Metadata(
+                application: .init(id: segment.applicationID),
+                end: segment.end,
+                hasFullSnapshot: segment.hasFullSnapshot,
+                indexInView: segment.indexInView,
+                recordsCount: segment.recordsCount,
+                session: .init(id: segment.sessionID),
+                source: segment.source,
+                start: segment.start,
+                view: .init(id: segment.viewID),
+                rawSegmentSize: data.count,
+                compressedSegmentSize: compressedData.count
+            )
+        }
+
+        let encodedMetadata = try jsonEncoder.encode(metadata)
+        multipart.addFormData(
+            name: "event",
+            filename: "blob",
+            data: encodedMetadata,
+            mimeType: "application/json"
+        )
+
+        // Data is already compressed, so request building request w/o compression:
+        return builder.uploadRequest(with: multipart.build(), compress: false)
+    }
+
+    private func url(with context: DatadogContext) -> URL {
+        customUploadURL ?? context.site.endpoint.appendingPathComponent("api/v2/replay")
+    }
+}
+
+internal struct Metadata: Codable {
+    let application: Application
+    let end: Int64
+    let hasFullSnapshot: Bool?
+    let indexInView: Int64?
+    let recordsCount: Int64
+    let session: Session
+    let source: String
+    let start: Int64
+    let view: View
+    let rawSegmentSize: Int
+    let compressedSegmentSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case application = "application"
+        case end = "end"
+        case hasFullSnapshot = "has_full_snapshot"
+        case indexInView = "index_in_view"
+        case recordsCount = "records_count"
+        case session = "session"
+        case source = "source"
+        case start = "start"
+        case view = "view"
+        case rawSegmentSize = "raw_segment_size"
+        case compressedSegmentSize = "compressed_segment_size"
+    }
+
+    public struct Application: Codable {
+        /// UUID of the application
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    /// Session properties
+    public struct Session: Codable {
+        /// UUID of the session
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+
+    public struct View: Codable {
+        /// UUID of the view
+        public let id: String
+
+        enum CodingKeys: String, CodingKey {
+            case id = "id"
+        }
+    }
+}

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
@@ -6,7 +6,7 @@ import Foundation
 import DatadogInternal
 
 internal struct RequestBuilder: FeatureRequestBuilder {
-    private static let newlineByte = "\n".data(using: .utf8)! // swiftlint:disable:this force_unwrapping
+    private static let newlineByte = Data("\n".utf8)
 
     /// Custom URL for uploading data to.
     let customUploadURL: URL?
@@ -15,7 +15,11 @@ internal struct RequestBuilder: FeatureRequestBuilder {
     /// Builds multipart form for request's body.
     var multipartBuilder: MultipartFormDataBuilder = MultipartFormData()
 
-    func request(for events: [Event], with context: DatadogContext, execution: DatadogInternal.ExecutionContext) throws -> URLRequest {
+    func request(
+        for events: [Event],
+        with context: DatadogContext,
+        execution: DatadogInternal.ExecutionContext
+    ) throws -> URLRequest {
         let source = context.source
 
         // If we can't decode `events: [Data]` there is no way to recover, so we throw an
@@ -100,6 +104,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
     }
 }
 
+// swiftlint:disable nesting
 internal struct Metadata: Codable {
     let application: Application
     let end: Int64
@@ -114,15 +119,15 @@ internal struct Metadata: Codable {
     let compressedSegmentSize: Int
 
     enum CodingKeys: String, CodingKey {
-        case application = "application"
-        case end = "end"
+        case application
+        case end
         case hasFullSnapshot = "has_full_snapshot"
         case indexInView = "index_in_view"
         case recordsCount = "records_count"
-        case session = "session"
-        case source = "source"
-        case start = "start"
-        case view = "view"
+        case session
+        case source
+        case start
+        case view
         case rawSegmentSize = "raw_segment_size"
         case compressedSegmentSize = "compressed_segment_size"
     }
@@ -132,7 +137,7 @@ internal struct Metadata: Codable {
         public let id: String
 
         enum CodingKeys: String, CodingKey {
-            case id = "id"
+            case id
         }
     }
 
@@ -142,7 +147,7 @@ internal struct Metadata: Codable {
         public let id: String
 
         enum CodingKeys: String, CodingKey {
-            case id = "id"
+            case id
         }
     }
 
@@ -151,7 +156,8 @@ internal struct Metadata: Codable {
         public let id: String
 
         enum CodingKeys: String, CodingKey {
-            case id = "id"
+            case id
         }
     }
 }
+// swiftlint:enable nesting

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SRCompression.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SRCompression.swift
@@ -1,0 +1,104 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+#if os(iOS)
+import Foundation
+import zlib
+
+internal struct SRCompression {
+    /// Compresses the data into ZLIB Compressed Data Format as described in IETF RFC 1950.
+    ///
+    /// To meet `dogweb` expectation for Session Replay, it uses compression level `6` and `Z_SYNC_FLUSH`
+    /// + `Z_FINISH` flags for flushing compressed data to the output. This allows the receiver (SR player) to
+    /// concatenate succeeding chunks of compressed data and perform inflate only once instead of decompressing
+    /// each chunk individually.
+    static func compress(data: Data) throws -> Data {
+        return try zcompress(
+            data: data,
+            level: 6,
+            // To ensure zlib has enough size in its buffer, we allocate chunk size for worst-case scenario (compression of 1 byte):
+            //
+            // > Ref.: https://github.com/madler/zlib/blob/04f42ceca40f73e2978b50e93806c2a18c1281fc/compress.c#L15
+            // > destination buffer (...) must be at least 0.1% larger than sourceLen plus 12 bytes
+            chunk: Int((Double(data.count) * 1.01).rounded(.up) + 12)
+        )
+    }
+
+    private static func zcompress(data: Data, level: Int, chunk: Int) throws -> Data {
+        // z_streamp->next_in requires mutable bytes
+        var m_data = data
+
+        return try m_data.withUnsafeMutableBytes {
+            guard let ptr = $0.bindMemory(to: Bytef.self).baseAddress else {
+                throw InternalError(description: "zlib compress: failed to bind data memory")
+            }
+
+            let buffer = UnsafeMutablePointer<Bytef>.allocate(capacity: chunk)
+            defer { buffer.deallocate() }
+
+            let stream = z_streamp.allocate(capacity: 1)
+            defer { stream.deallocate() }
+
+            // Configure initial state of zlib:
+            // - Setting `Z_NULL` for memory allocation routines means that zlib will use its default implementations.
+            // - This mutable state is shared between our code and zlib. In later do / while iterations zlib will leverage
+            // it to empower `deflate()` calls and walk through original `data` with `next_in` and `avail_in`.
+            // - A good explanation of how to use `z_stream`: https://zlib.net/zlib_how.html
+            // - A practical explanation of different ZLIB APIs: https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zlib.h
+            stream.pointee.next_in = ptr // pointer to next input byte
+            stream.pointee.avail_in = uInt(data.count) // number of bytes available at next_in
+            stream.pointee.total_out = 0 // total number of bytes output so far
+            stream.pointee.zalloc = nil // Z_NULL: nil points to addr 0x0, equivalent of Z_NULL
+            stream.pointee.zfree = nil // Z_NULL
+            stream.pointee.opaque = nil // Z_NULL
+
+            var result = deflateInit_(stream, Int32(level), ZLIB_VERSION, Int32(MemoryLayout<z_stream>.size))
+            defer { deflateEnd(stream) } // free the allocated zlib state
+
+            guard result == Z_OK else {
+                throw InternalError(description: "zlib deflateInit_() error: \(zerror(result)) when compressing data of \(data.count) bytes")
+            }
+
+            var c_data = Data()
+            repeat {
+                stream.pointee.next_out = buffer
+                stream.pointee.avail_out = uInt(chunk)
+
+                let flush = stream.pointee.avail_in == 0 ? Z_FINISH : Z_SYNC_FLUSH // if no more data to compress
+                result = deflate(stream, flush)
+
+                let count = chunk - Int(stream.pointee.avail_out)
+                c_data.append(buffer, count: count)
+            } while result == Z_OK
+
+            guard result == Z_STREAM_END else {
+                throw InternalError(description: "zlib deflate() error: \(zerror(result)) when compressing data of \(data.count) bytes")
+            }
+
+            return c_data
+        }
+    }
+
+    private static func zerror(_ code: Int32) -> String {
+        switch code {
+        case Z_ERRNO:
+            return "Z_ERRNO"
+        case Z_STREAM_ERROR:
+            return "Z_STREAM_ERROR"
+        case Z_DATA_ERROR:
+            return "Z_DATA_ERROR"
+        case Z_MEM_ERROR:
+            return "Z_MEM_ERROR"
+        case Z_BUF_ERROR:
+            return "Z_BUF_ERROR"
+        case Z_VERSION_ERROR:
+            return "Z_VERSION_ERROR"
+        default:
+            return "unknown error (\(code))"
+        }
+    }
+}
+#endif

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SRCompression.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SRCompression.swift
@@ -19,7 +19,8 @@ internal struct SRCompression {
         return try zcompress(
             data: data,
             level: 6,
-            // To ensure zlib has enough size in its buffer, we allocate chunk size for worst-case scenario (compression of 1 byte):
+            // To ensure zlib has enough size in its buffer, we allocate chunk size for worst-case scenario
+            // (compression of 1 byte):
             //
             // > Ref.: https://github.com/madler/zlib/blob/04f42ceca40f73e2978b50e93806c2a18c1281fc/compress.c#L15
             // > destination buffer (...) must be at least 0.1% larger than sourceLen plus 12 bytes
@@ -29,9 +30,9 @@ internal struct SRCompression {
 
     private static func zcompress(data: Data, level: Int, chunk: Int) throws -> Data {
         // z_streamp->next_in requires mutable bytes
-        var m_data = data
+        var mutableData = data
 
-        return try m_data.withUnsafeMutableBytes {
+        return try mutableData.withUnsafeMutableBytes {
             guard let ptr = $0.bindMemory(to: Bytef.self).baseAddress else {
                 throw InternalError(description: "zlib compress: failed to bind data memory")
             }
@@ -42,12 +43,14 @@ internal struct SRCompression {
             let stream = z_streamp.allocate(capacity: 1)
             defer { stream.deallocate() }
 
+            // swiftlint:disable line_length
             // Configure initial state of zlib:
             // - Setting `Z_NULL` for memory allocation routines means that zlib will use its default implementations.
             // - This mutable state is shared between our code and zlib. In later do / while iterations zlib will leverage
             // it to empower `deflate()` calls and walk through original `data` with `next_in` and `avail_in`.
             // - A good explanation of how to use `z_stream`: https://zlib.net/zlib_how.html
             // - A practical explanation of different ZLIB APIs: https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zlib.h
+            // swiftlint:enable line_length
             stream.pointee.next_in = ptr // pointer to next input byte
             stream.pointee.avail_in = uInt(data.count) // number of bytes available at next_in
             stream.pointee.total_out = 0 // total number of bytes output so far
@@ -59,10 +62,11 @@ internal struct SRCompression {
             defer { deflateEnd(stream) } // free the allocated zlib state
 
             guard result == Z_OK else {
+                // swiftlint:disable:next line_length
                 throw InternalError(description: "zlib deflateInit_() error: \(zerror(result)) when compressing data of \(data.count) bytes")
             }
 
-            var c_data = Data()
+            var cData = Data()
             repeat {
                 stream.pointee.next_out = buffer
                 stream.pointee.avail_out = uInt(chunk)
@@ -71,14 +75,15 @@ internal struct SRCompression {
                 result = deflate(stream, flush)
 
                 let count = chunk - Int(stream.pointee.avail_out)
-                c_data.append(buffer, count: count)
+                cData.append(buffer, count: count)
             } while result == Z_OK
 
             guard result == Z_STREAM_END else {
+                // swiftlint:disable:next line_length
                 throw InternalError(description: "zlib deflate() error: \(zerror(result)) when compressing data of \(data.count) bytes")
             }
 
-            return c_data
+            return cData
         }
     }
 

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SegmentJSON.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SegmentJSON.swift
@@ -8,6 +8,7 @@ import Foundation
 // NOTE: This code is pulled from dd-sdk-ios
 
 internal struct SegmentJSON {
+    // swiftlint:disable line_length
     enum Constants {
         /// The `timestamp` is common to all records.
         /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/session-replay/common/_common-record-schema.json#L9
@@ -21,6 +22,7 @@ internal struct SegmentJSON {
         /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/session-replay/mobile/full-snapshot-record-schema.json#L14L19
         static let nativeFullsnapshotValue = 10
     }
+    // swiftlint:enable line_length
 
     enum CodingKeys: String, CodingKey {
         case applicationID = "application"

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SegmentJSON.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/SegmentJSON.swift
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+#if os(iOS)
+import Foundation
+
+// NOTE: This code is pulled from dd-sdk-ios
+
+internal struct SegmentJSON {
+    enum Constants {
+        /// The `timestamp` is common to all records.
+        /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/session-replay/common/_common-record-schema.json#L9
+        static let timestampKey = "timestamp"
+        /// The `type` key can be used to identify the type of record.
+        static let typeKey = "type"
+        /// The constant type value for browser full snapshot is `2`.
+        /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/session-replay/browser/full-snapshot-record-schema.json#L14L19
+        static let browserFullsnapshotValue = 2
+        /// The constant type value for mobile full snapshot is `10`.
+        /// see. https://github.com/DataDog/rum-events-format/blob/master/schemas/session-replay/mobile/full-snapshot-record-schema.json#L14L19
+        static let nativeFullsnapshotValue = 10
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case applicationID = "application"
+        case end = "end"
+        case hasFullSnapshot = "has_full_snapshot"
+        case indexInView = "index_in_view"
+        case records = "records"
+        case recordsCount = "records_count"
+        case sessionID = "session"
+        case source = "source"
+        case start = "start"
+        case viewID = "view"
+    }
+
+    /// The RUM application ID common to all records.
+    let applicationID: String
+    /// The RUM session ID common to all records.
+    let sessionID: String
+    /// The RUM view ID common to all records.
+    let viewID: String
+    /// The `source` of SDK in which the segment was recorded (e.g. `"flutter"`).
+    let source: String
+    /// The timestamp of the earliest record.
+    let start: Int64
+    /// The timestamp of the latest record.
+    let end: Int64
+    /// Records to be sent in this segment.
+    let records: [JSONObject]
+    /// Number of records.
+    let recordsCount: Int64
+    /// If there is a Full Snapshot among records.
+    let hasFullSnapshot: Bool
+    /// The index of this Segment in the segments list that was recorded for this view ID. Starts from 0.
+    let indexInView: Int64?
+
+    init(
+            applicationID: String,
+            sessionID: String,
+            viewID: String,
+            source: String,
+            start: Int64,
+            end: Int64,
+            records: [JSONObject],
+            recordsCount: Int64,
+            hasFullSnapshot: Bool,
+            indexInView: Int64?
+    ) {
+        self.applicationID = applicationID
+        self.sessionID = sessionID
+        self.viewID = viewID
+        self.source = source
+        self.start = start
+        self.end = end
+        self.records = records
+        self.recordsCount = recordsCount
+        self.hasFullSnapshot = hasFullSnapshot
+        self.indexInView = indexInView
+    }
+
+    init(_ enrichedRecord: EnrichedRecordJSON, source: String) throws {
+        self.records = enrichedRecord.records
+        self.recordsCount = Int64(records.count)
+
+        var hasFullSnapshot = false
+        var start: Int64 = .max
+        var end: Int64 = .min
+
+        for record in records {
+            guard let timestamp = record[Constants.timestampKey] as? Int64 else {
+                // records must contain a timestamp
+                throw InternalError(description: "Record is missing timestamp")
+            }
+
+            start = min(timestamp, start)
+            end = max(timestamp, end)
+
+            guard let type = record[Constants.typeKey] as? Int64 else {
+                continue // ignore records with no type
+            }
+
+            // check for native or browser full snapshot
+            if type == Constants.nativeFullsnapshotValue || type == Constants.browserFullsnapshotValue {
+                hasFullSnapshot = true
+            }
+        }
+
+        self.applicationID = enrichedRecord.applicationID
+        self.sessionID = enrichedRecord.sessionID
+        self.viewID = enrichedRecord.viewID
+        self.hasFullSnapshot = hasFullSnapshot
+        self.start = start
+        self.end = end
+        self.source = source
+        self.indexInView = nil
+    }
+
+    func toJSONObject() -> JSONObject {
+        return [
+            segmentKey(.applicationID): ["id": applicationID],
+            segmentKey(.sessionID): ["id": sessionID],
+            segmentKey(.viewID): ["id": viewID],
+            segmentKey(.source): source,
+            segmentKey(.start): start,
+            segmentKey(.end): end,
+            segmentKey(.hasFullSnapshot): hasFullSnapshot,
+            segmentKey(.indexInView): indexInView,
+            segmentKey(.records): records,
+            segmentKey(.recordsCount): recordsCount
+        ]
+    }
+}
+
+private func segmentKey(_ codingKey: SegmentJSON.CodingKeys) -> String { codingKey.stringValue }
+
+extension Array where Element == SegmentJSON {
+    /// Merges Segments from the same `view.id`
+    ///
+    /// - Returns: The new list of segments grouped by view id.
+    func merge() -> [SegmentJSON] {
+        var indexes: [String: Int] = [:]
+        return reduce(into: []) { segments, segment in
+            if let index = indexes[segment.viewID] {
+                let current = segments[index]
+                segments[index] = SegmentJSON(
+                    applicationID: current.applicationID,
+                    sessionID: current.sessionID,
+                    viewID: current.viewID,
+                    source: current.source,
+                    start: Swift.min(current.start, segment.start),
+                    end: Swift.max(current.end, segment.end),
+                    records: current.records + segment.records,
+                    recordsCount: current.recordsCount + segment.recordsCount,
+                    hasFullSnapshot: current.hasFullSnapshot || segment.hasFullSnapshot,
+                    indexInView: nil
+                )
+            } else {
+                indexes[segment.viewID] = segments.count
+                segments.append(segment)
+            }
+        }
+    }
+}
+
+#endif

--- a/packages/datadog_session_replay/ios/Classes/FlutterSessionReplay.swift
+++ b/packages/datadog_session_replay/ios/Classes/FlutterSessionReplay.swift
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import DatadogInternal
+
+internal class FlutterSessionReplay {
+    public struct Configuration {
+        public var customEndpoint: URL?
+        public var onContextChanged: ((RUMContext?) -> Void)?
+
+        public init(
+            customEndpoint: URL? = nil,
+            onContextChanged: ((RUMContext?) -> Void)? = nil
+        ) {
+            self.customEndpoint = customEndpoint
+            self.onContextChanged = onContextChanged
+        }
+
+        public init?(fromEncoded encoded: [String: Any?]) {
+            var customEndpoint: URL?
+            if let customEndpointString = encoded["customEndpoint"] as? String {
+                customEndpoint = URL(string: customEndpointString)
+            }
+
+            self.init(customEndpoint: customEndpoint)
+        }
+    }
+
+    public static func enable(
+        with configuration: FlutterSessionReplay.Configuration,
+        in core: DatadogCoreProtocol = CoreRegistry.default
+    ) -> FlutterSessionReplayFeature? {
+        do {
+            let feature = try enableOrThrow(with: configuration, in: core)
+            return feature
+        } catch let error {
+            consolePrint("\(error)", .error)
+        }
+        return nil
+    }
+
+    internal static func enableOrThrow(
+        with configuration: FlutterSessionReplay.Configuration,
+        in core: DatadogCoreProtocol
+    ) throws -> FlutterSessionReplayFeature {
+        guard !(core is NOPDatadogCore) else {
+            throw ProgrammerError(
+                description: "Datadog SDK must be initialized before calling `SessionReplay.enable(with:)`."
+            )
+        }
+
+        let sessionReplay = try FlutterSessionReplayFeature(core: core, configuration: configuration)
+        try core.register(feature: sessionReplay)
+
+        // sessionReplay.writer.startWriting(to: core)
+
+        return sessionReplay
+    }
+}

--- a/packages/datadog_session_replay/ios/datadog_session_replay.podspec
+++ b/packages/datadog_session_replay/ios/datadog_session_replay.podspec
@@ -15,6 +15,7 @@ Support for Datadog Session Replay in Flutter.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.dependency 'DatadogCore', '~> 2'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -2,6 +2,7 @@ name: datadog_session_replay
 description: "Support for Flutter Session Replay in Datadog"
 version: 0.1.0
 homepage: https://datadoghq.com
+repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
   sdk: ^3.7.2
@@ -14,6 +15,7 @@ dependencies:
     sdk: flutter
   web: ^1.0.0
   plugin_platform_interface: ^2.0.2
+  datadog_flutter_plugin: ^2.11.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What and why?

This adds a Feature that will pass through Flutter generated Session Replay Records into SRSegments. The iOS Feature and RequestBuilder take care of serializing data to disk, assembling and compressing the SRSegments to send to intake.

The feature also takes care of broadcasting RUM context changes back to Flutter.

refs: RUM-9551

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
