### PR TITLE
fix: Remove the check for `debugNeedsLayout`

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -195,9 +195,14 @@ class SessionReplayRecorder {
       final renderObject = e.renderObject;
       if (renderObject == null) return;
 
+      // TODO(RUM-10473): debugNeedsLayout is also set during scrolling and does not throw from
+      // the recorder, so we'll need to look for a different flag to prevent the throw
+      // during hot reload.
       // During hot reload, the recorder can try to capture items that still need
       // layout, which will throw. Prevent this.
-      if (kDebugMode && renderObject.debugNeedsLayout) return;
+      // if (kDebugMode && renderObject.debugNeedsLayout) {
+      //   return;
+      // }
 
       final transformMatrix = renderObject.getTransformTo(
         topElement.renderObject,
@@ -209,9 +214,7 @@ class SessionReplayRecorder {
         renderObject.paintBounds,
       );
       // Don't capture things that take up no space.
-      if (paintBounds.width == 0 && paintBounds.height == 0) {
-        return;
-      }
+      if (paintBounds.width == 0 && paintBounds.height == 0) return;
 
       final scaleX = paintBounds.width / untransformedPaintBounds.width;
       final scaleY = paintBounds.height / untransformedPaintBounds.height;

--- a/packages/datadog_session_replay/lib/src/processor/diff.dart
+++ b/packages/datadog_session_replay/lib/src/processor/diff.dart
@@ -22,7 +22,7 @@ class TableEntry {
 
 class Entry {
   bool isTableReference;
-  int id; // Can eb either an entry into the table or an index into na or oa.
+  int id; // Can be either an entry into the table or an index into na or oa.
 
   Entry(this.isTableReference, this.id);
 }


### PR DESCRIPTION
### What and why?

Checking `debugNeedsLayout` was an attempt to fix a throw during hot reload, but `debugNeedsLayout` can be set during scrolling as well, so skipping elements that have it set causes those elements to removed during replay (this is the cause of the blanking during scroll)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
