### PR TITLE
feat!: Change TraceContextInjection default to sampled.

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -381,8 +381,8 @@ class DatadogAttachConfiguration {
 
   /// The strategy for injecting trace context into requests. See [TraceContextInjection].
   ///
-  /// Defaults to [TraceContextInjection.all].
-  TraceContextInjection traceContextInjection = TraceContextInjection.all;
+  /// Defaults to [TraceContextInjection.sampled].
+  TraceContextInjection traceContextInjection = TraceContextInjection.sampled;
 
   /// Configurations for additional plugins that will be created after Datadog
   /// is initialized.
@@ -395,7 +395,7 @@ class DatadogAttachConfiguration {
     this.reportFlutterPerformance = false,
     List<String>? firstPartyHosts,
     this.firstPartyHostsWithTracingHeaders = const {},
-    this.traceContextInjection = TraceContextInjection.all,
+    this.traceContextInjection = TraceContextInjection.sampled,
   }) {
     // Attempt a union if both configuration options are present
     if (firstPartyHosts != null) {

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -81,8 +81,8 @@ class DatadogRumConfiguration {
 
   /// The strategy for injecting trace context into requests. See [TraceContextInjection].
   ///
-  /// Defaults to [TraceContextInjection.all].
-  TraceContextInjection traceContextInjection = TraceContextInjection.all;
+  /// Defaults to [TraceContextInjection.sampled].
+  TraceContextInjection traceContextInjection = TraceContextInjection.sampled;
 
   /// Enable or disable detection of "long tasks"
   ///
@@ -205,7 +205,7 @@ class DatadogRumConfiguration {
     required this.applicationId,
     double sessionSamplingRate = 100.0,
     double traceSampleRate = 20.0,
-    this.traceContextInjection = TraceContextInjection.all,
+    this.traceContextInjection = TraceContextInjection.sampled,
     this.detectLongTasks = true,
     double longTaskThreshold = 0.1,
     this.trackFrustrations = true,

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -217,7 +217,7 @@ Map<String, Object?> generateDatadogAttributes(
 Map<String, String> getTracingHeaders(
   TracingContext context,
   TracingHeaderType headersType, {
-  TraceContextInjection contextInjection = TraceContextInjection.all,
+  TraceContextInjection contextInjection = TraceContextInjection.sampled,
 }) {
   var headers = <String, String>{};
 

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -81,6 +81,22 @@ void main() {
     expect(resourceTypeFromContentType(other), RumResourceType.native);
   });
 
+  test('configuration has correct defaults', () {
+    final configuration = DatadogRumConfiguration(applicationId: 'fake-app-id');
+
+    expect(configuration.sessionSamplingRate, 100.0);
+    expect(configuration.traceSampleRate, 20.0);
+    expect(configuration.traceContextInjection, TraceContextInjection.sampled);
+    expect(configuration.detectLongTasks, true);
+    expect(configuration.longTaskThreshold, 0.1);
+    expect(configuration.vitalUpdateFrequency, VitalsFrequency.average);
+    expect(configuration.reportFlutterPerformance, false);
+    expect(configuration.trackNonFatalAnrs, isNull);
+    expect(configuration.appHangThreshold, isNull);
+    expect(configuration.trackAnonymousUser, true);
+    expect(configuration.initialResourceThreshold, 0.1);
+  });
+
   test('configuration is encoded correctly', () {
     final applicationId = randomString();
     final detectLongTasks = randomBool();

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -174,11 +174,11 @@ void main() {
     );
 
     expect(headers['x-datadog-trace-id'],
-          context.traceId.asString(TracingIdRepresentation.lowDecimal));
-      expect(headers['x-datadog-tags'],
-          '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
-      expect(headers['x-datadog-parent-id'],
-          context.spanId.asString(TracingIdRepresentation.decimal));
+        context.traceId.asString(TracingIdRepresentation.lowDecimal));
+    expect(headers['x-datadog-tags'],
+        '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
+    expect(headers['x-datadog-parent-id'],
+        context.spanId.asString(TracingIdRepresentation.decimal));
     expect(headers['x-datadog-sampling-priority'], '0');
     expect(headers['x-datadog-origin'], 'rum');
   });
@@ -192,6 +192,20 @@ void main() {
       context,
       TracingHeaderType.datadog,
       contextInjection: TraceContextInjection.sampled,
+    );
+
+    expect(headers['x-datadog-trace-id'], isNull);
+    expect(headers['x-datadog-parent-id'], isNull);
+    expect(headers['x-datadog-sampling-priority'], isNull);
+    expect(headers['x-datadog-origin'], isNull);
+  });
+
+  test('Default for tracing headers is TraceContextInjection.sampled', () {
+    final context = generateTracingContext(false);
+
+    final headers = getTracingHeaders(
+      context,
+      TracingHeaderType.datadog,
     );
 
     expect(headers['x-datadog-trace-id'], isNull);


### PR DESCRIPTION
### What and why?

To better align SDKs, we're changing the default behavior for trace context injection from `all` to `sampled`.

`TraceContextInjection.all` added trace sampling decisions to all requests to first party hosts, regardless of the sampling decision.

`TraceContextInjection.sampled` only adds sampling information to requests that have been sampled in for tracing.

refs: RUM-7748

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
