### PR TITLE
fix: Fix random trace id generation on web

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/tracing_helpers_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/tracing_helpers_test.dart
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // Because of the way we generate random numbers, add an integration test
+  // to ensure that we don't break Web's ability to generate traceIds from Dart
+  // libraries.
+  testWidgets('test generating trace ids', (WidgetTester tester) async {
+    final nowSeconds = (DateTime.now().millisecondsSinceEpoch ~/ 1000);
+    final traceId = TracingId.traceId();
+
+    final traceIdString = traceId.asString(TracingIdRepresentation.hex);
+    int traceSeconds = int.parse(traceIdString.substring(0, 8), radix: 16);
+    expect(traceSeconds, closeTo(nowSeconds, 1));
+    expect('00000000', traceIdString.substring(8, 16));
+    expect(traceIdString.substring(16), isNot('0000000000000000'));
+  });
+
+  testWidgets('generateTracingContext generates proper bit values',
+      (WidgetTester tester) async {
+    final context = generateTracingContext(true);
+
+    expect(context.traceId.value.bitLength, lessThanOrEqualTo(128));
+    expect(context.spanId.value.bitLength, lessThanOrEqualTo(63));
+    expect(context.sampled, true);
+  });
+}

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -78,6 +78,8 @@ typedef TraceIdRepresentation = TracingIdRepresentation;
 @visibleForTesting
 final lowTraceMask = (BigInt.from(0xffffffff) << 32) + BigInt.from(0xffffffff);
 
+final _maxRandInt = kIsWeb ? 1 << 31 : 1 << 32;
+
 /// [TracingId] is used as both a unsigned 64-bit "Span Id" and unsigned 128-bit "Trace Id"
 @immutable
 class TracingId {
@@ -152,8 +154,8 @@ class TracingId {
   static BigInt _generateTraceId() {
     final time = (DateTime.now().millisecondsSinceEpoch ~/ 1000);
 
-    final highBits = BigInt.from(_traceRandom.nextInt(1 << 32));
-    final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+    final highBits = BigInt.from(_traceRandom.nextInt(_maxRandInt));
+    final lowBits = BigInt.from(_traceRandom.nextInt(_maxRandInt));
 
     var traceId = BigInt.from(time) << 96;
     traceId += (highBits << 32);
@@ -168,7 +170,7 @@ class TracingId {
     // we assume it needs to be a positive signed 64-bit int, so only
     // use 63-bits.
     final highBits = _traceRandom.nextInt(1 << 31);
-    final lowBits = BigInt.from(_traceRandom.nextInt(1 << 32));
+    final lowBits = BigInt.from(_traceRandom.nextInt(_maxRandInt));
 
     var spanId = BigInt.from(highBits) << 32;
     spanId += lowBits;


### PR DESCRIPTION
### What and why?

Certain packages for distributed tracing (gRPC and GraphQL) generate tracing headers in Dart. In those cases, the library tries to generate a random 32-bit id, which throws on web. Fix so that these random ids are 31-bits instead.

Add an web integration test to ensure these trace ids work on web.

refs: #744

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
