### PR TITLE
chore: Remove use of GITHUB_TOKEN from release process

### DIFF
--- a/tools/releaser/bin/deployer.dart
+++ b/tools/releaser/bin/deployer.dart
@@ -5,9 +5,10 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:git/git.dart';
-import 'package:github/github.dart';
 import 'package:logging/logging.dart';
+import 'package:releaser/github_cmd_wrapper.dart';
 import 'package:releaser/helpers.dart';
 
 class ReleaseInfo {
@@ -30,26 +31,55 @@ void main(List<String> arguments) async {
     print(event.message);
   });
 
-  if (arguments.isEmpty) {
+  final argParser = ArgParser()
+    ..addOption('repo-root', help: 'The root of the repo to release from')
+    ..addFlag('verbose', defaultsTo: false)
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      help: 'Print the help',
+      negatable: false,
+      defaultsTo: false,
+    );
+
+  ArgResults argResults;
+  try {
+    argResults = argParser.parse(arguments);
+  } on FormatException catch (e) {
+    print('❌ ${e.message}');
+    _printUsage(argParser);
+    return;
+  }
+
+  if (argResults['verbose']) {
+    Logger.root.level = Level.FINEST;
+  }
+
+  if (argResults['help']) {
+    _printUsage(argParser);
+    return;
+  }
+
+  if (argResults.rest.isEmpty) {
     Logger.root.shout('❌ Package name to deploy is required.');
     exit(1);
   }
 
-  final githubToken = Platform.environment['GITHUB_TOKEN'];
-  if (githubToken == null) {
-    Logger.root.shout(
-        '❌ Must have the environment variable GITHUB_TOKEN set to deploy.');
-    exit(1);
-  }
-
-  var packageName = arguments.first;
-
-  final gitDir = await getGitDir();
+  final root = argResults['repo-root'];
+  final gitDir = await getGitDir(root);
   if (gitDir == null) {
     Logger.root.shout('💥 Could not establish your current git directory.');
     exit(1);
   }
 
+  final github = GithubCommandWrapper(gitDir.path);
+  if (!await github.checkAuth(Logger.root)) {
+    Logger.root
+        .shout('❌ Could not auth with `gh` command. Run `gh auth login`.');
+    exit(1);
+  }
+
+  var packageName = arguments.first;
   if (!(await _validateBranchState(gitDir))) exit(1);
 
   final releaseInfo = await _getReleaseInfo(gitDir, packageName);
@@ -58,16 +88,13 @@ void main(List<String> arguments) async {
     exit(1);
   }
 
