### PR TITLE
feat: Support basic capture of text fields.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ variables:
   IS_ON_CI: $CI
   SLACK_CHANNEL: "#mobile-sdk-ops"
 
-  KUBERNETES_MEMORY_REQUEST: "8Gi"
+  KUBERNETES_MEMORY_REQUEST: "12Gi"
   KUBERNETES_MEMORY_LIMIT: "16Gi"
 
 stages:

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_method_channel.dart';
-import 'package:datadog_flutter_plugin/src/time_provider.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -11,7 +11,6 @@ import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_noop_platform.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_platform_interface.dart';
-import 'package:datadog_flutter_plugin/src/time_provider.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/datadog_session_replay/example/lib/app.dart
+++ b/packages/datadog_session_replay/example/lib/app.dart
@@ -12,6 +12,7 @@ import 'screens/cupertino_widgets_screen.dart';
 import 'screens/main_screen.dart';
 import 'screens/material_widgets_screen.dart';
 import 'screens/simple_containers_screen.dart';
+import 'screens/text_fields_screen.dart';
 import 'screens/text_recording_screen.dart';
 
 const Color datadogPurple = Color.fromARGB(255, 99, 44, 166);
@@ -45,6 +46,10 @@ class _MyAppState extends State<MyApp> {
       GoRoute(
         path: Routes.materialWidgets,
         builder: (context, state) => MaterialWidgetsScreen(),
+      ),
+      GoRoute(
+        path: Routes.textFieldWidgets,
+        builder: (context, state) => TextFieldsScreen(),
       ),
     ],
   );

--- a/packages/datadog_session_replay/example/lib/main.dart
+++ b/packages/datadog_session_replay/example/lib/main.dart
@@ -31,7 +31,10 @@ void main() async {
             )
             : null,
   )..enableSessionReplay(
-    DatadogSessionReplayConfiguration(replaySampleRate: 1.0),
+    DatadogSessionReplayConfiguration(
+      textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      replaySampleRate: 1.0,
+    ),
   );
 
   final ddsdk = DatadogSdk.instance;

--- a/packages/datadog_session_replay/example/lib/routes.dart
+++ b/packages/datadog_session_replay/example/lib/routes.dart
@@ -8,4 +8,5 @@ abstract final class Routes {
   static const String textRecording = '/text_recording';
   static const String cupertinoWidgets = '/cupertino_widgets';
   static const String materialWidgets = '/material_widgets';
+  static const String textFieldWidgets = '/text_fields';
 }

--- a/packages/datadog_session_replay/example/lib/screens/main_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/main_screen.dart
@@ -28,6 +28,7 @@ class _MainScreenState extends State<MainScreen> {
     _RouteScreen('Text Rendering', Routes.textRecording),
     _RouteScreen('Cupertino Widgets', Routes.cupertinoWidgets),
     _RouteScreen('Material Widgets', Routes.materialWidgets),
+    _RouteScreen('Text Fields', Routes.textFieldWidgets),
   ];
 
   @override

