### PR TITLE
chore: Fix android build in SR package

### DIFF
--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
@@ -10,6 +10,7 @@ import com.datadog.android.DatadogSite
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.DeviceInfo
 import com.datadog.android.api.context.DeviceType
+import com.datadog.android.api.context.LocaleInfo
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.ProcessInfo
 import com.datadog.android.api.context.TimeInfo
@@ -21,6 +22,7 @@ import java.util.Locale
 import java.util.UUID
 
 class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
+    @Suppress("LongMethod")
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
             site = forge.aValueFrom(DatadogSite::class.java),
@@ -61,7 +63,12 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
                 osVersion = forge.aString(),
                 osMajorVersion = forge.aString(),
                 architecture = forge.aString(),
-                numberOfDisplays = forge.aNullable { anInt() }
+                numberOfDisplays = forge.aNullable { anInt() },
+                localeInfo = LocaleInfo(
+                    locales = forge.aList { forge.aString() },
+                    currentLocale = forge.aString(),
+                    timeZone = forge.aString()
+                )
             ),
             userInfo = UserInfo(
                 id = forge.aNullable { anHexadecimalString() },


### PR DESCRIPTION
### What and why?

The addition of `localInfo` to `DatadogContext` broke the Session Replay package. Add `localInfo` to the forgery to fix.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
