### PR TITLE
chore: Update all versions to v3

### DIFF
--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ^3.6.0
+  flutter: ">=3.3.0"
 
 dependencies:
   collection: ^1.15.0
@@ -21,5 +21,3 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   json_serializable: ^6.1.0
   build_runner: ^2.1.10
-
-flutter:

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -1,10 +1,10 @@
 name: datadog_flutter_plugin
 description: Flutter bindings and tools for utilizing Datadog Mobile SDks
-version: 2.12.0
+version: 3.0.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
   flutter: ">=3.3.0"
 
 dependencies:

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -2,16 +2,16 @@ name: datadog_gql_link
 description: A package for tracking GraphQL calls in Datadog compatible with gql_link 
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
-version: 1.2.0
+version: 2.0.0
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
+  sdk: ">=3.6.0 <4.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.7.0
+  datadog_flutter_plugin: ^3.0.0
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   uuid: ^4.0.0
@@ -24,6 +24,3 @@ dev_dependencies:
   mocktail: ^1.0.0
   datadog_common_test:
     path: ../datadog_common_test
-
-flutter:
-  uses-material-design: true

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -1,17 +1,17 @@
 name: datadog_grpc_interceptor
 description: A plugin for use with the DatadogSdk, used to track performance of gRPC and enable Datadog Distributed Tracing.
-version: 1.3.0
+version: 2.0.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.7.0
+  datadog_flutter_plugin: ^3.0.0
   grpc: ">=3.0.2 <5.0.0"
   uuid: ^4.0.0
 
@@ -23,5 +23,3 @@ dev_dependencies:
   protobuf: ^2.1.0
   datadog_common_test:
     path: ../datadog_common_test
-
-flutter:

--- a/packages/datadog_inappwebview_tracking/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/pubspec.yaml
@@ -1,17 +1,17 @@
 name: datadog_inappwebview_tracking
 description: "A package for tracking Datadog sessions in webviews create with flutter_inappwebview"
-version: 1.1.0-beta.2
+version: 2.0.0
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.6.0 <4.0.0"
   flutter: '>=3.3.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.10.0
+  datadog_flutter_plugin: ^3.0.0
   plugin_platform_interface: ^2.0.2
   flutter_inappwebview: ^6.2.0-beta
 

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   web: ^1.0.0
   meta: ^1.16.0  
   plugin_platform_interface: ^2.0.2
-  datadog_flutter_plugin: ^2.12.0
+  datadog_flutter_plugin: ^3.0.0
   json_annotation: ^4.9.0
 
 dev_dependencies:

--- a/tools/ci/pubspec.yaml
+++ b/tools/ci/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.7.0
 
 # Add regular dependencies here.
 dependencies:

--- a/tools/e2e_generator/pubspec.lock
+++ b/tools/e2e_generator/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.1 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"

--- a/tools/e2e_generator/pubspec.yaml
+++ b/tools/e2e_generator/pubspec.yaml
@@ -3,7 +3,7 @@ description: A simple command-line application.
 version: 1.0.0
 
 environment:
-  sdk: '>=2.16.1 <4.0.0'
+  sdk: ^3.7.0
 
 dependencies:
   args: ^2.3.0

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
+  sdk: ^3.7.0
 
 dependencies:
   args: ^2.3.0

--- a/tools/third_party_scanner/pubspec.lock
+++ b/tools/third_party_scanner/pubspec.lock
@@ -482,4 +482,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"

--- a/tools/third_party_scanner/pubspec.yaml
+++ b/tools/third_party_scanner/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 # homepage: https://www.example.com
 
 environment:
-  sdk: '>=2.16.1 <4.0.0'
+  sdk: ^3.7.0
 
 dependencies:
   path: ^1.8.0


### PR DESCRIPTION
### What and why?

Update all pubspecs to bump major versions and set core package dependency to 3.0.0.

We are updating the required Dart version to 3.6+, which sets a requirement for Flutter 3.27, released in 2024.  This gives us support for Dart workspaces which should improve some issues with analysis slowness in the project.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
