### PR TITLE
feat: Update to new type safe iOS contexts

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
@@ -31,7 +31,7 @@ void main() {
     var logs = <LogDecoder>[];
 
     await recordedSession.pollSessionRequests(
-      const Duration(seconds: 50),
+      const Duration(seconds: 30),
       (requests) {
         requests
             .map((e) {

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_mapping_test.dart
@@ -31,7 +31,7 @@ void main() {
     var logs = <LogDecoder>[];
 
     await recordedSession.pollSessionRequests(
-      const Duration(seconds: 30),
+      const Duration(seconds: 50),
       (requests) {
         requests
             .map((e) {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -14,6 +14,9 @@ class LoggingScenario extends StatefulWidget {
 }
 
 class _LoggingScenarioState extends State<LoggingScenario> {
+  late DatadogLogger logger;
+  late DatadogLogger secondLogger;
+
   @override
   void initState() {
     super.initState();
@@ -27,7 +30,7 @@ class _LoggingScenarioState extends State<LoggingScenario> {
     );
     silentLogger.info('Interesting logging information');
 
-    var logger =
+    logger =
         DatadogSdk.instance.logs!.createLogger(DatadogLoggerConfiguration());
     logger.addTag('tag1', 'tag-value');
     logger.addTag('my-tag');
@@ -60,7 +63,7 @@ class _LoggingScenarioState extends State<LoggingScenario> {
       name: 'second_logger',
       networkInfoEnabled: false,
     );
-    final secondLogger = DatadogSdk.instance.logs!.createLogger(config);
+    secondLogger = DatadogSdk.instance.logs!.createLogger(config);
 
     secondLogger.addAttribute('second-logger-attribute', 'second-value');
     secondLogger.info('message on second logger');

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/main.dart
@@ -40,6 +40,7 @@ Future<void> runScenario({
   }
 
   // Default runner
+  DatadogSdk.instance.sdkVerbosity = CoreLoggerLevel.debug;
   final configuration = DatadogConfiguration(
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
@@ -97,6 +98,7 @@ Future<void> main() async {
     }
   }
 
+  DatadogSdk.instance.sdkVerbosity = CoreLoggerLevel.debug;
   await runScenario(
     clientToken: clientToken,
     applicationId: applicationId,

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -1,25 +1,25 @@
 PODS:
   - datadog_flutter_plugin (0.0.1):
-    - DatadogCore (= 2.25.0)
-    - DatadogCrashReporting (= 2.25.0)
-    - DatadogInternal (= 2.25.0)
-    - DatadogLogs (= 2.25.0)
-    - DatadogRUM (= 2.25.0)
+    - DatadogCore (~> 2)
+    - DatadogCrashReporting (~> 2)
+    - DatadogInternal (~> 2)
+    - DatadogLogs (~> 2)
+    - DatadogRUM (~> 2)
     - DictionaryCoder (= 1.0.8)
     - Flutter
   - datadog_session_replay (0.0.1):
     - DatadogCore (~> 2)
     - Flutter
-  - DatadogCore (2.25.0):
-    - DatadogInternal (= 2.25.0)
-  - DatadogCrashReporting (2.25.0):
-    - DatadogInternal (= 2.25.0)
+  - DatadogCore (2.28.0):
+    - DatadogInternal (= 2.28.0)
+  - DatadogCrashReporting (2.28.0):
+    - DatadogInternal (= 2.28.0)
     - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (2.25.0)
-  - DatadogLogs (2.25.0):
-    - DatadogInternal (= 2.25.0)
-  - DatadogRUM (2.25.0):
-    - DatadogInternal (= 2.25.0)
+  - DatadogInternal (2.28.0)
+  - DatadogLogs (2.28.0):
+    - DatadogInternal (= 2.28.0)
+  - DatadogRUM (2.28.0):
+    - DatadogInternal (= 2.28.0)
   - DictionaryCoder (1.0.8)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -53,13 +53,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: 0536db97da04dda6e0198a732efb599a179cd316
+  datadog_flutter_plugin: d7c707cfa57f67bc7bd71d275cf38d94eef1aa48
   datadog_session_replay: 50aac665d5a87dc45b9cb2df38c779e6cf43f9b0
-  DatadogCore: a068d264191f687d00125aafa8042110cf886cd7
-  DatadogCrashReporting: b19d80a98b1eb51bdb3ec5b1a7f339769fb70b95
-  DatadogInternal: e9b6cef84448ee32f73bc9b37646708a65c1b8ae
-  DatadogLogs: 623d89158ef3a4a7545a8fbce9afa4cedc576324
-  DatadogRUM: ff0661b42124d90c9ff2538c3cc1b806ddf7620c
+  DatadogCore: 5d6e64cd6f7413a767d786e8ccce792e8b4a085c
+  DatadogCrashReporting: 70b1f3aa65b101484f2cbd75cadd811c04f9a4dd
+  DatadogInternal: b92d09bd55e3d1d598ec34d162310151a7347a5b
+  DatadogLogs: de72f05ee0f759676cac4f4159512afcc7af504f
+  DatadogRUM: d3ad3310ae1b0af4575d6a5cc30ca89f2c19f217
   DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -96,7 +96,7 @@ class SessionReplayPluginTests {
         }
 
         // Then
-        #expect(status == .called(value: nil))
+        #expect(status == .called(value: true))
         #expect(mockCore.get(feature: FlutterSessionReplayFeature.self) != nil)
     }
 
@@ -136,8 +136,8 @@ class SessionReplayPluginTests {
 
         // Then
         #expect(status == .called(value: nil))
-        let value = try mockCore.context.baggages["sr_has_replay"]?.encode() as? Bool
-        #expect(value == expectedValue)
+        let value = mockCore.context.additionalContext(ofType: SessionReplayCoreContext.HasReplay.self)
+        #expect(value?.value == expectedValue)
     }
 
     @Test
@@ -164,7 +164,7 @@ class SessionReplayPluginTests {
     func setsContext_WhenSetRecordCountMethodCall() throws {
         // Given
         let plugin = DatadogSessionReplayPlugin(channel: FlutterMethodChannelMock())
-        let expectedValue: Int = .mockRandom()
+        let expectedValue: Int64 = .mockRandom()
         let expectedViewId: String = .mockRandom()
         let arguments: [String: Any] = [
             "viewId": expectedViewId,
@@ -181,9 +181,9 @@ class SessionReplayPluginTests {
 
         // Then
         #expect(status == .called(value: nil))
-        let value = try mockCore.context.baggages["sr_records_count_by_view_id"]?.encode() as? [String: Any]
-        #expect(value?.count == 1)
-        #expect(value?[expectedViewId] as? Int == expectedValue)
+        let value = mockCore.context.additionalContext(ofType: SessionReplayCoreContext.RecordsCount.self)
+        #expect(value?.value.count == 1)
+        #expect(value?.value[expectedViewId] as? Int64 == expectedValue)
     }
 
     @Test
@@ -194,11 +194,9 @@ class SessionReplayPluginTests {
         plugin.enable(configuration: .init())
 
         // When
-        let expectedRumContext: RUMContext = .mockRandom()
-        let datadogContext: DatadogContext = .mockRandom(
-            withBaggages: [
-                RUMContext.key: .init(expectedRumContext)]
-        )
+        let expectedRumContext: RUMCoreContext = .mockRandom()
+        var datadogContext: DatadogContext = .mockRandom()
+        datadogContext.set(additionalContext: expectedRumContext)
         mockCore.send(message: .context(datadogContext), else: {})
 
         // Then

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayFeatureTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayFeatureTests.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import Testing
+import DatadogInternal
 
 @testable import datadog_session_replay
 
@@ -19,8 +20,8 @@ func setsReplayBaggage_WhenSetHasReplay() throws {
     feature.setHasReplay(expectedValue)
 
     // Then
-    let value = try core.context.baggages["sr_has_replay"]?.encode() as? Bool
-    #expect(value == expectedValue)
+    let value = core.context.additionalContext(ofType: SessionReplayCoreContext.HasReplay.self)
+    #expect(value?.value == expectedValue)
 }
 
 @Test
@@ -32,12 +33,12 @@ func setsBaggage_WhenSetRecordCount() throws {
 
     // When
     let viewId: String = .mockRandom()
-    let expectedCount: Int = .mockRandom()
+    let expectedCount: Int64 = .mockRandom()
     feature.setRecordCount(for: viewId, count: expectedCount)
 
     // Then
-    let baggage = try core.context.baggages["sr_records_count_by_view_id"]?.encode() as? [String: Any]
-    let value = baggage?[viewId] as? Int
+    let baggage = core.context.additionalContext(ofType: SessionReplayCoreContext.RecordsCount.self)
+    let value = baggage?.value[viewId] as? Int64
     #expect(value == expectedCount)
 }
 
@@ -51,15 +52,15 @@ func setsBaggage_WhenSetRecordCount_MultipleViews() throws {
     // When
     let viewIdA: String = .mockRandom()
     let viewIdB: String = .mockRandom()
-    let expectedCountA: Int = .mockRandom()
-    let expectedCountB: Int = .mockRandom()
+    let expectedCountA: Int64 = .mockRandom()
+    let expectedCountB: Int64 = .mockRandom()
     feature.setRecordCount(for: viewIdA, count: expectedCountA)
     feature.setRecordCount(for: viewIdB, count: expectedCountB)
 
     // Then
-    let baggage = try core.context.baggages["sr_records_count_by_view_id"]?.encode() as? [String: Any]
-    let valueA = baggage?[viewIdA] as? Int
+    let baggage = core.context.additionalContext(ofType: SessionReplayCoreContext.RecordsCount.self)
+    let valueA = baggage?.value[viewIdA] as? Int64
     #expect(valueA == expectedCountA)
-    let valueB = baggage?[viewIdB] as? Int
+    let valueB = baggage?.value[viewIdB] as? Int64
     #expect(valueB == expectedCountB)
 }

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayTests.swift
@@ -58,7 +58,7 @@ func writeSegmentWritesWrappedSegmentToCore() {
 func changeInRumContextCallOnContextChanged() throws {
     // Given
     var config: FlutterSessionReplay.Configuration = .init()
-    var recievedContext: RUMContext?
+    var recievedContext: RUMCoreContext?
     config.onContextChanged = { context in
         recievedContext = context
     }
@@ -66,11 +66,10 @@ func changeInRumContextCallOnContextChanged() throws {
     _ = FlutterSessionReplay.enable(with: config, in: mockCore)
 
     // When
-    let expectedRumContext: RUMContext = .mockRandom()
-    let datadogContext: DatadogContext = .mockRandom(
-        withBaggages: [
-            RUMContext.key: .init(expectedRumContext)]
-    )
+    let expectedRumContext: RUMCoreContext = .mockRandom()
+    var datadogContext: DatadogContext = .mockRandom()
+    datadogContext.set(additionalContext: expectedRumContext)
+
     mockCore.send(message: .context(datadogContext), else: {})
 
     // Then

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
@@ -36,8 +36,7 @@ extension DatadogContext {
         networkConnectionInfo: NetworkConnectionInfo? = .mockWith(reachability: .yes),
         carrierInfo: CarrierInfo? = .mockAny(),
         batteryStatus: BatteryStatus? = .mockAny(),
-        isLowPowerModeEnabled: Bool = false,
-        baggages: [String: FeatureBaggage] = [:]
+        isLowPowerModeEnabled: Bool = false
     ) -> DatadogContext {
         .init(
             site: site,
@@ -65,12 +64,11 @@ extension DatadogContext {
             networkConnectionInfo: networkConnectionInfo,
             carrierInfo: carrierInfo,
             batteryStatus: batteryStatus,
-            isLowPowerModeEnabled: isLowPowerModeEnabled,
-            baggages: baggages
+            isLowPowerModeEnabled: isLowPowerModeEnabled
         )
     }
 
-    public static func mockRandom(withBaggages: [String: FeatureBaggage] = [:]) -> DatadogContext {
+    public static func mockRandom() -> DatadogContext {
         .init(
             site: .mockRandom(),
             clientToken: .mockRandom(),
@@ -96,15 +94,14 @@ extension DatadogContext {
             networkConnectionInfo: .mockRandom(),
             carrierInfo: .mockRandom(),
             batteryStatus: nil,
-            isLowPowerModeEnabled: .mockRandom(),
-            baggages: withBaggages
+            isLowPowerModeEnabled: .mockRandom()
         )
     }
 }
 
-extension RUMContext {
+extension RUMCoreContext {
     public static func mockRandom() -> Self {
-        return RUMContext.init(
+        return RUMCoreContext.init(
             applicationID: .mockRandom(),
             sessionID: .mockRandom(),
             viewID: .mockRandom(),

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogCoreMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogCoreMock.swift
@@ -72,8 +72,8 @@ open class PassthroughCoreMock: DatadogCoreProtocol, FeatureScope, @unchecked Se
         self
     }
 
-    public func set(baggage: @escaping () -> FeatureBaggage?, forKey key: String) {
-        context.baggages[key] = baggage()
+    public func set<Context>(context: @escaping () -> Context?) where Context: AdditionalContext {
+        self.context.set(additionalContext: context())
     }
 
     public func send(message: FeatureMessage, else fallback: () -> Void) {

--- a/packages/datadog_session_replay/example/ios/RunnerTests/RequestBuilderTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/RequestBuilderTests.swift
@@ -11,7 +11,7 @@ import Compression
 
 // Records are encoded by Flutter, so the models aren't in
 // the Flutter SR feature for flutter, so we encode JSON manually.
-func createEnrichedRecordJson(context: RUMContext, records: [String] = []) -> String {
+func createEnrichedRecordJson(context: RUMCoreContext, records: [String] = []) -> String {
     let viewId = context.viewID ?? "null"
     let recordsString = "[\(records.joined(separator: ","))]"
     return """
@@ -47,7 +47,7 @@ func createEvents(_ records: [RecordWrapper]) throws -> [Event] {
 func requestBuildsURLRequest_WithCorrectHeaders() throws {
     // Given
     let mockCore = PassthroughCoreMock()
-    let rumContext = RUMContext.mockRandom()
+    let rumContext = RUMCoreContext.mockRandom()
     let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry)
     let events = try createEvents([
         RecordWrapper(
@@ -56,9 +56,8 @@ func requestBuildsURLRequest_WithCorrectHeaders() throws {
     ])
 
     // When
-    let context: DatadogContext = .mockRandom(
-        withBaggages: [RUMContext.key: .init(rumContext)]
-    )
+    var context: DatadogContext = .mockRandom()
+    context.set(additionalContext: RUMCoreContext.mockRandom())
     let request = try requestBuilder.request(
         for: events,
         with: context,
@@ -82,7 +81,7 @@ func requestBuildsURLRequest_WithCorrectHeaders() throws {
 func requestBuilder_BuildsFormData_WithMultipartBuilder() throws {
     // Given
     let mockCore = PassthroughCoreMock()
-    let rumContext = RUMContext.mockRandom()
+    let rumContext = RUMCoreContext.mockRandom()
     let multipartSpy = MultipartBuilderSpy()
     let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry, multipartBuilder: multipartSpy)
     let events = try createEvents([
@@ -92,9 +91,8 @@ func requestBuilder_BuildsFormData_WithMultipartBuilder() throws {
     ])
 
     // When
-    let context: DatadogContext = .mockRandom(
-        withBaggages: [RUMContext.key: .init(rumContext)]
-    )
+    var context: DatadogContext = .mockRandom()
+    context.set(additionalContext: rumContext)
     _ = try requestBuilder.request(
         for: events,
         with: context,
@@ -132,7 +130,7 @@ func requestBuilder_BuildsFormData_WithMultipartBuilder() throws {
 func requestBuilder_BuildsFormDataWithRecords_WithMultipartBuilder() throws {
     // Given
     let mockCore = PassthroughCoreMock()
-    let rumContext = RUMContext.mockRandom()
+    let rumContext = RUMCoreContext.mockRandom()
     let multipartSpy = MultipartBuilderSpy()
     let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry, multipartBuilder: multipartSpy)
     let events = try createEvents([
@@ -145,9 +143,8 @@ func requestBuilder_BuildsFormDataWithRecords_WithMultipartBuilder() throws {
     ])
 
     // When
-    let context: DatadogContext = .mockRandom(
-        withBaggages: [RUMContext.key: .init(rumContext)]
-    )
+    var context: DatadogContext = .mockRandom()
+    context.set(additionalContext: rumContext)
     _ = try requestBuilder.request(
         for: events,
         with: context,
@@ -181,8 +178,8 @@ func requestBuilder_BuildsFormDataWithRecords_WithMultipartBuilder() throws {
 func requestBuilder_BuildsFormDataWithMultipleContexts_WithMultipartBuilder() throws {
     // Given
     let mockCore = PassthroughCoreMock()
-    let context0 = RUMContext.mockRandom()
-    let context1 = RUMContext.mockRandom()
+    let context0 = RUMCoreContext.mockRandom()
+    let context1 = RUMCoreContext.mockRandom()
     let multipartSpy = MultipartBuilderSpy()
     let requestBuilder = RequestBuilder(customUploadURL: nil, telemetry: mockCore.telemetry, multipartBuilder: multipartSpy)
     let events = try createEvents([
@@ -213,9 +210,8 @@ func requestBuilder_BuildsFormDataWithMultipleContexts_WithMultipartBuilder() th
     ])
 
     // When
-    let context: DatadogContext = .mockRandom(
-        withBaggages: [RUMContext.key: .init(context0)]
-    )
+    var context: DatadogContext = .mockRandom()
+    context.set(additionalContext: context0)
     _ = try requestBuilder.request(
         for: events,
         with: context,

--- a/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/Classes/DatadogSessionReplayPlugin.swift
@@ -3,6 +3,7 @@
 // Copyright 2025-Present Datadog, Inc.
 import Flutter
 import UIKit
+import DatadogInternal
 
 public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -49,7 +50,7 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
 
         enable(configuration: configuration)
 
-        result(nil)
+        result(true)
     }
 
     // Visible for testing
@@ -79,7 +80,7 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        feature?.setRecordCount(for: viewId, count: count)
+        feature?.setRecordCount(for: viewId, count: Int64(count))
 
         result(nil)
     }
@@ -95,7 +96,7 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
         result(nil)
     }
 
-    private func onContextChanged(rumContext: RUMContext?) {
+    private func onContextChanged(rumContext: RUMCoreContext?) {
         if let dictionary = rumContext?.encodedForFlutter() {
             DispatchQueue.main.async {
                 self.channel.invokeMethod("onContextChanged", arguments: dictionary)

--- a/packages/datadog_session_replay/ios/Classes/Feature/Baggages.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/Baggages.swift
@@ -3,6 +3,7 @@
 // Copyright 2023-Present Datadog, Inc.
 
 import Foundation
+import DatadogInternal
 
 /// Defines dependency between Session Replay (SR) and RUM modules.
 /// It aims at centralizing documentation of contracts between both products.
@@ -16,28 +17,7 @@ internal enum RUMDependency {
     static let recordsCountByViewID = "sr_records_count_by_view_id"
 }
 
-/// The RUM context received from `DatadogCore`.
-internal struct RUMContext: Codable, Equatable {
-    static let key = "rum"
-
-    enum CodingKeys: String, CodingKey {
-        case applicationID = "application.id"
-        case sessionID = "session.id"
-        case viewID = "view.id"
-        case viewServerTimeOffset = "server_time_offset"
-    }
-
-    /// Current RUM application ID - standard UUID string, lowecased.
-    let applicationID: String
-    /// Current RUM session ID - standard UUID string, lowecased.
-    let sessionID: String
-    /// Current RUM view ID - standard UUID string, lowecased. It can be empty when view is being loaded.
-    let viewID: String?
-    /// Current view related server time offset
-    let viewServerTimeOffset: TimeInterval?
-}
-
-extension RUMContext {
+extension RUMCoreContext {
     func encodedForFlutter() -> [String: Any?] {
         return [
             "applicationId": applicationID,

--- a/packages/datadog_session_replay/ios/Classes/Feature/FlutterSeasionReplayFeature.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/FlutterSeasionReplayFeature.swift
@@ -14,7 +14,7 @@ class FlutterSessionReplayFeature: DatadogRemoteFeature {
     private var core: DatadogCoreProtocol?
     private var featureScope: FeatureScope?
 
-    private var recordCountByViewId: [String: Int] = [:]
+    private var recordCountByViewId: [String: Int64] = [:]
 
     init(
         core: DatadogCoreProtocol,
@@ -38,12 +38,12 @@ class FlutterSessionReplayFeature: DatadogRemoteFeature {
     }
 
     func setHasReplay(_ hasReplay: Bool) {
-        core?.set(baggage: hasReplay, forKey: RUMDependency.hasReplay)
+        core?.set(context: SessionReplayCoreContext.HasReplay(value: hasReplay))
     }
 
-    func setRecordCount(for viewId: String, count: Int) {
+    func setRecordCount(for viewId: String, count: Int64) {
         recordCountByViewId[viewId] = count
-        core?.set(baggage: recordCountByViewId, forKey: RUMDependency.recordsCountByViewID)
+        core?.set(context: SessionReplayCoreContext.RecordsCount(value: recordCountByViewId))
     }
 
     func writeSegment(segment: String) {

--- a/packages/datadog_session_replay/ios/Classes/Feature/RUMContextReceiver.swift
+++ b/packages/datadog_session_replay/ios/Classes/Feature/RUMContextReceiver.swift
@@ -11,14 +11,14 @@ internal protocol RUMContextObserver {
     /// - Parameters:
     ///   - queue: a queue to call `notify` block on
     ///   - notify: a closure receiving new `RUMContext` or `nil` if current RUM session is not sampled
-    func observe(notify: @escaping (RUMContext?) -> Void)
+    func observe(notify: @escaping (RUMCoreContext?) -> Void)
 }
 
 /// Receives RUM context from `DatadogCore` and notifies it through `RUMContextObserver` interface.
 internal class RUMContextReceiver: FeatureMessageReceiver, RUMContextObserver {
     /// Notifies new `RUMContext` or `nil` if current RUM session is not sampled.
-    private var onNew: ((RUMContext?) -> Void)?
-    private var previous: RUMContext?
+    private var onNew: ((RUMCoreContext?) -> Void)?
+    private var previous: RUMCoreContext?
 
     // MARK: - FeatureMessageReceiver
 
@@ -27,26 +27,18 @@ internal class RUMContextReceiver: FeatureMessageReceiver, RUMContextObserver {
             return false
         }
 
-        var new: RUMContext?
-
-        do {
-            // Extract the `RUMContext` or `nil` if RUM session is not sampled:
-            new = try context.baggages[RUMContext.key].map { try $0.decode() }
-        } catch {
-            core.telemetry
-                .error("Fails to decode RUM context from Session Replay", error: error)
-        }
+        let newContext = context.additionalContext(ofType: RUMCoreContext.self)
 
         // Notify only if it has changed:
-        if new != previous {
-            onNew?(new)
-            previous = new
+        if newContext != previous {
+            onNew?(newContext)
+            previous = newContext
         }
 
         return true
     }
 
-    func observe(notify: @escaping (RUMContext?) -> Void) {
+    func observe(notify: @escaping (RUMCoreContext?) -> Void) {
         onNew = { new in
             notify(new)
         }

--- a/packages/datadog_session_replay/ios/Classes/FlutterSessionReplay.swift
+++ b/packages/datadog_session_replay/ios/Classes/FlutterSessionReplay.swift
@@ -8,11 +8,11 @@ import DatadogInternal
 internal class FlutterSessionReplay {
     public struct Configuration {
         public var customEndpoint: URL?
-        public var onContextChanged: ((RUMContext?) -> Void)?
+        public var onContextChanged: ((RUMCoreContext?) -> Void)?
 
         public init(
             customEndpoint: URL? = nil,
-            onContextChanged: ((RUMContext?) -> Void)? = nil
+            onContextChanged: ((RUMCoreContext?) -> Void)? = nil
         ) {
             self.customEndpoint = customEndpoint
             self.onContextChanged = onContextChanged


### PR DESCRIPTION
### What and why?
New changes in iOS `develop` require using type safe `AdditionalContext` objects over old `baggages`. This updates Flutter SR to use this system instead.

Fixes the build for current iOS `develop` branch.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