-  if (!await _performGitHubRelease(gitDir, releaseInfo, githubToken)) {
+  if (!await _performGitHubRelease(gitDir, releaseInfo)) {
     exit(1);
   }
 }
 
 Future<bool> _performGitHubRelease(
-    GitDir gitDir, ReleaseInfo releaseInfo, String githubToken) async {
-  const githubOrganization = 'DataDog';
-  const repoName = 'dd-sdk-flutter';
-
+    GitDir gitDir, ReleaseInfo releaseInfo) async {
   final tag = '${releaseInfo.package}/v${releaseInfo.version}';
   Logger.root.fine('ℹ️ Creating tag $tag');
   await gitDir.runCommand(
@@ -75,20 +102,17 @@ Future<bool> _performGitHubRelease(
   Logger.root.fine('ℹ️ Pushing to origin');
   await gitDir.runCommand(['push', 'origin', tag]);
 
-  var github = GitHub(auth: Authentication.withToken(githubToken));
+  var github = GithubCommandWrapper(gitDir.path);
 
   Logger.root.fine('ℹ️ Creating github release for $tag');
   try {
-    var createRelease = CreateRelease.from(
-      tagName: tag,
-      name: '${releaseInfo.package} ${releaseInfo.version}',
-      targetCommitish: releaseInfo.commitSha,
-      body: releaseInfo.changeLog,
-      isDraft: true,
-      isPrerelease: releaseInfo.version.contains('-'),
+    await github.createRelease(
+      Logger.root,
+      tag,
+      '${releaseInfo.package} ${releaseInfo.version}',
+      releaseInfo.changeLog,
+      releaseInfo.version.contains('-'),
     );
-    await github.repositories.createRelease(
-        RepositorySlug(githubOrganization, repoName), createRelease);
   } catch (e) {
     Logger.root.shout('❌ Failed to create release: ${e.toString()}');
     return false;
@@ -177,4 +201,9 @@ Future<ReleaseInfo?> _getReleaseInfo(GitDir gitDir, String packageName) async {
     pubspecVersion!,
     changeLog.toString(),
   );
+}
+
+void _printUsage(ArgParser argParser) {
+  print('\nUsage: releaser.dart [package] [options]');
+  print('\n${argParser.usage}');
 }

--- a/tools/releaser/bin/pinner.dart
+++ b/tools/releaser/bin/pinner.dart
@@ -47,7 +47,7 @@ Future<int> main(List<String> arguments) async {
     exit(1);
   }
 
-  final gitDir = await getGitDir();
+  final gitDir = await getGitDir(path.current);
   if (gitDir == null) {
     Logger.root.shout('💥 Could not establish your current git directory.');
     exit(1);

--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -2,8 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
@@ -11,6 +9,7 @@ import 'package:releaser/cocoapod_util.dart';
 import 'package:releaser/command.dart';
 import 'package:releaser/generate_changelog.dart';
 import 'package:releaser/git_actions.dart';
+import 'package:releaser/github_cmd_wrapper.dart';
 import 'package:releaser/gradle_util.dart';
 import 'package:releaser/helpers.dart';
 import 'package:releaser/release_validator.dart';
@@ -25,6 +24,7 @@ void main(List<String> arguments) async {
 
   final argParser = ArgParser()
     ..addOption('version', abbr: 'v', mandatory: true)
+    ..addOption('repo-root', help: 'The root of the repo to release from')
     ..addFlag(
       'skip-git-checks',
       help: "Don't perform checks on branch names or un-staged files",
@@ -83,10 +83,10 @@ void main(List<String> arguments) async {
     return;
   }
 
-  final githubToken = Platform.environment['GITHUB_TOKEN'];
-  if (githubToken == null) {
-    Logger.root.shout(
-        '❌ Must have the environment variable GITHUB_TOKEN set to validate native SDK releases.');
+  final gh = GithubCommandWrapper(commandArgs.gitDir.path);
+  if (!await gh.checkAuth(Logger.root)) {
+    print(
+        '❌ Could not validate your authentication with the gh command line tool. Please login with `gh auth login`.');
     return;
   }
 
@@ -149,7 +149,9 @@ Future<CommandArguments?> _validateArguments(ArgResults argResults) async {
   bool skipGitChecks = argResults['skip-git-checks'];
   bool skipChangelogCheck = argResults['skip-changelog-check'];
 
-  final gitDir = await getGitDir();
+  final root = argResults['repo-root'];
+
+  final gitDir = await getGitDir(root);
   if (gitDir == null) {
     return null;
   }

--- a/tools/releaser/lib/generate_changelog.dart
+++ b/tools/releaser/lib/generate_changelog.dart
@@ -4,8 +4,10 @@
 
 import 'dart:io';
 
+import 'package:git/git.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
+import 'package:version/version.dart';
 
 import 'command.dart';
 import 'helpers.dart';
@@ -15,7 +17,7 @@ class GenerateChangelogCommand extends Command {
 
   @override
   Future<bool> run(CommandArguments args, Logger logger) async {
-    final lastReleaseSha = await _findLastReleaseSha(args);
+    final lastReleaseSha = await _findLastReleaseSha(logger, args);
     if (lastReleaseSha == null) {
       Logger.root.shout(
           '⚠️ Could not find last release! Hopefully this is a new package!.');
@@ -50,7 +52,7 @@ class GenerateChangelogCommand extends Command {
           oldLine = null;
         }
 
-        line = '## ${args.version}\n\n$versionChangelog';
+        line = '## ${args.version}\n\n$versionChangelog\n';
         if (oldLine != null) {
           line += '\n$oldLine';
         }
@@ -88,13 +90,38 @@ class GenerateChangelogCommand extends Command {
     return true;
   }
 
-  Future<String?> _findLastReleaseSha(CommandArguments args) async {
+  Future<String?> _findLastReleaseSha(
+      Logger logger, CommandArguments args) async {
     final packageTags = await args.gitDir
         .tags()
         .where((t) => t.tag.startsWith('${args.packageName}/'))
         .toList();
 
+    Version? _getVersion(Tag tag) {
+      Version? v;
+      try {
+        final versionString = tag.tag.split('/').last.replaceFirst('v', '');
+        v = Version.parse(versionString);
+      } catch (_) {
+        // Nothing to do
+      }
+      return v;
+    }
+
+    packageTags.sort((a, b) {
+      Version? versionA = _getVersion(a);
+      Version? versionB = _getVersion(b);
+      if (versionA == null) return -1;
+      if (versionB == null) return 1;
+
+      return versionA.compareTo(versionB);
+    });
+
     if (packageTags.isEmpty) return null;
+
+    final lastTag = packageTags.last;
+
+    logger.fine('Found tag ${lastTag.tag} with sha ${lastTag.objectSha}');
 
     return packageTags.last.objectSha;
   }
@@ -157,7 +184,7 @@ List<String> _getChangelogItems(List<String> commitMessages) {
         if (githubRefs.isNotEmpty) {
           final seeStrings = githubRefs
               .map((r) => '[#$r](${GenerateChangelogCommand.issuesLink}$r)');
-          changelogItem += 'See ${seeStrings.join(' ')}';
+          changelogItem += ' See ${seeStrings.join(' ')}';
         }
 
         items.add(changelogItem);

--- a/tools/releaser/lib/github_cmd_wrapper.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.dart
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:logging/logging.dart';
+
+import 'process_helper.dart';
+
+part 'github_cmd_wrapper.g.dart';
+
+@JsonSerializable()
+class GHRelease {
+  final bool isLatest;
+  final String name;
+  final String tagName;
+
+  GHRelease({
+    required this.isLatest,
+    required this.name,
+    required this.tagName,
+  });
+
+  factory GHRelease.fromJson(Map<String, dynamic> json) =>
+      _$GHReleaseFromJson(json);
+  Map<String, dynamic> toJson() => _$GHReleaseToJson(this);
+}
+
+/// Wraps the `gh` command line tool for performing operations with Github
+class GithubCommandWrapper {
+  final String cwd;
+
+  const GithubCommandWrapper(this.cwd);
+
+  Future<bool> checkAuth(Logger logger) async {
+    final exitCode = await runProcess(
+      'gh',
+      ['auth', 'status'],
+      workingDirectory: cwd,
+      stdout: (line) => logger.info(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    return exitCode == 0;
+  }
+
+  Future<List<GHRelease>> fetchReleases(Logger logger, String repoSlug) async {
+    final buffer = StringBuffer();
+    final exitCode = await runProcess(
+      'gh',
+      [
+        'release',
+        'list',
+        '--repo',
+        repoSlug,
+        '--json',
+        'name,isLatest,tagName'
+      ],
+      workingDirectory: cwd,
+      stdout: (line) => buffer.write(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    if (exitCode != 0) {
+      throw Exception('gh returned exit code $exitCode.');
+    }
+
+    final json = jsonDecode(buffer.toString()) as List;
+    final releases = json.map((e) => GHRelease.fromJson(e)).toList();
+    return releases;
+  }
+
+  Future<GHRelease> getLatestRelease(Logger logger, String repoSlug) async {
+    final releases = await fetchReleases(logger, repoSlug);
+    return releases.firstWhere((e) => e.isLatest);
+  }
+
+  Future<GHRelease?> getReleaseByTagName(
+      Logger logger, String repoSlug, String tagName) async {
+    final releases = await fetchReleases(logger, repoSlug);
+    return releases.firstWhereOrNull((e) => e.tagName == tagName);
+  }
+
+  Future<void> createRelease(Logger logger, String tag, String name,
+      String changelog, bool isPrerelease) async {
+    final buffer = StringBuffer();
+    final exitCode = await runProcess(
+      'gh',
+      [
+        'release',
+        'create',
+        name,
+        '--notes',
+        changelog,
+        '--draft',
+        if (isPrerelease) '--prerelease'
+      ],
+      workingDirectory: cwd,
+      stdout: (line) => buffer.write(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    if (exitCode != 0) {
+      throw Exception('gh returned exit code $exitCode.');
+    }
+  }
+}

--- a/tools/releaser/lib/github_cmd_wrapper.g.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'github_cmd_wrapper.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+GHRelease _$GHReleaseFromJson(Map<String, dynamic> json) => GHRelease(
+      isLatest: json['isLatest'] as bool,
+      name: json['name'] as String,
+      tagName: json['tagName'] as String,
+    );
+
+Map<String, dynamic> _$GHReleaseToJson(GHRelease instance) => <String, dynamic>{
+      'isLatest': instance.isLatest,
+      'name': instance.name,
+      'tagName': instance.tagName,
+    };

--- a/tools/releaser/lib/helpers.dart
+++ b/tools/releaser/lib/helpers.dart
@@ -14,8 +14,8 @@ bool hasNativeDependency(String packageName) {
       packageName == 'datadog_webview_tracking';
 }
 
-Future<GitDir?> getGitDir() async {
-  final currentPath = path.current;
+Future<GitDir?> getGitDir(String? root) async {
+  final currentPath = root ?? path.current;
 
   if (!await GitDir.isGitDir(currentPath)) {
     Logger.root.shout('❌ Current directory is not a git directory.');
@@ -23,7 +23,7 @@ Future<GitDir?> getGitDir() async {
   }
 
   return await GitDir.fromExisting(
-    path.current,
+    currentPath,
     allowSubdirectory: true,
   );
 }

--- a/tools/releaser/lib/process_helper.dart
+++ b/tools/releaser/lib/process_helper.dart
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:convert';
+import 'dart:io';
+
+typedef OutputPipeHandler = void Function(String line);
+
+Future<int> runProcess(String executable, List<String> args,
+    {String? workingDirectory,
+    OutputPipeHandler? stdout,
+    OutputPipeHandler? stderr}) async {
+  var process =
+      await Process.start(executable, args, workingDirectory: workingDirectory);
+  if (stdout != null) {
+    process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((event) {
+      stdout(event);
+    });
+  }
+  if (stderr != null) {
+    process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((event) {
+      stderr(event);
+    });
+  }
+
+  return await process.exitCode;
+}

--- a/tools/releaser/lib/release_validator.dart
+++ b/tools/releaser/lib/release_validator.dart
@@ -2,17 +2,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:git/git.dart';
-import 'package:github/github.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 import 'package:version/version.dart';
 
 import 'command.dart';
+import 'github_cmd_wrapper.dart';
 import 'helpers.dart';
+import 'process_helper.dart';
 
 final versionHeadingRegEx = RegExp(r'\s*#');
 final changeItemRegEx = RegExp(r'\s*\*');
@@ -83,49 +81,37 @@ class ValidateReleaseCommand extends Command {
 
   Future<bool> _validateiOSRelease(
       String packagePath, CommandArguments args, Logger logger) async {
-    const githubOrganization = 'DataDog';
-    const repoName = 'dd-sdk-ios';
-    final repoSlug = RepositorySlug(githubOrganization, repoName);
-
-    args.iOSRelease =
-        await _validateReleaseVersion(repoSlug, 'iOS', args.iOSRelease, logger);
+    args.iOSRelease = await _validateReleaseVersion(
+        args, 'DataDog/dd-sdk-ios', 'iOS', args.iOSRelease, logger);
     return args.iOSRelease != null;
   }
 
   Future<bool> _validateAndroidRelease(
       String packagePath, CommandArguments args, Logger logger) async {
-    const githubOrganization = 'DataDog';
-    const repoName = 'dd-sdk-android';
-    final repoSlug = RepositorySlug(githubOrganization, repoName);
-
     args.androidRelease = await _validateReleaseVersion(
-        repoSlug, 'Android', args.androidRelease, logger);
+        args, 'DataDog/dd-sdk-android', 'Android', args.androidRelease, logger);
 
     return args.androidRelease != null;
   }
 
   Future<String?> _validateReleaseVersion(
-    RepositorySlug repoSlug,
+    CommandArguments args,
+    String repoName,
     String platform,
     String? release,
     Logger logger,
   ) async {
-    final githubToken = Platform.environment['GITHUB_TOKEN'];
-    final github = GitHub(auth: Authentication.withToken(githubToken));
-
     // If we didn't specify a version get the current latest release from github.
     // If we did specify a release, check that it actually exists.
+    final gh = GithubCommandWrapper(args.gitDir.path);
     if (release == null) {
       logger.fine('🌎 Fetching latest $platform release from github... ');
-      final latestRelease =
-          await github.repositories.getLatestRelease(repoSlug);
+      final latestRelease = await gh.getLatestRelease(logger, repoName);
       logger.fine('ℹ️ Latest $platform release is ${latestRelease.name}');
       release = latestRelease.tagName;
     } else {
-      try {
-        final _ =
-            await github.repositories.getReleaseByTagName(repoSlug, release);
-      } on RepositoryNotFound {
+      final ghRelease = await gh.getReleaseByTagName(logger, repoName, release);
+      if (ghRelease == null) {
         logger.shout(
             '❌ Could not find target $platform release $release. Please check the tag name');
         return null;
@@ -134,46 +120,6 @@ class ValidateReleaseCommand extends Command {
 
     logger.info('ℹ️ Releasing with $platform version $release.');
 
-    logger.fine('🌎 Getting the difference between "$release" and "develop"');
-    final compare =
-        await github.repositories.compareCommits(repoSlug, release!, 'develop');
-
-    while (true) {
-      print(
-          'Current $platform code on develop is ahead of $release by ${compare.aheadBy} commits.');
-      print('Are you okay with this? ([Y]es, [N]o, [S]ee Changes: ');
-
-      final input = stdin.readLineSync();
-      if (input != null && input.isNotEmpty) {
-        final firstChar = input[0].toLowerCase();
-        if (firstChar == 'y') {
-          break;
-        } else if (firstChar == 'n') {
-          logger.shout('😳 Oh, I\'m glad we stopped then!');
-          return null;
-        } else if (firstChar == 's') {
-          if (compare.commits != null) {
-            final nonMergeCommits = compare.commits!.where((commit) {
-              final message = commit.commit?.message;
-              return message != null && !message.startsWith('Merge');
-            });
-
-            if (nonMergeCommits.isNotEmpty) {
-              for (final commit in nonMergeCommits) {
-                var firstLine = commit.commit!.message!.split('\n').first;
-                print('- $firstLine by ${commit.commit?.author?.name}');
-              }
-            } else {
-              print('There are only merge commits.');
-            }
-          } else {
-            print('There are no commits to see?');
-          }
-        }
-      }
-    }
-
-    logger.fine('✅ Confirmed okay shipping with $platform release $release');
     return release;
   }
 }
@@ -181,30 +127,15 @@ class ValidateReleaseCommand extends Command {
 class ValidatePublishDryRun extends Command {
   @override
   Future<bool> run(CommandArguments args, Logger logger) async {
-    if (args.dryRun) {
-      logger.info(
-          '⚠️ Skipping `dart pub publish --dry-run` step due to --dry-run');
-      return true;
-    }
-
-    logger.info('ℹ️ Running `flutter pub publish --dry-run`');
-    var process = await Process.start(
-        'flutter', ['pub', 'publish', '--dry-run'],
-        workingDirectory: args.packageRoot);
-    process.stdout
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((event) {
-      logger.fine(event);
-    });
-    process.stderr
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((event) {
-      logger.shout(event);
-    });
-
-    var exitCode = await process.exitCode;
+    logger.info(
+        'ℹ️ Running `flutter pub publish --dry-run` in ${args.packageRoot}');
+    final exitCode = await runProcess(
+      'flutter',
+      ['pub', 'publish', '--dry-run'],
+      workingDirectory: args.packageRoot,
+      stdout: (line) => logger.fine(line),
+      stderr: (line) => logger.shout(line),
+    );
     if (exitCode != 0) {
       logger.info('❌ Publish exited with code $exitCode.');
       logger.info('Fix the above errors and try again.');

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -5,170 +5,274 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: cf8fb49539ecd6fea20ce18f2f858b88f8c27d4e7e3c09e1c6ed3289552bf223
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "36.0.0"
+    version: "85.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "45ebaf3b2fc49c371de62c5ec855207f0503a41f94bd92ae50d7320fdf28accd"
+      sha256: "01949bf52ad33f0e0f74f881fbaac4f348c556531951d92c8d16f1262aa19ff8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "7.5.4"
   args:
     dependency: "direct main"
     description:
       name: args
-      sha256: "0bd9a99b6eb96f07af141f0eb53eace8983e8e5aa5de59777aca31684680ef22"
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: db4766341bd8ecb66556f31ab891a5d596ef829221993531bd64a8e6342f0cda
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
-  charcode:
+    version: "2.1.2"
+  build:
     dependency: transitive
     description:
-      name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      name: build
+      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
-  collection:
+    version: "2.5.4"
+  build_config:
     dependency: transitive
+    description:
+      name: build_config
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.4"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.10.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.1"
+  collection:
+    dependency: "direct main"
     description:
       name: collection
-      sha256: ef7e3a5529178ce8f37a9d0b11cbbc8b1e025940f9cf9f76c42da6796301219d
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: f08428ad63615f96a27e34221c65e1a451439b5f26030f78d790f461c686d65d
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: c0122af6b3548369d6b7830c7a140d85c9a988d8d29c4976aa9ce4de46b122ef
+      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.14.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.6"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: b69516f2c26a5bcac4eee2e32512e1a5205ab312b3536c1c1227b2b942b5f9ad
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "6d2930621b9377f6a4b7d260fce525d48dd77a334f0d5d4177d07b0dcb76c032"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "4.0.0"
   git:
     dependency: "direct main"
     description:
       name: git
-      sha256: daea03e7471607e7ed942bccd4814cfc7e4fa8ca5d3dd6ad4fb170e44423d1a0
+      sha256: de678c6f0d5e2761c2c3643d31b1010883cc4d3e352949ef7c15f98f27d676ea
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
-  github:
-    dependency: "direct main"
-    description:
-      name: github
-      sha256: "159fa9a495e018070c0e70a30e7c9b6c446cf96e95211de8e363aef9db72cc70"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.5.0"
+    version: "2.3.1"
   glob:
     dependency: transitive
     description:
       name: glob
-      sha256: "8321dd2c0ab0683a91a51307fa844c6db4aa8e3981219b78961672aaab434658"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.3"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "1.4.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: ab298ef2b2acd283bd36837df7801dcf6e6b925f8da6e09efb81111230aa9037
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.2"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "0d4c73c3653ab85bf696d51a9657604c900a370549196a91f33e4c39af760852"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.2"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "2639efc0237c7b71c6584696c0847ea4e4733ddaf571ae9c79d5295e8ae17272"
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.5"
   lints:
     dependency: "direct dev"
     description:
@@ -181,215 +285,271 @@ packages:
     dependency: "direct main"
     description:
       name: logging
-      sha256: "293ae2d49fd79d4c04944c3a26dfd313382d5f52e821ec57119230ae16031ad4"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "2e2c34e631f93410daa3ee3410250eadc77ac6befc02a040eda8a123f34e6f5a"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.17"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "5202fdd37b4da5fd14a237ed0a01cad6c1efd4c99b5b5a0d3c9237f3728c9485"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: fd5f81041e6a9fc9b9d7fa2cb8a01123f9f5d5d49136e06cb9dc7d33689529f4
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: a4d5ede5ca9c3d88a2fef1147a078570c861714c806485c596b109819135bc12
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.2.0"
   path:
     dependency: "direct main"
     description:
       name: path
-      sha256: "240ed0e9bd73daa2182e33c4efc68c7dd53c7c656f3da73515a2d163e151412d"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
       name: pool
-      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "816c1a640e952d213ddd223b3e7aafae08cd9f8e1f6864eed304cc13b0272b07"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: c240984c924796e055e831a0a36db23be8cb04f170b26df572931ab36418421d
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      sha256: e0b44ebddec91e70a713e13adf93c1b2100821303b86a18e1ef1d082bd8bd9b8
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: "4a0d12cd512aa4fc55fed5f6280f02ef183f47ba29b4b0dfd621b1c99b7e6361"
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: fd84910bf7d58db109082edf7326b75322b8f186162028482f53dc892f00332d
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "3.0.0"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.5"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: d77dbb9d0b7469d91e42d352334b2b4bbd5cec4379542f1bdb630db368c4d9f6
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: dd11571b8a03f7cadcf91ec26a77e02bfbd6bbba2a512924d3116646b4198fc4
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.2"
   test:
     dependency: "direct dev"
     description:
       name: test
-      sha256: fd53f3bac5c70f26eec065456f73b20b11ea969aaa1099928bf9a6c1fd0e1403
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.20.1"
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: d8ca35bbbeef2d037e5693a3c8a381505afebfbfee7bc33fff5581bc4e16a939
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.7.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: cc8bc45cbe52e8133293537ac4cffc4d9b35c93e91481eb64ef2304e2e722949
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.11"
+    version: "0.6.11"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   version:
     dependency: "direct main"
     description:
       name: version
-      sha256: "86d4b7303604b3616f47ccc7b2bca92460c1b391095e3b286a8c3cf41fa8cdaa"
+      sha256: b8d9fc75327de5da108942502043f0b7d6500fbded3137560ec2254dc4b9f8ba
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5e10b8a57f571c4bc3bc45dddf708141fe10ceb5c1d44652a78e8ff497dc6db8"
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.1"
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: e42dfcc48f67618344da967b10f62de57e04bae01d9d3af4c2596f3712a88c99
+      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
@@ -397,25 +557,25 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "0c2ada1b1aeb2ad031ca81872add6be049b8cb479262c6ad3c4b0f9c24eaab2f"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "5adb6ab8ed14e22bb907aae7338f0c206ea21e7a27004e97664b16c120306f00"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      sha256: "3cee79b1715110341012d27756d9bae38e650588acd38d3f3c610822e1337ace"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -11,9 +11,12 @@ dependencies:
   logging: ^1.0.2
   path: ^1.8.0
   git: ^2.3.0
-  github: ^9.5.0
   version: ^2.0.0
+  json_annotation: ^4.9.0
+  collection: ^1.19.1
 
 dev_dependencies:
+  build_runner: ^2.5.4
+  json_serializable: ^6.9.5
   lints: ^1.0.0
   test: ^1.20.1


### PR DESCRIPTION
### What and why?

Instead of using PATs for Github operations, we're going to depend on the Github command line tool to do any operations involving Github.

Currently the only Github related commands revolve around querying the Android and iOS release versions, and creating the Draft release through the `deployer` script.

Also improve some functionality in the release process, including being able to run the script from a separate directory (to enable development of the script in parallel to writing a release).

refs: RUM-10261

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
