### PR TITLE
feat: Add Android plugin overhead for Session Replay

### DIFF
--- a/packages/datadog_session_replay/android/build.gradle
+++ b/packages/datadog_session_replay/android/build.gradle
@@ -50,17 +50,17 @@ android {
     }
 
     dependencies {
-        implementation "com.datadoghq:dd-sdk-android-core:$datadog_version"
-        implementation "com.squareup.okhttp3:okhttp:4.12.0"
-        implementation "com.google.code.gson:gson:2.12.1"
+        implementation("com.datadoghq:dd-sdk-android-core:$datadog_version")
+        implementation("com.squareup.okhttp3:okhttp:4.12.0")
+        implementation("com.google.code.gson:gson:2.12.1")
 
         testImplementation("com.willowtreeapps.assertk:assertk:0.28.1")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation "org.junit.jupiter:junit-jupiter"
-        testImplementation "com.github.xgouchet.Elmyr:core:1.3.1"
-        testImplementation "com.github.xgouchet.Elmyr:junit5:1.3.1"
-        testImplementation "com.github.xgouchet.Elmyr:jvm:1.3.1"
-        testImplementation "io.mockk:mockk:1.14.2"
+        testImplementation("org.junit.jupiter:junit-jupiter")
+        testImplementation("com.github.xgouchet.Elmyr:core:1.3.1")
+        testImplementation("com.github.xgouchet.Elmyr:junit5:1.3.1")
+        testImplementation("com.github.xgouchet.Elmyr:jvm:1.3.1")
+        testImplementation("io.mockk:mockk:1.14.2")
     }
 
     testOptions {

--- a/packages/datadog_session_replay/android/build.gradle
+++ b/packages/datadog_session_replay/android/build.gradle
@@ -3,6 +3,8 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.8.22"
+    ext.datadog_version = "2.20.0"
+
     repositories {
         google()
         mavenCentral()
@@ -48,8 +50,17 @@ android {
     }
 
     dependencies {
+        implementation "com.datadoghq:dd-sdk-android-core:$datadog_version"
+        implementation "com.squareup.okhttp3:okhttp:4.12.0"
+        implementation "com.google.code.gson:gson:2.12.1"
+
+        testImplementation("com.willowtreeapps.assertk:assertk:0.28.1")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation("org.mockito:mockito-core:5.0.0")
+        testImplementation "org.junit.jupiter:junit-jupiter"
+        testImplementation "com.github.xgouchet.Elmyr:core:1.3.1"
+        testImplementation "com.github.xgouchet.Elmyr:junit5:1.3.1"
+        testImplementation "com.github.xgouchet.Elmyr:jvm:1.3.1"
+        testImplementation "io.mockk:mockk:1.14.2"
     }
 
     testOptions {

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
@@ -1,8 +1,14 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2025-Present Datadog, Inc.
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
 package com.datadoghq.flutter.sessionreplay
 
+import com.datadog.android.Datadog
+import com.datadoghq.flutter.missingParameter
+import com.datadoghq.flutter.sessionreplay.feature.FlutterSessionReplayFeature
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -10,14 +16,98 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
 class DatadogSessionReplayPlugin : FlutterPlugin, MethodCallHandler {
-    private lateinit var channel: MethodChannel
+    // Internal only for unit testing purposes
+    internal lateinit var channel: MethodChannel
+
+    private var feature: FlutterSessionReplayFeature? = null
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "datadog_session_replay")
+        channel = MethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            "datadog_sdk_flutter.session_replay"
+        )
         channel.setMethodCallHandler(this)
     }
 
-    override fun onMethodCall(call: MethodCall, result: Result) {}
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "enable" -> {
+                enable(call, result)
+            }
+            "setHasReplay" -> {
+                setHasReplay(call, result)
+            }
+            "setRecordCount" -> {
+                setRecordCount(call, result)
+            }
+            "writeSegment" -> {
+                writeSegment(call, result)
+            }
+            else -> {
+                result.notImplemented()
+            }
+        }
+    }
+
+    private fun enable(call: MethodCall, result: Result) {
+        val options = call.argument<Map<String, Any?>>("configuration")
+        if (options == null) {
+            result.missingParameter(call.method)
+            return
+        }
+        val configuration = FlutterSessionReplay.fromFlutter(options)
+        enable(configuration)
+        result.success(null)
+    }
+
+    internal fun enable(configuration: FlutterSessionReplay.Configuration) {
+        feature = FlutterSessionReplay.enable(
+            configuration = configuration,
+            onContextChanged = { context ->
+                onContextChanged(context)
+            },
+            sdkCore = Datadog.getInstance()
+        )
+    }
+
+    internal fun onContextChanged(context: Map<String, Any?>) {
+        channel.invokeMethod(
+            "onContextChanged",
+            context
+        )
+    }
+
+    private fun setHasReplay(call: MethodCall, result: Result) {
+        val viewId = call.argument<String>("viewId")
+        val hasReplay = call.argument<Boolean>("hasReplay")
+        if (hasReplay == null || viewId == null) {
+            result.missingParameter(call.method)
+            return
+        }
+        feature?.setHasReplay(viewId, hasReplay)
+        result.success(null)
+    }
+
+    private fun setRecordCount(call: MethodCall, result: Result) {
+        val viewId = call.argument<String>("viewId")
+        val recordCount = call.argument<Int>("count")
+        if (recordCount == null || viewId == null) {
+            result.missingParameter(call.method)
+            return
+        }
+        feature?.setRecordCount(viewId, recordCount)
+        result.success(null)
+    }
+
+    private fun writeSegment(call: MethodCall, result: MethodChannel.Result) {
+        val segment = call.argument<String>("segment")
+        if (segment == null) {
+            result.missingParameter(call.method)
+            return
+        }
+        feature?.writeSegment(segment)
+        result.success(null)
+    }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplay.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplay.kt
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+package com.datadoghq.flutter.sessionreplay
+
+import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadoghq.flutter.sessionreplay.feature.FlutterSessionReplayFeature
+
+object FlutterSessionReplay {
+    data class Configuration(
+        val customEndpointUrl: String? = null
+    )
+
+    fun enable(
+        configuration: Configuration,
+        onContextChanged: (Map<String, Any?>) -> Unit,
+        sdkCore: SdkCore
+    ): FlutterSessionReplayFeature {
+        val featureSdkCore = sdkCore as FeatureSdkCore
+        val sessionReplayFeature = FlutterSessionReplayFeature(
+            featureSdkCore,
+            onContextChanged,
+            configuration.customEndpointUrl
+        )
+        featureSdkCore.registerFeature(sessionReplayFeature)
+
+        return sessionReplayFeature
+    }
+
+    fun fromFlutter(configuration: Map<String, Any?>): Configuration {
+        val customEndpointUrl = configuration["customEndpointUrl"] as? String
+        return Configuration(customEndpointUrl)
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/BatchesToSegmentsMapper.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/BatchesToSegmentsMapper.kt
@@ -1,0 +1,205 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.feature
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadoghq.flutter.sessionreplay.gson.safeGetAsJsonArray
+import com.datadoghq.flutter.sessionreplay.gson.safeGetAsJsonObject
+import com.datadoghq.flutter.sessionreplay.gson.safeGetAsLong
+import com.datadoghq.flutter.sessionreplay.models.EnrichedRecord
+import com.datadoghq.flutter.sessionreplay.models.MobileSegment
+import com.datadoghq.flutter.sessionreplay.models.SessionReplayRumContext
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+
+/**
+ *  Maps a batch to a Pair<MobileSegment, SerializedMobileSegment> for uploading.
+ *
+ *  This is copied from dd-sdk-android and modified for use in the Flutter SDK.
+ */
+internal class BatchesToSegmentsMapper(private val internalLogger: InternalLogger) {
+
+    fun map(
+        datadogContext: DatadogContext,
+        batchData: List<ByteArray>
+    ): List<Pair<MobileSegment, JsonObject>> {
+        return groupBatchDataIntoSegments(datadogContext, batchData)
+    }
+
+    // region Internal
+    private fun groupBatchDataIntoSegments(
+        datadogContext: DatadogContext,
+        batchData: List<ByteArray>
+    ): List<Pair<MobileSegment, JsonObject>> {
+        return batchData
+            .asSequence()
+            .mapNotNull {
+                @Suppress("SwallowedException")
+                try {
+                    JsonParser.parseString(String(it)).safeGetAsJsonObject(internalLogger)
+                } catch (e: JsonParseException) {
+                    internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.TELEMETRY,
+                        { UNABLE_TO_DESERIALIZE_ENRICHED_RECORD_ERROR_MESSAGE },
+                        e
+                    )
+                    null
+                } catch (e: IllegalStateException) {
+                    internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.TELEMETRY,
+                        { UNABLE_TO_DESERIALIZE_ENRICHED_RECORD_ERROR_MESSAGE },
+                        e
+                    )
+                    null
+                }
+            }
+            .mapNotNull {
+                val records = it.records()
+                val rumContext = it.rumContext()
+                if (records == null || rumContext == null || records.isEmpty) {
+                    null
+                } else {
+                    Pair(rumContext, records)
+                }
+            }
+            .groupBy { it.first }
+            .mapValues {
+                it.value.fold(JsonArray()) { acc, pair ->
+                    acc.addAll(pair.second)
+                    acc
+                }
+            }
+            .filter { !it.value.isEmpty }
+            .mapNotNull {
+                mapToSegment(datadogContext, it.key, it.value)
+            }
+    }
+
+    @Suppress("ReturnCount")
+    private fun mapToSegment(
+        datadogContext: DatadogContext,
+        rumContext: SessionReplayRumContext,
+        records: JsonArray
+    ): Pair<MobileSegment, JsonObject>? {
+        val orderedRecords = records
+            .asSequence()
+            .mapNotNull {
+                it.safeGetAsJsonObject(internalLogger)
+            }
+            .mapNotNull {
+                val timestamp = it.timestamp()
+                if (timestamp == null) {
+                    null
+                } else {
+                    Pair(it, timestamp)
+                }
+            }
+            .sortedBy { it.second }
+            .map { it.first }
+            .fold(JsonArray()) { acc, jsonObject ->
+                acc.add(jsonObject)
+                acc
+            }
+
+        if (orderedRecords.isEmpty) {
+            return null
+        }
+
+        val startTimestamp = orderedRecords
+            .firstOrNull()
+            ?.safeGetAsJsonObject(internalLogger)
+            ?.timestamp()
+        val stopTimestamp = orderedRecords
+            .lastOrNull()
+            ?.safeGetAsJsonObject(internalLogger)
+            ?.timestamp()
+
+        if (startTimestamp == null || stopTimestamp == null) {
+            // this is just to avoid having kotlin warnings but the elements
+            // without timestamp property were already removed in the logic above
+            return null
+        }
+
+        val hasFullSnapshotRecord = hasFullSnapshotRecord(orderedRecords)
+        val segment = MobileSegment(
+            application = MobileSegment.Application(rumContext.applicationId),
+            session = MobileSegment.Session(rumContext.sessionId),
+            view = MobileSegment.View(rumContext.viewId),
+            start = startTimestamp,
+            end = stopTimestamp,
+            recordsCount = orderedRecords.size().toLong(),
+            // TODO RUM-861 Find a way or alternative to provide a reliable indexInView
+            indexInView = null,
+            hasFullSnapshot = hasFullSnapshotRecord,
+            source = datadogContext.source,
+            records = JsonArray()
+        )
+        val segmentAsJsonObject = segment.toJson().safeGetAsJsonObject(internalLogger)
+            ?: return null
+        segmentAsJsonObject.add(RECORDS_KEY, orderedRecords)
+        return Pair(segment, segmentAsJsonObject)
+    }
+
+    private fun hasFullSnapshotRecord(records: JsonArray) =
+        records.any {
+            val typeAsLong = it.asJsonObject.getAsJsonPrimitive(RECORD_TYPE_KEY)?.safeGetAsLong(
+                internalLogger
+            )
+            typeAsLong == FULL_SNAPSHOT_RECORD_TYPE_MOBILE ||
+                typeAsLong == FULL_SNAPSHOT_RECORD_TYPE_BROWSER
+        }
+
+    private fun JsonObject.records(): JsonArray? {
+        return get(EnrichedRecord.RECORDS_KEY)?.safeGetAsJsonArray(internalLogger)
+    }
+
+    private fun JsonObject.timestamp(): Long? {
+        return getAsJsonPrimitive(TIMESTAMP_KEY)?.safeGetAsLong(internalLogger)
+    }
+
+    private fun JsonObject.rumContext(): SessionReplayRumContext? {
+        val applicationId = get(EnrichedRecord.APPLICATION_ID_KEY)?.asString
+        val sessionId = get(EnrichedRecord.SESSION_ID_KEY)?.asString
+        val viewId = get(EnrichedRecord.VIEW_ID_KEY)?.asString
+        if (applicationId == null || sessionId == null || viewId == null) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.TELEMETRY,
+                { ILLEGAL_STATE_ENRICHED_RECORD_ERROR_MESSAGE },
+                null,
+                true
+            )
+            return null
+        }
+        return SessionReplayRumContext(
+            applicationId = applicationId,
+            sessionId = sessionId,
+            viewId = viewId
+        )
+    }
+
+    // endregion
+
+    companion object {
+
+        private const val FULL_SNAPSHOT_RECORD_TYPE_MOBILE = 10L
+        private const val FULL_SNAPSHOT_RECORD_TYPE_BROWSER = 2L
+
+        internal const val RECORDS_KEY = "records"
+        private const val RECORD_TYPE_KEY = "type"
+        internal const val TIMESTAMP_KEY = "timestamp"
+        internal const val UNABLE_TO_DESERIALIZE_ENRICHED_RECORD_ERROR_MESSAGE =
+            "SR BatchesToSegmentMapper: unable to deserialize EnrichedRecord"
+        internal const val ILLEGAL_STATE_ENRICHED_RECORD_ERROR_MESSAGE =
+            "SR BatchesToSegmentMapper: Enriched record was missing the context information"
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/BytesCompressor.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/BytesCompressor.kt
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.feature
+
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
+
+/**
+ *  Compresses the payload data using the ZIP compression algorithm.
+ */
+internal object BytesCompressor {
+    fun compressBytes(uncompressedData: ByteArray): ByteArray {
+        // Create the compressor with highest level of compression.
+        val deflater = Deflater(COMPRESSION_LEVEL)
+        // We will start with an OutputStream double the size of the data
+        val outputStream = ByteArrayOutputStream(uncompressedData.size * 2)
+        // Compress the data
+        // in order to align with dogweb way of decompressing the segments we need to compress
+        // using the SYNC_FLUSH flag which adds the 0000FFFF flag at the end of the
+        // compressed data
+        val compressedData = outputStream.use {
+            compress(deflater, uncompressedData, it, Deflater.SYNC_FLUSH)
+            // in order to align with dogweb way of decompressing the segments we need to add
+            // a fake checksum at the end
+            compress(deflater, ByteArray(0), it, Deflater.FULL_FLUSH)
+            deflater.end()
+            it.toByteArray()
+        }
+        // Get the compressed data
+        return compressedData
+    }
+
+    private fun compress(
+        deflater: Deflater,
+        data: ByteArray,
+        output: ByteArrayOutputStream,
+        flag: Int
+    ) {
+        var buffer = getBufferByDataAndFlag(data, flag)
+        var retriesCounter = 1
+        var bytesRead: Int
+        do {
+            buffer = ByteArray(buffer.size * retriesCounter)
+            if (flag == Deflater.SYNC_FLUSH) {
+                deflater.reset()
+            }
+            deflater.setInput(data)
+            if (flag == Deflater.FULL_FLUSH) {
+                deflater.finish()
+            }
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            // we are only calling this with valid flags
+            bytesRead = deflater.deflate(buffer, 0, buffer.size, flag)
+            // according with the API if bytesRead >= buffer.size we need
+            // to retry with a bigger buffer
+            retriesCounter += 1
+        } while (bytesRead >= buffer.size)
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        // we are calling this function always with a valid buffer (bytesRead < buffer.size)
+        output.write(buffer, 0, bytesRead)
+    }
+
+    private fun getBufferByDataAndFlag(data: ByteArray, flag: Int): ByteArray {
+        return when (flag) {
+            Deflater.FULL_FLUSH -> ByteArray(
+                HEADER_SIZE_IN_BYTES +
+                    data.size + CHECKSUM_FLAG_SIZE_IN_BYTES
+            )
+            Deflater.SYNC_FLUSH -> ByteArray(
+                HEADER_SIZE_IN_BYTES +
+                    data.size + SYNC_FLAG_SIZE_IN_BYTES
+            )
+            else -> ByteArray(HEADER_SIZE_IN_BYTES + data.size)
+        }
+    }
+
+    private const val HEADER_SIZE_IN_BYTES = 2
+    private const val SYNC_FLAG_SIZE_IN_BYTES = 4
+    internal const val CHECKSUM_FLAG_SIZE_IN_BYTES = 6
+
+    // We are using compression level 6 in order to align with the same compression type used
+    // in the browser sdk.
+    private const val COMPRESSION_LEVEL = 6
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
@@ -1,0 +1,124 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.feature
+
+import android.content.Context
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureContextUpdateReceiver
+import com.datadog.android.api.feature.FeatureEventReceiver
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.feature.StorageBackedFeature
+import com.datadog.android.api.net.RequestFactory
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.api.storage.RawBatchEvent
+
+class FlutterSessionReplayFeature(
+    private val sdkCore: FeatureSdkCore,
+    private val onContextChanged: (Map<String, Any?>) -> Unit,
+    private val customEndpointUrl: String?
+) : StorageBackedFeature, FeatureEventReceiver, FeatureContextUpdateReceiver {
+
+    override val name = Feature.SESSION_REPLAY_FEATURE_NAME
+    override val storageConfiguration = STORAGE_CONFIGURATION
+
+    override val requestFactory: RequestFactory by lazy {
+        SegmentRequestFactory(
+            customEndpointUrl,
+            BatchesToSegmentsMapper(sdkCore.internalLogger)
+        )
+    }
+
+    override fun onInitialize(appContext: Context) {
+        sdkCore.setContextUpdateReceiver(
+            SESSION_REPLAY_FEATURE_NAME,
+            this
+        )
+    }
+
+    override fun onStop() {
+    }
+
+    override fun onReceive(event: Any) {
+    }
+
+    override fun onContextUpdate(featureName: String, event: Map<String, Any?>) {
+        if (featureName == Feature.RUM_FEATURE_NAME) {
+            val applicationId = event[APPLICATION_ID_KEY] as? String
+            val sessionId = event[SESSION_ID_KEY] as? String
+            val viewId = event[VIEW_ID_KEY] as? String
+            val serverTimeOffset = event[VIEW_SERVER_TIME_OFFSET_KEY] as? Long
+
+            val flutterEncodedContext = mapOf<String, Any?>(
+                "applicationId" to applicationId,
+                "sessionId" to sessionId,
+                "viewId" to viewId,
+                "viewServerTimeOffset" to serverTimeOffset
+            )
+            onContextChanged(flutterEncodedContext)
+        }
+    }
+
+    fun setHasReplay(viewId: String, hasReplay: Boolean) {
+        sdkCore.updateFeatureContext(SESSION_REPLAY_FEATURE_NAME) {
+            @Suppress("UNCHECKED_CAST")
+            val viewMetadata: MutableMap<String, Any?> =
+                (it[viewId] as? MutableMap<String, Any?>) ?: mutableMapOf()
+            viewMetadata[HAS_REPLAY_KEY] = hasReplay
+            it[viewId] = viewMetadata
+        }
+    }
+
+    fun setRecordCount(viewId: String, recordCount: Int) {
+        sdkCore.updateFeatureContext(SESSION_REPLAY_FEATURE_NAME) {
+            @Suppress("UNCHECKED_CAST")
+            val viewMetadata: MutableMap<String, Any?> =
+                (it[viewId] as? MutableMap<String, Any?>) ?: mutableMapOf()
+            viewMetadata[HAS_REPLAY_KEY] = true
+            viewMetadata[VIEW_RECORDS_COUNT_KEY] = recordCount
+            it[viewId] = viewMetadata
+        }
+    }
+
+    fun writeSegment(segment: String) {
+        sdkCore.getFeature(SESSION_REPLAY_FEATURE_NAME)?.withWriteContext { _, eventBatchWriter ->
+            synchronized(this) {
+                val serializedSegment = segment.toByteArray(Charsets.UTF_8)
+                val rawBatchEvent = RawBatchEvent(data = serializedSegment)
+                eventBatchWriter.write(
+                    event = rawBatchEvent,
+                    batchMetadata = null,
+                    eventType = EventType.DEFAULT
+                )
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Session Replay storage configuration with the following parameters:
+         * max item size = 10 MB,
+         * max items per batch = 500,
+         * max batch size = 10 MB, SR intake batch limit is 10MB
+         * old batch threshold = 18 hours.
+         */
+        internal val STORAGE_CONFIGURATION: FeatureStorageConfiguration =
+            FeatureStorageConfiguration.DEFAULT.copy(
+                maxItemSize = 10 * 1024 * 1024,
+                maxBatchSize = 10 * 1024 * 1024
+            )
+
+        const val SESSION_REPLAY_FEATURE_NAME = "session_replay"
+        const val HAS_REPLAY_KEY = "has_replay"
+        const val VIEW_RECORDS_COUNT_KEY = "records_count"
+
+        const val APPLICATION_ID_KEY = "application_id"
+        const val SESSION_ID_KEY = "session_id"
+        const val VIEW_ID_KEY = "view_id"
+        const val VIEW_SERVER_TIME_OFFSET_KEY = "view_timestamp_offset"
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/InvalidPayloadFormatException.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/InvalidPayloadFormatException.kt
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.feature
+
+internal class InvalidPayloadFormatException(message: String) : RuntimeException(message)

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/SegmentRequestBodyFactory.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/SegmentRequestBodyFactory.kt
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.feature
+
+import com.datadoghq.flutter.sessionreplay.models.MobileSegment
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+internal class SegmentRequestBodyFactory {
+    @Suppress("UnsafeThirdPartyFunctionCall") // Caught in the caller
+    fun create(serializedSegmentsPairs: List<Pair<MobileSegment, JsonObject>>): RequestBody {
+        val multipartBody = MultipartBody.Builder().setType(MultipartBody.FORM)
+        val metadata = JsonArray()
+        serializedSegmentsPairs.forEachIndexed { index, segment ->
+            // because of the way the compressed segments are concatenated in order to be
+            // decompressed when retrieved by the player,
+            // we need to add a new line at the end of each segment
+            val segmentAsByteArray = (segment.second.toString() + "\n").toByteArray()
+            val compressedData = BytesCompressor.compressBytes(segmentAsByteArray)
+            val segmentAsJson = segment.first.toJson().asJsonObject.apply {
+                addProperty(COMPRESSED_SEGMENT_SIZE_FORM_KEY, compressedData.size)
+                addProperty(RAW_SEGMENT_SIZE_FORM_KEY, segmentAsByteArray.size)
+            }
+            multipartBody.addFormDataPart(
+                name = SEGMENT_DATA_FORM_KEY,
+                filename = "${BINARY_FILENAME_PREFIX}$index",
+                body = compressedData.toRequestBody(CONTENT_TYPE_BINARY_TYPE)
+            )
+            metadata.add(segmentAsJson)
+        }
+
+        multipartBody.addFormDataPart(
+            name = EVENT_NAME_FORM_KEY,
+            filename = BLOB_FILENAME,
+            body = metadata.toString().toRequestBody(CONTENT_TYPE_JSON_TYPE)
+        )
+
+        return multipartBody.build()
+    }
+
+    companion object {
+        internal const val BINARY_FILENAME_PREFIX = "file"
+        internal const val BLOB_FILENAME = "blob"
+        internal const val EVENT_NAME_FORM_KEY = "event"
+        internal const val RAW_SEGMENT_SIZE_FORM_KEY = "raw_segment_size"
+        internal const val COMPRESSED_SEGMENT_SIZE_FORM_KEY = "compressed_segment_size"
+        internal const val SEGMENT_DATA_FORM_KEY = "segment"
+        internal val CONTENT_TYPE_BINARY_TYPE = "application/octet-stream".toMediaTypeOrNull()
+        internal val CONTENT_TYPE_JSON_TYPE = "application/json".toMediaTypeOrNull()
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/SegmentRequestFactory.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/SegmentRequestFactory.kt
@@ -60,7 +60,6 @@ internal class SegmentRequestFactory(
         )
     }
 
-    @Suppress("ReturnCount")
     private fun resolveRequest(context: DatadogContext, body: RequestBody): Request {
         val bodyAsByteArray = extractByteArrayFromBody(body)
         val requestId = UUID.randomUUID().toString()
@@ -79,9 +78,7 @@ internal class SegmentRequestFactory(
 
     private fun extractByteArrayFromBody(body: RequestBody): ByteArray {
         val buffer = Buffer()
-        @Suppress("UnsafeThirdPartyFunctionCall")
         body.writeTo(buffer)
-        @Suppress("UnsafeThirdPartyFunctionCall")
         return buffer.readByteArray()
     }
 

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/SegmentRequestFactory.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/SegmentRequestFactory.kt
@@ -1,0 +1,91 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.feature
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.net.Request
+import com.datadog.android.api.net.RequestExecutionContext
+import com.datadog.android.api.net.RequestFactory
+import com.datadog.android.api.storage.RawBatchEvent
+import java.util.Locale
+import java.util.UUID
+import okhttp3.RequestBody
+import okio.Buffer
+
+internal class SegmentRequestFactory(
+    private val customEndpointUrl: String?,
+    private val batchesToSegmentsMapper: BatchesToSegmentsMapper,
+    private val segmentRequestBodyFactory: SegmentRequestBodyFactory = SegmentRequestBodyFactory()
+) : RequestFactory {
+    override fun create(
+        context: DatadogContext,
+        executionContext: RequestExecutionContext,
+        batchData: List<RawBatchEvent>,
+        batchMetadata: ByteArray?
+    ): Request {
+        val serializedSegmentPair = batchesToSegmentsMapper.map(context, batchData.map { it.data })
+        if (serializedSegmentPair.isEmpty()) {
+            @Suppress("ThrowingInternalException")
+            throw InvalidPayloadFormatException(
+                "The payload format was broken and an upload" +
+                    " request could not be created"
+            )
+        }
+        val body = segmentRequestBodyFactory.create(serializedSegmentPair)
+        return resolveRequest(context, body)
+    }
+
+    private fun buildUrl(datadogContext: DatadogContext): String {
+        return String.format(
+            Locale.US,
+            UPLOAD_URL,
+            customEndpointUrl ?: datadogContext.site.intakeEndpoint,
+            "replay"
+        )
+    }
+
+    private fun resolveHeaders(
+        datadogContext: DatadogContext,
+        requestId: String
+    ): Map<String, String> {
+        return mapOf(
+            RequestFactory.HEADER_API_KEY to datadogContext.clientToken,
+            RequestFactory.HEADER_EVP_ORIGIN to datadogContext.source,
+            RequestFactory.HEADER_EVP_ORIGIN_VERSION to datadogContext.sdkVersion,
+            RequestFactory.HEADER_REQUEST_ID to requestId
+        )
+    }
+
+    @Suppress("ReturnCount")
+    private fun resolveRequest(context: DatadogContext, body: RequestBody): Request {
+        val bodyAsByteArray = extractByteArrayFromBody(body)
+        val requestId = UUID.randomUUID().toString()
+        val description = "Session Replay Segment Upload Request"
+        val headers = resolveHeaders(context, requestId)
+        val requestUrl = buildUrl(context)
+        return Request(
+            requestId,
+            description,
+            requestUrl,
+            headers,
+            body = bodyAsByteArray,
+            contentType = body.contentType().toString()
+        )
+    }
+
+    private fun extractByteArrayFromBody(body: RequestBody): ByteArray {
+        val buffer = Buffer()
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        body.writeTo(buffer)
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        return buffer.readByteArray()
+    }
+
+    companion object {
+        private const val UPLOAD_URL = "%s/api/v2/%s"
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/gson/GsonExt.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/gson/GsonExt.kt
@@ -30,7 +30,7 @@ internal fun JsonElement.safeGetAsJsonObject(internalLogger: InternalLogger): Js
             InternalLogger.Target.TELEMETRY,
             {
                 BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
-                    Locale.ENGLISH,
+                    Locale.US,
                     this.toString(),
                     JSON_OBJECT_TYPE
                 )
@@ -50,7 +50,7 @@ internal fun JsonPrimitive.safeGetAsLong(internalLogger: InternalLogger): Long? 
             InternalLogger.Target.TELEMETRY,
             {
                 BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
-                    Locale.ENGLISH,
+                    Locale.US,
                     this.toString(),
                     JSON_PRIMITIVE_TYPE
                 )
@@ -71,7 +71,7 @@ internal fun JsonElement.safeGetAsJsonArray(internalLogger: InternalLogger): Jso
             InternalLogger.Target.TELEMETRY,
             {
                 BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
-                    Locale.ENGLISH,
+                    Locale.US,
                     this.toString(),
                     JSON_ARRAY_TYPE
                 )

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/gson/GsonExt.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/gson/GsonExt.kt
@@ -20,7 +20,6 @@ internal const val JSON_OBJECT_TYPE = "JsonObject"
 internal const val JSON_ARRAY_TYPE = "JsonArray"
 internal const val JSON_PRIMITIVE_TYPE = "JsonPrimitive"
 
-@Suppress("SwallowedException")
 internal fun JsonElement.safeGetAsJsonObject(internalLogger: InternalLogger): JsonObject? {
     return if (isJsonObject) {
         asJsonObject
@@ -40,7 +39,6 @@ internal fun JsonElement.safeGetAsJsonObject(internalLogger: InternalLogger): Js
     }
 }
 
-@Suppress("SwallowedException")
 internal fun JsonPrimitive.safeGetAsLong(internalLogger: InternalLogger): Long? {
     return try {
         asLong
@@ -61,7 +59,6 @@ internal fun JsonPrimitive.safeGetAsLong(internalLogger: InternalLogger): Long? 
     }
 }
 
-@Suppress("SwallowedException")
 internal fun JsonElement.safeGetAsJsonArray(internalLogger: InternalLogger): JsonArray? {
     return if (isJsonArray) {
         asJsonArray

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/gson/GsonExt.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/gson/GsonExt.kt
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+// This file is copied from the `dd-sdk-android`.
+package com.datadoghq.flutter.sessionreplay.gson
+
+import com.datadog.android.api.InternalLogger
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import java.util.Locale
+
+internal const val BROKEN_JSON_ERROR_MESSAGE_FORMAT =
+    "SR GsonExt: Unable parse the batch data into a JsonObject: expected to parse [%s] as %s"
+internal const val JSON_OBJECT_TYPE = "JsonObject"
+internal const val JSON_ARRAY_TYPE = "JsonArray"
+internal const val JSON_PRIMITIVE_TYPE = "JsonPrimitive"
+
+@Suppress("SwallowedException")
+internal fun JsonElement.safeGetAsJsonObject(internalLogger: InternalLogger): JsonObject? {
+    return if (isJsonObject) {
+        asJsonObject
+    } else {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.TELEMETRY,
+            {
+                BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
+                    Locale.ENGLISH,
+                    this.toString(),
+                    JSON_OBJECT_TYPE
+                )
+            }
+        )
+        null
+    }
+}
+
+@Suppress("SwallowedException")
+internal fun JsonPrimitive.safeGetAsLong(internalLogger: InternalLogger): Long? {
+    return try {
+        asLong
+    } catch (e: NumberFormatException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.TELEMETRY,
+            {
+                BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
+                    Locale.ENGLISH,
+                    this.toString(),
+                    JSON_PRIMITIVE_TYPE
+                )
+            },
+            e
+        )
+        null
+    }
+}
+
+@Suppress("SwallowedException")
+internal fun JsonElement.safeGetAsJsonArray(internalLogger: InternalLogger): JsonArray? {
+    return if (isJsonArray) {
+        asJsonArray
+    } else {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.TELEMETRY,
+            {
+                BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
+                    Locale.ENGLISH,
+                    this.toString(),
+                    JSON_ARRAY_TYPE
+                )
+            }
+        )
+        null
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/models/EnrichedRecord.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/models/EnrichedRecord.kt
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.models
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+
+/**
+ * Wraps the Session Replay records together with the related Rum Context.
+ * Intended for internal usage.
+ */
+internal data class EnrichedRecord(
+    val applicationId: String,
+    val sessionId: String,
+    val viewId: String,
+    val records: JsonArray
+) {
+
+    /**
+     * Returns the JSON string equivalent of this object.
+     */
+    fun toJson(): String {
+        val json = JsonObject()
+        json.addProperty(APPLICATION_ID_KEY, applicationId)
+        json.addProperty(SESSION_ID_KEY, sessionId)
+        json.addProperty(VIEW_ID_KEY, viewId)
+        json.add(RECORDS_KEY, records)
+        return json.toString()
+    }
+
+    // These keys are different from Android native, in order to be the same as the keys used iOS
+    companion object {
+        const val APPLICATION_ID_KEY: String = "applicationID"
+        const val SESSION_ID_KEY: String = "sessionID"
+        const val VIEW_ID_KEY: String = "viewID"
+        const val RECORDS_KEY: String = "records"
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/models/MobileSegment.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/models/MobileSegment.kt
@@ -1,0 +1,128 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.models
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
+import com.google.gson.JsonPrimitive
+import java.lang.IllegalStateException
+import java.lang.NullPointerException
+import java.lang.NumberFormatException
+import kotlin.jvm.Throws
+
+/**
+ * MobileSegment is what is sent to Datadog intake.
+ *
+ * Only a portion of the data is needed for processing, so only a portion is deserialized - the
+ * rest is left as raw JSON.
+ */
+internal data class MobileSegment(
+    val application: Application,
+    val session: Session,
+    val view: View,
+    val start: Long,
+    val end: Long,
+    val recordsCount: Long,
+    val indexInView: Long? = null,
+    val hasFullSnapshot: Boolean? = null,
+    val source: String,
+    val records: JsonArray
+) {
+    fun toJson(): JsonElement {
+        val json = JsonObject()
+        json.add("application", application.toJson())
+        json.add("session", session.toJson())
+        json.add("view", view.toJson())
+        json.addProperty("start", start)
+        json.addProperty("end", end)
+        json.addProperty("records_count", recordsCount)
+        indexInView?.let { indexInViewNonNull ->
+            json.addProperty("index_in_view", indexInViewNonNull)
+        }
+        hasFullSnapshot?.let { hasFullSnapshotNonNull ->
+            json.addProperty("has_full_snapshot", hasFullSnapshotNonNull)
+        }
+        json.add("source", JsonPrimitive(source))
+        json.add("records", records)
+        return json
+    }
+
+    /**
+     * Application properties.
+     * @param id UUID of the application
+     */
+    data class Application(
+        val id: String
+    ) {
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("id", id)
+            return json
+        }
+
+        companion object {
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            @Suppress("TooGenericExceptionCaught")
+            fun fromJsonObject(jsonObject: JsonObject): Application {
+                try {
+                    val id = jsonObject.get("id").asString
+                    return Application(id)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(
+                        PARSE_ERROR_MESSAGE,
+                        e
+                    )
+                } catch (e: NumberFormatException) {
+                    throw JsonParseException(
+                        PARSE_ERROR_MESSAGE,
+                        e
+                    )
+                } catch (e: NullPointerException) {
+                    throw JsonParseException(
+                        PARSE_ERROR_MESSAGE,
+                        e
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Session properties.
+     * @param id UUID of the session
+     */
+    data class Session(
+        val id: String
+    ) {
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("id", id)
+            return json
+        }
+    }
+
+    /**
+     * View properties.
+     * @param id UUID of the view
+     */
+    data class View(
+        val id: String
+    ) {
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("id", id)
+            return json
+        }
+    }
+
+    companion object {
+        const val PARSE_ERROR_MESSAGE: String = "Unable to parse json into type Application"
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/models/SessionReplayRumContext.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/models/SessionReplayRumContext.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.models
+
+import java.util.UUID
+
+/**
+ * Provides the necessary RUM context for Session Replay records.
+ * @param applicationId the RUM application id
+ * @param sessionId the current RUM session id
+ * @param viewId the current RUM view id
+ */
+internal data class SessionReplayRumContext(
+    val applicationId: String = NULL_UUID,
+    val sessionId: String = NULL_UUID,
+    val viewId: String = NULL_UUID
+) {
+
+    internal fun isNotValid(): Boolean =
+        applicationId == NULL_UUID ||
+            sessionId == NULL_UUID ||
+            viewId == NULL_UUID
+
+    internal fun isValid(): Boolean =
+        applicationId != NULL_UUID &&
+            sessionId != NULL_UUID &&
+            viewId != NULL_UUID
+
+    companion object {
+        private val NULL_UUID = UUID(0, 0).toString()
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/BytesCompressorTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/BytesCompressorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.datadoghq.flutter.sessionreplay.feature.BytesCompressor
+import com.datadoghq.flutter.sessionreplay.forge.SRForgeConfigurator
+import com.datadoghq.flutter.sessionreplay.models.EnrichedRecord
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.zip.Inflater
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(ExtendWith(ForgeExtension::class))
+@ForgeConfiguration(SRForgeConfigurator::class)
+internal class BytesCompressorTest {
+    @RepeatedTest(20)
+    fun `M compress the provided bytearray W compressBytes`(
+        @Forgery fakeEnrichedRecord: EnrichedRecord
+    ) {
+        // Given
+        val fakeData = fakeEnrichedRecord.toJson()
+        val fakeDataAsByteArray = fakeData.toByteArray()
+
+        // When
+        val compressed = BytesCompressor.compressBytes(fakeDataAsByteArray)
+
+        // Then
+        // Decompress the bytes by removing the last fake checksum
+        val decompressor = Inflater()
+        decompressor.setInput(
+            compressed.sliceArray(
+                0..compressed.size -
+                    BytesCompressor.CHECKSUM_FLAG_SIZE_IN_BYTES
+            )
+        )
+        val result = ByteArray(fakeDataAsByteArray.size)
+        val resultLength = decompressor.inflate(result)
+        decompressor.end()
+        val outputString = String(result, 0, resultLength)
+        assertThat(fakeData).isEqualTo(outputString)
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
@@ -49,7 +49,7 @@ internal class DatadogSessionReplayPluginTest {
     }
 
     @Test
-    fun `M return NotImplemented W methodCall { unknown }`() {
+    fun `M return NotImplemented W onMethodCall { unknown }`() {
         // Given
         val plugin = DatadogSessionReplayPlugin()
         val result = mockk<MethodChannel.Result>(relaxed = true)
@@ -63,7 +63,7 @@ internal class DatadogSessionReplayPluginTest {
     }
 
     @Test
-    fun `M enable feature W enable methodCall`() {
+    fun `M enable feature W enable onMethodCall`() {
         // Given
         val plugin = DatadogSessionReplayPlugin()
         val result = mockk<MethodChannel.Result>(relaxed = true)
@@ -89,7 +89,7 @@ internal class DatadogSessionReplayPluginTest {
     }
 
     @Test
-    fun `M return error W enable methodCall { missing configuration }`() {
+    fun `M return error W enable onMethodCall { missing configuration }`() {
         // Given
         val plugin = DatadogSessionReplayPlugin()
         val result = mockk<MethodChannel.Result>(relaxed = true)
@@ -110,7 +110,7 @@ internal class DatadogSessionReplayPluginTest {
     }
 
     @Test
-    fun `M set context W setHasReplay methodCall`(
+    fun `M set context W setHasReplay onMethodCall`(
         @StringForgery viewId: String,
         @BoolForgery hasReplay: Boolean
     ) {
@@ -147,7 +147,7 @@ internal class DatadogSessionReplayPluginTest {
     }
 
     @Test
-    fun `M return error W setHasReplay methodCall { missing parameters }`() {
+    fun `M return error W setHasReplay onMethodCall { missing parameters }`() {
         // Given
         val plugin = DatadogSessionReplayPlugin()
         val result = mockk<MethodChannel.Result>(relaxed = true)
@@ -206,7 +206,7 @@ internal class DatadogSessionReplayPluginTest {
     }
 
     @Test
-    fun `M return error W setRecordCount methodCall { missing parameters }`() {
+    fun `M return error W setRecordCount onMethodCall { missing parameters }`() {
         // Given
         val plugin = DatadogSessionReplayPlugin()
         val result = mockk<MethodChannel.Result>(relaxed = true)

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
@@ -1,13 +1,308 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2025-Present Datadog, Inc.
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
 package com.datadoghq.flutter.sessionreplay
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import com.datadog.android.Datadog
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
+import com.datadoghq.flutter.DatadogSdkPlugin
+import com.datadoghq.flutter.sessionreplay.feature.FlutterSessionReplayFeature
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.invoke
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(ForgeExtension::class)
 internal class DatadogSessionReplayPluginTest {
+    lateinit var mockCore: FeatureSdkCore
+    lateinit var mockMethodChannel: MethodChannel
+
+    @BeforeEach
+    fun beforeEach() {
+        mockCore = mockk(relaxed = true)
+        mockkStatic(Datadog::class)
+        every { Datadog.getInstance() } returns mockCore
+
+        mockMethodChannel = mockk(relaxed = true)
+    }
+
     @Test
-    fun `Passing Placeholder`() {
-        assert(true)
+    fun `M return NotImplemented W methodCall { unknown }`() {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall("unknown", mapOf<String, Any?>())
+
+        // When
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify { result.notImplemented() }
+    }
+
+    @Test
+    fun `M enable feature W enable methodCall`() {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall(
+            "enable",
+            mapOf<String, Any?>(
+                "configuration" to mapOf<String, Any?>()
+            )
+        )
+
+        // When
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify { result.success(null) }
+        verify {
+            mockCore.registerFeature(
+                withArg {
+                    assertThat(it).isInstanceOf(FlutterSessionReplayFeature::class)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `M return error W enable methodCall { missing configuration }`() {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall("enable", mapOf<String, Any?>())
+
+        // When
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify {
+            result.error(
+                DatadogSdkPlugin.CONTRACT_VIOLATION,
+                "Missing required parameter in call to enable",
+                null
+            )
+        }
+        verify { mockCore wasNot Called }
+    }
+
+    @Test
+    fun `M set context W setHasReplay methodCall`(
+        @StringForgery viewId: String,
+        @BoolForgery hasReplay: Boolean
+    ) {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall(
+            "setHasReplay",
+            mapOf<String, Any?>(
+                "viewId" to viewId,
+                "hasReplay" to hasReplay
+            )
+        )
+        var context = mutableMapOf<String, Any?>()
+        every { mockCore.updateFeatureContext(any(), captureLambda()) } answers {
+            lambda<(MutableMap<String, Any?>) -> Unit>().invoke(context)
+        }
+
+        // When
+        plugin.enable(FlutterSessionReplay.Configuration())
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify { result.success(null) }
+        verify {
+            mockCore.updateFeatureContext(
+                FlutterSessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
+                any()
+            )
+        }
+        val viewMap = context[viewId] as? MutableMap<String, Any?>
+        assertThat(viewMap).isNotNull()
+        assertThat(viewMap?.get("has_replay")).isEqualTo(hasReplay)
+    }
+
+    @Test
+    fun `M return error W setHasReplay methodCall { missing parameters }`() {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall("setHasReplay", mapOf<String, Any?>())
+
+        // When
+        plugin.enable(FlutterSessionReplay.Configuration())
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify {
+            result.error(
+                DatadogSdkPlugin.CONTRACT_VIOLATION,
+                "Missing required parameter in call to setHasReplay",
+                null
+            )
+        }
+    }
+
+    @Test
+    fun `M set context W setRecordCountMethodCall`(
+        @StringForgery viewId: String,
+        @IntForgery recordCount: Int
+    ) {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall(
+            "setRecordCount",
+            mapOf<String, Any?>(
+                "viewId" to viewId,
+                "count" to recordCount
+            )
+        )
+        var context = mutableMapOf<String, Any?>()
+        every { mockCore.updateFeatureContext(any(), captureLambda()) } answers {
+            lambda<(MutableMap<String, Any?>) -> Unit>().invoke(context)
+        }
+
+        // When
+        plugin.enable(FlutterSessionReplay.Configuration())
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify { result.success(null) }
+        verify {
+            mockCore.updateFeatureContext(
+                FlutterSessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
+                any()
+            )
+        }
+        val viewMap = context[viewId] as? MutableMap<String, Any?>
+        assertThat(viewMap).isNotNull()
+        assertThat(viewMap?.get("has_replay")).isEqualTo(true)
+        assertThat(viewMap?.get("records_count")).isEqualTo(recordCount)
+    }
+
+    @Test
+    fun `M return error W setRecordCount methodCall { missing parameters }`() {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall("setRecordCount", mapOf<String, Any?>())
+
+        // When
+        plugin.enable(FlutterSessionReplay.Configuration())
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify {
+            result.error(
+                DatadogSdkPlugin.CONTRACT_VIOLATION,
+                "Missing required parameter in call to setRecordCount",
+                null
+            )
+        }
+    }
+
+    @Test
+    fun `M broadcastRumContext W onReceive`(
+        @StringForgery applicationId: String,
+        @StringForgery sessionId: String,
+        @StringForgery viewId: String
+    ) {
+        // Given
+        val plugin = DatadogSessionReplayPlugin()
+        plugin.enable(FlutterSessionReplay.Configuration())
+
+        // When
+        plugin.channel = mockMethodChannel
+        plugin.onContextChanged(
+            mapOf(
+                "applicationId" to applicationId,
+                "sessionId" to sessionId,
+                "viewId" to viewId,
+                "viewServerTimeOffset" to 0L
+            )
+        )
+
+        // Then
+        verify {
+            mockMethodChannel.invokeMethod(
+                "onContextChanged",
+                mapOf(
+                    "applicationId" to applicationId,
+                    "sessionId" to sessionId,
+                    "viewId" to viewId,
+                    "viewServerTimeOffset" to 0L
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `M writeSegment W writeSegment`(
+        @StringForgery segment: String
+    ) {
+        // Given
+        val mockEventBatchWriter = mockk<EventBatchWriter>(relaxed = true)
+        val mockFeatureScope = mockk<FeatureScope>(relaxed = true)
+        val fakeDatadogContext = mockk<DatadogContext>()
+        val plugin = DatadogSessionReplayPlugin()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        val call = MethodCall(
+            "writeSegment",
+            mapOf<String, Any?>(
+                "segment" to segment
+            )
+        )
+        every {
+            mockCore.getFeature(FlutterSessionReplayFeature.SESSION_REPLAY_FEATURE_NAME)
+        } answers { mockFeatureScope }
+        every {
+            mockFeatureScope.withWriteContext(any(), captureLambda())
+        } answers {
+            lambda<(DatadogContext, EventBatchWriter) -> Unit>().invoke(
+                fakeDatadogContext,
+                mockEventBatchWriter
+            )
+        }
+
+        // When
+        plugin.enable(FlutterSessionReplay.Configuration())
+        plugin.onMethodCall(call, result)
+
+        // Then
+        verify { result.success(null) }
+        verify {
+            mockEventBatchWriter.write(
+                withArg {
+                    assertThat(it.data).isEqualTo(segment.toByteArray(Charsets.UTF_8))
+                },
+                null,
+                EventType.DEFAULT
+            )
+        }
     }
 }

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayFeatureTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayFeatureTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadoghq.flutter.sessionreplay.feature.FlutterSessionReplayFeature
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.mockk.every
+import io.mockk.invoke
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+internal class FlutterSessionReplayFeatureTest {
+    lateinit var mockCore: FeatureSdkCore
+    lateinit var feature: FlutterSessionReplayFeature
+
+    @BeforeEach
+    fun beforeEach() {
+        mockCore = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `M call context changed callback W onContextUpdate`(
+        @StringForgery applicationId: String,
+        @StringForgery sessionId: String,
+        @StringForgery viewId: String,
+        @LongForgery serverTimeOffset: Long
+    ) {
+        // Given
+        val onContextChanged = mockk<(Map<String, Any?>) -> Unit>(relaxed = true)
+        val configuration = FlutterSessionReplay.Configuration()
+        feature = FlutterSessionReplayFeature(
+            mockCore,
+            onContextChanged,
+            configuration.customEndpointUrl
+        )
+        val contextValue = mapOf(
+            "application_id" to applicationId,
+            "session_id" to sessionId,
+            "view_id" to viewId,
+            "view_timestamp_offset" to serverTimeOffset
+        )
+
+        // When
+        feature.onContextUpdate(Feature.RUM_FEATURE_NAME, contextValue)
+
+        // Then - note the transform of property names
+        val expectedContextValue = mapOf(
+            "applicationId" to applicationId,
+            "sessionId" to sessionId,
+            "viewId" to viewId,
+            "viewServerTimeOffset" to serverTimeOffset
+        )
+        verify { onContextChanged(expectedContextValue) }
+    }
+
+    @Test
+    fun `M set context W setHasReplay`(
+        @StringForgery viewId: String,
+        @BoolForgery hasReplay: Boolean
+    ) {
+        // Given
+        val onContextChanged = mockk<(Map<String, Any?>) -> Unit>(relaxed = true)
+        val configuration = FlutterSessionReplay.Configuration()
+        feature = FlutterSessionReplayFeature(
+            mockCore,
+            onContextChanged,
+            configuration.customEndpointUrl
+        )
+        var context = mutableMapOf<String, Any?>()
+        every { mockCore.updateFeatureContext(any(), captureLambda()) } answers {
+            lambda<(MutableMap<String, Any?>) -> Unit>().invoke(context)
+        }
+
+        // When
+        feature.setHasReplay(viewId, hasReplay)
+
+        // Then
+        verify {
+            mockCore.updateFeatureContext(
+                FlutterSessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
+                any()
+            )
+        }
+        val viewMap = context[viewId] as? MutableMap<String, Any?>
+        assertThat(viewMap).isNotNull()
+        assertThat(viewMap?.get("has_replay")).isEqualTo(hasReplay)
+    }
+
+    @Test
+    fun `M set context W setRecordCount`(
+        @StringForgery viewId: String,
+        @IntForgery recordCount: Int
+    ) {
+        // Given
+        val onContextChanged = mockk<(Map<String, Any?>) -> Unit>(relaxed = true)
+        val configuration = FlutterSessionReplay.Configuration()
+        feature = FlutterSessionReplayFeature(
+            mockCore,
+            onContextChanged,
+            configuration.customEndpointUrl
+        )
+        var context = mutableMapOf<String, Any?>()
+        every { mockCore.updateFeatureContext(any(), captureLambda()) } answers {
+            lambda<(MutableMap<String, Any?>) -> Unit>().invoke(context)
+        }
+
+        // When
+        feature.setRecordCount(viewId, recordCount)
+
+        // Then
+        verify {
+            mockCore.updateFeatureContext(
+                FlutterSessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
+                any()
+            )
+        }
+        val viewMap = context[viewId] as? MutableMap<String, Any?>
+        assertThat(viewMap).isNotNull()
+        assertThat(viewMap?.get("has_replay")).isEqualTo(true)
+        assertThat(viewMap?.get("records_count")).isEqualTo(recordCount)
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayFeatureTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayFeatureTest.kt
@@ -21,19 +21,12 @@ import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ForgeExtension::class)
 internal class FlutterSessionReplayFeatureTest {
-    lateinit var mockCore: FeatureSdkCore
-    lateinit var feature: FlutterSessionReplayFeature
-
-    @BeforeEach
-    fun beforeEach() {
-        mockCore = mockk(relaxed = true)
-    }
+    var mockCore: FeatureSdkCore = mockk(relaxed = true)
 
     @Test
     fun `M call context changed callback W onContextUpdate`(
@@ -45,7 +38,7 @@ internal class FlutterSessionReplayFeatureTest {
         // Given
         val onContextChanged = mockk<(Map<String, Any?>) -> Unit>(relaxed = true)
         val configuration = FlutterSessionReplay.Configuration()
-        feature = FlutterSessionReplayFeature(
+        val feature = FlutterSessionReplayFeature(
             mockCore,
             onContextChanged,
             configuration.customEndpointUrl
@@ -78,7 +71,7 @@ internal class FlutterSessionReplayFeatureTest {
         // Given
         val onContextChanged = mockk<(Map<String, Any?>) -> Unit>(relaxed = true)
         val configuration = FlutterSessionReplay.Configuration()
-        feature = FlutterSessionReplayFeature(
+        val feature = FlutterSessionReplayFeature(
             mockCore,
             onContextChanged,
             configuration.customEndpointUrl
@@ -111,7 +104,7 @@ internal class FlutterSessionReplayFeatureTest {
         // Given
         val onContextChanged = mockk<(Map<String, Any?>) -> Unit>(relaxed = true)
         val configuration = FlutterSessionReplay.Configuration()
-        feature = FlutterSessionReplayFeature(
+        val feature = FlutterSessionReplayFeature(
             mockCore,
             onContextChanged,
             configuration.customEndpointUrl

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/SegmentRequestBodyFactoryTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/SegmentRequestBodyFactoryTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay
+
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import com.datadoghq.flutter.sessionreplay.feature.BytesCompressor
+import com.datadoghq.flutter.sessionreplay.feature.SegmentRequestBodyFactory
+import com.datadoghq.flutter.sessionreplay.forge.SRForgeConfigurator
+import com.datadoghq.flutter.sessionreplay.models.MobileSegment
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.MultipartBody
+import okhttp3.MultipartBody.Part
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+@ForgeConfiguration(SRForgeConfigurator::class)
+internal class SegmentRequestBodyFactoryTest {
+    @Test
+    fun `M return a multipart body W create`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeGroupedSegments = forge.aList(size = forge.anInt(min = 1, max = 10)) {
+            val mobileSegment = forge.getForgery<MobileSegment>()
+            Pair(mobileSegment, mobileSegment.toJson() as JsonObject)
+        }
+        val compressedData = fakeGroupedSegments.map {
+            BytesCompressor.compressBytes((it.second.toString() + "\n").toByteArray())
+        }
+        val expectedFormMetadata = fakeGroupedSegments
+            .mapIndexed { index, pair ->
+                pair.first.toJson().asJsonObject.apply {
+                    addProperty(
+                        SegmentRequestBodyFactory.COMPRESSED_SEGMENT_SIZE_FORM_KEY,
+                        compressedData[index].size
+                    )
+                    addProperty(
+                        SegmentRequestBodyFactory.RAW_SEGMENT_SIZE_FORM_KEY,
+                        (pair.second.toString() + "\n").toByteArray().size
+                    )
+                }
+            }.fold(JsonArray()) { acc, element ->
+                acc.add(element)
+                acc
+            }
+
+        // When
+        val requestBodyFactory = SegmentRequestBodyFactory()
+        val body = requestBodyFactory.create(fakeGroupedSegments)
+
+        // Then
+        assertThat(body).isInstanceOf(MultipartBody::class.java)
+        val multipartBody = body as MultipartBody
+        assertThat(multipartBody.type).isEqualTo(MultipartBody.FORM)
+        val parts = multipartBody.parts
+
+        val compressedSegmentParts = compressedData.mapIndexed { index, bytes ->
+            Part.createFormData(
+                SegmentRequestBodyFactory.SEGMENT_DATA_FORM_KEY,
+                "${SegmentRequestBodyFactory.BINARY_FILENAME_PREFIX}$index",
+                bytes.toRequestBody(SegmentRequestBodyFactory.CONTENT_TYPE_BINARY_TYPE)
+            )
+        }
+        val metadataPart = Part.createFormData(
+            SegmentRequestBodyFactory.EVENT_NAME_FORM_KEY,
+            filename = SegmentRequestBodyFactory.BLOB_FILENAME,
+            expectedFormMetadata.toString()
+                .toRequestBody(SegmentRequestBodyFactory.CONTENT_TYPE_JSON_TYPE)
+        )
+
+        assertThat(parts).hasSize(compressedData.size + 1)
+        for (i in compressedSegmentParts.indices) {
+            val part = parts[i]
+            val expectedPart = if (i < compressedSegmentParts.size) {
+                compressedSegmentParts[i]
+            } else {
+                metadataPart
+            }
+            assertThat(part.headers).isEqualTo(expectedPart.headers)
+            assertThat(part.body.toByteArray()).isEqualTo(expectedPart.body.toByteArray())
+        }
+    }
+
+    private fun RequestBody.toByteArray(): ByteArray {
+        val buffer = Buffer()
+        writeTo(buffer)
+        return buffer.readByteArray()
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/SegmentRequestFactoryTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/SegmentRequestFactoryTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.startsWith
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.net.RequestFactory
+import com.datadoghq.flutter.sessionreplay.feature.BatchesToSegmentsMapper
+import com.datadoghq.flutter.sessionreplay.feature.InvalidPayloadFormatException
+import com.datadoghq.flutter.sessionreplay.feature.SegmentRequestBodyFactory
+import com.datadoghq.flutter.sessionreplay.feature.SegmentRequestFactory
+import com.datadoghq.flutter.sessionreplay.forge.SRForgeConfigurator
+import com.datadoghq.flutter.sessionreplay.models.MobileSegment
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.nio.charset.Charset
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody
+import okio.Buffer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+@ForgeConfiguration(SRForgeConfigurator::class)
+internal class SegmentRequestFactoryTest {
+    @Test
+    fun `M throw InvalidPayloadException W empty batchData`(
+        @Forgery fakeDatadogContext: DatadogContext
+    ) {
+        // Given
+        val mockBatchesToSegmentsMapper = mockk<BatchesToSegmentsMapper>(relaxed = true)
+        every { mockBatchesToSegmentsMapper.map(any(), any()) } answers {
+            listOf()
+        }
+
+        // When
+        val requestFactory = SegmentRequestFactory(
+            customEndpointUrl = null,
+            batchesToSegmentsMapper = mockBatchesToSegmentsMapper
+        )
+
+        // Then
+        assertFailure {
+            requestFactory.create(
+                context = fakeDatadogContext,
+                executionContext = mockk(),
+                batchData = emptyList(),
+                batchMetadata = null
+            )
+        }.isInstanceOf(InvalidPayloadFormatException::class.java)
+    }
+
+    @Test
+    fun `M return valid Request W create`(
+        forge: Forge,
+        @StringForgery fakeBody: String,
+        @Forgery fakeDatadogContext: DatadogContext
+    ) {
+        // Given
+        val mockBatchesToSegmentsMapper = mockk<BatchesToSegmentsMapper>()
+        every { mockBatchesToSegmentsMapper.map(any(), any()) } answers {
+            listOf(
+                fakeMobileSegment(forge)
+            )
+        }
+        val mockRequestBodyFactory = mockk<SegmentRequestBodyFactory>()
+        val mockRequestBody = mockk<RequestBody>(relaxed = true)
+        every { mockRequestBodyFactory.create(any()) } answers {
+            mockRequestBody
+        }
+        every { mockRequestBody.contentType() } returns
+            "multipart/form-data; charset=utf-8".toMediaTypeOrNull()
+        val bufferSlot = slot<Buffer>()
+        every { mockRequestBody.writeTo(capture(bufferSlot)) } answers {
+            bufferSlot.captured.writeString(fakeBody, Charset.defaultCharset())
+        }
+
+        // When
+        val requestFactory = SegmentRequestFactory(
+            customEndpointUrl = null,
+            batchesToSegmentsMapper = mockBatchesToSegmentsMapper,
+            segmentRequestBodyFactory = mockRequestBodyFactory
+        )
+        val request = requestFactory.create(
+            context = fakeDatadogContext,
+            executionContext = mockk(),
+            batchData = listOf(),
+            batchMetadata = null
+        )
+
+        // Then
+        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.intakeEndpoint))
+        assertThat(request.contentType).isNotNull().startsWith("multipart/form-data;")
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]?.isNotEmpty()).isEqualTo(true)
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("Session Replay Segment Upload Request")
+        assertThat(request.body).isEqualTo(mockRequestBody.toByteArray())
+    }
+
+    @Test
+    fun `M return valid Request W create { custom endpoint }`(
+        forge: Forge,
+        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String,
+        @Forgery fakeDatadogContext: DatadogContext
+    ) {
+        // Given
+        val mockBatchesToSegmentsMapper = mockk<BatchesToSegmentsMapper>()
+        every { mockBatchesToSegmentsMapper.map(any(), any()) } answers {
+            listOf(
+                fakeMobileSegment(forge)
+            )
+        }
+
+        // When
+        val requestFactory = SegmentRequestFactory(
+            customEndpointUrl = fakeEndpoint,
+            batchesToSegmentsMapper = mockBatchesToSegmentsMapper
+        )
+        val request = requestFactory.create(
+            context = fakeDatadogContext,
+            executionContext = mockk(),
+            batchData = listOf(),
+            batchMetadata = null
+        )
+
+        // Then
+        assertThat(request.url).isEqualTo(expectedUrl(fakeEndpoint))
+    }
+
+    // region Internal
+
+    private fun expectedUrl(endpointUrl: String): String {
+        return "$endpointUrl/api/v2/replay"
+    }
+
+    private fun RequestBody.toByteArray(): ByteArray {
+        val buffer = Buffer()
+        writeTo(buffer)
+        return buffer.readByteArray()
+    }
+
+    private fun fakeMobileSegment(forge: Forge): Pair<MobileSegment, JsonObject> {
+        val mobileSegment = forge.getForgery<MobileSegment>()
+
+        // This is not actually what's stored in the Pair, but for testing purposes it should work.
+        return Pair(mobileSegment, mobileSegment.toJson() as JsonObject)
+    }
+
+    // endregion
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
@@ -61,7 +61,7 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
                 osVersion = forge.aString(),
                 osMajorVersion = forge.aString(),
                 architecture = forge.aString(),
-                numberOfDisplays = forge.aNullable {anInt() }
+                numberOfDisplays = forge.aNullable { anInt() }
             ),
             userInfo = UserInfo(
                 id = forge.aNullable { anHexadecimalString() },

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.forge
+
+import com.datadog.android.DatadogSite
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.context.DeviceInfo
+import com.datadog.android.api.context.DeviceType
+import com.datadog.android.api.context.NetworkInfo
+import com.datadog.android.api.context.ProcessInfo
+import com.datadog.android.api.context.TimeInfo
+import com.datadog.android.api.context.UserInfo
+import com.datadog.android.privacy.TrackingConsent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.Locale
+import java.util.UUID
+
+class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
+    override fun getForgery(forge: Forge): DatadogContext {
+        return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
+            clientToken = forge.anHexadecimalString().lowercase(Locale.US),
+            service = forge.anAlphabeticalString(),
+            version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),
+            variant = forge.anAlphabeticalString(),
+            env = forge.anAlphabeticalString().lowercase(Locale.US),
+            source = forge.anAlphabeticalString(),
+            sdkVersion = forge.aStringMatching("[0-9](\\.[0-9]{1,2}){1,3}"),
+            time = TimeInfo(
+                deviceTimeNs = forge.aLong(min = 0),
+                serverTimeNs = forge.aLong(min = 0),
+                serverTimeOffsetNs = forge.aLong(),
+                serverTimeOffsetMs = forge.aLong()
+            ),
+            processInfo = ProcessInfo(isMainProcess = forge.aBool()),
+            networkInfo = NetworkInfo(
+                connectivity = forge.aValueFrom(NetworkInfo.Connectivity::class.java),
+                carrierName = forge.anElementFrom(
+                    forge.anAlphabeticalString(),
+                    forge.aWhitespaceString(),
+                    null
+                ),
+                carrierId = forge.aNullable { forge.aLong(0, 10000) },
+                upKbps = forge.aNullable { forge.aLong(1, Long.MAX_VALUE) },
+                downKbps = forge.aNullable { forge.aLong(1, Long.MAX_VALUE) },
+                strength = forge.aNullable { forge.aLong(-100, -30) }, // dBm for wifi signal
+                cellularTechnology = forge.aNullable { anAlphabeticalString() }
+            ),
+            deviceInfo = DeviceInfo(
+                deviceName = forge.anAlphabeticalString(),
+                deviceBrand = forge.anAlphabeticalString(),
+                deviceModel = forge.anAlphabeticalString(),
+                deviceType = forge.aValueFrom(DeviceType::class.java),
+                deviceBuildId = forge.anAlphaNumericalString(),
+                osName = forge.aString(),
+                osVersion = forge.aString(),
+                osMajorVersion = forge.aString(),
+                architecture = forge.aString(),
+                numberOfDisplays = forge.aNullable { forge.anInt() }
+            ),
+            userInfo = UserInfo(
+                id = forge.aNullable { anHexadecimalString() },
+                name = forge.aNullable {
+                    forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+")
+                },
+                email = forge.aNullable {
+                    forge.aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}")
+                },
+                additionalProperties = mapOf()
+            ),
+            trackingConsent = forge.aValueFrom(TrackingConsent::class.java),
+            appBuildId = forge.aNullable { getForgery<UUID>().toString() },
+            // building nested maps with default size slows down tests quite a lot, so will use
+            // an explicit small size
+            featuresContext = mapOf()
+        )
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
@@ -45,10 +45,10 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
                     forge.aWhitespaceString(),
                     null
                 ),
-                carrierId = forge.aNullable { forge.aLong(0, 10000) },
-                upKbps = forge.aNullable { forge.aLong(1, Long.MAX_VALUE) },
-                downKbps = forge.aNullable { forge.aLong(1, Long.MAX_VALUE) },
-                strength = forge.aNullable { forge.aLong(-100, -30) }, // dBm for wifi signal
+                carrierId = forge.aNullable { aLong(0, 10000) },
+                upKbps = forge.aNullable { aLong(1, Long.MAX_VALUE) },
+                downKbps = forge.aNullable { aLong(1, Long.MAX_VALUE) },
+                strength = forge.aNullable { aLong(-100, -30) }, // dBm for wifi signal
                 cellularTechnology = forge.aNullable { anAlphabeticalString() }
             ),
             deviceInfo = DeviceInfo(
@@ -61,15 +61,15 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
                 osVersion = forge.aString(),
                 osMajorVersion = forge.aString(),
                 architecture = forge.aString(),
-                numberOfDisplays = forge.aNullable { forge.anInt() }
+                numberOfDisplays = forge.aNullable {anInt() }
             ),
             userInfo = UserInfo(
                 id = forge.aNullable { anHexadecimalString() },
                 name = forge.aNullable {
-                    forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+")
+                    aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+")
                 },
                 email = forge.aNullable {
-                    forge.aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}")
+                    aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}")
                 },
                 additionalProperties = mapOf()
             ),

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/EnrichedRecordForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/EnrichedRecordForgeryFactory.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.forge
+
+import com.datadoghq.flutter.sessionreplay.models.EnrichedRecord
+import com.google.gson.JsonArray
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class EnrichedRecordForgeryFactory : ForgeryFactory<EnrichedRecord> {
+    override fun getForgery(forge: Forge): EnrichedRecord {
+        return EnrichedRecord(
+            applicationId = forge.getForgery<UUID>().toString(),
+            sessionId = forge.getForgery<UUID>().toString(),
+            viewId = forge.getForgery<UUID>().toString(),
+            JsonArray()
+        )
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/GsonJsonObjectForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/GsonJsonObjectForgeryFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.forge
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+/**
+ *  A [ForgeryFactory] generating a random [JsonObject] instance.
+ */
+class GsonJsonObjectForgeryFactory : ForgeryFactory<JsonObject> {
+
+    /** @inheritDoc */
+    override fun getForgery(forge: Forge): JsonObject {
+        return JsonObject().apply {
+            val fieldCount = forge.aTinyInt()
+            repeat(fieldCount + 1) {
+                add(
+                    forge.anAlphabeticalString(),
+                    forge.anElementFrom(
+                        JsonPrimitive(forge.aString())
+                    )
+                )
+            }
+        }
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/MobileSegmentForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/MobileSegmentForgeryFactory.kt
@@ -17,7 +17,7 @@ internal class MobileSegmentForgeryFactory : ForgeryFactory<MobileSegment> {
     override fun getForgery(forge: Forge): MobileSegment {
         val fakeRecords = JsonArray()
         forge.aList(size = forge.anInt(min = 1, max = 5)) {
-            forge.getForgery<JsonObject>()
+            getForgery<JsonObject>()
         }.forEach {
             fakeRecords.add(it)
         }
@@ -28,8 +28,8 @@ internal class MobileSegmentForgeryFactory : ForgeryFactory<MobileSegment> {
             start = forge.aPositiveLong(),
             end = forge.aPositiveLong(),
             recordsCount = forge.aPositiveLong(),
-            indexInView = forge.aNullable { forge.aPositiveLong() },
-            hasFullSnapshot = forge.aNullable { forge.aBool() },
+            indexInView = forge.aNullable { aPositiveLong() },
+            hasFullSnapshot = forge.aNullable { aBool() },
             source = forge.aString(),
             records = fakeRecords
         )

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/MobileSegmentForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/MobileSegmentForgeryFactory.kt
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.forge
+
+import com.datadoghq.flutter.sessionreplay.models.MobileSegment
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class MobileSegmentForgeryFactory : ForgeryFactory<MobileSegment> {
+    override fun getForgery(forge: Forge): MobileSegment {
+        val fakeRecords = JsonArray()
+        forge.aList(size = forge.anInt(min = 1, max = 5)) {
+            forge.getForgery<JsonObject>()
+        }.forEach {
+            fakeRecords.add(it)
+        }
+        return MobileSegment(
+            application = MobileSegment.Application(forge.getForgery<UUID>().toString()),
+            session = MobileSegment.Session(forge.getForgery<UUID>().toString()),
+            view = MobileSegment.View(forge.getForgery<UUID>().toString()),
+            start = forge.aPositiveLong(),
+            end = forge.aPositiveLong(),
+            recordsCount = forge.aPositiveLong(),
+            indexInView = forge.aNullable { forge.aPositiveLong() },
+            hasFullSnapshot = forge.aNullable { forge.aBool() },
+            source = forge.aString(),
+            records = fakeRecords
+        )
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/SRForgeConfigurator.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/SRForgeConfigurator.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.forge
+
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeConfigurator
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+
+internal class SRForgeConfigurator : ForgeConfigurator {
+    override fun configure(forge: Forge) {
+        forge.useJvmFactories()
+
+        forge.addFactory(DatadogContextForgeryFactory())
+        forge.addFactory(EnrichedRecordForgeryFactory())
+        forge.addFactory(GsonJsonObjectForgeryFactory())
+        forge.addFactory(MobileSegmentForgeryFactory())
+    }
+}

--- a/packages/datadog_session_replay/example/android/build.gradle.kts
+++ b/packages/datadog_session_replay/example/android/build.gradle.kts
@@ -18,7 +18,10 @@ allprojects {
     }
 }
 
-val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("../../build").get()
+val newBuildDir: Directory =
+    rootProject.layout.buildDirectory
+        .dir("../../build")
+        .get()
 rootProject.layout.buildDirectory.value(newBuildDir)
 
 subprojects {

--- a/packages/datadog_session_replay/example/android/settings.gradle.kts
+++ b/packages/datadog_session_replay/example/android/settings.gradle.kts
@@ -1,11 +1,12 @@
 pluginManagement {
-    val flutterSdkPath = run {
-        val properties = java.util.Properties()
-        file("local.properties").inputStream().use { properties.load(it) }
-        val flutterSdkPath = properties.getProperty("flutter.sdk")
-        require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
-        flutterSdkPath
-    }
+    val flutterSdkPath =
+        run {
+            val properties = java.util.Properties()
+            file("local.properties").inputStream().use { properties.load(it) }
+            val flutterSdkPath = properties.getProperty("flutter.sdk")
+            require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
+            flutterSdkPath
+        }
 
     includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayFeatureTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayFeatureTests.swift
@@ -24,7 +24,7 @@ func setsReplayBaggage_WhenSetHasReplay() throws {
 }
 
 @Test
-func setsBackage_WhenSetRecordCount() throws {
+func setsBaggage_WhenSetRecordCount() throws {
     // Given
     let core = PassthroughCoreMock()
     let config = FlutterSessionReplay.Configuration()
@@ -42,7 +42,7 @@ func setsBackage_WhenSetRecordCount() throws {
 }
 
 @Test
-func setsBackage_WhenSetRecordCount_MultipleViews() throws {
+func setsBaggage_WhenSetRecordCount_MultipleViews() throws {
     // Given
     let core = PassthroughCoreMock()
     let config = FlutterSessionReplay.Configuration()

--- a/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
@@ -6,7 +6,7 @@ import UIKit
 
 public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let channel = FlutterMethodChannel(name: "datadog_session_replay", binaryMessenger: registrar.messenger())
+        let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.session_replay", binaryMessenger: registrar.messenger())
         let instance = DatadogSessionReplayPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
     }


### PR DESCRIPTION
### What and why?

This adds a Feature that will pass through Flutter generated Session Replay Records into Android MobileSegments, which can then be compressed and sent to intake. The Android Feature and SegmentRequestFactory take care of serializing data to disk, assembling and compressing the SRSegments to sending them intake.

The feature also takes care of broadcasting RUM context changes back to Flutter.

refs: RUM-9552

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
