### PR TITLE
feat: Support Flutter overhead for Session Replay

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Hybrid: attach",
-            "cwd": "examples/native-hybrid-app/flutter_module",
-            "type": "dart",
-            "request": "attach"
-        },
-        {
             "name": "Simple Example",
             "cwd": "examples/simple_example",
             "type": "dart",
@@ -41,28 +35,10 @@
             "request": "launch"
         },
         {
-            "name": "auto instrumented app",
-            "cwd": "packages/datadog_flutter_plugin/integration_test_app",
-            "program": "lib/auto_integration_scenarios/main.dart",
+            "name": "Session Replay Example",
+            "cwd": "packages/datadog_session_replay/example",
             "request": "launch",
             "type": "dart"
-        },
-        {
-            "name": "example (profile mode)",
-            "cwd": "packages/datadog_flutter_plugin/example",
-            "request": "launch",
-            "type": "dart",
-            "flutterMode": "profile"
-        },
-        {
-            "name": "e2e generator",
-            "cwd": "${workspaceFolder}/tools/e2e_generator",
-            "request": "launch",
-            "type": "dart",
-            "program": "bin/e2e_generator.dart",
-            "args": [
-                "../../e2e_test_app/integration_test"
-            ]
         }
     ]
 }

--- a/packages/datadog_common_test/lib/src/data_helpers.dart
+++ b/packages/datadog_common_test/lib/src/data_helpers.dart
@@ -4,7 +4,6 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
-import 'package:flutter/widgets.dart';
 
 final _random = Random();
 const _alphas = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -30,19 +29,6 @@ int randomInt() {
 
 double randomDouble({double min = -1000000, double max = 100000}) {
   return min + ((max - min) * _random.nextDouble());
-}
-
-Color randomColor({bool withRandomAlpha = false}) {
-  int randomColorComponent() {
-    return _random.nextInt(255);
-  }
-
-  return Color.fromARGB(
-    withRandomAlpha ? randomColorComponent() : 255,
-    randomColorComponent(),
-    randomColorComponent(),
-    randomColorComponent(),
-  );
 }
 
 extension RandomExtension<T> on List<T> {

--- a/packages/datadog_common_test/lib/src/data_helpers.dart
+++ b/packages/datadog_common_test/lib/src/data_helpers.dart
@@ -4,6 +4,7 @@
 import 'dart:math';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/widgets.dart';
 
 final _random = Random();
 const _alphas = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -21,6 +22,27 @@ String randomString({int length = 10}) {
 
 bool randomBool() {
   return _random.nextBool();
+}
+
+int randomInt() {
+  return _random.nextInt(1 << 16);
+}
+
+double randomDouble({double min = -1000000, double max = 100000}) {
+  return min + ((max - min) * _random.nextDouble());
+}
+
+Color randomColor({bool withRandomAlpha = false}) {
+  int randomColorComponent() {
+    return _random.nextInt(255);
+  }
+
+  return Color.fromARGB(
+    withRandomAlpha ? randomColorComponent() : 255,
+    randomColorComponent(),
+    randomColorComponent(),
+    randomColorComponent(),
+  );
 }
 
 extension RandomExtension<T> on List<T> {

--- a/packages/datadog_flutter_plugin/lib/datadog_internal.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_internal.dart
@@ -16,6 +16,7 @@ export 'src/datadog_sdk_platform_interface.dart';
 export 'src/helpers.dart';
 export 'src/internal_logger.dart';
 export 'src/rum/attributes.dart';
+export 'src/time_provider.dart';
 export 'src/tracing/tracing_headers.dart';
 
 // Because resource tracking is in a separate package, but web needs resource

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -12,7 +12,6 @@ import 'package:meta/meta.dart';
 
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
-import '../time_provider.dart';
 import 'ddrum_platform_interface.dart';
 import 'inv_metric_provider.dart';
 import 'rum_long_task_observer.dart';
@@ -107,7 +106,7 @@ class DatadogRum {
   @internal
   final TraceContextInjection traceContextInjection;
 
-  @visibleForTesting
+  @internal
   DatadogTimeProvider timeProvider = DefaultTimeProvider();
 
   final _sampleRandom = Random();

--- a/packages/datadog_flutter_plugin/lib/src/time_provider.dart
+++ b/packages/datadog_flutter_plugin/lib/src/time_provider.dart
@@ -13,6 +13,8 @@ abstract interface class DatadogTimeProvider {
 
 /// Default time provider which uses `DateTime` to provide the current timestamp.
 class DefaultTimeProvider implements DatadogTimeProvider {
+  const DefaultTimeProvider();
+
   @override
   int nowMs() {
     return DateTime.now().millisecondsSinceEpoch;

--- a/packages/datadog_session_replay/.gitignore
+++ b/packages/datadog_session_replay/.gitignore
@@ -31,3 +31,5 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 build/
+*.g.dart
+.env

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
@@ -57,7 +57,7 @@ class DatadogSessionReplayPlugin : FlutterPlugin, MethodCallHandler {
         }
         val configuration = FlutterSessionReplay.fromFlutter(options)
         enable(configuration)
-        result.success(null)
+        result.success(true)
     }
 
     internal fun enable(configuration: FlutterSessionReplay.Configuration) {

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
@@ -78,7 +78,7 @@ internal class DatadogSessionReplayPluginTest {
         plugin.onMethodCall(call, result)
 
         // Then
-        verify { result.success(null) }
+        verify { result.success(true) }
         verify {
             mockCore.registerFeature(
                 withArg {

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/packages/datadog_session_replay/example/lib/app.dart
+++ b/packages/datadog_session_replay/example/lib/app.dart
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
+import 'package:flutter/material.dart';
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final captureKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SessionReplayCapture(
+      key: captureKey,
+      rum: DatadogSdk.instance.rum!,
+      sessionReplay: DatadogSessionReplay.instance!,
+      child: MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Session Replay example app')),
+          body: Center(
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(width: 2),
+                borderRadius: BorderRadius.circular(10.0),
+                color: Colors.blueAccent,
+              ),
+              width: 200.0,
+              height: 200.0,
+              alignment: Alignment.center,
+              child: Text('Running\n'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/datadog_session_replay/example/lib/main.dart
+++ b/packages/datadog_session_replay/example/lib/main.dart
@@ -1,32 +1,42 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-void main() {
-  runApp(const MyApp());
-}
+import 'app.dart';
 
-class MyApp extends StatefulWidget {
-  const MyApp({super.key});
+void main() async {
+  await dotenv.load();
 
-  @override
-  State<MyApp> createState() => _MyAppState();
-}
+  var applicationId = dotenv.maybeGet('DD_APPLICATION_ID');
 
-class _MyAppState extends State<MyApp> {
-  @override
-  void initState() {
-    super.initState();
-  }
+  final configuration = DatadogConfiguration(
+    clientToken: dotenv.get('DD_CLIENT_TOKEN', fallback: ''),
+    env: dotenv.get('DD_ENV', fallback: ''),
+    service: 'com.datadoghq.example.flutter',
+    version: '1.2.3',
+    site: DatadogSite.us1,
+    nativeCrashReportEnabled: true,
+    loggingConfiguration: DatadogLoggingConfiguration(),
+    rumConfiguration:
+        applicationId != null
+            ? DatadogRumConfiguration(
+              sessionSamplingRate: 100.0,
+              applicationId: applicationId,
+              detectLongTasks: true,
+              reportFlutterPerformance: true,
+            )
+            : null,
+  )..enableSessionReplay(
+    DatadogSessionReplayConfiguration(replaySampleRate: 1.0),
+  );
 
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('Session Replay example app')),
-        body: Center(child: Text('Running\n')),
-      ),
-    );
-  }
+  final ddsdk = DatadogSdk.instance;
+  ddsdk.sdkVerbosity = CoreLoggerLevel.debug;
+  await DatadogSdk.runApp(configuration, TrackingConsent.granted, () async {
+    return runApp(const MyApp());
+  });
 }

--- a/packages/datadog_session_replay/example/pubspec.yaml
+++ b/packages/datadog_session_replay/example/pubspec.yaml
@@ -9,9 +9,11 @@ dependencies:
   flutter:
     sdk: flutter
 
+  datadog_flutter_plugin: ^2.12.0
   datadog_session_replay:
     path: ../
   cupertino_icons: ^1.0.8
+  flutter_dotenv: ^5.2.1
 
 dev_dependencies:
   integration_test:
@@ -22,3 +24,6 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  
+  assets:
+    - .env

--- a/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RequestBuilder/RequestBuilder.swift
@@ -32,7 +32,7 @@ internal struct RequestBuilder: FeatureRequestBuilder {
             .map { try SegmentJSON($0, source: source) }
             .merge()
 
-        return try createRequest(segments: segments, context: context)        
+        return try createRequest(segments: segments, context: context)
     }
 
     private func createRequest(segments: [SegmentJSON], context: DatadogContext) throws -> URLRequest {

--- a/packages/datadog_session_replay/lib/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/datadog_session_replay.dart
@@ -2,4 +2,25 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
-class DatadogSessionReplay {}
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+
+import 'src/datadog_session_replay_plugin.dart';
+
+export 'src/datadog_session_replay.dart' show DatadogSessionReplay;
+export 'src/widgets.dart' show SessionReplayCapture;
+
+class DatadogSessionReplayConfiguration {
+  double replaySampleRate;
+  String? customEndpoint;
+
+  DatadogSessionReplayConfiguration({
+    required this.replaySampleRate,
+    this.customEndpoint,
+  });
+}
+
+extension SessionReplayExtension on DatadogConfiguration {
+  void enableSessionReplay(DatadogSessionReplayConfiguration config) {
+    addPlugin(DatadogSessionReplayPluginConfiguration(configuration: config));
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/capture_node.dart
+++ b/packages/datadog_session_replay/lib/src/capture/capture_node.dart
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/widgets.dart';
+
+import '../sr_data_models.dart';
+
+abstract class WireframeBuilder {
+  List<SRWireframe> buildWireframes(CaptureNode node);
+}
+
+@immutable
+class CapturedViewAttributes {
+  final Rect paintBounds;
+  final double scaleX;
+  final double scaleY;
+
+  int get x => paintBounds.left.round();
+  int get y => paintBounds.top.round();
+  int get width => paintBounds.width.round();
+  int get height => paintBounds.height.round();
+
+  const CapturedViewAttributes({
+    required this.paintBounds,
+    required this.scaleX,
+    required this.scaleY,
+  });
+}
+
+@immutable
+abstract class CaptureNode {
+  final CapturedViewAttributes attributes;
+
+  const CaptureNode(this.attributes);
+
+  List<SRWireframe> buildWireframes();
+}

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/material.dart';
+
+import '../../extensions.dart';
+import '../../sr_data_models.dart';
+import '../capture_node.dart';
+import '../recorder.dart';
+import '../view_tree_snapshot.dart';
+
+class ContainerRecorder implements ElementRecorder {
+  final KeyGenerator keyGenerator;
+
+  const ContainerRecorder(this.keyGenerator);
+
+  @override
+  CaptureNodeSemantics? captureSemantics(
+    Element element,
+    CapturedViewAttributes attributes,
+  ) {
+    final widget = element.widget;
+    // Material is also considered a container
+    if (widget is! Container && widget is! Material) return null;
+
+    Color? backgroundColor;
+    double? cornerRadius;
+    double? borderWidth;
+    Color? borderColor;
+    if (widget is Container) {
+      backgroundColor = widget.color;
+      final decoration = widget.decoration;
+      if (decoration is BoxDecoration) {
+        // TODO: TextDirection
+        cornerRadius = decoration.borderRadius?.resolve(null).topLeft.x;
+
+        // It is illegal to supply both Container.color and Decoration.color,
+        // so overwriting the background color here is okay.
+        backgroundColor = decoration.color;
+        if (decoration.border case final border?) {
+          // TODO: Look into non-uniform borders for SR
+          if (border.top.width > 0) {
+            borderWidth = border.top.width;
+            borderColor = border.top.color;
+          } else if (border.bottom.width > 0) {
+            borderWidth = border.bottom.width;
+            borderColor = border.bottom.color;
+          }
+        }
+      }
+    }
+
+    final key = keyGenerator.keyForElement(element);
+    final node = _ContainerNode(
+      attributes,
+      wireframeId: key,
+      backgroundColor: backgroundColor,
+      borderWidth: borderWidth,
+      borderColor: borderColor,
+      cornerRadius: cornerRadius ?? 0,
+    );
+    return AmbiguousElement(nodes: [node]);
+  }
+}
+
+@immutable
+class _ContainerNode extends CaptureNode {
+  final int wireframeId;
+  final Color? backgroundColor;
+  final Color? borderColor;
+  final double? borderWidth;
+  final double cornerRadius;
+
+  const _ContainerNode(
+    super.attributes, {
+    required this.wireframeId,
+    required this.backgroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.cornerRadius = 0.0,
+  });
+
+  @override
+  List<SRWireframe> buildWireframes() {
+    final attrs = attributes;
+    SRShapeStyle? style;
+    SRShapeBorder? border;
+    if (backgroundColor != null || borderWidth != null) {
+      style = SRShapeStyle(
+        backgroundColor:
+            backgroundColor?.toHexString() ?? srTransparentColorString,
+        cornerRadius: cornerRadius,
+      );
+
+      if (borderWidth != null) {
+        border = SRShapeBorder(
+          color: borderColor!.toHexString(),
+          width: borderWidth!.round(),
+        );
+      }
+    }
+    return [
+      SRShapeWireframe(
+        id: wireframeId,
+        x: attrs.x,
+        y: attrs.y,
+        width: attrs.width,
+        height: attrs.height,
+        shapeStyle: style,
+        border: border,
+      ),
+    ];
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/pointer_capture.dart
+++ b/packages/datadog_session_replay/lib/src/capture/pointer_capture.dart
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:meta/meta.dart';
+
+import '../sr_data_models.dart';
+
+@immutable
+class PointerSnapshot {
+  final DateTime firstRecord;
+  final List<PointerCapture> pointerEvents;
+
+  const PointerSnapshot(this.firstRecord, this.pointerEvents);
+}
+
+@immutable
+class PointerCapture {
+  final DateTime date;
+  final int pointerId;
+  final SRPointerEventType eventType;
+  final double x;
+  final double y;
+
+  const PointerCapture({
+    required this.date,
+    required this.pointerId,
+    required this.eventType,
+    required this.x,
+    required this.y,
+  });
+}
+
+class PointerSnapshotRecorder {
+  final DatadogTimeProvider timeProvider;
+
+  List<PointerCapture> _pointerBuffer = [];
+
+  PointerSnapshotRecorder(this.timeProvider);
+
+  void capturePointer(
+    int pointerId,
+    SRPointerEventType eventType,
+    double x,
+    double y,
+  ) {
+    final now = timeProvider.now();
+
+    _pointerBuffer.add(
+      PointerCapture(
+        date: now,
+        pointerId: pointerId,
+        eventType: eventType,
+        x: x,
+        y: y,
+      ),
+    );
+  }
+
+  PointerSnapshot? takeSnapshot() {
+    if (_pointerBuffer.isEmpty) {
+      return null;
+    }
+
+    final copy = _pointerBuffer;
+    _pointerBuffer = [];
+    return PointerSnapshot(copy.first.date, copy);
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -26,9 +26,9 @@ class KeyGenerator {
   var nextKey = 0;
 
   final Expando<int> _nodeIdExpando = Expando('sr-key');
+  // ignore: unused_field
   final Expando<List<int>> _nodeIdsExpando = Expando('multi-sr-key');
 
-  @override
   int keyForElement(Element e) {
     var value = _nodeIdExpando[e];
     if (value != null) return value;

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -1,0 +1,196 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:flutter/widgets.dart';
+
+import '../datadog_session_replay_platform_interface.dart';
+import '../rum_context.dart';
+import '../widgets.dart';
+import 'capture_node.dart';
+import 'element_recorders/container_recorder.dart';
+import 'pointer_capture.dart';
+import 'view_tree_snapshot.dart';
+
+abstract interface class ElementRecorder {
+  CaptureNodeSemantics? captureSemantics(
+    Element element,
+    CapturedViewAttributes attributes,
+  );
+}
+
+class KeyGenerator {
+  // This is close to JavaScript's MAX_SAFE_INT (53-bit)
+  static const int maxKey = 0x20000000000000;
+  var nextKey = 0;
+
+  final Expando<int> _nodeIdExpando = Expando('sr-key');
+  final Expando<List<int>> _nodeIdsExpando = Expando('multi-sr-key');
+
+  @override
+  int keyForElement(Element e) {
+    var value = _nodeIdExpando[e];
+    if (value != null) return value;
+
+    value = nextKey;
+    nextKey = nextKey + 1;
+    if (nextKey >= maxKey) nextKey = 0;
+
+    _nodeIdExpando[e] = value;
+
+    return value;
+  }
+}
+
+@immutable
+class CaptureResult {
+  final ViewTreeSnapshot viewTreeSnapshot;
+  final PointerSnapshot? pointerSnapshot;
+
+  const CaptureResult(this.viewTreeSnapshot, this.pointerSnapshot);
+}
+
+class SessionReplayRecorder {
+  final Map<Key, Element> _elements = {};
+
+  RUMContext? _currentContext;
+
+  final DatadogTimeProvider _timeProvider;
+  final List<ElementRecorder> _elementRecorders;
+
+  SessionReplayRecorder({
+    DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
+  }) : this._(KeyGenerator(), timeProvider);
+
+  SessionReplayRecorder._(KeyGenerator keyGenerator, this._timeProvider)
+    : _elementRecorders = [ContainerRecorder(keyGenerator)];
+
+  @visibleForTesting
+  SessionReplayRecorder.withCustomRecorders(
+    this._elementRecorders, {
+    DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
+  }) : _timeProvider = timeProvider;
+
+  void updateContext(RUMContext? context) {
+    _currentContext = context;
+  }
+
+  void addElement(Key key, Element e) {
+    _elements[key] = e;
+  }
+
+  void removeElement(Key key) {
+    _elements.remove(key);
+  }
+
+  CaptureResult? performCapture() {
+    final context = _currentContext;
+    if (context == null) {
+      return null;
+    }
+
+    DateTime now = _timeProvider.now();
+    List<CaptureNode> nodes = [];
+    List<PointerSnapshot> pointerSnapshots = [];
+    var size = Size.zero;
+    for (final e in _elements.values) {
+      final elementSize = e.size;
+      if (elementSize != null) {
+        // Need to copy this value because the size class
+        // returned by the element is not serializable over the isolate
+        size = Size(elementSize.width, elementSize.height);
+      }
+      _captureElement(e, nodes, pointerSnapshots);
+    }
+
+    if (nodes.isEmpty) return null;
+
+    final viewTreeSnapshot = ViewTreeSnapshot(
+      date: now,
+      context: context,
+      viewportSize: size,
+      nodes: nodes,
+    );
+
+    // TODO: We dhouldn't have multiple pointer snapshots, but even if we
+    // do, for now just take the first one.
+    final pointerSnapshot = pointerSnapshots.firstOrNull;
+
+    return CaptureResult(viewTreeSnapshot, pointerSnapshot);
+  }
+
+  void onContextChanged(RUMContext context) {
+    _currentContext = context;
+
+    DatadogSessionReplayPlatform.instance.setHasReplay(context.viewId != null);
+  }
+
+  void _captureElement(
+    Element topElement,
+    List<CaptureNode> nodes,
+    List<PointerSnapshot> pointerSnapshots,
+  ) {
+    void visit(Element e, int depth) {
+      if (e.widget case final PointerRecorder snapshotWidget) {
+        if (snapshotWidget.snapshotRecorder.takeSnapshot()
+            case final snapshot?) {
+          pointerSnapshots.add(snapshot);
+        }
+      }
+
+      final renderObject = e.renderObject;
+      if (renderObject == null) return;
+
+      final transformMatrix = renderObject.getTransformTo(
+        topElement.renderObject,
+      );
+      final paintBounds = MatrixUtils.transformRect(
+        transformMatrix,
+        renderObject.paintBounds,
+      );
+      final viewAttributes = CapturedViewAttributes(
+        paintBounds: paintBounds,
+        scaleX: 1.0,
+        scaleY: 1,
+      );
+
+      final elementSemantics = _elementSemantics(e, viewAttributes);
+
+      nodes.addAll(elementSemantics.nodes);
+
+      if (elementSemantics.subtreeStrategy ==
+          CaptureNodeSubtreeStrategy.record) {
+        e.visitChildElements((child) {
+          final renderObject = child.renderObject;
+          if (renderObject == null) return;
+
+          visit(child, depth + 1);
+        });
+      }
+    }
+
+    visit(topElement, 0);
+  }
+
+  CaptureNodeSemantics _elementSemantics(
+    Element element,
+    CapturedViewAttributes viewAttributes,
+  ) {
+    CaptureNodeSemantics semantics = const UnknownElement();
+
+    for (final recorder in _elementRecorders) {
+      final nextSemantics = recorder.captureSemantics(element, viewAttributes);
+      if (nextSemantics == null) continue;
+
+      if (nextSemantics.importance >= semantics.importance) {
+        semantics = nextSemantics;
+        if (semantics.importance == CaptureNodeSemantics.maxImporance) {
+          break;
+        }
+      }
+    }
+
+    return semantics;
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/view_tree_snapshot.dart
+++ b/packages/datadog_session_replay/lib/src/capture/view_tree_snapshot.dart
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/widgets.dart';
+
+import '../rum_context.dart';
+import 'capture_node.dart';
+
+@immutable
+class ViewTreeSnapshot {
+  final DateTime date;
+  final RUMContext context;
+  final Size viewportSize;
+  final List<CaptureNode> nodes;
+
+  const ViewTreeSnapshot({
+    required this.date,
+    required this.context,
+    required this.viewportSize,
+    required this.nodes,
+  });
+}
+
+enum CaptureNodeSubtreeStrategy { record, ignore }
+
+@immutable
+abstract class CaptureNodeSemantics {
+  static const maxImporance = 1000000;
+  static const minImportance = -1000000;
+
+  final int importance;
+  final CaptureNodeSubtreeStrategy subtreeStrategy;
+  final List<CaptureNode> nodes;
+
+  const CaptureNodeSemantics({
+    required this.importance,
+    required this.subtreeStrategy,
+    required this.nodes,
+  });
+}
+
+@immutable
+class UnknownElement extends CaptureNodeSemantics {
+  const UnknownElement()
+    : super(
+        importance: CaptureNodeSemantics.minImportance,
+        subtreeStrategy: CaptureNodeSubtreeStrategy.record,
+        nodes: const [],
+      );
+}
+
+@immutable
+class InvisibleElement extends CaptureNodeSemantics {
+  const InvisibleElement({required super.subtreeStrategy})
+    : super(importance: 0, nodes: const []);
+}
+
+@immutable
+class IgnoredElement extends CaptureNodeSemantics {
+  const IgnoredElement({required super.subtreeStrategy, super.nodes = const []})
+    : super(importance: CaptureNodeSemantics.maxImporance);
+}
+
+@immutable
+class AmbiguousElement extends CaptureNodeSemantics {
+  const AmbiguousElement({
+    super.subtreeStrategy = CaptureNodeSubtreeStrategy.record,
+    required super.nodes,
+  }) : super(importance: 0);
+}
+
+@immutable
+class SpecificElement extends CaptureNodeSemantics {
+  const SpecificElement({required super.subtreeStrategy, required super.nodes})
+    : super(importance: CaptureNodeSemantics.maxImporance);
+}

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:async';
+
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
+
+import '../datadog_session_replay.dart';
+import 'capture/recorder.dart';
+import 'datadog_session_replay_platform_interface.dart';
+import 'processor/processor.dart';
+import 'rum_context.dart';
+
+class DatadogSessionReplay {
+  static DatadogSessionReplay? _instance;
+  static DatadogSessionReplay? get instance => _instance;
+
+  final DatadogSessionReplayConfiguration _configuration;
+  @internal
+  final InternalLogger internalLogger;
+
+  final SessionReplayProcessor _processor = SessionReplayProcessor();
+  final SessionReplayRecorder _recorder = SessionReplayRecorder();
+
+  @internal
+  static Future<DatadogSessionReplay> init(
+    DatadogSessionReplayConfiguration configuration,
+    InternalLogger logger,
+  ) async {
+    _instance = DatadogSessionReplay._(configuration, logger);
+    await _instance!._start();
+    return _instance!;
+  }
+
+  DatadogSessionReplay._(this._configuration, this.internalLogger);
+
+  void addElement(Key key, Element e) {
+    _recorder.addElement(key, e);
+  }
+
+  void removeElement(Key key) {
+    _recorder.removeElement(key);
+  }
+
+  void _onContextChanged(RUMContext context) {
+    _recorder.onContextChanged(context);
+  }
+
+  Future<void> _start() async {
+    final platform = DatadogSessionReplayPlatform.instance;
+    bool success = false;
+    await wrapAsync('enable', internalLogger, {}, () async {
+      success = await platform.enable(_configuration, _onContextChanged);
+    });
+
+    if (success) {
+      await _processor.start();
+
+      const timerDuration = Duration(milliseconds: 100);
+      // TODO(RUM-10155): See if we can be smarter about how often we perform tree captures
+      final replayTimer = Timer.periodic(timerDuration, (timer) {
+        final captureResult = _recorder.performCapture();
+        if (captureResult != null) {
+          _processor.process(captureResult);
+        }
+      });
+    }
+  }
+}

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -61,7 +61,7 @@ class DatadogSessionReplay {
 
       const timerDuration = Duration(milliseconds: 100);
       // TODO(RUM-10155): See if we can be smarter about how often we perform tree captures
-      final replayTimer = Timer.periodic(timerDuration, (timer) {
+      Timer.periodic(timerDuration, (timer) {
         final captureResult = _recorder.performCapture();
         if (captureResult != null) {
           _processor.process(captureResult);

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay_method_channel.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay_method_channel.dart
@@ -4,7 +4,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import '../datadog_session_replay.dart';
 import 'datadog_session_replay_platform_interface.dart';
+import 'rum_context.dart';
 
 /// An implementation of [DatadogSessionReplayPlatform] that uses method channels.
 class MethodChannelDatadogSessionReplay extends DatadogSessionReplayPlatform {
@@ -13,4 +15,43 @@ class MethodChannelDatadogSessionReplay extends DatadogSessionReplayPlatform {
   final methodChannel = const MethodChannel(
     'datadog_sdk_flutter.session_replay',
   );
+
+  @override
+  Future<bool> enable(
+    DatadogSessionReplayConfiguration configuration,
+    void Function(RUMContext) onContextChanged,
+  ) async {
+    // All we actually need at the moment is the customEndpoint if set
+    final arguments = {
+      'configuration': {'customEndpoint': configuration.customEndpoint},
+    };
+    methodChannel.setMethodCallHandler((call) async {
+      if (call.method == 'onContextChanged') {
+        final contextMap = call.arguments as Map<Object?, Object?>;
+        final context = RUMContext.fromMap(contextMap);
+        onContextChanged(context);
+      }
+    });
+    bool success = await methodChannel.invokeMethod('enable', arguments);
+    return success;
+  }
+
+  @override
+  Future<void> writeSegment(String record, String viewId) {
+    final arguments = {'segment': record, 'viewId': viewId};
+    return methodChannel.invokeMethod('writeSegment', arguments);
+  }
+
+  @override
+  Future<void> setHasReplay(bool hasReplay) {
+    return methodChannel.invokeMethod('setHasReplay', {'hasReplay': hasReplay});
+  }
+
+  @override
+  Future<void> setRecordCount(String viewId, int count) {
+    return methodChannel.invokeMethod('setRecordCount', {
+      'viewId': viewId,
+      'count': count,
+    });
+  }
 }

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay_platform_interface.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay_platform_interface.dart
@@ -1,6 +1,8 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../datadog_session_replay.dart';
 import 'datadog_session_replay_method_channel.dart';
+import 'rum_context.dart';
 
 abstract class DatadogSessionReplayPlatform extends PlatformInterface {
   /// Constructs a DatadogSessionReplayPlatform.
@@ -23,4 +25,15 @@ abstract class DatadogSessionReplayPlatform extends PlatformInterface {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }
+
+  Future<bool> enable(
+    DatadogSessionReplayConfiguration configuration,
+    void Function(RUMContext) onContextChanged,
+  );
+
+  Future<void> setHasReplay(bool hasReplay);
+
+  Future<void> setRecordCount(String viewId, int count);
+
+  Future<void> writeSegment(String record, String viewId);
 }

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay_plugin.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay_plugin.dart
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+// ignore_for_file: invalid_use_of_internal_member
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+
+import '../datadog_session_replay.dart';
+import 'datadog_session_replay.dart';
+
+class DatadogSessionReplayPluginConfiguration
+    extends DatadogPluginConfiguration {
+  DatadogSessionReplayConfiguration configuration;
+
+  DatadogSessionReplayPluginConfiguration({required this.configuration});
+
+  @override
+  DatadogPlugin create(DatadogSdk datadogInstance) {
+    return _SessionReplayPlugin(datadogInstance, configuration);
+  }
+}
+
+class _SessionReplayPlugin extends DatadogPlugin {
+  final DatadogSessionReplayConfiguration configuration;
+
+  _SessionReplayPlugin(super.instance, this.configuration);
+
+  @override
+  Future<void> initialize() async {
+    await wrapAsync(
+      '_SessionReplayPlugin.initialize',
+      instance.internalLogger,
+      null,
+      () async {
+        await DatadogSessionReplay.init(configuration, instance.internalLogger);
+        instance.internalLogger.debug('Flutter Session Replay Enabled');
+      },
+    );
+  }
+}

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay_web.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay_web.dart
@@ -5,14 +5,40 @@
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
+import '../datadog_session_replay.dart';
 import 'datadog_session_replay_platform_interface.dart';
+import 'rum_context.dart';
 
-/// A web implementation of the DatadogSessionReplayPlatform of the DatadogSessionReplay plugin.
+/// A stub implementation for Flutter Session Replay for Web. Datadog Session
+/// Replay is not currently supported for the Flutter Web.
 class DatadogSessionReplayWeb extends DatadogSessionReplayPlatform {
   /// Constructs a DatadogSessionReplayWeb
   DatadogSessionReplayWeb();
 
   static void registerWith(Registrar registrar) {
     DatadogSessionReplayPlatform.instance = DatadogSessionReplayWeb();
+  }
+
+  @override
+  Future<bool> enable(
+    DatadogSessionReplayConfiguration configuration,
+    void Function(RUMContext p1) onContextChanged,
+  ) {
+    return Future.value(false);
+  }
+
+  @override
+  Future<void> setHasReplay(bool hasReplay) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> setRecordCount(String viewId, int count) {
+    return Future.value();
+  }
+
+  @override
+  Future<void> writeSegment(String record, String viewId) {
+    return Future.value();
   }
 }

--- a/packages/datadog_session_replay/lib/src/extensions.dart
+++ b/packages/datadog_session_replay/lib/src/extensions.dart
@@ -2,7 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
-import 'dart:ui';
+import 'package:flutter/widgets.dart' show Color;
 
 int _floatToInt8(double x) {
   return (x * 255.0).round() & 0xff;

--- a/packages/datadog_session_replay/lib/src/extensions.dart
+++ b/packages/datadog_session_replay/lib/src/extensions.dart
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:ui';
+
+int _floatToInt8(double x) {
+  return (x * 255.0).round() & 0xff;
+}
+
+extension HexColor on Color {
+  String toHexString() {
+    int rint = _floatToInt8(r);
+    int gint = _floatToInt8(g);
+    int bint = _floatToInt8(b);
+    int aint = _floatToInt8(a);
+    return '#${rint.toRadixString(16).padLeft(2, '0')}'
+        '${gint.toRadixString(16).padLeft(2, '0')}'
+        '${bint.toRadixString(16).padLeft(2, '0')}'
+        '${aint.toRadixString(16).padLeft(2, '0')}';
+  }
+}

--- a/packages/datadog_session_replay/lib/src/processor/diff.dart
+++ b/packages/datadog_session_replay/lib/src/processor/diff.dart
@@ -1,0 +1,187 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+import '../sr_data_models.dart';
+
+class Diff {
+  List<SRIntrementalAdd> adds;
+  List<SRIncrementalUpdate> updates;
+  List<SRIncrementalRemove> removes;
+
+  bool get isEmpty => adds.isEmpty && updates.isEmpty && removes.isEmpty;
+
+  Diff(this.adds, this.updates, this.removes);
+}
+
+class TableEntry {
+  bool inNew;
+  int? indexInOld;
+
+  TableEntry(this.inNew, this.indexInOld);
+}
+
+class Entry {
+  bool isTableReference;
+  int id; // Can eb either an entry into the table or an index into na or oa.
+
+  Entry(this.isTableReference, this.id);
+}
+
+/// Computes a diff between two arrays.
+///
+/// This implementation is based on Paul Heckel's algorithm for finding
+/// differences between files. It isolates differences in a way that corresponds
+/// closely to our intuitive notion of difference (it finds the longest common
+/// subsequence). It is computationally efficient: `O(n)` in time and memory.
+///
+/// Unlike original Heckel's algorithm, our implementation assumes that elements
+/// are unique within each of two arrays. It means that all elements in
+/// `oldArray` are guaranteed to have different `id` (same for `newArray`).
+/// Elements with the same `id` can appear in both arrays, which indicates one
+/// of two things determined by `newElement.isDifferent(than: oldElement)`:
+/// - either the element was not altered and can be skipped in diff,
+/// - or the element was changed and it should be reflected in `Diff.Update`.
+///
+/// Like original algorithm, our implementation uses 6 passes over both arrays
+/// to determine diff
+///
+/// Ref.:
+/// - _"A technique for isolating differences between files"_ Paul Heckel (1978)
+///   - https://dl.acm.org/citation.cfm?id=359467
+///
+/// - Parameters:
+///   - oldArray: original array
+///   - newArray: new array
+/// - Returns: `Diff` describing changes from `oldArray` to `newArray`.
+Diff computeDiff(List<SRWireframe> oldArray, List<SRWireframe> newArray) {
+  var table = <int, TableEntry>{};
+  var oldEntries = <Entry>[];
+  var newEntries = <Entry>[];
+
+  // 1st pass
+  // Read `newArray` and store info on each element in symbols `table`:
+  for (final e in newArray) {
+    table[e.id] = TableEntry(true, null);
+    newEntries.add(Entry(true, e.id));
+  }
+
+  // 2nd pass
+  // Read `oldArray` and store info on each element in symbols `table`. If certain element already
+  // exists, update its information (otherwise create new entry):
+  for (var i = 0; i < oldArray.length; ++i) {
+    final e = oldArray[i];
+    final tableEntry = table[e.id];
+    if (tableEntry != null) {
+      tableEntry.indexInOld = i;
+    } else {
+      table[e.id] = TableEntry(false, e.id);
+    }
+    oldEntries.add(Entry(true, e.id));
+  }
+
+  // 3rd pass
+  // Uses "Observation 1":
+  // > If a line occurs only once in each file, then it must be the same line, although it may have been moved.
+  // > We use this observation to locate unaltered lines that we subsequently exclude from further treatment.
+  for (var i = 0; i < newEntries.length; ++i) {
+    final entry = newEntries[i];
+    if (entry.isTableReference) {
+      final tableEntry = table[entry.id];
+      if (tableEntry == null) {
+        // TODO: Make a better error
+        throw Error();
+      }
+      if (tableEntry.inNew) {
+        final oldIndex = tableEntry.indexInOld;
+        if (oldIndex != null) {
+          newEntries[i] = Entry(false, oldIndex);
+          oldEntries[oldIndex] = Entry(false, i);
+        }
+      }
+    }
+  }
+
+  // 4th pass
+  // > If a line has been found to be unaltered, and the lines immediately adjacent to it in both files are identical,
+  // > then these lines must be the same line. This information can be used to find blocks of unchanged lines.
+  for (var i = 0; i < newEntries.length - 1; ++i) {
+    final currentEntry = newEntries[i];
+    final j = currentEntry.id;
+    if (!currentEntry.isTableReference && (j + 1) < oldEntries.length) {
+      final nextNewEntry = newEntries[i + 1];
+      final nextOldEntry = oldEntries[j + 1];
+      if (nextNewEntry.isTableReference &&
+          nextOldEntry.isTableReference &&
+          nextNewEntry.id == nextOldEntry.id) {
+        newEntries[i + 1] = Entry(false, j + 1);
+        oldEntries[j + 1] = Entry(false, i + 1);
+      }
+    }
+  }
+
+  // 5th pass
+  // Similar to 4th pass, except it processes entries in descending order.
+  for (var i = newEntries.length - 1; i > 1; --i) {
+    final currentEntry = newEntries[i];
+    final j = currentEntry.id;
+    if (!currentEntry.isTableReference && (j - 1) < oldEntries.length) {
+      final nextNewEntry = newEntries[i - 1];
+      final nextOldEntry = oldEntries[j - 1];
+      if (nextNewEntry.isTableReference &&
+          nextOldEntry.isTableReference &&
+          nextNewEntry.id == nextOldEntry.id) {
+        newEntries[i - 1] = Entry(false, j - 1);
+        oldEntries[j - 1] = Entry(false, i - 1);
+      }
+    }
+  }
+
+  // Final pass
+  // Constructing the actual diff from information stored in `oldEntries` and `newEntries`.
+  var adds = <SRIntrementalAdd>[];
+  var removes = <SRIncrementalRemove>[];
+  var updates = <SRIncrementalUpdate>[];
+
+  var removalOffsets = List<int>.filled(oldArray.length, 0);
+  var runningOffset = 0;
+
+  for (int i = 0; i < oldEntries.length; ++i) {
+    final entry = oldEntries[i];
+    removalOffsets[i] = runningOffset;
+    if (entry.isTableReference) {
+      removes.add(SRIncrementalRemove(id: oldArray[i].id));
+      runningOffset += 1;
+    }
+  }
+
+  runningOffset = 0;
+  for (int i = 0; i < newEntries.length; ++i) {
+    final entry = newEntries[i];
+    if (entry.isTableReference) {
+      final previousId = i > 0 ? newArray[i - 1].id : null;
+      adds.add(
+        SRIntrementalAdd(previousId: previousId, wireframe: newArray[i]),
+      );
+    } else {
+      final indexInOld = entry.id;
+      final removalOffset = removalOffsets[indexInOld];
+      final newElement = newArray[i];
+      final oldElement = oldArray[indexInOld];
+
+      if ((indexInOld - removalOffset + runningOffset) != i) {
+        // Old element was moved to another position
+        final previousId = i > 0 ? newArray[i - 1].id : null;
+        removes.add(SRIncrementalRemove(id: newArray[i].id));
+        adds.add(
+          SRIntrementalAdd(previousId: previousId, wireframe: newArray[i]),
+        );
+      } else if (newElement.isDifferent(oldElement)) {
+        final mutations = newElement.mutationsFrom(oldElement);
+
+        updates.add(mutations);
+      }
+    }
+  }
+
+  return Diff(adds, updates, removes);
+}

--- a/packages/datadog_session_replay/lib/src/processor/processor.dart
+++ b/packages/datadog_session_replay/lib/src/processor/processor.dart
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:isolate';
+
+import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
+
+import '../capture/recorder.dart';
+import 'processor_worker.dart';
+
+/// Spawns a background isolate to process session replay snapshots before
+/// sending them to the native platform for serialization and distribution to
+/// intake
+class SessionReplayProcessor {
+  final ReceivePort _mainReceivePort = ReceivePort('sr-replay-port');
+  SendPort? _mainSendPort;
+
+  Future<void> start() async {
+    await Isolate.spawn(
+      _captureProcessor,
+      _ProcessorArgs(RootIsolateToken.instance!, _mainReceivePort.sendPort),
+    );
+
+    _mainSendPort = await _mainReceivePort.first;
+  }
+
+  void process(CaptureResult captureResult) {
+    _mainSendPort?.send(captureResult);
+  }
+
+  static Future<void> _captureProcessor(_ProcessorArgs args) async {
+    BackgroundIsolateBinaryMessenger.ensureInitialized(args.rootIsolateToken);
+    final ReceivePort commandPort = ReceivePort();
+    final responsePort = args.sendPort;
+    responsePort.send(commandPort.sendPort);
+
+    final internalProcessor = ProcessorWorker();
+
+    await for (final message in commandPort) {
+      if (message is CaptureResult) {
+        await internalProcessor.processSnapshot(message);
+      } else if (message == null) {
+        break;
+      }
+    }
+
+    Isolate.exit();
+  }
+}
+
+@immutable
+class _ProcessorArgs {
+  final RootIsolateToken rootIsolateToken;
+  final SendPort sendPort;
+
+  const _ProcessorArgs(this.rootIsolateToken, this.sendPort);
+}

--- a/packages/datadog_session_replay/lib/src/processor/processor_worker.dart
+++ b/packages/datadog_session_replay/lib/src/processor/processor_worker.dart
@@ -1,0 +1,157 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:async';
+import 'dart:convert';
+
+import '../capture/pointer_capture.dart';
+import '../capture/recorder.dart';
+import '../capture/view_tree_snapshot.dart';
+import '../datadog_session_replay_platform_interface.dart';
+import '../sr_data_models.dart';
+import 'diff.dart';
+
+/// An internal class that does all of the work for processing a ViewSnapshot into SRRecords,
+/// including creating diffs for non full records. When complete, the processor sends
+/// the records to the native method channel so they can be serialized and sent to intake.
+class ProcessorWorker {
+  ViewTreeSnapshot? _lastSnapshot;
+  List<SRWireframe>? _lastWireframes;
+  final Map<String, int> _recordCountByViewId = {};
+
+  Future<void> processSnapshot(CaptureResult snapshot) async {
+    final viewSnapshot = snapshot.viewTreeSnapshot;
+    final viewId = viewSnapshot.context.viewId;
+    if (viewId == null) return;
+
+    final wireframes =
+        viewSnapshot.nodes
+            .expand((element) => element.buildWireframes())
+            .toList();
+
+    var records = <SRRecord>[];
+
+    final timestamp = viewSnapshot.date.toUtc().millisecondsSinceEpoch;
+
+    if (viewSnapshot.context.applicationId !=
+            _lastSnapshot?.context.applicationId ||
+        viewSnapshot.context.sessionId != _lastSnapshot?.context.sessionId ||
+        viewSnapshot.context.viewId != _lastSnapshot?.context.viewId) {
+      // Generate full snapshot
+      records.add(
+        SRMetaRecord(
+          data: SRMetaRecordData(
+            width: viewSnapshot.viewportSize.width.toInt(),
+            height: viewSnapshot.viewportSize.height.toInt(),
+          ),
+          timestamp: timestamp,
+        ),
+      );
+      records.add(
+        SRFocusRecord(
+          data: SRFocusRecordData(hasFocus: true),
+          timestamp: timestamp,
+        ),
+      );
+      records.add(
+        SRFullSnapshotRecord(
+          data: SRFullSnapshotRecordData(wireframes: wireframes),
+          timestamp: timestamp,
+        ),
+      );
+    } else if (_lastWireframes != null) {
+      final incrementalRecord = _createIncrementalRecord(
+        viewSnapshot,
+        wireframes,
+        _lastWireframes!,
+      );
+      if (incrementalRecord != null) {
+        records.add(incrementalRecord);
+      }
+    }
+
+    if (snapshot.pointerSnapshot case final pointerSnapshot?) {
+      if (pointerSnapshot.pointerEvents.isNotEmpty) {
+        records.addAll(
+          pointerSnapshot.pointerEvents.map(_createIncrementalPointerRecord),
+        );
+      }
+    }
+
+    if (records.isNotEmpty) {
+      final enrichedRecord = SREnrichedRecord(
+        records: records,
+        applicationID: viewSnapshot.context.applicationId,
+        sessionID: viewSnapshot.context.sessionId,
+        viewID: viewId,
+      );
+
+      var totalRecordCount = _recordCountByViewId[viewId] ?? 0;
+      totalRecordCount += records.length;
+      _recordCountByViewId[viewId] = totalRecordCount;
+      // We don't have to wait for this to respond before sending the segment. They'll
+      // still be processed in order and this gives us more time to perform the encode.
+      unawaited(
+        DatadogSessionReplayPlatform.instance.setRecordCount(
+          viewId,
+          totalRecordCount,
+        ),
+      );
+
+      var encoded = jsonEncode(enrichedRecord.toJson());
+      try {
+        await DatadogSessionReplayPlatform.instance.writeSegment(
+          encoded,
+          viewId,
+        );
+      } catch (e) {
+        // TODO: Report telemetry
+      }
+    }
+
+    _lastSnapshot = viewSnapshot;
+    _lastWireframes = wireframes;
+  }
+
+  SRRecord _createIncrementalPointerRecord(PointerCapture pointer) {
+    return SRIncrementalSnapshotRecord(
+      data: SRPointerInteractionData(
+        pointerEventType: pointer.eventType,
+        pointerId: pointer.pointerId,
+        pointerType: SRPointerType.touch,
+        x: pointer.x,
+        y: pointer.y,
+      ),
+      timestamp: pointer.date.millisecondsSinceEpoch,
+    );
+  }
+
+  SRRecord? _createIncrementalRecord(
+    ViewTreeSnapshot viewTreeSnapshot,
+    List<SRWireframe> wireframes,
+    List<SRWireframe> lastWireframes,
+  ) {
+    final timestamp = viewTreeSnapshot.date.toUtc().millisecondsSinceEpoch;
+    try {
+      final diff = computeDiff(lastWireframes, wireframes);
+      if (diff.isEmpty) {
+        return null;
+      }
+      return SRIncrementalSnapshotRecord(
+        data: SRIncrementalMutationData(
+          adds: diff.adds,
+          removes: diff.removes,
+          updates: diff.updates,
+        ),
+        timestamp: timestamp,
+      );
+    } catch (_) {
+      // default back to full snaposhot
+      return SRFullSnapshotRecord(
+        data: SRFullSnapshotRecordData(wireframes: wireframes),
+        timestamp: timestamp,
+      );
+    }
+  }
+}

--- a/packages/datadog_session_replay/lib/src/rum_context.dart
+++ b/packages/datadog_session_replay/lib/src/rum_context.dart
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:meta/meta.dart';
+
+@immutable
+class RUMContext {
+  final String applicationId;
+  final String sessionId;
+  final String? viewId;
+  final double? viewServerTimeOffset;
+
+  const RUMContext({
+    required this.applicationId,
+    required this.sessionId,
+    this.viewId,
+    this.viewServerTimeOffset,
+  });
+
+  factory RUMContext.fromMap(Map<Object?, Object?> map) {
+    return RUMContext(
+      applicationId: map['applicationId'] as String,
+      sessionId: map['sessionId'] as String,
+      viewId: map['viewId'] as String?,
+      viewServerTimeOffset: map['viewServerTimeOffset'] as double?,
+    );
+  }
+}

--- a/packages/datadog_session_replay/lib/src/sr_data_models.dart
+++ b/packages/datadog_session_replay/lib/src/sr_data_models.dart
@@ -1,0 +1,839 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+
+part 'sr_data_models.g.dart';
+
+const String srTransparentColorString = '#ffffff00';
+
+// Helper for mutations, maybe move?
+T? useIfDifferent<T>(T? use, T? compare) {
+  return use == compare ? null : use;
+}
+
+enum SRRecordType {
+  @JsonValue(10)
+  fullSnapshot,
+
+  @JsonValue(11)
+  incrementalSnapshot,
+
+  @JsonValue(4)
+  meta,
+
+  @JsonValue(6)
+  focus,
+
+  @JsonValue(7)
+  viewEnd,
+
+  @JsonValue(8)
+  visualViewport,
+}
+
+enum SRPointerEventType {
+  @JsonValue('down')
+  down,
+
+  @JsonValue('up')
+  up,
+
+  @JsonValue('move')
+  move,
+}
+
+enum SRPointerType {
+  @JsonValue('mouse')
+  mouse,
+
+  @JsonValue('touch')
+  touch,
+
+  @JsonValue('pen')
+  pen,
+}
+
+abstract class SRRecord {
+  static const int metaRecordType = 4;
+  static const int focusRecordType = 6;
+  static const int viewEndRecordType = 7;
+  static const int visualViewportRecordType = 8;
+  static const int fullSnapshotRecordType = 10;
+  static const int incrementalSnapshotRecordType = 11;
+
+  final int type;
+
+  SRRecord({required this.type});
+
+  factory SRRecord.fromJson(Map<String, dynamic> json) {
+    final recordType = json['type'];
+    if (recordType is int) {
+      switch (recordType) {
+        case fullSnapshotRecordType:
+          return SRFullSnapshotRecord.fromJson(json);
+      }
+    }
+    // TODO:
+    throw Error();
+  }
+  Map<String, dynamic> toJson();
+}
+
+@JsonSerializable()
+class SRMetaRecord extends SRRecord {
+  final SRMetaRecordData data;
+  final int timestamp;
+
+  SRMetaRecord({
+    super.type = SRRecord.metaRecordType,
+    required this.data,
+    required this.timestamp,
+  });
+
+  factory SRMetaRecord.fromJson(Map<String, dynamic> json) =>
+      _$SRMetaRecordFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRMetaRecordToJson(this);
+}
+
+@JsonSerializable()
+class SRMetaRecordData {
+  final int width;
+  final int height;
+
+  SRMetaRecordData({required this.width, required this.height});
+
+  factory SRMetaRecordData.fromJson(Map<String, dynamic> json) =>
+      _$SRMetaRecordDataFromJson(json);
+  Map<String, dynamic> toJson() => _$SRMetaRecordDataToJson(this);
+}
+
+@JsonSerializable()
+class SRFocusRecordData {
+  @JsonKey(name: 'has_focus')
+  final bool hasFocus;
+
+  SRFocusRecordData({required this.hasFocus});
+
+  factory SRFocusRecordData.fromJson(Map<String, dynamic> json) =>
+      _$SRFocusRecordDataFromJson(json);
+  Map<String, dynamic> toJson() => _$SRFocusRecordDataToJson(this);
+}
+
+@JsonSerializable()
+class SRFocusRecord extends SRRecord {
+  final SRFocusRecordData data;
+  final int timestamp;
+
+  SRFocusRecord({
+    super.type = SRRecord.focusRecordType,
+    required this.data,
+    required this.timestamp,
+  });
+
+  factory SRFocusRecord.fromJson(Map<String, dynamic> json) =>
+      _$SRFocusRecordFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRFocusRecordToJson(this);
+}
+
+@JsonSerializable()
+class SRFullSnapshotRecordData {
+  final List<SRWireframe> wireframes;
+
+  SRFullSnapshotRecordData({required this.wireframes});
+
+  factory SRFullSnapshotRecordData.fromJson(Map<String, dynamic> json) =>
+      _$SRFullSnapshotRecordDataFromJson(json);
+  Map<String, dynamic> toJson() => _$SRFullSnapshotRecordDataToJson(this);
+}
+
+@JsonSerializable()
+class SRFullSnapshotRecord extends SRRecord {
+  final SRFullSnapshotRecordData data;
+  final int timestamp;
+
+  SRFullSnapshotRecord({
+    super.type = SRRecord.fullSnapshotRecordType,
+    required this.data,
+    required this.timestamp,
+  });
+
+  factory SRFullSnapshotRecord.fromJson(Map<String, dynamic> json) =>
+      _$SRFullSnapshotRecordFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRFullSnapshotRecordToJson(this);
+}
+
+abstract class SRWireframe {
+  final int id;
+  final String type;
+  final int x;
+  final int y;
+  final int width;
+  final int height;
+
+  SRWireframe({
+    required this.id,
+    required this.type,
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  @mustBeOverridden
+  bool isDifferent(SRWireframe other) {
+    if (runtimeType != other.runtimeType) return true;
+
+    return !(id == other.id &&
+        type == other.type &&
+        x == other.x &&
+        y == other.y &&
+        width == other.width &&
+        height == other.height);
+  }
+
+  SRIncrementalUpdate mutationsFrom(SRWireframe other);
+
+  factory SRWireframe.fromJson(Map<String, dynamic> json) {
+    throw Error();
+  }
+  Map<String, dynamic> toJson();
+}
+
+@JsonSerializable()
+class SRShapeBorder {
+  final String color;
+  final int width;
+
+  SRShapeBorder({required this.color, required this.width});
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRShapeBorder && color == other.color && width == other.width;
+
+  @override
+  int get hashCode => Object.hash(color, width);
+
+  factory SRShapeBorder.fromJson(Map<String, dynamic> json) =>
+      _$SRShapeBorderFromJson(json);
+  Map<String, dynamic> toJson() => _$SRShapeBorderToJson(this);
+}
+
+@JsonSerializable()
+class SRContentClip {
+  final int bottom;
+  final int left;
+  final int right;
+  final int top;
+
+  SRContentClip({
+    required this.bottom,
+    required this.left,
+    required this.right,
+    required this.top,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRContentClip &&
+      bottom == other.bottom &&
+      left == other.left &&
+      right == other.right &&
+      top == other.top;
+
+  @override
+  int get hashCode => Object.hash(bottom, left, right, top);
+
+  factory SRContentClip.fromJson(Map<String, dynamic> json) =>
+      _$SRContentClipFromJson(json);
+  Map<String, dynamic> toJson() => _$SRContentClipToJson(this);
+}
+
+@JsonSerializable()
+class SRTextStyle {
+  final String color;
+  final String family;
+  final int size;
+
+  SRTextStyle({required this.color, required this.family, required this.size});
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRTextStyle &&
+      color == other.color &&
+      family == other.family &&
+      size == other.size;
+
+  @override
+  int get hashCode => Object.hash(color, family, size);
+
+  factory SRTextStyle.fromJson(Map<String, dynamic> json) =>
+      _$SRTextStyleFromJson(json);
+  Map<String, dynamic> toJson() => _$SRTextStyleToJson(this);
+}
+
+@JsonSerializable()
+class SRShapeStyle {
+  final double cornerRadius;
+  final String backgroundColor;
+  final double opacity;
+
+  SRShapeStyle({
+    this.cornerRadius = 0.0,
+    this.backgroundColor = srTransparentColorString,
+    this.opacity = 1.0,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRShapeStyle &&
+      cornerRadius == other.cornerRadius &&
+      backgroundColor == other.backgroundColor &&
+      opacity == other.opacity;
+
+  @override
+  int get hashCode => Object.hash(cornerRadius, backgroundColor, opacity);
+
+  factory SRShapeStyle.fromJson(Map<String, dynamic> json) =>
+      _$SRShapeStyleFromJson(json);
+  Map<String, dynamic> toJson() => _$SRShapeStyleToJson(this);
+}
+
+@JsonSerializable()
+class SRShapeWireframe extends SRWireframe {
+  final SRShapeBorder? border;
+  final SRContentClip? clip;
+  final SRShapeStyle? shapeStyle;
+
+  SRShapeWireframe({
+    super.type = 'shape',
+    required super.id,
+    required super.x,
+    required super.y,
+    required super.width,
+    required super.height,
+    this.border,
+    this.clip,
+    this.shapeStyle,
+  });
+
+  @override
+  bool isDifferent(SRWireframe other) {
+    if (other is! SRShapeWireframe) return false;
+
+    return super.isDifferent(other) ||
+        !(border == other.border &&
+            clip == other.clip &&
+            shapeStyle == other.shapeStyle);
+  }
+
+  @override
+  SRIncrementalUpdate mutationsFrom(SRWireframe other) {
+    if (other is! SRShapeWireframe || id != other.id) {
+      throw Error();
+    }
+
+    return SRShapeWireframeUpdate(
+      id: id,
+      x: useIfDifferent(x, other.x),
+      y: useIfDifferent(y, other.y),
+      width: useIfDifferent(width, other.width),
+      height: useIfDifferent(height, other.height),
+      border: useIfDifferent(border, other.border),
+      clip: useIfDifferent(clip, other.clip),
+      shapeStyle: useIfDifferent(shapeStyle, other.shapeStyle),
+    );
+  }
+
+  factory SRShapeWireframe.fromJson(Map<String, dynamic> json) =>
+      _$SRShapeWireframeFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRShapeWireframeToJson(this);
+}
+
+@JsonSerializable()
+class SRPadding {
+  final int? top;
+  final int? left;
+  final int? bottom;
+  final int? right;
+
+  SRPadding({this.top, this.left, this.bottom, this.right});
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRPadding &&
+      top == other.top &&
+      left == other.left &&
+      bottom == other.bottom &&
+      right == other.right;
+
+  @override
+  int get hashCode => Object.hash(top, left, bottom, right);
+
+  factory SRPadding.fromJson(Map<String, dynamic> json) =>
+      _$SRPaddingFromJson(json);
+  Map<String, dynamic> toJson() => _$SRPaddingToJson(this);
+}
+
+enum SRHorizontalAlignment {
+  @JsonValue('left')
+  left,
+
+  @JsonValue('center')
+  center,
+
+  @JsonValue('right')
+  right,
+}
+
+enum SRVerticalAlignment {
+  @JsonValue('top')
+  top,
+
+  @JsonValue('center')
+  center,
+
+  @JsonValue('bottom')
+  bottom,
+}
+
+@JsonSerializable()
+class SRAlignment {
+  SRHorizontalAlignment? horizontal;
+  SRVerticalAlignment? vertical;
+
+  SRAlignment({this.horizontal, this.vertical});
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRAlignment &&
+      horizontal == other.horizontal &&
+      vertical == other.vertical;
+
+  @override
+  int get hashCode => Object.hash(horizontal, vertical);
+
+  factory SRAlignment.fromJson(Map<String, dynamic> json) =>
+      _$SRAlignmentFromJson(json);
+  Map<String, dynamic> toJson() => _$SRAlignmentToJson(this);
+}
+
+@JsonSerializable()
+class SRTextPosition {
+  final SRAlignment? alignment;
+  final SRPadding? padding;
+
+  SRTextPosition({this.alignment, this.padding});
+
+  @override
+  bool operator ==(Object other) =>
+      other is SRTextPosition &&
+      alignment == other.alignment &&
+      padding == other.padding;
+
+  @override
+  int get hashCode => Object.hash(alignment, padding);
+
+  factory SRTextPosition.fromJson(Map<String, dynamic> json) =>
+      _$SRTextPositionFromJson(json);
+  Map<String, dynamic> toJson() => _$SRTextPositionToJson(this);
+}
+
+@JsonSerializable()
+class SRTextWireframe extends SRWireframe {
+  final String text;
+  final SRTextStyle textStyle;
+
+  final SRShapeBorder? border;
+  final SRContentClip? clip;
+  final SRShapeStyle? shapeStyle;
+  final SRTextPosition? textPosition;
+
+  SRTextWireframe({
+    super.type = 'text',
+    required super.id,
+    required super.x,
+    required super.y,
+    required super.width,
+    required super.height,
+    required this.text,
+    required this.textStyle,
+    this.border,
+    this.clip,
+    this.shapeStyle,
+    this.textPosition,
+  });
+
+  @override
+  bool isDifferent(SRWireframe other) {
+    if (other is! SRTextWireframe) return false;
+
+    return super.isDifferent(other) ||
+        !(text == other.text &&
+            textStyle == other.textStyle &&
+            border == other.border &&
+            clip == other.clip &&
+            shapeStyle == other.shapeStyle &&
+            textPosition == other.textPosition);
+  }
+
+  @override
+  SRIncrementalUpdate mutationsFrom(SRWireframe other) {
+    if (other is! SRTextWireframe || id != other.id) {
+      throw Error();
+    }
+
+    return SRTextWireframeUpdate(
+      id: id,
+      x: useIfDifferent(x, other.x),
+      y: useIfDifferent(y, other.y),
+      width: useIfDifferent(width, other.width),
+      height: useIfDifferent(height, other.height),
+      text: useIfDifferent(text, other.text),
+      textStyle: useIfDifferent(textStyle, other.textStyle),
+      border: useIfDifferent(border, other.border),
+      clip: useIfDifferent(clip, other.clip),
+      shapeStyle: useIfDifferent(shapeStyle, other.shapeStyle),
+      textPosition: useIfDifferent(textPosition, other.textPosition),
+    );
+  }
+
+  factory SRTextWireframe.fromJson(Map<String, dynamic> json) =>
+      _$SRTextWireframeFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRTextWireframeToJson(this);
+}
+
+@JsonSerializable()
+class SRPlaceholderWireframe extends SRWireframe {
+  final String? label;
+  final SRContentClip? clip;
+
+  SRPlaceholderWireframe({
+    super.type = 'placeholder',
+    required super.id,
+    required super.x,
+    required super.y,
+    required super.width,
+    required super.height,
+    this.label,
+    this.clip,
+  });
+
+  @override
+  bool isDifferent(SRWireframe other) {
+    if (other is! SRPlaceholderWireframe) return false;
+
+    return super.isDifferent(other) ||
+        !(label == other.label && clip == other.clip);
+  }
+
+  @override
+  SRIncrementalUpdate mutationsFrom(SRWireframe other) {
+    if (other is! SRPlaceholderWireframe || id != other.id) {
+      throw Error();
+    }
+
+    return SRPlaceholderWireframeUpdate(
+      id: id,
+      x: useIfDifferent(x, other.x),
+      y: useIfDifferent(y, other.y),
+      width: useIfDifferent(width, other.width),
+      height: useIfDifferent(height, other.height),
+      label: useIfDifferent(label, other.label),
+      clip: useIfDifferent(clip, other.clip),
+    );
+  }
+
+  factory SRPlaceholderWireframe.fromJson(Map<String, dynamic> json) =>
+      _$SRPlaceholderWireframeFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRPlaceholderWireframeToJson(this);
+}
+
+@JsonSerializable()
+class SRIdHolder {
+  final String id;
+
+  SRIdHolder({required this.id});
+
+  factory SRIdHolder.fromJson(Map<String, dynamic> json) =>
+      _$SRIdHolderFromJson(json);
+  Map<String, dynamic> toJson() => _$SRIdHolderToJson(this);
+}
+
+@JsonSerializable()
+class SRSegment {
+  final SRIdHolder application;
+  final SRIdHolder session;
+  final SRIdHolder view;
+  final int start;
+  final int end;
+  final bool? hasFullSnapshot;
+  final int indexInView;
+  final List<SRRecord> records;
+  final int recordsCount;
+  final String source;
+
+  SRSegment({
+    required this.application,
+    required this.session,
+    required this.view,
+    required this.start,
+    required this.end,
+    this.hasFullSnapshot,
+    required this.indexInView,
+    required this.records,
+    required this.recordsCount,
+    this.source = 'flutter',
+  });
+
+  factory SRSegment.fromJson(Map<String, dynamic> json) =>
+      _$SRSegmentFromJson(json);
+  Map<String, dynamic> toJson() => _$SRSegmentToJson(this);
+}
+
+abstract class SRIncrementalSnapshotData {
+  final int source;
+
+  SRIncrementalSnapshotData({required this.source});
+
+  factory SRIncrementalSnapshotData.fromJson(Map<String, dynamic> json) {
+    throw Error();
+  }
+  Map<String, dynamic> toJson();
+}
+
+@JsonSerializable()
+class SRIntrementalAdd {
+  final int? previousId;
+  final SRWireframe wireframe;
+
+  SRIntrementalAdd({this.previousId, required this.wireframe});
+
+  factory SRIntrementalAdd.fromJson(Map<String, dynamic> json) =>
+      _$SRIntrementalAddFromJson(json);
+  Map<String, dynamic> toJson() => _$SRIntrementalAddToJson(this);
+}
+
+@JsonSerializable()
+class SRIncrementalRemove {
+  final int id;
+
+  SRIncrementalRemove({required this.id});
+
+  factory SRIncrementalRemove.fromJson(Map<String, dynamic> json) =>
+      _$SRIncrementalRemoveFromJson(json);
+  Map<String, dynamic> toJson() => _$SRIncrementalRemoveToJson(this);
+}
+
+abstract class SRIncrementalUpdate {
+  final String type;
+  final int id;
+  final int? x;
+  final int? y;
+  final int? width;
+  final int? height;
+
+  SRIncrementalUpdate({
+    required this.type,
+    required this.id,
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  factory SRIncrementalUpdate.fromJson(Map<String, dynamic> json) {
+    throw Error();
+  }
+  Map<String, dynamic> toJson();
+}
+
+@JsonSerializable()
+class SRShapeWireframeUpdate extends SRIncrementalUpdate {
+  final SRShapeBorder? border;
+  final SRContentClip? clip;
+  final SRShapeStyle? shapeStyle;
+
+  SRShapeWireframeUpdate({
+    super.type = 'shape',
+    required super.id,
+    super.x,
+    super.y,
+    super.width,
+    super.height,
+    required this.border,
+    required this.clip,
+    required this.shapeStyle,
+  });
+
+  factory SRShapeWireframeUpdate.fromJson(Map<String, dynamic> json) =>
+      _$SRShapeWireframeUpdateFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRShapeWireframeUpdateToJson(this);
+}
+
+@JsonSerializable()
+class SRTextWireframeUpdate extends SRIncrementalUpdate {
+  final String? text;
+  final SRTextStyle? textStyle;
+
+  final SRShapeBorder? border;
+  final SRContentClip? clip;
+  final SRShapeStyle? shapeStyle;
+  final SRTextPosition? textPosition;
+
+  SRTextWireframeUpdate({
+    super.type = 'text',
+    required super.id,
+    super.x,
+    super.y,
+    super.width,
+    super.height,
+    this.text,
+    this.textStyle,
+    this.border,
+    this.clip,
+    this.shapeStyle,
+    this.textPosition,
+  });
+
+  factory SRTextWireframeUpdate.fromJson(Map<String, dynamic> json) =>
+      _$SRTextWireframeUpdateFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRTextWireframeUpdateToJson(this);
+}
+
+@JsonSerializable()
+class SRImageWireframeUpdate extends SRIncrementalUpdate {
+  SRShapeBorder? border;
+  SRContentClip? clip;
+  SRShapeStyle? shapeStyle;
+
+  SRImageWireframeUpdate({
+    super.type = 'shape',
+    required super.id,
+    super.x,
+    super.y,
+    super.width,
+    super.height,
+    this.border,
+    this.clip,
+    this.shapeStyle,
+  });
+
+  factory SRImageWireframeUpdate.fromJson(Map<String, dynamic> json) =>
+      _$SRImageWireframeUpdateFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRImageWireframeUpdateToJson(this);
+}
+
+@JsonSerializable()
+class SRPlaceholderWireframeUpdate extends SRIncrementalUpdate {
+  String? label;
+  SRContentClip? clip;
+
+  SRPlaceholderWireframeUpdate({
+    super.type = 'placeholder',
+    required super.id,
+    super.x,
+    super.y,
+    super.width,
+    super.height,
+    this.label,
+    this.clip,
+  });
+
+  factory SRPlaceholderWireframeUpdate.fromJson(Map<String, dynamic> json) =>
+      _$SRPlaceholderWireframeUpdateFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRPlaceholderWireframeUpdateToJson(this);
+}
+
+@JsonSerializable()
+class SRIncrementalMutationData extends SRIncrementalSnapshotData {
+  List<SRIntrementalAdd> adds;
+  List<SRIncrementalRemove> removes;
+  List<SRIncrementalUpdate> updates;
+
+  SRIncrementalMutationData({
+    super.source = 0,
+    required this.adds,
+    required this.removes,
+    required this.updates,
+  });
+
+  factory SRIncrementalMutationData.fromJson(Map<String, dynamic> json) =>
+      _$SRIncrementalMutationDataFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRIncrementalMutationDataToJson(this);
+}
+
+@JsonSerializable()
+class SRIncrementalSnapshotRecord extends SRRecord {
+  final SRIncrementalSnapshotData data;
+  final int timestamp;
+
+  SRIncrementalSnapshotRecord({
+    super.type = 11,
+    required this.data,
+    required this.timestamp,
+  });
+
+  factory SRIncrementalSnapshotRecord.fromJson(Map<String, dynamic> json) =>
+      _$SRIncrementalSnapshotRecordFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRIncrementalSnapshotRecordToJson(this);
+}
+
+@JsonSerializable()
+class SRPointerInteractionData extends SRIncrementalSnapshotData {
+  final SRPointerEventType pointerEventType;
+  final int pointerId;
+  final SRPointerType pointerType;
+  final double x;
+  final double y;
+
+  SRPointerInteractionData({
+    super.source = 9,
+    required this.pointerEventType,
+    required this.pointerId,
+    required this.pointerType,
+    required this.x,
+    required this.y,
+  });
+
+  factory SRPointerInteractionData.fromJson(Map<String, dynamic> json) =>
+      _$SRPointerInteractionDataFromJson(json);
+  @override
+  Map<String, dynamic> toJson() => _$SRPointerInteractionDataToJson(this);
+}
+
+// Don't rename these as they are not used by the SR endpoint, only
+// internally by iOS (which expects these names unchanged.)
+@JsonSerializable(fieldRename: FieldRename.none)
+class SREnrichedRecord {
+  final List<SRRecord> records;
+
+  final String applicationID;
+  final String sessionID;
+  final String viewID;
+
+  SREnrichedRecord({
+    required this.records,
+    required this.applicationID,
+    required this.sessionID,
+    required this.viewID,
+  });
+
+  factory SREnrichedRecord.fromJson(Map<String, dynamic> json) =>
+      _$SREnrichedRecordFromJson(json);
+  Map<String, dynamic> toJson() => _$SREnrichedRecordToJson(this);
+}

--- a/packages/datadog_session_replay/lib/src/widgets.dart
+++ b/packages/datadog_session_replay/lib/src/widgets.dart
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+import 'capture/pointer_capture.dart';
+import 'datadog_session_replay.dart';
+import 'sr_data_models.dart';
+
+class SessionReplayCapture extends StatefulWidget {
+  final DatadogRum rum;
+  final DatadogSessionReplay sessionReplay;
+  final Widget child;
+
+  SessionReplayCapture({
+    super.key,
+    required this.child,
+    required this.rum,
+    required this.sessionReplay,
+  }) {
+    if (key == null) {
+      sessionReplay.internalLogger.log(
+        CoreLoggerLevel.warn,
+        'SessionReplayCapture has a null Key value. A Key is required for Session Replay to work.',
+      );
+    }
+  }
+
+  @override
+  StatefulElement createElement() {
+    final e = super.createElement();
+    if (key != null) {
+      sessionReplay.addElement(key!, e);
+    }
+
+    return e;
+  }
+
+  @override
+  State<SessionReplayCapture> createState() => _SessionReplayCaptureState();
+}
+
+class _SessionReplayCaptureState extends State<SessionReplayCapture> {
+  @override
+  Widget build(BuildContext context) {
+    return PointerRecorder(
+      // ignore: invalid_use_of_internal_member
+      snapshotRecorder: PointerSnapshotRecorder(widget.rum.timeProvider),
+      child: RumUserActionDetector(rum: widget.rum, child: widget.child),
+    );
+  }
+}
+
+@immutable
+class PointerRecorder extends StatelessWidget {
+  final PointerSnapshotRecorder snapshotRecorder;
+  final Widget child;
+
+  const PointerRecorder({
+    super.key,
+    required this.snapshotRecorder,
+    required this.child,
+  });
+
+  void _onPointerDown(PointerDownEvent event) =>
+      _capturePointerEvent(SRPointerEventType.down, event);
+
+  void _onPointerMove(PointerMoveEvent event) =>
+      _capturePointerEvent(SRPointerEventType.move, event);
+
+  void _onPointerCancel(PointerCancelEvent event) =>
+      _capturePointerEvent(SRPointerEventType.up, event);
+
+  void _onPointerHover(PointerHoverEvent event) =>
+      _capturePointerEvent(SRPointerEventType.move, event);
+
+  void _onPointerUp(PointerUpEvent event) =>
+      _capturePointerEvent(SRPointerEventType.up, event);
+
+  void _capturePointerEvent(SRPointerEventType type, PointerEvent event) {
+    snapshotRecorder.capturePointer(
+      event.pointer,
+      type,
+      event.position.dx,
+      event.position.dy,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerCancel: _onPointerCancel,
+      onPointerHover: _onPointerHover,
+      onPointerUp: _onPointerUp,
+      child: child,
+    );
+  }
+}

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -14,13 +14,20 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   web: ^1.0.0
+  meta: ^1.16.0  
   plugin_platform_interface: ^2.0.2
-  datadog_flutter_plugin: ^2.11.0
+  datadog_flutter_plugin: ^2.12.0
+  json_annotation: ^4.9.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  mocktail: ^1.0.4
+  json_serializable: ^6.9.5
+  build_runner: ^2.4.15
+  datadog_common_test:
+    path: ../datadog_common_test
 
 flutter:
   plugin:

--- a/packages/datadog_session_replay/test/capture/container_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/container_recorder_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import '../test_utils.dart';
 import 'simple_test_capture.dart';
 
 // Note: to properly test recorders, we need to supply a full widget tree, as Element

--- a/packages/datadog_session_replay/test/capture/container_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/container_recorder_test.dart
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/src/capture/capture_node.dart';
+import 'package:datadog_session_replay/src/capture/element_recorders/container_recorder.dart';
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:datadog_session_replay/src/extensions.dart';
+import 'package:datadog_session_replay/src/rum_context.dart';
+import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'simple_test_capture.dart';
+
+// Note: to properly test recorders, we need to supply a full widget tree, as Element
+// is too difficult to mock effectively.
+void main() {
+  late SessionReplayRecorder recorder;
+  late RUMContext context;
+
+  setUp(() {
+    recorder = SessionReplayRecorder.withCustomRecorders([
+      ContainerRecorder(KeyGenerator()),
+    ]);
+
+    registerFallbackValue(
+      CapturedViewAttributes(paintBounds: Rect.zero, scaleX: 1.0, scaleY: 1.0),
+    );
+
+    context = RUMContext(
+      applicationId: randomString(),
+      sessionId: randomString(),
+    );
+    recorder.updateContext(context);
+  });
+
+  testWidgets('container returns captured node semantics', (tester) async {
+    // Given
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+    final color = randomColor();
+    final tree = SimpleTestCapture(
+      key: Key('key'),
+      recorder: recorder,
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: [
+            Container(
+              color: color,
+              width: width,
+              height: height,
+              child: Placeholder(),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture, isNotNull);
+    final treeCapture = capture!.viewTreeSnapshot;
+    expect(treeCapture, isNotNull);
+    expect(treeCapture.nodes.length, 1);
+    final containerNode = treeCapture.nodes.first;
+    expect(containerNode.attributes.x, 0);
+    expect(containerNode.attributes.y, 0);
+    expect(containerNode.attributes.width, width.round());
+    expect(containerNode.attributes.height, height.round());
+
+    final builtWireframes = containerNode.buildWireframes();
+    expect(builtWireframes.length, 1);
+    final shapeWireframe = builtWireframes.first as SRShapeWireframe;
+    expect(shapeWireframe.x, 0);
+    expect(shapeWireframe.y, 0);
+    expect(shapeWireframe.width, width.round());
+    expect(shapeWireframe.height, height.round());
+    expect(shapeWireframe.shapeStyle!.backgroundColor, color.toHexString());
+  });
+
+  testWidgets('container returns box decoration in wireframe', (tester) async {
+    // Given
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+    final color = randomColor();
+    final tree = SimpleTestCapture(
+      key: Key('key'),
+      recorder: recorder,
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                color: color,
+                border: Border.all(width: 3.4, color: color),
+                borderRadius: BorderRadius.circular(10.0),
+              ),
+              width: width,
+              height: height,
+              child: Placeholder(),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture, isNotNull);
+    final treeCapture = capture!.viewTreeSnapshot;
+    final containerNode = treeCapture.nodes.first;
+
+    final builtWireframes = containerNode.buildWireframes();
+    final shapeWireframe = builtWireframes.first as SRShapeWireframe;
+    expect(shapeWireframe.border, isNotNull);
+    expect(shapeWireframe.border!.color, color.toHexString());
+    expect(shapeWireframe.border!.width, 3);
+    expect(shapeWireframe.shapeStyle!.cornerRadius, 10.0);
+    expect(shapeWireframe.shapeStyle!.backgroundColor, color.toHexString());
+  });
+}

--- a/packages/datadog_session_replay/test/capture/recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/recorder_test.dart
@@ -1,0 +1,339 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_session_replay/src/capture/capture_node.dart';
+import 'package:datadog_session_replay/src/capture/pointer_capture.dart';
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:datadog_session_replay/src/capture/view_tree_snapshot.dart';
+import 'package:datadog_session_replay/src/rum_context.dart';
+import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:datadog_session_replay/src/widgets.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'simple_test_capture.dart';
+
+class MockElement extends Mock implements Element {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return super.toString();
+  }
+}
+
+class MockElementRecorder extends Mock implements ElementRecorder {}
+
+class MockCaptureNode extends Mock implements CaptureNode {}
+
+class MockPointerSnapshotRecorder extends Mock
+    implements PointerSnapshotRecorder {}
+
+class MockTimeProvider extends Mock implements DatadogTimeProvider {}
+
+void main() {
+  late SessionReplayRecorder recorder;
+  late MockTimeProvider mockTimeProvider;
+  DateTime expectedDateTime = DateTime(2025, 3, 5, 10, 22, 11);
+
+  group('null capture states', () {
+    setUp(() {
+      mockTimeProvider = MockTimeProvider();
+      when(() => mockTimeProvider.now()).thenReturn(expectedDateTime);
+      recorder = SessionReplayRecorder(timeProvider: mockTimeProvider);
+    });
+
+    test('capture with no context returns null ', () {
+      // When
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNull);
+    });
+
+    test('capture with context and no elements returns null', () {
+      // Given
+      recorder.updateContext(
+        RUMContext(applicationId: randomString(), sessionId: randomString()),
+      );
+
+      // When
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNull);
+    });
+  });
+
+  group('recorder', () {
+    final mockRecorderA = MockElementRecorder();
+
+    setUp(() {
+      recorder = SessionReplayRecorder.withCustomRecorders([
+        mockRecorderA,
+      ], timeProvider: mockTimeProvider);
+
+      registerFallbackValue(
+        CapturedViewAttributes(
+          paintBounds: Rect.zero,
+          scaleX: 1.0,
+          scaleY: 1.0,
+        ),
+      );
+      registerFallbackValue(MockElement());
+    });
+
+    testWidgets('capture specific recorded element returns view tree result', (
+      tester,
+    ) async {
+      // Given
+      when(
+        () => mockRecorderA.captureSemantics(any(), captureAny()),
+      ).thenAnswer(
+        (invocation) => SpecificElement(
+          subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
+          nodes: [MockCaptureNode()],
+        ),
+      );
+      final context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+
+      // When
+      final testedTree = SimpleTestCapture(
+        key: UniqueKey(),
+        recorder: recorder,
+      );
+      await tester.pumpWidget(testedTree);
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNotNull);
+      expect(capture!.viewTreeSnapshot.context, context);
+      expect(capture.viewTreeSnapshot.nodes.length, 1);
+    });
+
+    testWidgets('snapshot time uses time from provider in view tree snapshot', (
+      tester,
+    ) async {
+      // Given
+      when(
+        () => mockRecorderA.captureSemantics(any(), captureAny()),
+      ).thenAnswer(
+        (invocation) => SpecificElement(
+          subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
+          nodes: [MockCaptureNode()],
+        ),
+      );
+      final context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+
+      // When
+      final testedTree = SimpleTestCapture(
+        key: UniqueKey(),
+        recorder: recorder,
+      );
+      await tester.pumpWidget(testedTree);
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNotNull);
+      expect(capture!.viewTreeSnapshot.date, expectedDateTime);
+    });
+
+    testWidgets(
+      'capture ignores subtree when CaptureNodeSubtreeStrategy.ignore',
+      (tester) async {
+        // Given
+        when(
+          () => mockRecorderA.captureSemantics(any(), captureAny()),
+        ).thenAnswer(
+          (invocation) => SpecificElement(
+            subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
+            nodes: [MockCaptureNode()],
+          ),
+        );
+        final context = RUMContext(
+          applicationId: randomString(),
+          sessionId: randomString(),
+        );
+        recorder.updateContext(context);
+
+        // When
+        final testedTree = SimpleTestCapture(
+          key: UniqueKey(),
+          recorder: recorder,
+          child: Container(),
+        );
+        await tester.pumpWidget(testedTree);
+        final capture = recorder.performCapture();
+
+        // Then
+        expect(capture, isNotNull);
+        expect(capture!.viewTreeSnapshot.context, context);
+        expect(capture.viewTreeSnapshot.nodes.length, 1);
+      },
+    );
+
+    testWidgets('capture subtree when CaptureNodeSubtreeStrategy.record', (
+      tester,
+    ) async {
+      // Given
+      when(
+        () => mockRecorderA.captureSemantics(any(), captureAny()),
+      ).thenAnswer((invocation) {
+        var subtreeStrategy = CaptureNodeSubtreeStrategy.record;
+        if ((invocation.positionalArguments[0] as Element).widget
+            is Placeholder) {
+          subtreeStrategy = CaptureNodeSubtreeStrategy.ignore;
+        }
+        return SpecificElement(
+          subtreeStrategy: subtreeStrategy,
+          nodes: [MockCaptureNode()],
+        );
+      });
+      final context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+
+      // When
+      final testedTree = SimpleTestCapture(
+        key: UniqueKey(),
+        recorder: recorder,
+        child: Center(child: Placeholder()),
+      );
+      await tester.pumpWidget(testedTree);
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNotNull);
+      expect(capture!.viewTreeSnapshot.nodes.length, 3);
+    });
+
+    testWidgets('capture uses recorder nodes with highest importance', (
+      tester,
+    ) async {
+      // Given
+      final lowImportanceRecorder = MockElementRecorder();
+      when(
+        () => lowImportanceRecorder.captureSemantics(any(), captureAny()),
+      ).thenAnswer((invocation) {
+        return AmbiguousElement(
+          subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
+          nodes: [MockCaptureNode(), MockCaptureNode()],
+        );
+      });
+      when(
+        () => mockRecorderA.captureSemantics(any(), captureAny()),
+      ).thenAnswer((invocation) {
+        return SpecificElement(
+          subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
+          nodes: [MockCaptureNode()],
+        );
+      });
+      final context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+
+      // When
+      final testedTree = SimpleTestCapture(
+        key: UniqueKey(),
+        recorder: recorder,
+      );
+      await tester.pumpWidget(testedTree);
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNotNull);
+      // The 2 nodes that come from the low importance recorder
+      // (AmbiguousElement) are discarded in favor of the 1 node from the high
+      // importance one (SpecificElement)
+      expect(capture!.viewTreeSnapshot.nodes.length, 1);
+    });
+  });
+
+  group('pointer capture', () {
+    setUp(() {
+      registerFallbackValue(
+        CapturedViewAttributes(
+          paintBounds: Rect.zero,
+          scaleX: 1.0,
+          scaleY: 1.0,
+        ),
+      );
+      registerFallbackValue(MockElement());
+
+      final mockElementRecorder = MockElementRecorder();
+      when(
+        () => mockElementRecorder.captureSemantics(any(), captureAny()),
+      ).thenAnswer(
+        (invocation) => SpecificElement(
+          subtreeStrategy: CaptureNodeSubtreeStrategy.record,
+          nodes: [MockCaptureNode()],
+        ),
+      );
+      recorder = SessionReplayRecorder.withCustomRecorders([
+        mockElementRecorder,
+      ]);
+    });
+
+    testWidgets('pointer recorder snapshot returned from capture', (
+      tester,
+    ) async {
+      // Given
+      final mockPointerRecorder = MockPointerSnapshotRecorder();
+      final expectedPointerNodes = <PointerCapture>[
+        PointerCapture(
+          date: DateTime.now(),
+          pointerId: 0,
+          eventType: SRPointerEventType.down,
+          x: randomDouble(),
+          y: randomDouble(),
+        ),
+        PointerCapture(
+          date: DateTime.now().add(Duration(milliseconds: 100)),
+          pointerId: 0,
+          eventType: SRPointerEventType.up,
+          x: randomDouble(),
+          y: randomDouble(),
+        ),
+      ];
+      when(
+        () => mockPointerRecorder.takeSnapshot(),
+      ).thenReturn(PointerSnapshot(DateTime.now(), expectedPointerNodes));
+      final context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+
+      // When
+      final testedTree = SimpleTestCapture(
+        key: UniqueKey(),
+        recorder: recorder,
+        child: PointerRecorder(
+          snapshotRecorder: mockPointerRecorder,
+          child: Placeholder(),
+        ),
+      );
+      await tester.pumpWidget(testedTree);
+      final capture = recorder.performCapture();
+
+      // Then
+      expect(capture, isNotNull);
+      expect(capture!.pointerSnapshot, isNotNull);
+      expect(capture.pointerSnapshot!.pointerEvents, expectedPointerNodes);
+    });
+  });
+}

--- a/packages/datadog_session_replay/test/capture/simple_test_capture.dart
+++ b/packages/datadog_session_replay/test/capture/simple_test_capture.dart
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:flutter/widgets.dart';
+
+/// A simplified implementation of [SessionReplayCapture] used for testing.
+class SimpleTestCapture extends StatefulWidget {
+  final SessionReplayRecorder recorder;
+  final Widget? child;
+
+  const SimpleTestCapture({super.key, required this.recorder, this.child});
+
+  @override
+  StatefulElement createElement() {
+    final e = super.createElement();
+    if (key != null) {
+      recorder.addElement(key!, e);
+    }
+
+    return e;
+  }
+
+  @override
+  State<SimpleTestCapture> createState() => _SimpleTestCaptureState();
+}
+
+class _SimpleTestCaptureState extends State<SimpleTestCapture> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.child ?? Placeholder();
+  }
+}

--- a/packages/datadog_session_replay/test/datadog_session_replay_method_channel_test.dart
+++ b/packages/datadog_session_replay/test/datadog_session_replay_method_channel_test.dart
@@ -2,12 +2,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/datadog_session_replay_method_channel.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  final List<MethodCall> log = [];
 
   // ignore: unused_local_variable
   MethodChannelDatadogSessionReplay platform =
@@ -19,12 +23,87 @@ void main() {
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+          log.add(methodCall);
+          if (methodCall.method == 'enable') {
+            return Future.value(true);
+          }
           return null;
         });
   });
 
   tearDown(() {
+    log.clear();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, null);
+  });
+
+  test('enable calls to channel with configuration', () async {
+    // Given
+    final mockEndpoint = randomString();
+    final configuration = DatadogSessionReplayConfiguration(
+      replaySampleRate: 1.0,
+      customEndpoint: mockEndpoint,
+    );
+
+    // When
+    final success = await platform.enable(configuration, (_) {});
+
+    // Then
+    expect(success, isTrue);
+    expect(log, [
+      isMethodCall(
+        'enable',
+        arguments: {
+          'configuration': {'customEndpoint': mockEndpoint},
+        },
+      ),
+    ]);
+  });
+
+  test('setHasReplay calls to channel', () async {
+    // Given
+    final mockHasReplay = randomBool();
+
+    // When
+    await platform.setHasReplay(mockHasReplay);
+
+    // Then
+    expect(log, [
+      isMethodCall('setHasReplay', arguments: {'hasReplay': mockHasReplay}),
+    ]);
+  });
+
+  test('writeSegment calls to channel', () async {
+    // Given
+    final mockSegment = randomString();
+    final mockViewId = randomString();
+
+    // When
+    await platform.writeSegment(mockSegment, mockViewId);
+
+    // Then
+    expect(log, [
+      isMethodCall(
+        'writeSegment',
+        arguments: {'segment': mockSegment, 'viewId': mockViewId},
+      ),
+    ]);
+  });
+
+  test('setRecordCount calls to channel', () async {
+    // Given
+    final mockViewId = randomString();
+    final mockRecordCount = randomInt();
+
+    // when
+    await platform.setRecordCount(mockViewId, mockRecordCount);
+
+    // Then
+    expect(log, [
+      isMethodCall(
+        'setRecordCount',
+        arguments: {'viewId': mockViewId, 'count': mockRecordCount},
+      ),
+    ]);
   });
 }

--- a/packages/datadog_session_replay/test/datadog_session_replay_test.dart
+++ b/packages/datadog_session_replay/test/datadog_session_replay_test.dart
@@ -2,12 +2,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
+import 'package:datadog_session_replay/src/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/datadog_session_replay_method_channel.dart';
 import 'package:datadog_session_replay/src/datadog_session_replay_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-class MockDatadogSessionReplayPlatform
+class MockInternalLogger extends Mock implements InternalLogger {}
+
+class MockDatadogSessionReplayPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements DatadogSessionReplayPlatform {}
 
@@ -17,5 +23,35 @@ void main() {
 
   test('$MethodChannelDatadogSessionReplay is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelDatadogSessionReplay>());
+  });
+
+  group('DatadogSessionReplay', () {
+    final mockPlatform = MockDatadogSessionReplayPlatform();
+    final mockInternalLogger = MockInternalLogger();
+
+    setUp(() {
+      // Replace the default platform with the mock one
+      DatadogSessionReplayPlatform.instance = mockPlatform;
+
+      registerFallbackValue(
+        DatadogSessionReplayConfiguration(replaySampleRate: 100),
+      );
+    });
+
+    test('.init() calls enable on platform', () {
+      // Given
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(false));
+
+      // When
+      final config = DatadogSessionReplayConfiguration(replaySampleRate: 100.0);
+      DatadogSessionReplay.init(config, mockInternalLogger);
+
+      // Then
+      verify(() => mockPlatform.enable(config, any()));
+    });
+
+    // TODO: Test setup of Recorder / Processor?
   });
 }

--- a/packages/datadog_session_replay/test/processor/processor_worker_test.dart
+++ b/packages/datadog_session_replay/test/processor/processor_worker_test.dart
@@ -19,6 +19,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import '../test_utils.dart';
+
 class MockDatadogSessionReplayPlatform extends Mock
     with MockPlatformInterfaceMixin
     implements DatadogSessionReplayPlatform {}

--- a/packages/datadog_session_replay/test/processor/processor_worker_test.dart
+++ b/packages/datadog_session_replay/test/processor/processor_worker_test.dart
@@ -1,0 +1,452 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/src/capture/capture_node.dart';
+import 'package:datadog_session_replay/src/capture/pointer_capture.dart';
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:datadog_session_replay/src/capture/view_tree_snapshot.dart';
+import 'package:datadog_session_replay/src/datadog_session_replay_platform_interface.dart';
+import 'package:datadog_session_replay/src/extensions.dart';
+import 'package:datadog_session_replay/src/processor/processor_worker.dart';
+import 'package:datadog_session_replay/src/rum_context.dart';
+import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockDatadogSessionReplayPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements DatadogSessionReplayPlatform {}
+
+class MockCaptureNode extends Mock implements CaptureNode {}
+
+void main() {
+  late MockDatadogSessionReplayPlatform mockPlatform;
+
+  void initializeMockPlatform() {
+    mockPlatform = MockDatadogSessionReplayPlatform();
+    DatadogSessionReplayPlatform.instance = mockPlatform;
+
+    when(
+      () => mockPlatform.setHasReplay(any()),
+    ).thenAnswer((_) => Future.value());
+    when(
+      () => mockPlatform.setRecordCount(any(), any()),
+    ).thenAnswer((_) => Future.value());
+    when(
+      () => mockPlatform.writeSegment(any(), any()),
+    ).thenAnswer((_) => Future.value());
+  }
+
+  setUp(() {
+    initializeMockPlatform();
+  });
+
+  test('processSnapshot for no viewId does nothing', () async {
+    // Given
+    final ProcessorWorker worker = ProcessorWorker();
+    final capture = CaptureResult(
+      ViewTreeSnapshot(
+        date: DateTime.now(),
+        context: RUMContext(
+          applicationId: randomString(),
+          sessionId: randomString(),
+        ),
+        viewportSize: Size(600, 800),
+        nodes: [MockCaptureNode()],
+      ),
+      null,
+    );
+
+    // When
+    await worker.processSnapshot(capture);
+
+    // Then
+    verifyNoMoreInteractions(mockPlatform);
+  });
+
+  SRShapeWireframe createMockShapeWireframe(int id) {
+    return SRShapeWireframe(
+      id: id,
+      x: randomInt(),
+      y: randomInt(),
+      width: randomInt(),
+      height: randomInt(),
+      shapeStyle: SRShapeStyle(
+        cornerRadius: randomDouble(min: 0.0, max: 5.0),
+        backgroundColor: randomColor().toHexString(),
+      ),
+    );
+  }
+
+  test('processSnapshot for first snapshot generates full record', () async {
+    // Given
+    final ProcessorWorker worker = ProcessorWorker();
+    final mockCapture = MockCaptureNode();
+
+    final mockShape = createMockShapeWireframe(0);
+    when(() => mockCapture.buildWireframes()).thenReturn([mockShape]);
+    final rumContext = RUMContext(
+      applicationId: randomString(),
+      sessionId: randomString(),
+      viewId: randomString(),
+    );
+    final expectedTimestamp = DateTime.now();
+    final capture = CaptureResult(
+      ViewTreeSnapshot(
+        date: expectedTimestamp,
+        context: rumContext,
+        viewportSize: Size(600, 800),
+        nodes: [mockCapture],
+      ),
+      null,
+    );
+
+    // When
+    await worker.processSnapshot(capture);
+
+    // Then - Send a Meta, Focus, and Full Snapshot
+    verify(() => mockPlatform.setRecordCount(rumContext.viewId!, 3));
+
+    final expectedRecord = SREnrichedRecord(
+      records: [
+        SRMetaRecord(
+          data: SRMetaRecordData(width: 600, height: 800),
+          timestamp: expectedTimestamp.toUtc().millisecondsSinceEpoch,
+        ),
+        SRFocusRecord(
+          data: SRFocusRecordData(hasFocus: true),
+          timestamp: expectedTimestamp.toUtc().millisecondsSinceEpoch,
+        ),
+        SRFullSnapshotRecord(
+          data: SRFullSnapshotRecordData(wireframes: [mockShape]),
+          timestamp: expectedTimestamp.toUtc().millisecondsSinceEpoch,
+        ),
+      ],
+      applicationID: rumContext.applicationId,
+      sessionID: rumContext.sessionId,
+      viewID: rumContext.viewId!,
+    );
+    final encodedRecord = jsonEncode(expectedRecord.toJson());
+    verify(() => mockPlatform.writeSegment(encodedRecord, rumContext.viewId!));
+  });
+
+  group('with initial snapshot', () {
+    initializeMockPlatform();
+
+    final mockCapture = MockCaptureNode();
+
+    final mockShape = createMockShapeWireframe(0);
+    when(() => mockCapture.buildWireframes()).thenReturn([mockShape]);
+    final rumContext = RUMContext(
+      applicationId: randomString(),
+      sessionId: randomString(),
+      viewId: randomString(),
+    );
+    final firstTimestamp = DateTime.now();
+
+    late ProcessorWorker worker;
+
+    setUp(() async {
+      worker = ProcessorWorker();
+      final firstCapture = CaptureResult(
+        ViewTreeSnapshot(
+          date: firstTimestamp,
+          context: rumContext,
+          viewportSize: Size(600, 800),
+          nodes: [mockCapture],
+        ),
+        null,
+      );
+
+      await worker.processSnapshot(firstCapture);
+
+      // Sends a Meta, Focus, and FullSnapshot record
+      verify(() => mockPlatform.setRecordCount(rumContext.viewId!, 3));
+      verify(() => mockPlatform.writeSegment(any(), any()));
+    });
+
+    test('processSnapshot with no changes generates no records', () async {
+      // Given
+      final secondTimestamp = firstTimestamp.add(Duration(milliseconds: 200));
+      final secondCapture = CaptureResult(
+        ViewTreeSnapshot(
+          date: secondTimestamp,
+          context: rumContext,
+          viewportSize: Size(600, 800),
+          nodes: [mockCapture],
+        ),
+        null,
+      );
+
+      // When
+      await worker.processSnapshot(secondCapture);
+
+      // Then
+      verifyNoMoreInteractions(mockPlatform);
+    });
+
+    test('processSnapshot with changes generates incremental record', () async {
+      // Given
+      final secondMockCapture = MockCaptureNode();
+      final mockShape = createMockShapeWireframe(0);
+      when(() => secondMockCapture.buildWireframes()).thenReturn([mockShape]);
+      final secondTimestamp = firstTimestamp.add(Duration(milliseconds: 200));
+      final secondCapture = CaptureResult(
+        ViewTreeSnapshot(
+          date: secondTimestamp,
+          context: rumContext,
+          viewportSize: Size(600, 800),
+          nodes: [secondMockCapture],
+        ),
+        null,
+      );
+
+      // When
+      await worker.processSnapshot(secondCapture);
+
+      // Then
+      final expectedRecord = SREnrichedRecord(
+        records: [
+          SRIncrementalSnapshotRecord(
+            data: SRIncrementalMutationData(
+              adds: [],
+              removes: [],
+              updates: [
+                SRShapeWireframeUpdate(
+                  id: 0,
+                  border: null,
+                  clip: null,
+                  shapeStyle: mockShape.shapeStyle,
+                  x: mockShape.x,
+                  y: mockShape.y,
+                  width: mockShape.width,
+                  height: mockShape.height,
+                ),
+              ],
+            ),
+            timestamp: secondTimestamp.toUtc().millisecondsSinceEpoch,
+          ),
+        ],
+        applicationID: rumContext.applicationId,
+        sessionID: rumContext.sessionId,
+        viewID: rumContext.viewId!,
+      );
+      final expectedJson = jsonEncode(expectedRecord.toJson());
+      verify(() => mockPlatform.setRecordCount(rumContext.viewId!, 4));
+      verify(() => mockPlatform.writeSegment(expectedJson, rumContext.viewId!));
+    });
+
+    test(
+      'processSnapshot with changes generates incremental record (add / remove)',
+      () async {
+        // Given
+        final secondMockCapture = MockCaptureNode();
+        final mockShape = createMockShapeWireframe(1);
+        when(() => secondMockCapture.buildWireframes()).thenReturn([mockShape]);
+        final secondTimestamp = firstTimestamp.add(Duration(milliseconds: 200));
+        final secondCapture = CaptureResult(
+          ViewTreeSnapshot(
+            date: secondTimestamp,
+            context: rumContext,
+            viewportSize: Size(600, 800),
+            nodes: [secondMockCapture],
+          ),
+          null,
+        );
+
+        // When
+        await worker.processSnapshot(secondCapture);
+
+        // Then
+        final expectedRecord = SREnrichedRecord(
+          records: [
+            SRIncrementalSnapshotRecord(
+              data: SRIncrementalMutationData(
+                adds: [SRIntrementalAdd(wireframe: mockShape)],
+                removes: [SRIncrementalRemove(id: 0)],
+                updates: [],
+              ),
+              timestamp: secondTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+          ],
+          applicationID: rumContext.applicationId,
+          sessionID: rumContext.sessionId,
+          viewID: rumContext.viewId!,
+        );
+        final expectedJson = jsonEncode(expectedRecord.toJson());
+        verify(() => mockPlatform.setRecordCount(rumContext.viewId!, 4));
+        verify(
+          () => mockPlatform.writeSegment(expectedJson, rumContext.viewId!),
+        );
+      },
+    );
+
+    test(
+      'process snapshot with change in context produces full snapshot',
+      () async {
+        // Given
+        final newContext = RUMContext(
+          applicationId: rumContext.applicationId,
+          sessionId: rumContext.sessionId,
+          viewId: randomString(),
+        );
+        final secondMockCapture = MockCaptureNode();
+        final mockShape = createMockShapeWireframe(1);
+        when(() => secondMockCapture.buildWireframes()).thenReturn([mockShape]);
+        final secondTimestamp = firstTimestamp.add(Duration(milliseconds: 200));
+        final secondCapture = CaptureResult(
+          ViewTreeSnapshot(
+            date: secondTimestamp,
+            context: newContext,
+            viewportSize: Size(600, 800),
+            nodes: [secondMockCapture],
+          ),
+          null,
+        );
+
+        // When
+        await worker.processSnapshot(secondCapture);
+
+        // Then
+        verify(() => mockPlatform.setRecordCount(newContext.viewId!, 3));
+
+        final expectedRecord = SREnrichedRecord(
+          records: [
+            SRMetaRecord(
+              data: SRMetaRecordData(width: 600, height: 800),
+              timestamp: secondTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+            SRFocusRecord(
+              data: SRFocusRecordData(hasFocus: true),
+              timestamp: secondTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+            SRFullSnapshotRecord(
+              data: SRFullSnapshotRecordData(wireframes: [mockShape]),
+              timestamp: secondTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+          ],
+          applicationID: newContext.applicationId,
+          sessionID: newContext.sessionId,
+          viewID: newContext.viewId!,
+        );
+        final encodedRecord = jsonEncode(expectedRecord.toJson());
+        verify(
+          () => mockPlatform.writeSegment(encodedRecord, newContext.viewId!),
+        );
+      },
+    );
+  });
+
+  group('pointer snapshot', () {
+    initializeMockPlatform();
+
+    final mockCapture = MockCaptureNode();
+
+    final mockShape = createMockShapeWireframe(0);
+    when(() => mockCapture.buildWireframes()).thenReturn([mockShape]);
+    final rumContext = RUMContext(
+      applicationId: randomString(),
+      sessionId: randomString(),
+      viewId: randomString(),
+    );
+    final firstTimestamp = DateTime.now();
+
+    late ProcessorWorker worker;
+
+    setUp(() async {
+      worker = ProcessorWorker();
+    });
+
+    test(
+      'process snapshot with empty pointer capture sends no pointer record',
+      () async {
+        // Given
+        final firstCapture = CaptureResult(
+          ViewTreeSnapshot(
+            date: firstTimestamp,
+            context: rumContext,
+            viewportSize: Size(600, 800),
+            nodes: [mockCapture],
+          ),
+          PointerSnapshot(firstTimestamp, []),
+        );
+
+        // When
+        await worker.processSnapshot(firstCapture);
+
+        // Sends a Meta, Focus, FullSnapshot, no pointer record
+        verify(() => mockPlatform.setRecordCount(rumContext.viewId!, 3));
+        verify(() => mockPlatform.writeSegment(any(), any()));
+      },
+    );
+
+    test(
+      'process snapshot with pointer capture sends pointers in snapshot',
+      () async {
+        // Given
+        final pointer = PointerCapture(
+          date: firstTimestamp,
+          pointerId: 0,
+          eventType: SRPointerEventType.down,
+          x: randomDouble(),
+          y: randomDouble(),
+        );
+        final firstCapture = CaptureResult(
+          ViewTreeSnapshot(
+            date: firstTimestamp,
+            context: rumContext,
+            viewportSize: Size(600, 800),
+            nodes: [mockCapture],
+          ),
+          PointerSnapshot(firstTimestamp, [pointer]),
+        );
+
+        // When
+        await worker.processSnapshot(firstCapture);
+
+        // Sends a Meta, Focus, FullSnapshot, and Pointer record
+        verify(() => mockPlatform.setRecordCount(rumContext.viewId!, 4));
+
+        final expectedRecord = SREnrichedRecord(
+          records: [
+            SRMetaRecord(
+              data: SRMetaRecordData(width: 600, height: 800),
+              timestamp: firstTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+            SRFocusRecord(
+              data: SRFocusRecordData(hasFocus: true),
+              timestamp: firstTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+            SRFullSnapshotRecord(
+              data: SRFullSnapshotRecordData(wireframes: [mockShape]),
+              timestamp: firstTimestamp.toUtc().millisecondsSinceEpoch,
+            ),
+            SRIncrementalSnapshotRecord(
+              data: SRPointerInteractionData(
+                pointerEventType: pointer.eventType,
+                pointerId: pointer.pointerId,
+                pointerType: SRPointerType.touch,
+                x: pointer.x,
+                y: pointer.y,
+              ),
+              timestamp: pointer.date.millisecondsSinceEpoch,
+            ),
+          ],
+          applicationID: rumContext.applicationId,
+          sessionID: rumContext.sessionId,
+          viewID: rumContext.viewId!,
+        );
+        final encodedRecord = jsonEncode(expectedRecord.toJson());
+        verify(
+          () => mockPlatform.writeSegment(encodedRecord, rumContext.viewId!),
+        );
+      },
+    );
+  });
+}

--- a/packages/datadog_session_replay/test/test_utils.dart
+++ b/packages/datadog_session_replay/test/test_utils.dart
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+// Because `Color` is defined in `dart:ui`, it can't be imported into the test library
+// when running integration tests on Web. When / if we support SR on web, we'll need to look
+// into a way to have the Color class work in the test test package.
+import 'dart:math';
+import 'dart:ui';
+
+Random _random = Random();
+
+Color randomColor({bool withRandomAlpha = false}) {
+  int randomColorComponent() {
+    return _random.nextInt(255);
+  }
+
+  return Color.fromARGB(
+    withRandomAlpha ? randomColorComponent() : 255,
+    randomColorComponent(),
+    randomColorComponent(),
+    randomColorComponent(),
+  );
+}


### PR DESCRIPTION
### What and why?

Initial capture and processor overhead, which traverses the Element tree looking for widgets to record, then provides those to the processor for diffing and serialization.

refs: RUM-9553

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
