### PR TITLE
RUM-10653: Update Maven snapshots repo URL

### DIFF
--- a/examples/native-hybrid-app/android/settings.gradle
+++ b/examples/native-hybrid-app/android/settings.gradle
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url "https://storage.googleapis.com/download.flutter.io" }
         maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
+            url "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }    
 }

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -34,7 +34,7 @@ rootProject.allprojects {
              }
         }
         maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
+            url "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }
 }

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -26,7 +26,7 @@ allprojects {
         google()
         mavenCentral()
         maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
+            url "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }
 }

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         google()
         mavenCentral()
         maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
+            url "https://central.sonatype.com/repository/maven-snapshots/"
         }
     }
 }

--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -53,7 +53,7 @@ class UpdateGradleFilesCommand extends Command {
 
         if (inMavenBlock) {
           mavenBlock.writeln(line);
-          if (line.contains('url') && line.contains('/snapshots/')) {
+          if (line.contains('url') && line.contains('/maven-snapshots/')) {
             // this is a request for a snapshots maven repo. Don't write it to the final file
             writeMavenBlock = false;
           }


### PR DESCRIPTION
### What and why?

Check https://github.com/DataDog/dd-sdk-android/pull/2770 for more details. The legacy repo is sunset https://central.sonatype.org/news/20250326_ossrh_sunset/.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