--- a/packages/datadog_session_replay/example/lib/screens/text_fields_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/text_fields_screen.dart
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class TextFieldsScreen extends StatefulWidget {
+  const TextFieldsScreen({super.key});
+
+  @override
+  State<TextFieldsScreen> createState() => _TextFieldsScreenState();
+}
+
+class _TextFieldsScreenState extends State<TextFieldsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Text Fields')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          spacing: 12,
+          children: [
+            TextField(
+              decoration: InputDecoration(labelText: 'Simple Text Field'),
+            ),
+            CupertinoTextField(placeholder: 'Cupertino Text Field'),
+            TextField(
+              decoration: InputDecoration(
+                labelText: 'Bordered Text Field',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            TextField(
+              decoration: InputDecoration(
+                labelText: 'Multiline Text Field',
+                border: OutlineInputBorder(),
+              ),
+              minLines: 3,
+              maxLines: 5,
+            ),
+            TextField(
+              decoration: InputDecoration(labelText: 'Password Field'),
+              obscureText: true,
+            ),
+            TextField(
+              decoration: InputDecoration(labelText: 'Email Field'),
+              keyboardType: TextInputType.emailAddress,
+            ),
+            TextField(
+              decoration: InputDecoration(labelText: 'Phone Field'),
+              keyboardType: TextInputType.phone,
+            ),
+            TextField(
+              decoration: InputDecoration(labelText: 'Address Field'),
+              keyboardType: TextInputType.streetAddress,
+            ),
+            TextField(
+              decoration: InputDecoration(labelText: 'Visible Password'),
+              keyboardType: TextInputType.visiblePassword,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/datadog_session_replay/lib/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/datadog_session_replay.dart
@@ -9,12 +9,26 @@ import 'src/datadog_session_replay_plugin.dart';
 export 'src/datadog_session_replay.dart' show DatadogSessionReplay;
 export 'src/widgets.dart' show SessionReplayCapture;
 
+/// Privacy levels for text and input masking in Session Replay
+enum TextAndInputPrivacyLevel {
+  /// Show all text except sensitive inputs (those with obscureText set)
+  maskSensitiveInputs,
+
+  /// Mask all input fields, such as TextField, Checkbox, Switch, etc.
+  maskAllInputs,
+
+  /// Mask all text and inputs, including all Text widgets.
+  maskAll,
+}
+
 class DatadogSessionReplayConfiguration {
   double replaySampleRate;
+  TextAndInputPrivacyLevel textAndInputPrivacyLevel;
   String? customEndpoint;
 
   DatadogSessionReplayConfiguration({
     required this.replaySampleRate,
+    this.textAndInputPrivacyLevel = TextAndInputPrivacyLevel.maskAll,
     this.customEndpoint,
   });
 }

--- a/packages/datadog_session_replay/lib/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/datadog_session_replay.dart
@@ -11,7 +11,7 @@ export 'src/widgets.dart' show SessionReplayCapture;
 
 /// Privacy levels for text and input masking in Session Replay
 enum TextAndInputPrivacyLevel {
-  /// Show all text except sensitive inputs (those with obscureText set)
+  /// Show all text except sensitive inputs (those with [EditableText.obscureText] set)
   maskSensitiveInputs,
 
   /// Mask all input fields, such as TextField, Checkbox, Switch, etc.

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/common_nodes.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/common_nodes.dart
@@ -1,0 +1,250 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/material.dart';
+
+import '../../extensions.dart';
+import '../../sr_data_models.dart';
+import '../capture_node.dart';
+
+@immutable
+class CapturedBorderStyle {
+  final double? cornerRadius;
+  final double? width;
+  final String? color;
+
+  const CapturedBorderStyle({
+    required this.cornerRadius,
+    required this.width,
+    required this.color,
+  });
+
+  static CapturedBorderStyle? fromShapeBorder(
+    ShapeBorder? shape,
+    CapturedViewAttributes attributes,
+  ) {
+    switch (shape) {
+      case final StadiumBorder _:
+        final shortSide = attributes.paintBounds.shortestSide;
+        return CapturedBorderStyle(
+          cornerRadius: shortSide / 2,
+          width: shape.side.width,
+          color: shape.side.color.toHexString(),
+        );
+      case final CircleBorder _:
+        final shortSide = attributes.paintBounds.shortestSide;
+        return CapturedBorderStyle(
+          cornerRadius: shortSide / 2,
+          width: shape.side.width,
+          color: shape.side.color.toHexString(),
+        );
+      case final RoundedRectangleBorder shape:
+        // TODO: TextDirection
+        return CapturedBorderStyle(
+          cornerRadius: shape.borderRadius.resolve(null).topLeft.x,
+          width: shape.side.width,
+          color: shape.side.color.toHexString(),
+        );
+      case final UnderlineInputBorder shape:
+        // TODO: Allow per-side borders
+        return CapturedBorderStyle(
+          cornerRadius: shape.borderRadius.resolve(null).topLeft.x,
+          width: shape.borderSide.width,
+          color: shape.borderSide.color.toHexString(),
+        );
+      case final OutlineInputBorder shape:
+        // TODO: TextDirection
+        return CapturedBorderStyle(
+          cornerRadius: shape.borderRadius.resolve(null).topLeft.x,
+          width: shape.borderSide.width,
+          color: shape.borderSide.color.toHexString(),
+        );
+    }
+    return null;
+  }
+}
+
+@immutable
+class ContainerStyle {
+  final String? backgroundColor;
+  final String? borderColor;
+  final double? borderWidth;
+  final double cornerRadius;
+
+  const ContainerStyle({
+    required this.backgroundColor,
+    this.borderColor,
+    this.borderWidth,
+    this.cornerRadius = 0.0,
+  });
+
+  static ContainerStyle? fromDecoration(
+    Decoration decoration,
+    CapturedViewAttributes attributes,
+  ) {
+    switch (decoration) {
+      case BoxDecoration boxDecoration:
+        return _captureBoxDecoration(boxDecoration);
+      case ShapeDecoration shapeDecoration:
+        return _captureShapeDecoration(shapeDecoration, attributes);
+    }
+    return null;
+  }
+
+  static ContainerStyle? fromInputDecoration(
+    InputDecoration decoration,
+    bool isFocused,
+    CapturedViewAttributes attributes,
+  ) {
+    bool hasError = decoration.errorText != null || decoration.error != null;
+    InputBorder? border;
+    if (!decoration.enabled) {
+      border = hasError ? decoration.errorBorder : decoration.disabledBorder;
+    } else if (isFocused) {
+      border =
+          hasError ? decoration.focusedErrorBorder : decoration.focusedBorder;
+    } else {
+      border = hasError ? decoration.errorBorder : decoration.enabledBorder;
+    }
+    border ??= decoration.border;
+    border ??= _getDefaultInputBorder();
+
+    final capturedBorder = CapturedBorderStyle.fromShapeBorder(
+      border,
+      attributes,
+    );
+    return ContainerStyle(
+      backgroundColor: decoration.fillColor?.toHexString(),
+      borderColor: capturedBorder?.color,
+      cornerRadius: capturedBorder?.cornerRadius ?? 0,
+      borderWidth: capturedBorder?.width,
+    );
+  }
+}
+
+InputBorder _getDefaultInputBorder() {
+  // TODO: Query material state. See input_border.dart:2181
+  return const UnderlineInputBorder();
+}
+
+ContainerStyle _captureBoxDecoration(BoxDecoration decoration) {
+  double? cornerRadius = decoration.borderRadius?.resolve(null).topLeft.x;
+  Color? backgroundColor = decoration.color;
+  double? borderWidth;
+  Color? borderColor;
+  if (decoration.border case final border?) {
+    // TODO: Look into non-uniform borders for SR
+    if (border.top.width > 0) {
+      borderWidth = border.top.width;
+      borderColor = border.top.color;
+    } else if (border.bottom.width > 0) {
+      borderWidth = border.bottom.width;
+      borderColor = border.bottom.color;
+    }
+  }
+
+  return ContainerStyle(
+    backgroundColor: backgroundColor?.toHexString(),
+    borderColor: borderColor?.toHexString(),
+    borderWidth: borderWidth,
+    cornerRadius: cornerRadius ?? 0.0,
+  );
+}
+
+ContainerStyle _captureShapeDecoration(
+  ShapeDecoration decoration,
+  CapturedViewAttributes attributes,
+) {
+  final borderStyle = CapturedBorderStyle.fromShapeBorder(
+    decoration.shape,
+    attributes,
+  );
+  return ContainerStyle(
+    backgroundColor: decoration.color?.toHexString(),
+    borderColor: borderStyle?.color,
+    borderWidth: borderStyle?.width,
+    cornerRadius: borderStyle?.cornerRadius ?? 0.0,
+  );
+}
+
+@immutable
+class ContainerNode extends CaptureNode {
+  final int wireframeId;
+  final ContainerStyle style;
+
+  const ContainerNode(
+    super.attributes, {
+    required this.wireframeId,
+    required this.style,
+  });
+
+  @override
+  List<SRWireframe> buildWireframes() {
+    final attrs = attributes;
+    SRShapeStyle? shapeStyle;
+    SRShapeBorder? shapeBorder;
+    if (style.backgroundColor != null || style.borderWidth != null) {
+      shapeStyle = SRShapeStyle(
+        backgroundColor: style.backgroundColor ?? srTransparentColorString,
+        cornerRadius: style.cornerRadius,
+      );
+
+      if (style.borderWidth != null) {
+        shapeBorder = SRShapeBorder(
+          color: style.borderColor!,
+          width: style.borderWidth!.round(),
+        );
+      }
+    }
+    return [
+      SRShapeWireframe(
+        id: wireframeId,
+        x: attrs.x,
+        y: attrs.y,
+        width: attrs.width,
+        height: attrs.height,
+        shapeStyle: shapeStyle,
+        border: shapeBorder,
+      ),
+    ];
+  }
+}
+
+@immutable
+class TextElementCaptureNode extends CaptureNode {
+  final int wireframeId;
+  final String text;
+  final String color;
+  final String family;
+  final int size;
+  final SRHorizontalAlignment alignment;
+
+  const TextElementCaptureNode(
+    super.attributes, {
+    required this.wireframeId,
+    required this.text,
+    required this.color,
+    required this.family,
+    required this.size,
+    required this.alignment,
+  });
+
+  @override
+  List<SRWireframe> buildWireframes() {
+    return [
+      SRTextWireframe(
+        id: wireframeId,
+        x: attributes.x,
+        y: attributes.y,
+        width: attributes.width,
+        height: attributes.height,
+        text: text,
+        textStyle: SRTextStyle(color: color, family: family, size: size),
+        textPosition: SRTextPosition(
+          alignment: SRAlignment(horizontal: alignment),
+        ),
+      ),
+    ];
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/common_nodes.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/common_nodes.dart
@@ -40,7 +40,8 @@ class CapturedBorderStyle {
           color: shape.side.color.toHexString(),
         );
       case final RoundedRectangleBorder shape:
-        // TODO: TextDirection
+        // Text direction only matters for border radius if we support
+        // per-side borders and per-corner border radius.
         return CapturedBorderStyle(
           cornerRadius: shape.borderRadius.resolve(null).topLeft.x,
           width: shape.side.width,
@@ -54,7 +55,8 @@ class CapturedBorderStyle {
           color: shape.borderSide.color.toHexString(),
         );
       case final OutlineInputBorder shape:
-        // TODO: TextDirection
+        // Text direction only matters for border radius if we support
+        // per-side borders and per-corner border radius.
         return CapturedBorderStyle(
           cornerRadius: shape.borderRadius.resolve(null).topLeft.x,
           width: shape.borderSide.width,

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
@@ -5,38 +5,10 @@
 import 'package:flutter/material.dart';
 
 import '../../extensions.dart';
-import '../../sr_data_models.dart';
 import '../capture_node.dart';
 import '../recorder.dart';
 import '../view_tree_snapshot.dart';
-
-@immutable
-class _ContainerStyle {
-  final String? backgroundColor;
-  final String? borderColor;
-  final double? borderWidth;
-  final double cornerRadius;
-
-  const _ContainerStyle({
-    required this.backgroundColor,
-    this.borderColor,
-    this.borderWidth,
-    this.cornerRadius = 0.0,
-  });
-}
-
-@immutable
-class _BorderStyle {
-  final double? cornerRadius;
-  final double? width;
-  final String? color;
-
-  const _BorderStyle({
-    required this.cornerRadius,
-    required this.width,
-    required this.color,
-  });
-}
+import 'common_nodes.dart';
 
 class ContainerRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
@@ -47,6 +19,7 @@ class ContainerRecorder implements ElementRecorder {
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
   ) {
     final widget = element.widget;
     // Material is also considered a container
@@ -56,7 +29,7 @@ class ContainerRecorder implements ElementRecorder {
       return null;
     }
 
-    _ContainerStyle? style;
+    ContainerStyle? style;
     switch (widget) {
       case Material widget:
         style = _captureMaterialStyle(widget, attributes);
@@ -64,73 +37,23 @@ class ContainerRecorder implements ElementRecorder {
       case Container widget:
         final decoration = widget.decoration;
         if (decoration != null) {
-          style = _captureDecoration(decoration, attributes);
+          style = ContainerStyle.fromDecoration(decoration, attributes);
         }
-        style ??= _ContainerStyle(backgroundColor: widget.color?.toHexString());
+        style ??= ContainerStyle(backgroundColor: widget.color?.toHexString());
         break;
       case DecoratedBox box:
         final decoration = box.decoration;
-        style = _captureDecoration(decoration, attributes);
-        style ??= _ContainerStyle(backgroundColor: null);
+        style = ContainerStyle.fromDecoration(decoration, attributes);
+        style ??= ContainerStyle(backgroundColor: null);
         break;
     }
 
     final key = keyGenerator.keyForElement(element);
-    final node = _ContainerNode(attributes, wireframeId: key, style: style!);
+    final node = ContainerNode(attributes, wireframeId: key, style: style!);
     return AmbiguousElement(nodes: [node]);
   }
 
-  _ContainerStyle? _captureDecoration(
-    Decoration decoration,
-    CapturedViewAttributes attributes,
-  ) {
-    switch (decoration) {
-      case BoxDecoration boxDecoration:
-        return _captureBoxDecoration(boxDecoration);
-      case ShapeDecoration shapeDecoration:
-        return _captureShapeDecoration(shapeDecoration, attributes);
-    }
-    return null;
-  }
-
-  _ContainerStyle _captureBoxDecoration(BoxDecoration decoration) {
-    double? cornerRadius = decoration.borderRadius?.resolve(null).topLeft.x;
-    Color? backgroundColor = decoration.color;
-    double? borderWidth;
-    Color? borderColor;
-    if (decoration.border case final border?) {
-      // TODO: Look into non-uniform borders for SR
-      if (border.top.width > 0) {
-        borderWidth = border.top.width;
-        borderColor = border.top.color;
-      } else if (border.bottom.width > 0) {
-        borderWidth = border.bottom.width;
-        borderColor = border.bottom.color;
-      }
-    }
-
-    return _ContainerStyle(
-      backgroundColor: backgroundColor?.toHexString(),
-      borderColor: borderColor?.toHexString(),
-      borderWidth: borderWidth,
-      cornerRadius: cornerRadius ?? 0.0,
-    );
-  }
-
-  _ContainerStyle _captureShapeDecoration(
-    ShapeDecoration decoration,
-    CapturedViewAttributes attributes,
-  ) {
-    final borderStyle = _extractShapeBorder(decoration.shape, attributes);
-    return _ContainerStyle(
-      backgroundColor: decoration.color?.toHexString(),
-      borderColor: borderStyle?.color,
-      borderWidth: borderStyle?.width,
-      cornerRadius: borderStyle?.cornerRadius ?? 0.0,
-    );
-  }
-
-  _ContainerStyle _captureMaterialStyle(
+  ContainerStyle _captureMaterialStyle(
     Material widget,
     CapturedViewAttributes attributes,
   ) {
@@ -146,86 +69,16 @@ class ContainerRecorder implements ElementRecorder {
       );
     }
 
-    final borderStyle = _extractShapeBorder(widget.shape, attributes);
+    final borderStyle = CapturedBorderStyle.fromShapeBorder(
+      widget.shape,
+      attributes,
+    );
 
-    return _ContainerStyle(
+    return ContainerStyle(
       backgroundColor: backgroundColor?.toHexString(),
       borderColor: borderStyle?.color,
       borderWidth: borderStyle?.width,
       cornerRadius: borderStyle?.cornerRadius ?? 0.0,
     );
-  }
-
-  _BorderStyle? _extractShapeBorder(
-    ShapeBorder? shape,
-    CapturedViewAttributes attributes,
-  ) {
-    switch (shape) {
-      case final StadiumBorder _:
-        final shortSide = attributes.paintBounds.shortestSide;
-        return _BorderStyle(
-          cornerRadius: shortSide / 2,
-          width: shape.side.width,
-          color: shape.side.color.toHexString(),
-        );
-      case final CircleBorder _:
-        final shortSide = attributes.paintBounds.shortestSide;
-        return _BorderStyle(
-          cornerRadius: shortSide / 2,
-          width: shape.side.width,
-          color: shape.side.color.toHexString(),
-        );
-      case final RoundedRectangleBorder shape:
-        // TODO: TextDirection
-        return _BorderStyle(
-          cornerRadius: shape.borderRadius.resolve(null).topLeft.x,
-          width: shape.side.width,
-          color: shape.side.color.toHexString(),
-        );
-    }
-    return null;
-  }
-}
-
-@immutable
-class _ContainerNode extends CaptureNode {
-  final int wireframeId;
-  final _ContainerStyle style;
-
-  const _ContainerNode(
-    super.attributes, {
-    required this.wireframeId,
-    required this.style,
-  });
-
-  @override
-  List<SRWireframe> buildWireframes() {
-    final attrs = attributes;
-    SRShapeStyle? shapeStyle;
-    SRShapeBorder? shapeBorder;
-    if (style.backgroundColor != null || style.borderWidth != null) {
-      shapeStyle = SRShapeStyle(
-        backgroundColor: style.backgroundColor ?? srTransparentColorString,
-        cornerRadius: style.cornerRadius,
-      );
-
-      if (style.borderWidth != null) {
-        shapeBorder = SRShapeBorder(
-          color: style.borderColor!,
-          width: style.borderWidth!.round(),
-        );
-      }
-    }
-    return [
-      SRShapeWireframe(
-        id: wireframeId,
-        x: attrs.x,
-        y: attrs.y,
-        width: attrs.width,
-        height: attrs.height,
-        shapeStyle: shapeStyle,
-        border: shapeBorder,
-      ),
-    ];
   }
 }

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
@@ -21,6 +21,7 @@ class CustomPaintRecorder implements ElementRecorder {
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
   ) {
     final widget = element.widget;
     if (widget is! CustomPaint) return null;

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
@@ -21,7 +21,7 @@ const _sensitiveInputTypes = [
   TextInputType.visiblePassword,
 ];
 
-/// EditableTextRecorder captures the actual editable portion of the
+/// [EditableTextRecorder] captures the actual editable portion of the
 /// text, and handles obscuring the text that's captured.
 class EditableTextRecorder implements ElementRecorder {
   KeyGenerator keyGenerator;
@@ -92,8 +92,8 @@ class EditableTextRecorder implements ElementRecorder {
   }
 }
 
-/// InputDecoratorRecorder handles capturing the border around TextField
-/// and CupertinoTextField widgets.
+/// [InputDecoratorRecorder] handles capturing the border around [TextField]
+/// and [CupertinoTextField] widgets.
 class InputDecoratorRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/material.dart';
+
+import '../../../datadog_session_replay.dart';
+import '../../extensions.dart';
+import '../capture_node.dart';
+import '../recorder.dart';
+import '../view_tree_snapshot.dart';
+import 'common_nodes.dart';
+import 'recording_extensions.dart';
+
+const _sensitiveInputTypes = [
+  TextInputType.name,
+  TextInputType.phone,
+  TextInputType.emailAddress,
+  TextInputType.streetAddress,
+  TextInputType.twitter,
+  TextInputType.visiblePassword,
+];
+
+/// EditableTextRecorder captures the actual editable portion of the
+/// text, and handles obscuring the text that's captured.
+class EditableTextRecorder implements ElementRecorder {
+  KeyGenerator keyGenerator;
+
+  EditableTextRecorder(this.keyGenerator);
+
+  @override
+  CaptureNodeSemantics? captureSemantics(
+    Element element,
+    CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
+  ) {
+    final widget = element.widget;
+    if (widget is! EditableText) {
+      return null;
+    }
+
+    EditableTextState? state;
+    if (element is StatefulElement && element.state is EditableTextState) {
+      state = element.state as EditableTextState;
+    }
+    if (state == null) return null;
+
+    var textValue = state.textEditingValue.text;
+    var textStyle = widget.style;
+    final key = keyGenerator.keyForElement(element);
+    String? font;
+    if (textStyle.fontFamily case final fontFamily?) {
+      font = fontFamily;
+      if (textStyle.fontFamilyFallback case final familyFallback?) {
+        font = [font, ...familyFallback].join(',');
+      }
+    }
+
+    if (_shouldObscureText(capturePrivacy, widget)) {
+      textValue = 'x' * textValue.length;
+    }
+
+    final node = TextElementCaptureNode(
+      attributes,
+      wireframeId: key,
+      text: textValue,
+      color: textStyle.color?.toHexString() ?? Colors.black.toHexString(),
+      family: font ?? '',
+      size: textStyle.fontSize?.round() ?? 10,
+      alignment: widget.textAlign.getSrHorizontalAlignment(
+        widget.textDirection,
+      ),
+    );
+    return SpecificElement(
+      subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
+      nodes: [node],
+    );
+  }
+
+  bool _shouldObscureText(CapturePrivacy capturePrivacy, EditableText widget) {
+    switch (capturePrivacy.textAndInputPrivacyLevel) {
+      case TextAndInputPrivacyLevel.maskSensitiveInputs:
+        if (_sensitiveInputTypes.contains(widget.keyboardType)) {
+          return true;
+        }
+      case TextAndInputPrivacyLevel.maskAllInputs:
+      case TextAndInputPrivacyLevel.maskAll:
+        return true;
+    }
+
+    return false;
+  }
+}
+
+/// InputDecoratorRecorder handles capturing the border around TextField
+/// and CupertinoTextField widgets.
+class InputDecoratorRecorder implements ElementRecorder {
+  final KeyGenerator keyGenerator;
+
+  InputDecoratorRecorder(this.keyGenerator);
+
+  @override
+  CaptureNodeSemantics? captureSemantics(
+    Element element,
+    CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
+  ) {
+    final widget = element.widget;
+    if (widget is! InputDecorator) {
+      return null;
+    }
+
+    final containerStyle = ContainerStyle.fromInputDecoration(
+      widget.decoration,
+      widget.isFocused,
+      attributes,
+    );
+
+    return containerStyle != null
+        ? SpecificElement(
+          subtreeStrategy: CaptureNodeSubtreeStrategy.record,
+          nodes: [
+            ContainerNode(
+              attributes,
+              wireframeId: keyGenerator.keyForElement(element),
+              style: containerStyle,
+            ),
+          ],
+        )
+        : null;
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/recording_extensions.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/recording_extensions.dart
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/widgets.dart';
+
+import '../../sr_data_models.dart';
+
+extension SRTextAlignment on TextAlign {
+  SRHorizontalAlignment getSrHorizontalAlignment(TextDirection? textDirection) {
+    switch (this) {
+      case TextAlign.left:
+      case TextAlign.justify:
+        return SRHorizontalAlignment.left;
+      case TextAlign.start:
+        return textDirection == TextDirection.rtl
+            ? SRHorizontalAlignment.right
+            : SRHorizontalAlignment.left;
+      case TextAlign.right:
+        return SRHorizontalAlignment.right;
+      case TextAlign.end:
+        return textDirection == TextDirection.rtl
+            ? SRHorizontalAlignment.left
+            : SRHorizontalAlignment.right;
+      case TextAlign.center:
+        return SRHorizontalAlignment.center;
+    }
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
@@ -5,10 +5,11 @@
 import 'package:flutter/material.dart';
 
 import '../../extensions.dart';
-import '../../sr_data_models.dart';
 import '../capture_node.dart';
 import '../recorder.dart';
 import '../view_tree_snapshot.dart';
+import 'common_nodes.dart';
+import 'recording_extensions.dart';
 
 class TextElementRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
@@ -19,6 +20,7 @@ class TextElementRecorder implements ElementRecorder {
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
   ) {
     final widget = element.widget;
     if (widget is! RichText) {
@@ -28,20 +30,22 @@ class TextElementRecorder implements ElementRecorder {
     final textSpan = widget.text;
     if (textSpan is TextSpan) {
       final style = textSpan.style;
-      final alignment = _getDatadogHorizontalAlignment(widget);
+      final alignment = widget.textAlign.getSrHorizontalAlignment(
+        widget.textDirection,
+      );
 
       // For now, contact all child spans into a single string.
       // TODO(RUM-10230: Research how to support inline spans with different styles
       final stringBuilder = StringBuffer();
       bool hasWidgetChildern = _getText(textSpan, stringBuilder);
 
-      final node = _TextElementCaptureNode(
+      final node = TextElementCaptureNode(
         attributes,
         wireframeId: keyGenerator.keyForElement(element),
         text: stringBuilder.toString(),
         color: style?.color?.toHexString() ?? Colors.black.toHexString(),
         family: style?.fontFamily ?? '',
-        size: style?.fontSize?.round() ?? 10,
+        size: ((style?.fontSize?.toInt() ?? 10) * attributes.scaleX).toInt(),
         alignment: alignment,
       );
 
@@ -70,64 +74,5 @@ class TextElementRecorder implements ElementRecorder {
       }
     });
     return hasWidgetChildren;
-  }
-
-  SRHorizontalAlignment _getDatadogHorizontalAlignment(RichText widget) {
-    final textDirection = widget.textDirection;
-    switch (widget.textAlign) {
-      case TextAlign.left:
-      case TextAlign.justify:
-        return SRHorizontalAlignment.left;
-      case TextAlign.start:
-        return textDirection == TextDirection.rtl
-            ? SRHorizontalAlignment.right
-            : SRHorizontalAlignment.left;
-      case TextAlign.right:
-        return SRHorizontalAlignment.right;
-      case TextAlign.end:
-        return textDirection == TextDirection.rtl
-            ? SRHorizontalAlignment.left
-            : SRHorizontalAlignment.right;
-      case TextAlign.center:
-        return SRHorizontalAlignment.center;
-    }
-  }
-}
-
-@immutable
-class _TextElementCaptureNode extends CaptureNode {
-  final int wireframeId;
-  final String text;
-  final String color;
-  final String family;
-  final int size;
-  final SRHorizontalAlignment alignment;
-
-  const _TextElementCaptureNode(
-    super.attributes, {
-    required this.wireframeId,
-    required this.text,
-    required this.color,
-    required this.family,
-    required this.size,
-    required this.alignment,
-  });
-
-  @override
-  List<SRWireframe> buildWireframes() {
-    return [
-      SRTextWireframe(
-        id: wireframeId,
-        x: attributes.x,
-        y: attributes.y,
-        width: attributes.width,
-        height: attributes.height,
-        text: text,
-        textStyle: SRTextStyle(color: color, family: family, size: size),
-        textPosition: SRTextPosition(
-          alignment: SRAlignment(horizontal: alignment),
-        ),
-      ),
-    ];
   }
 }

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -207,7 +207,9 @@ class SessionReplayRecorder {
         renderObject.paintBounds,
       );
       // Don't capture things that take up no space.
-      if (paintBounds.width == 0 || paintBounds.height == 0) return;
+      if (paintBounds.width == 0 && paintBounds.height == 0) {
+        return;
+      }
 
       final scaleX = paintBounds.width / untransformedPaintBounds.width;
       final scaleY = paintBounds.height / untransformedPaintBounds.height;

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -4,22 +4,46 @@
 
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
+import '../../datadog_session_replay.dart';
 import '../datadog_session_replay_platform_interface.dart';
 import '../rum_context.dart';
 import '../widgets.dart';
 import 'capture_node.dart';
 import 'element_recorders/container_recorder.dart';
 import 'element_recorders/custom_paint_recorder.dart';
+import 'element_recorders/editable_text_recorder.dart';
 import 'element_recorders/text_recorder.dart';
 import 'pointer_capture.dart';
 import 'view_tree_snapshot.dart';
+
+/// Capture privacy for the current tree of nodes. This is set by the configuration,
+/// to start, but can change if the capture encounters a Widget that modifies it.
+@immutable
+class CapturePrivacy {
+  final TextAndInputPrivacyLevel textAndInputPrivacyLevel;
+
+  const CapturePrivacy({required this.textAndInputPrivacyLevel});
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! CapturePrivacy) return false;
+
+    return other.textAndInputPrivacyLevel == textAndInputPrivacyLevel;
+  }
+
+  @override
+  int get hashCode {
+    return textAndInputPrivacyLevel.hashCode;
+  }
+}
 
 abstract interface class ElementRecorder {
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
   );
 }
 
@@ -61,15 +85,27 @@ class SessionReplayRecorder {
 
   final DatadogTimeProvider _timeProvider;
   final List<ElementRecorder> _elementRecorders;
+  CapturePrivacy _defaultCapturePrivacy;
+
+  @visibleForTesting
+  set defaultCapturePrivacy(CapturePrivacy value) =>
+      _defaultCapturePrivacy = value;
+  CapturePrivacy get defaultCapturePrivacy => _defaultCapturePrivacy;
 
   SessionReplayRecorder({
     DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
-  }) : this._(KeyGenerator(), timeProvider);
+    required CapturePrivacy defaultCapturePrivacy,
+  }) : this._(KeyGenerator(), timeProvider, defaultCapturePrivacy);
 
-  SessionReplayRecorder._(KeyGenerator keyGenerator, this._timeProvider)
-    : _elementRecorders = [
+  SessionReplayRecorder._(
+    KeyGenerator keyGenerator,
+    this._timeProvider,
+    this._defaultCapturePrivacy,
+  ) : _elementRecorders = [
         ContainerRecorder(keyGenerator),
         TextElementRecorder(keyGenerator),
+        EditableTextRecorder(keyGenerator),
+        InputDecoratorRecorder(keyGenerator),
         CustomPaintRecorder(keyGenerator),
       ];
 
@@ -77,7 +113,9 @@ class SessionReplayRecorder {
   SessionReplayRecorder.withCustomRecorders(
     this._elementRecorders, {
     DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
-  }) : _timeProvider = timeProvider;
+    required CapturePrivacy defaultCapturePrivacy,
+  }) : _timeProvider = timeProvider,
+       _defaultCapturePrivacy = defaultCapturePrivacy;
 
   void updateContext(RUMContext? context) {
     _currentContext = context;
@@ -113,7 +151,7 @@ class SessionReplayRecorder {
         // returned by the element is not serializable over the isolate
         size = Size(elementSize.width, elementSize.height);
       }
-      _captureElement(e, nodes, pointerSnapshots);
+      _captureElement(e, nodes, pointerSnapshots, _defaultCapturePrivacy);
     }
 
     if (nodes.isEmpty) return null;
@@ -125,7 +163,7 @@ class SessionReplayRecorder {
       nodes: nodes,
     );
 
-    // TODO: We dhouldn't have multiple pointer snapshots, but even if we
+    // We shouldn't have multiple pointer snapshots, but even if we
     // do, for now just take the first one.
     final pointerSnapshot = pointerSnapshots.firstOrNull;
 
@@ -142,8 +180,9 @@ class SessionReplayRecorder {
     Element topElement,
     List<CaptureNode> nodes,
     List<PointerSnapshot> pointerSnapshots,
+    CapturePrivacy capturePrivacy,
   ) {
-    void visit(Element e, int depth) {
+    void visit(Element e, CapturePrivacy capturePrivacy, int depth) {
       if (e.widget case final PointerRecorder snapshotWidget) {
         if (snapshotWidget.snapshotRecorder.takeSnapshot()
             case final snapshot?) {
@@ -161,17 +200,31 @@ class SessionReplayRecorder {
       final transformMatrix = renderObject.getTransformTo(
         topElement.renderObject,
       );
+      final untransformedPaintBounds = renderObject.paintBounds;
+
       final paintBounds = MatrixUtils.transformRect(
         transformMatrix,
         renderObject.paintBounds,
       );
+      // Don't capture things that take up no space.
+      if (paintBounds.width == 0 || paintBounds.height == 0) return;
+
+      final scaleX = paintBounds.width / untransformedPaintBounds.width;
+      final scaleY = paintBounds.height / untransformedPaintBounds.height;
       final viewAttributes = CapturedViewAttributes(
         paintBounds: paintBounds,
-        scaleX: 1.0,
-        scaleY: 1,
+        scaleX: scaleX,
+        scaleY: scaleY,
       );
 
-      final elementSemantics = _elementSemantics(e, viewAttributes);
+      final elementSemantics = _elementSemantics(
+        e,
+        viewAttributes,
+        capturePrivacy,
+      );
+      if (elementSemantics.subtreePrivacy case final newCapturePrivacy?) {
+        capturePrivacy = newCapturePrivacy;
+      }
 
       nodes.addAll(elementSemantics.nodes);
 
@@ -181,22 +234,27 @@ class SessionReplayRecorder {
           final renderObject = child.renderObject;
           if (renderObject == null) return;
 
-          visit(child, depth + 1);
+          visit(child, capturePrivacy, depth + 1);
         });
       }
     }
 
-    visit(topElement, 0);
+    visit(topElement, capturePrivacy, 0);
   }
 
   CaptureNodeSemantics _elementSemantics(
     Element element,
     CapturedViewAttributes viewAttributes,
+    CapturePrivacy capturePrivacy,
   ) {
     CaptureNodeSemantics semantics = const UnknownElement();
 
     for (final recorder in _elementRecorders) {
-      final nextSemantics = recorder.captureSemantics(element, viewAttributes);
+      final nextSemantics = recorder.captureSemantics(
+        element,
+        viewAttributes,
+        capturePrivacy,
+      );
       if (nextSemantics == null) continue;
 
       if (nextSemantics.importance >= semantics.importance) {

--- a/packages/datadog_session_replay/lib/src/capture/view_tree_snapshot.dart
+++ b/packages/datadog_session_replay/lib/src/capture/view_tree_snapshot.dart
@@ -6,6 +6,7 @@ import 'package:flutter/widgets.dart';
 
 import '../rum_context.dart';
 import 'capture_node.dart';
+import 'recorder.dart';
 
 @immutable
 class ViewTreeSnapshot {
@@ -31,18 +32,20 @@ abstract class CaptureNodeSemantics {
 
   final int importance;
   final CaptureNodeSubtreeStrategy subtreeStrategy;
+  final CapturePrivacy? subtreePrivacy;
   final List<CaptureNode> nodes;
 
   const CaptureNodeSemantics({
     required this.importance,
     required this.subtreeStrategy,
+    this.subtreePrivacy,
     required this.nodes,
   });
 }
 
 @immutable
 class UnknownElement extends CaptureNodeSemantics {
-  const UnknownElement()
+  const UnknownElement({super.subtreePrivacy})
     : super(
         importance: CaptureNodeSemantics.minImportance,
         subtreeStrategy: CaptureNodeSubtreeStrategy.record,
@@ -52,26 +55,33 @@ class UnknownElement extends CaptureNodeSemantics {
 
 @immutable
 class InvisibleElement extends CaptureNodeSemantics {
-  const InvisibleElement({required super.subtreeStrategy})
+  const InvisibleElement({required super.subtreeStrategy, super.subtreePrivacy})
     : super(importance: 0, nodes: const []);
 }
 
 @immutable
 class IgnoredElement extends CaptureNodeSemantics {
-  const IgnoredElement({required super.subtreeStrategy, super.nodes = const []})
-    : super(importance: CaptureNodeSemantics.maxImporance);
+  const IgnoredElement({
+    required super.subtreeStrategy,
+    super.nodes = const [],
+    final CapturePrivacy? subtreePrivacy,
+  }) : super(importance: CaptureNodeSemantics.maxImporance);
 }
 
 @immutable
 class AmbiguousElement extends CaptureNodeSemantics {
   const AmbiguousElement({
     super.subtreeStrategy = CaptureNodeSubtreeStrategy.record,
+    super.subtreePrivacy,
     required super.nodes,
   }) : super(importance: 0);
 }
 
 @immutable
 class SpecificElement extends CaptureNodeSemantics {
-  const SpecificElement({required super.subtreeStrategy, required super.nodes})
-    : super(importance: CaptureNodeSemantics.maxImporance);
+  const SpecificElement({
+    required super.subtreeStrategy,
+    super.subtreePrivacy,
+    required super.nodes,
+  }) : super(importance: CaptureNodeSemantics.maxImporance);
 }

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -25,7 +25,7 @@ class DatadogSessionReplay {
   final InternalLogger internalLogger;
 
   final SessionReplayProcessor _processor = SessionReplayProcessor();
-  final SessionReplayRecorder _recorder = SessionReplayRecorder();
+  final SessionReplayRecorder _recorder;
 
   @internal
   static Future<DatadogSessionReplay> init(
@@ -37,7 +37,12 @@ class DatadogSessionReplay {
     return _instance!;
   }
 
-  DatadogSessionReplay._(this._configuration, this.internalLogger);
+  DatadogSessionReplay._(this._configuration, this.internalLogger)
+    : _recorder = SessionReplayRecorder(
+        defaultCapturePrivacy: CapturePrivacy(
+          textAndInputPrivacyLevel: _configuration.textAndInputPrivacyLevel,
+        ),
+      );
 
   void addElement(Key key, Element e) {
     _recorder.addElement(key, e);

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay_plugin.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay_plugin.dart
@@ -8,7 +8,6 @@ import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 
 import '../datadog_session_replay.dart';
-import 'datadog_session_replay.dart';
 
 class DatadogSessionReplayPluginConfiguration
     extends DatadogPluginConfiguration {

--- a/packages/datadog_session_replay/test/capture/container_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/container_recorder_test.dart
@@ -3,6 +3,7 @@
 // Copyright 2025-Present Datadog, Inc.
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/capture/capture_node.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/container_recorder.dart';
 import 'package:datadog_session_replay/src/capture/recorder.dart';
@@ -23,9 +24,12 @@ void main() {
   late RUMContext context;
 
   setUp(() {
-    recorder = SessionReplayRecorder.withCustomRecorders([
-      ContainerRecorder(KeyGenerator()),
-    ]);
+    recorder = SessionReplayRecorder.withCustomRecorders(
+      [ContainerRecorder(KeyGenerator())],
+      defaultCapturePrivacy: CapturePrivacy(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      ),
+    );
 
     registerFallbackValue(
       CapturedViewAttributes(paintBounds: Rect.zero, scaleX: 1.0, scaleY: 1.0),

--- a/packages/datadog_session_replay/test/capture/custom_paint_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/custom_paint_recorder_test.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/capture/capture_node.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/custom_paint_recorder.dart';
 import 'package:datadog_session_replay/src/capture/recorder.dart';
@@ -28,9 +29,12 @@ void main() {
   late RUMContext context;
 
   setUp(() {
-    recorder = SessionReplayRecorder.withCustomRecorders([
-      CustomPaintRecorder(KeyGenerator()),
-    ]);
+    recorder = SessionReplayRecorder.withCustomRecorders(
+      [CustomPaintRecorder(KeyGenerator())],
+      defaultCapturePrivacy: CapturePrivacy(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      ),
+    );
 
     registerFallbackValue(
       CapturedViewAttributes(paintBounds: Rect.zero, scaleX: 1.0, scaleY: 1.0),

--- a/packages/datadog_session_replay/test/capture/editable_text_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/editable_text_recorder_test.dart
@@ -1,0 +1,304 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
+import 'package:datadog_session_replay/src/capture/capture_node.dart';
+import 'package:datadog_session_replay/src/capture/element_recorders/container_recorder.dart';
+import 'package:datadog_session_replay/src/capture/element_recorders/editable_text_recorder.dart';
+import 'package:datadog_session_replay/src/capture/element_recorders/text_recorder.dart';
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:datadog_session_replay/src/extensions.dart';
+import 'package:datadog_session_replay/src/rum_context.dart';
+import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils.dart';
+import 'simple_test_capture.dart';
+
+void main() {
+  late SessionReplayRecorder recorder;
+  late RUMContext context;
+
+  setUp(() {
+    final KeyGenerator keyGenerator = KeyGenerator();
+    recorder = SessionReplayRecorder.withCustomRecorders(
+      [
+        TextElementRecorder(keyGenerator),
+        ContainerRecorder(keyGenerator),
+        EditableTextRecorder(keyGenerator),
+        InputDecoratorRecorder(keyGenerator),
+      ],
+      defaultCapturePrivacy: CapturePrivacy(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      ),
+    );
+
+    registerFallbackValue(
+      CapturedViewAttributes(paintBounds: Rect.zero, scaleX: 1.0, scaleY: 1.0),
+    );
+
+    context = RUMContext(
+      applicationId: randomString(),
+      sessionId: randomString(),
+    );
+    recorder.updateContext(context);
+  });
+
+  testWidgets('returns elements of EditableText', (tester) async {
+    // Given
+    final x = randomDouble(min: 10, max: 50);
+    final y = randomDouble(min: 10, max: 50);
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                top: y,
+                left: x,
+                width: width,
+                height: height,
+                child: EditableText(
+                  controller: controller,
+                  focusNode: focusNode,
+                  style: TextStyle(),
+                  cursorColor: Colors.blue,
+                  backgroundCursorColor: Colors.white,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture!.viewTreeSnapshot.nodes.length, 2);
+
+    final capturedTextNode = capture.viewTreeSnapshot.nodes.last;
+    expect(capturedTextNode.attributes.x, x.round());
+    expect(capturedTextNode.attributes.y, y.round());
+    expect(capturedTextNode.attributes.width, width.round());
+    expect(capturedTextNode.attributes.height, height.round());
+  });
+
+  testWidgets('returns decorator elements of TextField', (tester) async {
+    // Given
+    final x = randomDouble(min: 10, max: 50);
+    final y = randomDouble(min: 10, max: 50);
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Scaffold(
+          body: Stack(
+            children: [
+              Positioned(
+                top: y,
+                left: x,
+                width: width,
+                height: height,
+                child: TextField(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    // Here, we get a top level material, the TextField border, and the Editable text
+    expect(capture!.viewTreeSnapshot.nodes.length, 3);
+
+    // Input decoration should be captured before editable text
+    final capturedTextNode = capture.viewTreeSnapshot.nodes[1];
+    expect(capturedTextNode.attributes.x, x.round());
+    expect(capturedTextNode.attributes.y, y.round());
+    expect(capturedTextNode.attributes.width, width.round());
+    expect(capturedTextNode.attributes.height, height.round());
+  });
+
+  testWidgets('build wireframes captures text style', (tester) async {
+    // Given
+    final style = TextStyle(
+      color: randomColor(),
+      fontFamily: 'Fake Font',
+      fontFamilyFallback: ['Fake Fallback A', 'Fake Fallback B'],
+      fontSize: randomDouble(min: 12, max: 80),
+    );
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Scaffold(body: Stack(children: [TextField(style: style)])),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture!.viewTreeSnapshot.nodes.length, 3);
+
+    final capturedTextNode = capture.viewTreeSnapshot.nodes.last;
+    final wireframes = capturedTextNode.buildWireframes();
+    expect(wireframes.length, 1);
+    final textWireframe = wireframes.first as SRTextWireframe;
+    expect(textWireframe.text, isEmpty);
+    expect(textWireframe.textStyle.color, style.color?.toHexString());
+    expect(
+      textWireframe.textStyle.family,
+      'Fake Font,Fake Fallback A,Fake Fallback B',
+    );
+    expect(textWireframe.textStyle.size, style.fontSize?.round());
+  });
+
+  testWidgets('build wireframes captures current text state', (tester) async {
+    // Given
+    final text = randomString();
+    final controller = TextEditingController(text: text);
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Scaffold(
+          body: Stack(children: [TextField(controller: controller)]),
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    final capturedTextNode = capture!.viewTreeSnapshot.nodes.last;
+    final wireframes = capturedTextNode.buildWireframes();
+    expect(wireframes.length, 1);
+    final textWireframe = wireframes.first as SRTextWireframe;
+    expect(textWireframe.text, text);
+  });
+
+  testWidgets('captured text is obscured when privacy set to maskAllInputs', (
+    tester,
+  ) async {
+    // Given
+    recorder.defaultCapturePrivacy = CapturePrivacy(
+      textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskAllInputs,
+    );
+    final text = randomString();
+    final controller = TextEditingController(text: text);
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Scaffold(
+          body: Stack(children: [TextField(controller: controller)]),
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    final capturedTextNode = capture!.viewTreeSnapshot.nodes.last;
+    final wireframes = capturedTextNode.buildWireframes();
+    expect(wireframes.length, 1);
+    final textWireframe = wireframes.first as SRTextWireframe;
+    expect(textWireframe.text, ('x' * text.length));
+  });
+
+  testWidgets('captured text is obscured when privacy set to maskAll', (
+    tester,
+  ) async {
+    // Given
+    recorder.defaultCapturePrivacy = CapturePrivacy(
+      textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskAll,
+    );
+    final text = randomString();
+    final controller = TextEditingController(text: text);
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Scaffold(
+          body: Stack(children: [TextField(controller: controller)]),
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    final capturedTextNode = capture!.viewTreeSnapshot.nodes.last;
+    final wireframes = capturedTextNode.buildWireframes();
+    expect(wireframes.length, 1);
+    final textWireframe = wireframes.first as SRTextWireframe;
+    expect(textWireframe.text, ('x' * text.length));
+  });
+
+  final maskedTextInputTypes = [
+    TextInputType.name,
+    TextInputType.phone,
+    TextInputType.emailAddress,
+    TextInputType.streetAddress,
+    TextInputType.twitter,
+    TextInputType.visiblePassword,
+  ];
+  for (final inputType in maskedTextInputTypes) {
+    testWidgets('captured text is obscured for $inputType', (tester) async {
+      // Given
+      final text = randomString();
+      final controller = TextEditingController(text: text);
+      final tree = MaterialApp(
+        home: SimpleTestCapture(
+          key: Key('key'),
+          recorder: recorder,
+          child: Scaffold(
+            body: Stack(
+              children: [
+                TextField(controller: controller, keyboardType: inputType),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpWidget(tree);
+
+      // When
+      final capture = recorder.performCapture();
+
+      // Then
+      final capturedTextNode = capture!.viewTreeSnapshot.nodes.last;
+      final wireframes = capturedTextNode.buildWireframes();
+      expect(wireframes.length, 1);
+      final textWireframe = wireframes.first as SRTextWireframe;
+      expect(textWireframe.text, ('x' * text.length));
+    });
+  }
+}

--- a/packages/datadog_session_replay/test/capture/recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/recorder_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/capture/capture_node.dart';
 import 'package:datadog_session_replay/src/capture/pointer_capture.dart';
 import 'package:datadog_session_replay/src/capture/recorder.dart';
@@ -42,7 +43,13 @@ void main() {
     setUp(() {
       mockTimeProvider = MockTimeProvider();
       when(() => mockTimeProvider.now()).thenReturn(expectedDateTime);
-      recorder = SessionReplayRecorder(timeProvider: mockTimeProvider);
+      recorder = SessionReplayRecorder(
+        timeProvider: mockTimeProvider,
+        defaultCapturePrivacy: CapturePrivacy(
+          textAndInputPrivacyLevel:
+              TextAndInputPrivacyLevel.maskSensitiveInputs,
+        ),
+      );
     });
 
     test('capture with no context returns null ', () {
@@ -71,15 +78,25 @@ void main() {
     final mockRecorderA = MockElementRecorder();
 
     setUp(() {
-      recorder = SessionReplayRecorder.withCustomRecorders([
-        mockRecorderA,
-      ], timeProvider: mockTimeProvider);
+      recorder = SessionReplayRecorder.withCustomRecorders(
+        [mockRecorderA],
+        timeProvider: mockTimeProvider,
+        defaultCapturePrivacy: CapturePrivacy(
+          textAndInputPrivacyLevel:
+              TextAndInputPrivacyLevel.maskSensitiveInputs,
+        ),
+      );
 
       registerFallbackValue(
         CapturedViewAttributes(
           paintBounds: Rect.zero,
           scaleX: 1.0,
           scaleY: 1.0,
+        ),
+      );
+      registerFallbackValue(
+        CapturePrivacy(
+          textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskAll,
         ),
       );
       registerFallbackValue(MockElement());
@@ -90,7 +107,7 @@ void main() {
     ) async {
       // Given
       when(
-        () => mockRecorderA.captureSemantics(any(), captureAny()),
+        () => mockRecorderA.captureSemantics(any(), captureAny(), any()),
       ).thenAnswer(
         (invocation) => SpecificElement(
           subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
@@ -122,7 +139,7 @@ void main() {
     ) async {
       // Given
       when(
-        () => mockRecorderA.captureSemantics(any(), captureAny()),
+        () => mockRecorderA.captureSemantics(any(), captureAny(), any()),
       ).thenAnswer(
         (invocation) => SpecificElement(
           subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
@@ -153,7 +170,7 @@ void main() {
       (tester) async {
         // Given
         when(
-          () => mockRecorderA.captureSemantics(any(), captureAny()),
+          () => mockRecorderA.captureSemantics(any(), captureAny(), any()),
         ).thenAnswer(
           (invocation) => SpecificElement(
             subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
@@ -187,7 +204,7 @@ void main() {
     ) async {
       // Given
       when(
-        () => mockRecorderA.captureSemantics(any(), captureAny()),
+        () => mockRecorderA.captureSemantics(any(), captureAny(), any()),
       ).thenAnswer((invocation) {
         var subtreeStrategy = CaptureNodeSubtreeStrategy.record;
         if ((invocation.positionalArguments[0] as Element).widget
@@ -219,13 +236,69 @@ void main() {
       expect(capture!.viewTreeSnapshot.nodes.length, 3);
     });
 
+    testWidgets('cpature subtree passes new capture privacy when overwritten', (
+      tester,
+    ) async {
+      // Given
+      when(
+        () => mockRecorderA.captureSemantics(any(), captureAny(), any()),
+      ).thenAnswer((invocation) {
+        var subtreeStrategy = CaptureNodeSubtreeStrategy.record;
+        if ((invocation.positionalArguments[0] as Element).widget
+            is Placeholder) {
+          subtreeStrategy = CaptureNodeSubtreeStrategy.ignore;
+        }
+        return SpecificElement(
+          subtreeStrategy: subtreeStrategy,
+          subtreePrivacy: CapturePrivacy(
+            textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskAll,
+          ),
+          nodes: [MockCaptureNode()],
+        );
+      });
+      final context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+
+      // When
+      final testedTree = SimpleTestCapture(
+        key: UniqueKey(),
+        recorder: recorder,
+        child: Center(child: Placeholder()),
+      );
+      await tester.pumpWidget(testedTree);
+      final _ = recorder.performCapture();
+
+      // Then
+      verifyInOrder([
+        () => mockRecorderA.captureSemantics(
+          any(),
+          any(),
+          CapturePrivacy(
+            textAndInputPrivacyLevel:
+                TextAndInputPrivacyLevel.maskSensitiveInputs,
+          ),
+        ),
+        () => mockRecorderA.captureSemantics(
+          any(),
+          any(),
+          CapturePrivacy(
+            textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskAll,
+          ),
+        ),
+      ]);
+    });
+
     testWidgets('capture uses recorder nodes with highest importance', (
       tester,
     ) async {
       // Given
       final lowImportanceRecorder = MockElementRecorder();
       when(
-        () => lowImportanceRecorder.captureSemantics(any(), captureAny()),
+        () =>
+            lowImportanceRecorder.captureSemantics(any(), captureAny(), any()),
       ).thenAnswer((invocation) {
         return AmbiguousElement(
           subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
@@ -233,7 +306,7 @@ void main() {
         );
       });
       when(
-        () => mockRecorderA.captureSemantics(any(), captureAny()),
+        () => mockRecorderA.captureSemantics(any(), captureAny(), any()),
       ).thenAnswer((invocation) {
         return SpecificElement(
           subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,
@@ -276,16 +349,20 @@ void main() {
 
       final mockElementRecorder = MockElementRecorder();
       when(
-        () => mockElementRecorder.captureSemantics(any(), captureAny()),
+        () => mockElementRecorder.captureSemantics(any(), captureAny(), any()),
       ).thenAnswer(
         (invocation) => SpecificElement(
           subtreeStrategy: CaptureNodeSubtreeStrategy.record,
           nodes: [MockCaptureNode()],
         ),
       );
-      recorder = SessionReplayRecorder.withCustomRecorders([
-        mockElementRecorder,
-      ]);
+      recorder = SessionReplayRecorder.withCustomRecorders(
+        [mockElementRecorder],
+        defaultCapturePrivacy: CapturePrivacy(
+          textAndInputPrivacyLevel:
+              TextAndInputPrivacyLevel.maskSensitiveInputs,
+        ),
+      );
     });
 
     testWidgets('pointer recorder snapshot returned from capture', (

--- a/packages/datadog_session_replay/test/capture/text_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/text_recorder_test.dart
@@ -5,6 +5,7 @@
 // Note: to properly test recorders, we need to supply a full widget tree, as Element
 // is too difficult to mock effectively.
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/capture/capture_node.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/container_recorder.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/text_recorder.dart';
@@ -24,9 +25,12 @@ void main() {
   late RUMContext context;
 
   setUp(() {
-    recorder = SessionReplayRecorder.withCustomRecorders([
-      TextElementRecorder(KeyGenerator()),
-    ]);
+    recorder = SessionReplayRecorder.withCustomRecorders(
+      [TextElementRecorder(KeyGenerator())],
+      defaultCapturePrivacy: CapturePrivacy(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      ),
+    );
 
     registerFallbackValue(
       CapturedViewAttributes(paintBounds: Rect.zero, scaleX: 1.0, scaleY: 1.0),
@@ -144,6 +148,49 @@ void main() {
     });
   });
 
+  testWidgets('text scale is modified transform', (tester) async {
+    // Given
+    final textData = randomString();
+
+    final tree = SimpleTestCapture(
+      key: Key('key'),
+      recorder: recorder,
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          children: [
+            Text(textData),
+            Transform(
+              transform: Matrix4.identity()..scale(0.5),
+              child: Text(textData),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture, isNotNull);
+    final treeCapture = capture!.viewTreeSnapshot;
+    final firstTextNode = treeCapture.nodes[0];
+    final secondTextNode = treeCapture.nodes[1];
+
+    final firstWireframe =
+        firstTextNode.buildWireframes().first as SRTextWireframe;
+    final secondWireframe =
+        secondTextNode.buildWireframes().first as SRTextWireframe;
+    expect(secondWireframe.width, (firstWireframe.width ~/ 2));
+    expect(secondWireframe.height, (firstWireframe.height ~/ 2));
+    expect(
+      secondWireframe.textStyle.size,
+      (firstWireframe.textStyle.size ~/ 2),
+    );
+  });
+
   group('rich text', () {
     testWidgets('text span tree is concatenated to single record', (
       tester,
@@ -229,10 +276,13 @@ void main() {
       // Given
       // Use a different recorder that is capable of capturing containers.
       final keyGenerator = KeyGenerator();
-      recorder = SessionReplayRecorder.withCustomRecorders([
-        TextElementRecorder(keyGenerator),
-        ContainerRecorder(keyGenerator),
-      ]);
+      recorder = SessionReplayRecorder.withCustomRecorders(
+        [TextElementRecorder(keyGenerator), ContainerRecorder(keyGenerator)],
+        defaultCapturePrivacy: CapturePrivacy(
+          textAndInputPrivacyLevel:
+              TextAndInputPrivacyLevel.maskSensitiveInputs,
+        ),
+      );
       recorder.updateContext(context);
 
       final textData = randomString();

--- a/packages/datadog_session_replay/test/capture/text_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/text_recorder_test.dart
@@ -115,7 +115,7 @@ void main() {
       final shapeWireframe = builtWireframes.first as SRTextWireframe;
       expect(shapeWireframe.text, textData);
       expect(shapeWireframe.textStyle.color, style.color!.toHexString());
-      expect(shapeWireframe.textStyle.size, style.fontSize!.round());
+      expect(shapeWireframe.textStyle.size, style.fontSize!.toInt());
     });
 
     testWidgets('text returns proper positioning', (tester) async {

--- a/packages/datadog_session_replay/test/datadog_session_replay_test.dart
+++ b/packages/datadog_session_replay/test/datadog_session_replay_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_session_replay/datadog_session_replay.dart';
-import 'package:datadog_session_replay/src/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/datadog_session_replay_method_channel.dart';
 import 'package:datadog_session_replay/src/datadog_session_replay_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
### What and why?

Capturing text fields currently captures both the InputDecorator widget and the EditableText widgets. For now, UnderlineInputDecorator is pretending it is a rounded rectangle, though we will change that when we get support either for custom paint or per-side borders.

Some bugs still exist with capture, including currently capturing placeholder text even when it shouldn't be visible, and borders overlapping text in bordered fields.

refs: RUM-10254

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
