### PR TITLE
fix: Restrict `json_serializable` package version.

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -224,7 +224,7 @@ scripts:
   build_runner:
     exec:
       concurrency: 1
-    run: flutter pub run build_runner build
+    run: flutter pub run build_runner build --delete-conflicting-outputs
     packageFilters:
       dependsOn: build_runner
   

--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -12,14 +12,14 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.4 <2.0.0"
-  json_annotation: ^4.4.0
+  json_annotation: ^4.9.0
   uuid: ^4.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-  json_serializable: ^6.1.0
+  json_serializable: '>=6.7.0 <6.10.0'
   build_runner: ^2.1.10
 
 flutter:

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  json_annotation: ^4.7.0
+  json_annotation: ^4.9.0
   uuid: ^4.0.0
   meta: ^1.7.0
 
@@ -22,7 +22,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ">=1.0.0"
   mocktail: ^0.3.0
-  json_serializable: ^6.7.0
+  json_serializable: '>=6.7.0 <6.10.0'
   build_runner: ^2.1.11
   datadog_common_test:
     path: ../datadog_common_test

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
   mocktail: ^1.0.4
-  json_serializable: ^6.9.5
+  json_serializable: '>=6.7.0 <6.10.0'
   build_runner: ^2.4.15
   datadog_common_test:
     path: ../datadog_common_test

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.5.4
-  json_serializable: ^6.9.5
+  json_serializable: '>=6.7.0 <6.10.0'
   lints: ^1.0.0
   test: ^1.20.1


### PR DESCRIPTION
### What and why?

Current `develop` nightlies are broken because of an update to the `json_serializable` package that requires Dart 3.8, which we are not currently using. This fixes that broken build by preventing the use of `json_serializable` 6.10+.

Thankfully, this does not affect clients of package, as the generated code is shipped in the package during release, and the package itself does not have a dependency on `json_serializable`.

As part of this, I've updates the `pubspec`s to use `json_annotation`, which should have ben ^4.9.0 for a while now.

Lastly, add a build step to delete conflicting outputs of builds during `melos prepare` step.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
