### PR TITLE
feat: Add placeholder image recording

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/widgets.dart';
+
+import '../../sr_data_models.dart';
+import '../capture_node.dart';
+import '../recorder.dart';
+import '../view_tree_snapshot.dart';
+
+// This size was chosen so that 'Content Image' would fit without
+// overlappping other content in the replay.
+const int labelMinWidth = 200;
+
+class ImageRecorder implements ElementRecorder {
+  final KeyGenerator keyGenerator;
+
+  const ImageRecorder(this.keyGenerator);
+
+  @override
+  CaptureNodeSemantics? captureSemantics(
+    Element element,
+    CapturedViewAttributes attributes,
+    CapturePrivacy capturePrivacy,
+  ) {
+    final widget = element.widget;
+    if (widget is! Image) return null;
+
+    final elementId = keyGenerator.keyForElement(element);
+    return SpecificElement(
+      subtreeStrategy: CaptureNodeSubtreeStrategy.record,
+      nodes: [_ImageNode(attributes, wireframeId: elementId)],
+    );
+  }
+}
+
+@immutable
+class _ImageNode extends CaptureNode {
+  final int wireframeId;
+
+  const _ImageNode(super.attributes, {required this.wireframeId});
+
+  @override
+  List<SRWireframe> buildWireframes() {
+    final label = attributes.width < labelMinWidth ? null : 'Content Image';
+    return [
+      SRPlaceholderWireframe(
+        id: wireframeId,
+        x: attributes.x,
+        y: attributes.y,
+        width: attributes.width,
+        height: attributes.height,
+        label: label,
+      ),
+    ];
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -14,6 +14,7 @@ import 'capture_node.dart';
 import 'element_recorders/container_recorder.dart';
 import 'element_recorders/custom_paint_recorder.dart';
 import 'element_recorders/editable_text_recorder.dart';
+import 'element_recorders/image_recorder.dart';
 import 'element_recorders/text_recorder.dart';
 import 'pointer_capture.dart';
 import 'view_tree_snapshot.dart';
@@ -106,6 +107,7 @@ class SessionReplayRecorder {
         TextElementRecorder(keyGenerator),
         EditableTextRecorder(keyGenerator),
         InputDecoratorRecorder(keyGenerator),
+        ImageRecorder(keyGenerator),
         CustomPaintRecorder(keyGenerator),
       ];
 

--- a/packages/datadog_session_replay/test/capture/image_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/image_recorder_test.dart
@@ -1,0 +1,222 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:ui' as ui;
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
+import 'package:datadog_session_replay/src/capture/capture_node.dart';
+import 'package:datadog_session_replay/src/capture/element_recorders/image_recorder.dart';
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:datadog_session_replay/src/rum_context.dart';
+import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../test_utils.dart';
+import 'simple_test_capture.dart';
+
+void main() {
+  late SessionReplayRecorder recorder;
+  late RUMContext context;
+
+  setUp(() {
+    final KeyGenerator keyGenerator = KeyGenerator();
+    recorder = SessionReplayRecorder.withCustomRecorders(
+      [ImageRecorder(keyGenerator)],
+      defaultCapturePrivacy: CapturePrivacy(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      ),
+    );
+
+    registerFallbackValue(
+      CapturedViewAttributes(paintBounds: Rect.zero, scaleX: 1.0, scaleY: 1.0),
+    );
+
+    context = RUMContext(
+      applicationId: randomString(),
+      sessionId: randomString(),
+    );
+    recorder.updateContext(context);
+  });
+
+  testWidgets('returns node for Image', (tester) async {
+    // Given
+    final x = randomDouble(min: 10, max: 50);
+    final y = randomDouble(min: 10, max: 50);
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+
+    ui.Image? testImage = await tester.runAsync(() {
+      return createTestImage(width: width.toInt(), height: height.toInt());
+    });
+
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Stack(
+          children: [
+            Positioned(
+              top: y,
+              left: x,
+              width: width,
+              height: height,
+              child: Image(image: TestImageProvider(testImage!)),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture!.viewTreeSnapshot.nodes.length, 1);
+
+    final capturedImageNode = capture.viewTreeSnapshot.nodes.last;
+    expect(capturedImageNode.attributes.x, x.round());
+    expect(capturedImageNode.attributes.y, y.round());
+    expect(capturedImageNode.attributes.width, width.round());
+    expect(capturedImageNode.attributes.height, height.round());
+  });
+
+  testWidgets('captured image builds placeholder wireframe', (tester) async {
+    // Given
+    final x = randomDouble(min: 10, max: 50);
+    final y = randomDouble(min: 10, max: 50);
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+
+    ui.Image? testImage = await tester.runAsync(() {
+      return createTestImage(width: width.round(), height: height.round());
+    });
+
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Stack(
+          children: [
+            Positioned(
+              top: y,
+              left: x,
+              width: width,
+              height: height,
+              child: Image(image: TestImageProvider(testImage!)),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture!.viewTreeSnapshot.nodes.length, 1);
+
+    final capturedImageNode = capture.viewTreeSnapshot.nodes.last;
+    final builtWireframes = capturedImageNode.buildWireframes();
+    expect(builtWireframes.length, 1);
+    final wireframe = builtWireframes.first as SRPlaceholderWireframe;
+
+    expect(wireframe.x, x.round());
+    expect(wireframe.y, y.round());
+    expect(wireframe.width, width.round());
+    expect(wireframe.height, height.round());
+  });
+
+  testWidgets('captured image below width has no label', (tester) async {
+    // Given
+    final x = randomDouble(min: 10, max: 50);
+    final y = randomDouble(min: 10, max: 50);
+    final width = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 10, max: 50);
+
+    ui.Image? testImage = await tester.runAsync(() {
+      return createTestImage(width: width.round(), height: height.round());
+    });
+
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Stack(
+          children: [
+            Positioned(
+              top: y,
+              left: x,
+              width: width,
+              height: height,
+              child: Image(image: TestImageProvider(testImage!)),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture!.viewTreeSnapshot.nodes.length, 1);
+
+    final capturedImageNode = capture.viewTreeSnapshot.nodes.last;
+    final builtWireframes = capturedImageNode.buildWireframes();
+    expect(builtWireframes.length, 1);
+    final wireframe = builtWireframes.first as SRPlaceholderWireframe;
+
+    expect(wireframe.label, isNull);
+  });
+
+  testWidgets('captured image above width has label', (tester) async {
+    // Given
+    final x = randomDouble(min: 10, max: 50);
+    final y = randomDouble(min: 10, max: 50);
+    final width = randomDouble(min: 200, max: 400);
+    final height = randomDouble(min: 10, max: 50);
+
+    ui.Image? testImage = await tester.runAsync(() {
+      return createTestImage(width: width.round(), height: height.round());
+    });
+
+    final tree = MaterialApp(
+      home: SimpleTestCapture(
+        key: Key('key'),
+        recorder: recorder,
+        child: Stack(
+          children: [
+            Positioned(
+              top: y,
+              left: x,
+              width: width,
+              height: height,
+              child: Image(image: TestImageProvider(testImage!)),
+            ),
+          ],
+        ),
+      ),
+    );
+    await tester.pumpWidget(tree);
+
+    // When
+    final capture = recorder.performCapture();
+
+    // Then
+    expect(capture!.viewTreeSnapshot.nodes.length, 1);
+
+    final capturedImageNode = capture.viewTreeSnapshot.nodes.last;
+    final builtWireframes = capturedImageNode.buildWireframes();
+    expect(builtWireframes.length, 1);
+    final wireframe = builtWireframes.first as SRPlaceholderWireframe;
+
+    expect(wireframe.label, 'Content Image');
+  });
+}

--- a/packages/datadog_session_replay/test/test_utils.dart
+++ b/packages/datadog_session_replay/test/test_utils.dart
@@ -5,8 +5,12 @@
 // Because `Color` is defined in `dart:ui`, it can't be imported into the test library
 // when running integration tests on Web. When / if we support SR on web, we'll need to look
 // into a way to have the Color class work in the test test package.
+import 'dart:async';
 import 'dart:math';
-import 'dart:ui';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 Random _random = Random();
 
@@ -21,4 +25,56 @@ Color randomColor({bool withRandomAlpha = false}) {
     randomColorComponent(),
     randomColorComponent(),
   );
+}
+
+class TestImageProvider extends ImageProvider<TestImageProvider> {
+  TestImageProvider(this.testImage);
+
+  final ui.Image testImage;
+
+  final Completer<ImageInfo> _completer = Completer<ImageInfo>.sync();
+  ImageConfiguration? configuration;
+  int loadCallCount = 0;
+
+  @override
+  Future<TestImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<TestImageProvider>(this);
+  }
+
+  @override
+  void resolveStreamForKey(
+    ImageConfiguration config,
+    ImageStream stream,
+    TestImageProvider key,
+    ImageErrorListener handleError,
+  ) {
+    configuration = config;
+    super.resolveStreamForKey(config, stream, key, handleError);
+  }
+
+  @override
+  ImageStreamCompleter loadBuffer(
+    TestImageProvider key,
+    DecoderBufferCallback decode,
+  ) {
+    throw UnsupportedError('Use ImageProvider.loadImage instead.');
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+    TestImageProvider key,
+    ImageDecoderCallback decode,
+  ) {
+    loadCallCount += 1;
+    return OneFrameImageStreamCompleter(_completer.future);
+  }
+
+  ImageInfo complete() {
+    final ImageInfo imageInfo = ImageInfo(image: testImage);
+    _completer.complete(imageInfo);
+    return imageInfo;
+  }
+
+  @override
+  String toString() => '${describeIdentity(this)}()';
 }


### PR DESCRIPTION
### What and why?

Add a placeholder wireframe for Image widgets until we can support full image capture.

refs: RUM-10400

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
