### PR TITLE
feat: Support manual resource tracking on web

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,6 +148,11 @@ build-web:
     - !reference [.pre, script]
     - melos run build:web
     - melos run unit_test:web
+  artifacts:
+    when: always
+    expire_in: "30 days"
+    reports:
+      junit: $CI_PROJECT_DIR/.build/test-results/*.xml
 
 # Integration Tests
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,6 +147,7 @@ build-web:
   script:
     - !reference [.pre, script]
     - melos run build:web
+    - melos run unit_test:web
 
 # Integration Tests
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,17 @@ stages:
     - mkdir -p $CI_PROJECT_DIR/.build/test-results/
     - melos prepare
 
+.pre-web:
+  script:
+    - pushd tools/ci && dart pub get && dart run ci_helpers chrome_driver --extract && popd
+    - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --version
+    - ./tools/ci/.tmp/chrome-linux64/chrome --version
+    - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --port=4444 &
+    - export CHROME_EXECUTABLE=${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/chrome
+    - export PATH="$PATH:${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/"
+    - echo $CHROME_EXECUTABLE
+    - flutter doctor
+
 .pre-ios:
   script:
     - xcode-select -p
@@ -146,6 +157,7 @@ build-web:
   image: $CI_IMAGE_DOCKER
   script:
     - !reference [.pre, script]
+    - !reference [.pre-web, script]
     - melos run build:web
     - melos run unit_test:web
   artifacts:
@@ -210,14 +222,7 @@ web-integration-test:
     [ "arch:amd64" ]
   script:
     - !reference [.pre, script]
-    - pushd tools/ci && dart pub get && dart run ci_helpers chrome_driver --extract && popd
-    - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --version
-    - ./tools/ci/.tmp/chrome-linux64/chrome --version
-    - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --port=4444 &
-    - export CHROME_EXECUTABLE=${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/chrome
-    - export PATH="$PATH:${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/"
-    - echo $CHROME_EXECUTABLE
-    - flutter doctor
+    - !reference [.pre-web, script]
     - melos run integration_test:web
 
 # Notify

--- a/examples/simple_example/pubspec.lock
+++ b/examples/simple_example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -87,14 +87,14 @@ packages:
       path: "../../packages/datadog_flutter_plugin"
       relative: true
     source: path
-    version: "2.12.0"
+    version: "3.0.0"
   datadog_gql_link:
     dependency: "direct main"
     description:
       path: "../../packages/datadog_gql_link"
       relative: true
     source: path
-    version: "1.2.0"
+    version: "2.0.0"
   datadog_tracking_http_client:
     dependency: "direct main"
     description:
@@ -121,10 +121,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -296,10 +296,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -557,10 +557,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   web:
     dependency: transitive
     description:

--- a/examples/simple_example/web/index.html
+++ b/examples/simple_example/web/index.html
@@ -38,8 +38,8 @@
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <script>

--- a/melos.yaml
+++ b/melos.yaml
@@ -62,7 +62,7 @@ scripts:
         - "*e2e_test_app*"
 
   unit_test:all:
-    run: melos unit_test:flutter && melos unit_test:ios && melos unit_test:android
+    run: melos unit_test:flutter && melos unit_test:ios && melos unit_test:android && melos unit_test:web
 
   unit_test:flutter:
     run: 
@@ -70,6 +70,13 @@ scripts:
       melos exec -c 1 -- "set -e -o pipefail && flutter test --machine | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit.xml\"" 
     packageFilters:
       dirExists: 'test'
+
+  unit_test:web:
+    run:
+      mkdir -p .build/test-results &&
+      melos exec -c 1 -- "set -e -o pipefail && flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"" 
+    packageFilters:
+      scope: 'datadog_flutter_plugin'
   
   golden_test:flutter:
     run: 

--- a/melos.yaml
+++ b/melos.yaml
@@ -72,9 +72,13 @@ scripts:
       dirExists: 'test'
 
   unit_test:web:
-    run:
-      mkdir -p .build/test-results &&
-      melos exec -c 1 -- "set -e -o pipefail && flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"" 
+    exec:
+      concurrency: 1
+    run: |
+      mkdir -p $MELOS_ROOT_PATH/.build/test-results
+
+      bash -c 'set -euxo pipefail; \
+      flutter test --machine --platform chrome | tojunit "--output" "$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml"'
     packageFilters:
       scope: 'datadog_flutter_plugin'
   

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -124,7 +124,7 @@ class RumEventDecoder {
   final RumViewInfoDecoder? viewInfo;
   final Dd dd;
 
-  String get eventType => rumEvent['type'] as String;
+  String? get eventType => rumEvent['type'] as String?;
   String get service {
     if (!kManualIsWeb) {
       if (Platform.isIOS) return rumEvent['service'];

--- a/packages/datadog_flutter_plugin/MIGRATING.md
+++ b/packages/datadog_flutter_plugin/MIGRATING.md
@@ -1,3 +1,16 @@
+# Migration from 2.x to 3.0
+
+## Flutter Web Changes
+
+Clients using Flutter Web should update to using the Datadog Browser SDK v6.  Change the following import in your `index.html`:
+
+```diff
+-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
+-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
++  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script> 
++  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script> 
+```
+
 # Migration from 1.x to 2.0
 
 This document describes the main changes introduced in SDK `2.0` compared to `1.x`.

--- a/packages/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/README.md
@@ -31,8 +31,8 @@ On Android, your `minSdkVersion` must be >= 21, and if you are using Kotlin, it 
 On Web, add the following to your `index.html` under your `head` tag:
 
 ```html
-<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
-<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
+<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script> 
+<script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script> 
 ```
 
 This loads the CDN-delivered Datadog Browser SDKs for Logs and RUM. The synchronous CDN-delivered version of the Datadog Browser SDK is the only version currently supported by the Flutter plugin.

--- a/packages/datadog_flutter_plugin/analysis_options.yaml
+++ b/packages/datadog_flutter_plugin/analysis_options.yaml
@@ -4,6 +4,8 @@ include: package:flutter_lints/flutter.yaml
 # https://dart.dev/guides/language/analysis-options
 
 analyzer:
+  errors:
+    library_annotations: ignore
   exclude:
     - "**/*.mocks.dart"
     - "**/*.g.dart"

--- a/packages/datadog_flutter_plugin/example/lib/rum_user_actions_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_user_actions_screen.dart
@@ -22,6 +22,13 @@ class _RumUserActionsScreenState extends State<RumUserActionsScreen> {
   int _radioValue = 0;
   bool _switchValue = false;
 
+  @override
+  void initState() {
+    super.initState();
+
+    DatadogSdk.instance.rum?.startView('RumUserActionScreen');
+  }
+
   void _buttonPressed(String name) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Tapped $name')),

--- a/packages/datadog_flutter_plugin/example/web/index.html
+++ b/packages/datadog_flutter_plugin/example/web/index.html
@@ -23,8 +23,8 @@
   <link rel="manifest" href="manifest.json">
 
   <!-- Datadog -->
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <script>

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -110,17 +110,13 @@ extension Waiter on WidgetTester {
 
 void verifyCommonTags(
     RequestLog request, String service, String version, String? variant) {
-  final sdkVersion = request.tags['sdk_version'];
-  if (kIsWeb) {
-    // Returning the browser version of the SDK.
-    expect(sdkVersion?.startsWith('5.'), true);
-  } else {
-    expect(sdkVersion, DatadogSdk.sdkVersion);
-  }
-
-  expect(request.tags['service'], service);
-
+  // Web is sending these on the session now, not the query parameters
   if (!kIsWeb) {
+    final sdkVersion = request.tags['sdk_version'];
+
+    expect(sdkVersion, DatadogSdk.sdkVersion);
+
+    expect(request.tags['service'], service);
     // Currently coming back as 'browser' on web
     expect(request.queryParameters['ddsource'], 'flutter');
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_auto_instrumentation_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_auto_instrumentation_test.dart
@@ -74,12 +74,11 @@ void main() {
       expect(view1.viewEvents.last.performance?.fbc, isNotNull);
       // Should not have INV as no interaction led here
       expect(view1.viewEvents.last.inv, isNull);
-
-      // Web doesn't support action tracking from Flutter
-      var actionEvent = view1.actionEvents.last;
-      expect(actionEvent.actionType, 'tap');
-      expect(actionEvent.actionName, 'InkWell(Item 0)');
     }
+
+    var actionEvent = view1.actionEvents.last;
+    expect(actionEvent.actionType, 'tap');
+    expect(actionEvent.actionName, 'InkWell(Item 0)');
 
     final view2 = session.visits[1];
     expect(view2.name, 'rum_second_screen');
@@ -99,12 +98,11 @@ void main() {
       // INV should be at least 10 milliseconds later, as the tap action also takes up 10 ms
       expect(view2.viewEvents.last.inv,
           greaterThan(firstBuildComplete! + tenMsInNs));
-
-      // Web doesn't support action tracking from Flutter
-      var actionEvent = view2.actionEvents[0];
-      expect(actionEvent.actionType, 'tap');
-      expect(actionEvent.actionName, 'Button(Next Page)');
     }
+
+    var actionEvent2 = view2.actionEvents[0];
+    expect(actionEvent2.actionType, 'tap');
+    expect(actionEvent2.actionName, 'Button(Next Page)');
 
     // Check last view name
     final view3 = session.visits[2];

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -61,20 +61,19 @@ void main() {
 
     var exceptionError = view.errorEvents[0];
     expect(exceptionError.message, contains(TypeError().toString()));
-    expect(exceptionError.source, kIsWeb ? 'custom' : 'source');
+    expect(exceptionError.source, 'source');
     expect(exceptionError.errorType, 'NullThrown');
-    if (!kIsWeb) {
-      expect(exceptionError.sourceType, 'flutter');
-    }
+    // This is correct -- all error formats are browser
+    expect(exceptionError.sourceType, kIsWeb ? 'browser' : 'flutter');
 
     var manualError = view.errorEvents[1];
     expect(manualError.message, contains('Rum error message'));
-    expect(manualError.source, kIsWeb ? 'custom' : 'network');
+    expect(manualError.source, 'network');
     expect(manualError.fingerprint, 'custom-fingerprint');
 
     var thrownError = view.errorEvents[2];
     expect(thrownError.message, contains('This was an error!'));
-    expect(thrownError.source, kIsWeb ? 'custom' : 'source');
+    expect(thrownError.source, 'source');
     expect(thrownError.stack, isNotNull);
   });
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_error_reporting_test.dart
@@ -63,8 +63,10 @@ void main() {
     expect(exceptionError.message, contains(TypeError().toString()));
     expect(exceptionError.source, 'source');
     expect(exceptionError.errorType, 'NullThrown');
-    // This is correct -- all error formats are browser
-    expect(exceptionError.sourceType, kIsWeb ? 'browser' : 'flutter');
+    if (!kIsWeb) {
+      // source_type is not supported on web, but type should be browser anyway.
+      expect(exceptionError.sourceType, 'flutter');
+    }
 
     var manualError = view.errorEvents[1];
     expect(manualError.message, contains('Rum error message'));

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -110,21 +110,17 @@ void main() {
     }
     expect(view1.viewEvents.last.view.actionCount, actionCount);
 
-    if (!kIsWeb) {
-      // Manual resources on web don't work (the error is a resource loading error)
-      expect(view1.viewEvents.last.view.resourceCount, 1);
-      expect(view1.viewEvents.last.view.errorCount, 1);
-    }
+    expect(
+        view1.viewEvents.last.view.resourceCount, view1.resourceEvents.length);
+    expect(view1.viewEvents.last.view.errorCount, 1);
     expect(view1.viewEvents.last.context![contextKey], expectedContextValue);
     expect(view1.viewEvents.last.featureFlags?.isEmpty, isTrue);
 
-    expect(view1.actionEvents[baseAction + 0].actionType,
-        kIsWeb ? 'custom' : 'tap');
+    expect(view1.actionEvents[baseAction + 0].actionType, 'tap');
     expect(view1.actionEvents[baseAction + 0].actionName, 'Tapped Download');
     expect(view1.actionEvents[baseAction + 0].context![contextKey],
         expectedContextValue);
-    expect(view1.actionEvents[baseAction + 1].actionType,
-        kIsWeb ? 'custom' : 'tap');
+    expect(view1.actionEvents[baseAction + 1].actionType, 'tap');
     expect(view1.actionEvents[baseAction + 1].actionName, 'Next Screen');
     expect(view1.actionEvents[baseAction + 1].context![contextKey],
         expectedContextValue);
@@ -148,24 +144,26 @@ void main() {
     // TODO: Figure out why occasionally these have really high values
     // expect(firstInteractionTiming, lessThan(800 * 1000 * 1000));
 
-    // Manual resource loading calls are ignored on Web.
-    if (!kIsWeb) {
-      expect(view1.resourceEvents[0].url, 'https://fake_url/resource/1');
-      expect(view1.resourceEvents[0].statusCode, 200);
-      expect(view1.resourceEvents[0].resourceType, 'image');
-      final resourceDuration = view1.resourceEvents[0].duration;
+    {
+      final manualResourceEvents = view1.resourceEvents
+          .where((e) => e.url == 'https://fake_url/resource/1')
+          .toList();
+      expect(manualResourceEvents.length, 1);
+      expect(manualResourceEvents[0].statusCode, 200);
+      expect(manualResourceEvents[0].resourceType, 'image');
+      final resourceDuration = manualResourceEvents[0].duration;
       expect(resourceDuration,
           greaterThan(const Duration(milliseconds: 90).inNanoseconds - 1));
       expect(resourceDuration,
           lessThan(const Duration(seconds: 10).inNanoseconds));
-
-      expect(view1.errorEvents.length, 1);
-      expect(view1.errorEvents[0].resourceUrl, 'https://fake_url/resource/2');
-      expect(view1.errorEvents[0].message, 'Status code 400');
-      expect(view1.errorEvents[0].errorType, 'ErrorLoading');
-      expect(view1.errorEvents[0].source, 'network');
-      expect(view1.errorEvents[0].context![contextKey], expectedContextValue);
     }
+
+    expect(view1.errorEvents.length, 1);
+    expect(view1.errorEvents[0].resourceUrl, 'https://fake_url/resource/2');
+    expect(view1.errorEvents[0].message, 'Status code 400');
+    expect(view1.errorEvents[0].errorType, 'ErrorLoading');
+    expect(view1.errorEvents[0].source, 'network');
+    expect(view1.errorEvents[0].context![contextKey], expectedContextValue);
 
     // Verify user in all events, except for the first view event
     for (final viewEvent in view1.viewEvents.sublist(1)) {
@@ -196,10 +194,9 @@ void main() {
     expect(view2.viewEvents.last.view.actionCount, kIsWeb ? 1 : 2);
     // We can have multiple long tasks
     expect(view2.viewEvents.last.view.longTaskCount, greaterThanOrEqualTo(1));
-    if (!kIsWeb) {
-      // Web can download extra resources
-      expect(view2.viewEvents.last.view.resourceCount, 1);
-    }
+    expect(
+        view2.viewEvents.last.view.resourceCount, view2.resourceEvents.length);
+
     if (!kIsWeb) {
       // The removal of this key happens at a weird point for web, so
       // let's not check it for now.
@@ -208,29 +205,35 @@ void main() {
     expect(view2.viewEvents.last.featureFlags?['mock_flag_a'], false);
     expect(view2.viewEvents.last.featureFlags?['mock_flag_b'], 'mock_value');
 
-    // Manual resource loading calls are ignored on Web.
-    if (!kIsWeb) {
+    {
       final viewStart = view2.viewEvents.first.date;
-      final resourceStart = view2.resourceEvents[0].date;
+      final manualResourceEvents = view2.resourceEvents
+          .where((e) => e.url == 'https://fake_url/tns-resource/1')
+          .toList();
+      expect(manualResourceEvents.length, 1);
 
-      expect(view2.resourceEvents[0].url, 'https://fake_url/tns-resource/1');
-      expect(view2.resourceEvents[0].statusCode, 200);
-      expect(view2.resourceEvents[0].resourceType, 'image');
-      final resourceDuration = view1.resourceEvents[0].duration;
+      final resourceStart = manualResourceEvents[0].date;
+      expect(manualResourceEvents[0].url, 'https://fake_url/tns-resource/1');
+      expect(manualResourceEvents[0].statusCode, 200);
+      expect(manualResourceEvents[0].resourceType, 'image');
+      final resourceDuration = manualResourceEvents[0].duration;
       expect(resourceDuration,
           greaterThan(const Duration(milliseconds: 90).inNanoseconds - 1));
       expect(resourceDuration,
           lessThan(const Duration(seconds: 10).inNanoseconds));
 
-      final tns =
-          Duration(milliseconds: resourceStart - viewStart).inNanoseconds +
-              resourceDuration!;
-      expect(view2.viewEvents.last.view.networkSettledTime,
-          closeTo(tns, const Duration(milliseconds: 100).inNanoseconds));
+      // TNS is not calculated on web
+      if (!kIsWeb) {
+        final tns =
+            Duration(milliseconds: resourceStart - viewStart).inNanoseconds +
+                resourceDuration!;
+        expect(view2.viewEvents.last.view.networkSettledTime,
+            closeTo(tns, const Duration(milliseconds: 100).inNanoseconds));
+      }
     }
 
     expect(view2.errorEvents[0].message, 'Simulated view error');
-    expect(view2.errorEvents[0].source, kIsWeb ? 'custom' : 'source');
+    expect(view2.errorEvents[0].source, 'source');
     expect(view2.errorEvents[0].context![contextKey], expectedContextValue);
     expect(view2.errorEvents[0].context!['custom_attribute'], 'my_attribute');
     expect(view2.errorEvents[0].fingerprint, 'custom-fingerprint');
@@ -333,4 +336,4 @@ class _BecameInactiveMatcher extends Matcher {
 }
 
 const becameInactive = _BecameInactiveMatcher();
-// 
+//

--- a/packages/datadog_flutter_plugin/integration_test_app/web/index.html
+++ b/packages/datadog_flutter_plugin/integration_test_app/web/index.html
@@ -26,8 +26,8 @@
   <link rel="manifest" href="manifest.json">
 
   <!-- Datadog -->
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <script>

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -14,7 +14,7 @@ import 'src/internal_logger.dart';
 import 'src/logs/ddlogs_platform_interface.dart';
 import 'src/logs/ddlogs_web.dart';
 import 'src/rum/ddrum_platform_interface.dart';
-import 'src/rum/ddrum_web.dart';
+import 'src/rum/web/ddrum_web.dart';
 
 /// A web implementation of the DatadogSdk plugin.
 class DatadogSdkWeb extends DatadogSdkPlatform {

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -26,7 +26,7 @@ RumHttpMethod rumMethodFromMethodString(String value) {
 }
 
 /// Describes the type of a RUM Action.
-enum RumActionType { tap, scroll, swipe, custom }
+enum RumActionType { click, tap, scroll, swipe, custom }
 
 /// Describe the source of a RUM Error.
 enum RumErrorSource {

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -65,7 +65,8 @@ class DdRumWeb extends DdRumPlatform {
       trackFrustrations: rumConfiguration.trackFrustrations,
       trackLongTasks: rumConfiguration.detectLongTasks,
       enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
-      compressIntakeRequests: true,
+      // TODO(RUM-11211): Support and document web configuration options.
+      compressIntakeRequests: false,
       plugins: plugins,
     ));
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -6,14 +6,21 @@
 import 'dart:js_interop';
 
 import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
 
-import '../../datadog_flutter_plugin.dart';
-import '../../datadog_internal.dart';
-import '../logs/ddweb_helpers.dart';
-import '../web_helpers.dart';
-import 'ddrum_platform_interface.dart';
+import '../../../datadog_flutter_plugin.dart';
+import '../../../datadog_internal.dart';
+import '../../web_helpers.dart';
+import '../ddrum_platform_interface.dart';
+import 'raw_events.dart';
+import 'resource_tracker.dart';
+import 'rum_web_plugin.dart';
 
 class DdRumWeb extends DdRumPlatform {
+  final Uuid _uuid = Uuid();
+  RumWebPlugin? _webPlugin;
+  ResourceTracker? _resourceTracker;
+
   // Because Web needs the full SDK configuration, we have a separate init method
   void initialize(DatadogConfiguration configuration,
       DatadogRumConfiguration rumConfiguration, InternalLogger logger) {
@@ -22,6 +29,11 @@ class DdRumWeb extends DdRumPlatform {
 
     final sanitizedFirstPartyHosts = FirstPartyHost.createSanitized(
         configuration.firstPartyHostsWithTracingHeaders, logger);
+
+    _webPlugin = RumWebPlugin();
+    final plugins = [createJSInteropWrapper<RumWebPlugin>(_webPlugin!)].toJS;
+
+    _resourceTracker = ResourceTracker(_webPlugin!);
 
     DD_RUM?.init(_RumInitOptions(
       applicationId: rumConfiguration.applicationId,
@@ -48,10 +60,13 @@ class DdRumWeb extends DdRumPlatform {
       traceContextInjection:
           _contextInjectionString(rumConfiguration.traceContextInjection),
       trackViewsManually: true,
+      trackUserInteractions: false,
       trackResources: trackResources,
       trackFrustrations: rumConfiguration.trackFrustrations,
       trackLongTasks: rumConfiguration.detectLongTasks,
       enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
+      compressIntakeRequests: true,
+      plugins: plugins,
     ));
   }
 
@@ -86,17 +101,29 @@ class DdRumWeb extends DdRumPlatform {
     String? errorType,
     Map<String, dynamic> attributes,
   ) async {
-    var jsError = JSError();
-    jsError.stack = convertWebStackTrace(stackTrace);
-    jsError.message = error.toString();
-    jsError.name = errorType ?? 'Error';
+    final epochTime = timestamp.millisecondsSinceEpoch;
+    final eventTime = _toRelativeTime(timestamp);
 
     final fingerprint = attributes.remove(DatadogAttributes.errorFingerprint);
-    if (fingerprint != null) {
-      jsError.dd_fingerprint = fingerprint;
-    }
 
-    DD_RUM?.addError(jsError, attributesToJs(attributes, 'attributes'));
+    final id = _uuid.v4();
+    final context = attributesToJs(attributes, 'attributes');
+    _webPlugin?.addEvent(
+      eventTime,
+      RumWebRawErrorEvent(
+        date: epochTime.toJS,
+        context: context,
+        error: RumWebRawErrorData(
+          id: id.toString(),
+          message: error.toString(),
+          source: errorSourceToJs(source),
+          stack: convertWebStackTrace(stackTrace),
+          type: errorType ?? 'UnknownError',
+          fingerprint: fingerprint,
+        ),
+      ),
+      RumWebErrorEventDomainContext(),
+    );
   }
 
   @override
@@ -108,17 +135,30 @@ class DdRumWeb extends DdRumPlatform {
     String? errorType,
     Map<String, dynamic> attributes,
   ) async {
-    var jsError = JSError();
-    jsError.stack = convertWebStackTrace(stackTrace);
-    jsError.message = message;
-    jsError.name = errorType ?? 'Error';
+    final epochTime = timestamp.millisecondsSinceEpoch;
+    final eventTime = _toRelativeTime(timestamp);
 
     final fingerprint = attributes.remove(DatadogAttributes.errorFingerprint);
-    if (fingerprint != null) {
-      jsError.dd_fingerprint = fingerprint;
-    }
 
-    DD_RUM?.addError(jsError, attributesToJs(attributes, 'attributes'));
+    final id = _uuid.v4();
+    final context = attributesToJs(attributes, 'attributes');
+
+    _webPlugin?.addEvent(
+      eventTime,
+      RumWebRawErrorEvent(
+        date: epochTime.toJS,
+        context: context,
+        error: RumWebRawErrorData(
+          id: id.toString(),
+          message: message,
+          source: errorSourceToJs(source),
+          stack: convertWebStackTrace(stackTrace),
+          type: errorType ?? 'UnknownError',
+          fingerprint: fingerprint,
+        ),
+      ),
+      RumWebErrorEventDomainContext(),
+    );
   }
 
   @override
@@ -134,7 +174,26 @@ class DdRumWeb extends DdRumPlatform {
   @override
   Future<void> addAction(DateTime timestamp, RumActionType type, String name,
       Map<String, dynamic> attributes) async {
-    DD_RUM?.addAction(name, attributesToJs(attributes, 'attributes'));
+    final epochTime = timestamp.millisecondsSinceEpoch;
+    final eventTime = _toRelativeTime(timestamp);
+
+    final id = _uuid.v4();
+    final context = attributesToJs(attributes, 'attributes');
+
+    // TODO(RUM-): Replace with plugin bridge call.
+    _webPlugin?.addEvent(
+      eventTime,
+      RumWebRawActionEvent(
+        date: epochTime.toJS,
+        context: context,
+        action: RumWebRawActionData(
+          id: id.toString(),
+          type: actionTypeToJs(type),
+          target: RumWebActionTarget(name: name),
+        ),
+      ),
+      RumWebActionEventDomainContext(),
+    );
   }
 
   @override
@@ -149,7 +208,8 @@ class DdRumWeb extends DdRumPlatform {
       RumHttpMethod httpMethod,
       String url,
       Map<String, dynamic> attributes) async {
-    // NOOP
+    _resourceTracker?.startResource(
+        timestamp, key, httpMethod, url, attributes);
   }
 
   @override
@@ -167,19 +227,21 @@ class DdRumWeb extends DdRumPlatform {
   @override
   Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
       RumResourceType kind, int? size, Map<String, dynamic> attributes) async {
-    // NOOP
+    _resourceTracker?.stopResource(
+        timestamp, key, statusCode, kind, size, attributes);
   }
 
   @override
   Future<void> stopResourceWithError(DateTime timestamp, String key,
       Exception error, Map<String, dynamic> attributes) async {
-    // NOOP
+    _resourceTracker?.stopResourceWithError(timestamp, key, error, attributes);
   }
 
   @override
   Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
       String message, String type, Map<String, dynamic> attributes) async {
-    // NOOP
+    _resourceTracker?.stopResourceWithErrorInfo(
+        timestamp, key, message, type, attributes);
   }
 
   @override
@@ -213,6 +275,11 @@ class DdRumWeb extends DdRumPlatform {
   Future<void> updatePerformanceMetrics(
       List<double> buildTimes, List<double> rasterTimes) async {
     // NOOP - Not supported by the Browser SDK
+  }
+
+  JSNumber _toRelativeTime(DateTime time) {
+    return _webPlugin?.getEventRelativeTime(time) ??
+        time.microsecondsSinceEpoch.toJS;
   }
 }
 
@@ -268,6 +335,8 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
   external String? get proxy;
   external JSArray get allowedTracingUrls;
   external JSArray get enableExperimentalFeatures;
+  external bool get compressIntakeRequests;
+  external JSArray? get plugins;
 
   external factory _RumInitOptions({
     String applicationId,
@@ -293,6 +362,8 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
     num? traceSampleRate,
     String? traceContextInjection,
     JSArray enableExperimentalFeatures,
+    bool compressIntakeRequests,
+    JSArray? plugins,
   });
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -18,7 +18,7 @@ import 'rum_web_plugin.dart';
 
 class DdRumWeb extends DdRumPlatform {
   final Uuid _uuid = Uuid();
-  RumWebPlugin? _webPlugin;
+  RumWebPluginImpl? _webPlugin;
   ResourceTracker? _resourceTracker;
 
   // Because Web needs the full SDK configuration, we have a separate init method
@@ -30,8 +30,9 @@ class DdRumWeb extends DdRumPlatform {
     final sanitizedFirstPartyHosts = FirstPartyHost.createSanitized(
         configuration.firstPartyHostsWithTracingHeaders, logger);
 
-    _webPlugin = RumWebPlugin();
-    final plugins = [createJSInteropWrapper<RumWebPlugin>(_webPlugin!)].toJS;
+    _webPlugin = RumWebPluginImpl();
+    final plugins =
+        [createJSInteropWrapper<RumWebPluginImpl>(_webPlugin!)].toJS;
 
     _resourceTracker = ResourceTracker(_webPlugin!);
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/raw_events.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/raw_events.dart
@@ -1,0 +1,306 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+// ignore_for_file: non_constant_identifier_names
+
+import 'dart:js_interop';
+
+import '../../web_helpers.dart';
+import '../rum.dart';
+
+extension type RumWebCount._(JSObject _) implements JSObject {
+  external int number;
+
+  external factory RumWebCount({required int number});
+}
+
+extension type RumWebRawEvent._(JSObject _) implements JSObject {
+  external JSObject context;
+
+  external factory RumWebRawEvent({JSObject context});
+}
+
+extension type RumWebEventDomainContext._(JSObject _) implements JSObject {
+  external RumWebEventDomainContext();
+}
+
+extension type RumWebRawEventViewData._(JSObject _) implements JSObject {
+  @JS('in_foreground')
+  external bool inForeground;
+}
+
+// MARK: Error Events and Context
+
+extension type RumWebRawErrorResource._(JSObject _) implements JSObject {
+  external String method;
+  @JS('status_code')
+  external int statusCode;
+  external String url;
+
+  external RumWebRawErrorResource({
+    required String method,
+    required int status_code,
+    required String url,
+  });
+}
+
+extension type RumWebRawErrorData._(JSObject _) implements JSObject {
+  external String id;
+  external String? type;
+  external String? stack;
+  @JS('handling_stack')
+  external String? handlingStack;
+  @JS('component_stack')
+  external String? componentStack;
+  external String? fingerprint;
+  external String? source;
+  external String message;
+  external String? handling;
+  @JS('source_type')
+  external String sourceType;
+  external RumWebRawErrorResource? resource;
+
+  external factory RumWebRawErrorData({
+    required String id,
+    String? type,
+    String? stack,
+    String? handling_stack,
+    String? component_stack,
+    String? fingerprint,
+    String? source,
+    required String message,
+    String? handling,
+    String source_type = 'browser',
+    RumWebRawErrorResource resource,
+  });
+}
+extension type RumWebRawErrorEvent.__(RumWebRawEvent __)
+    implements RumWebRawEvent {
+  external JSNumber date;
+  external String type;
+  external RumWebRawErrorData error;
+
+  factory RumWebRawErrorEvent({
+    required JSNumber date,
+    required JSObject context,
+    required RumWebRawErrorData error,
+  }) =>
+      RumWebRawErrorEvent._(
+        type: 'error',
+        date: date,
+        context: context,
+        error: error,
+      );
+
+  external factory RumWebRawErrorEvent._({
+    JSObject context,
+    required JSNumber date,
+    required String type,
+    required RumWebRawErrorData error,
+  });
+}
+
+String errorSourceToJs(RumErrorSource source) {
+  return switch (source) {
+    RumErrorSource.source => 'source',
+    RumErrorSource.network => 'network',
+    RumErrorSource.webview => 'webview',
+    RumErrorSource.console => 'console',
+    RumErrorSource.custom => 'custom',
+  };
+}
+
+extension type RumWebErrorEventDomainContext._(RumWebEventDomainContext _)
+    implements RumWebEventDomainContext {
+  external JSObject error;
+  external String? handlingStack;
+
+  external factory RumWebErrorEventDomainContext({
+    JSObject error,
+    String? handlingStack,
+  });
+}
+
+// MARK: Action Events and Context
+
+extension type RumWebActionTarget._(JSObject _) implements JSObject {
+  external String name;
+
+  external RumWebActionTarget({required String name});
+}
+
+extension type RumWebRawActionData._(JSObject _) implements JSObject {
+  external String id;
+  external String type;
+  @JS('loading_time')
+  external JSNumber? loadingTime;
+  external RumWebCount? error;
+  @JS('long_task')
+  external RumWebCount? longTask;
+  external RumWebCount? resource;
+  external RumWebActionTarget target;
+
+  external factory RumWebRawActionData({
+    required String id,
+    required String type,
+    JSNumber? loading_time,
+    RumWebCount? error,
+    RumWebCount? long_task,
+    RumWebCount? resource,
+    required RumWebActionTarget target,
+  });
+}
+
+extension type RumWebRawActionEvent.__(RumWebRawEvent __)
+    implements RumWebRawEvent {
+  external JSNumber date;
+  external String type;
+  external RumWebRawActionData action;
+
+  factory RumWebRawActionEvent({
+    required JSNumber date,
+    required JSObject context,
+    required RumWebRawActionData action,
+    RumWebRawEventViewData? view,
+  }) =>
+      RumWebRawActionEvent._(
+        date: date,
+        context: context,
+        type: 'action',
+        action: action,
+      );
+
+  external factory RumWebRawActionEvent._({
+    required JSNumber date,
+    required JSObject context,
+    required String type,
+    required RumWebRawActionData action,
+  });
+}
+
+extension type RumWebActionEventDomainContext._(RumWebEventDomainContext _)
+    implements RumWebEventDomainContext {
+  external String? handlingStack;
+
+  external factory RumWebActionEventDomainContext({String? handlingStack});
+}
+
+String actionTypeToJs(RumActionType source) {
+  return switch (source) {
+    RumActionType.click => 'click',
+    RumActionType.tap => 'tap',
+    RumActionType.scroll => 'scroll',
+    RumActionType.swipe => 'swipe',
+    RumActionType.custom => 'custom',
+  };
+}
+
+// MARK: Resource Events and Context
+
+extension type RumWebRawResourceData._(JSObject _) implements JSObject {
+  external String id;
+  external String type;
+  external JSNumber? duration;
+  external String url;
+  external String? method;
+  @JS('status_code')
+  external JSNumber? statusCode;
+  external JSNumber? size;
+  @JS('encoded_body_size')
+  external JSNumber? encodedBodySize;
+  @JS('decoded_body_size')
+  external JSNumber? decodedBodySize;
+  @JS('transfer_size')
+  external JSNumber? transferSize;
+  @JS('render_blocking_status')
+  external String? renderBlockingStatus;
+  external String? protocol;
+
+  external factory RumWebRawResourceData({
+    required String id,
+    required String type,
+    JSNumber? duration,
+    required String url,
+    String? method,
+    JSNumber? status_code,
+    JSNumber? size,
+    JSNumber? encoded_body_size,
+    JSNumber? decoded_body_size,
+    JSNumber? transfer_size,
+    String? render_blocking_status,
+    String? protocol,
+  });
+}
+
+extension type RumWebRawResourceDdData._(JSObject _) implements JSObject {
+  @JS('trace_id')
+  external String? traceId;
+  @JS('span_id')
+  external String? spanId;
+  @JS('rule_psr')
+  external JSNumber? rulePsr;
+  external bool discarded;
+
+  external factory RumWebRawResourceDdData({
+    String? trace_id,
+    String? span_id,
+    JSNumber? rule_psr,
+    required bool discarded,
+  });
+}
+
+@anonymous
+extension type RumWebRawError._(JSObject _) {
+  external String name;
+  external String message;
+  external String? stack;
+
+  external factory RumWebRawError({
+    required String name,
+    required String message,
+    String? stack,
+  });
+}
+
+extension type RumWebResourceEventDomainContext._(RumWebEventDomainContext _)
+    implements RumWebEventDomainContext {
+  external JSObject? performanceEntry;
+  external RumWebRawError? error;
+
+  external factory RumWebResourceEventDomainContext({
+    required JSObject? performanceEntry,
+    RumWebRawError? error,
+  });
+}
+
+extension type RumWebRawResourceEvent.__(RumWebRawEvent __)
+    implements RumWebRawEvent {
+  external JSNumber date;
+  external String type;
+  external RumWebRawResourceData resource;
+  @JS('_dd')
+  external RumWebRawResourceDdData dd;
+
+  factory RumWebRawResourceEvent({
+    required JSNumber date,
+    required RumWebRawResourceData resource,
+    required RumWebRawResourceDdData dd,
+    Map<String, Object?>? context,
+  }) {
+    final value = RumWebRawResourceEvent._(
+      date: date,
+      type: 'resource',
+      resource: resource,
+      context: valueToJs(context ?? {}, 'context') as JSObject,
+    )..dd = dd;
+    return value;
+  }
+
+  external factory RumWebRawResourceEvent._({
+    required JSNumber date,
+    required String type,
+    required RumWebRawResourceData resource,
+    required JSObject context,
+  });
+}

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/resource_tracker.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/resource_tracker.dart
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:js_interop';
+
+import 'package:uuid/uuid.dart';
+
+import '../../../datadog_internal.dart';
+import '../../web_helpers.dart';
+import '../rum.dart';
+import 'raw_events.dart';
+import 'rum_web_plugin.dart';
+
+/// This class is used to track resources until they finish and are sent to the
+/// Browser SDK. This class will be replaced by tracking done in a bridge plugin
+/// hosted in the Browser SDK in future versions.
+///
+/// See RUM-
+class ResourceTracker {
+  final Uuid _uuid = Uuid();
+  final RumWebPlugin _webPlugin;
+  final Map<String, _ResourceInfo> _resources = {};
+
+  ResourceTracker(this._webPlugin);
+
+  void startResource(
+    DateTime timestamp,
+    String key,
+    RumHttpMethod httpMethod,
+    String url,
+    Map<String, dynamic> attributes,
+  ) {
+    if (_resources.containsKey(key)) {
+      return;
+    }
+
+    final resouceInfo = _ResourceInfo(
+      timestamp: timestamp,
+      key: key,
+      method: httpMethod,
+      url: url,
+      attributes: attributes,
+    );
+    _resources[key] = resouceInfo;
+  }
+
+  void stopResource(
+    DateTime timestamp,
+    String key,
+    int? statusCode,
+    RumResourceType kind,
+    int? size,
+    Map<String, dynamic> attributes,
+  ) {
+    final resource = _resources[key];
+    if (resource == null) return;
+
+    final epochTime = timestamp.millisecondsSinceEpoch;
+    final duration = timestamp.difference(resource.timestamp).inNanoseconds;
+    final eventTime = _webPlugin.getEventRelativeTime(timestamp);
+    final finalAttributes = resource.attributes.mergedWith(attributes);
+
+    final ddData = _extractDdData(finalAttributes);
+
+    _webPlugin.addEvent(
+      eventTime,
+      RumWebRawResourceEvent(
+        date: epochTime.toJS,
+        resource: RumWebRawResourceData(
+          id: key,
+          type: kind.name,
+          url: resource.url,
+          duration: duration.toJS,
+          method: resource.method.name.toUpperCase(),
+          status_code: statusCode?.toJS,
+          transfer_size: size?.toJS,
+        ),
+        dd: ddData,
+        context: finalAttributes,
+      ),
+      RumWebResourceEventDomainContext(performanceEntry: null),
+    );
+  }
+
+  void stopResourceWithError(
+    DateTime timestamp,
+    String key,
+    Exception error,
+    Map<String, dynamic> attributes,
+  ) {
+    stopResourceWithErrorInfo(
+      timestamp,
+      key,
+      error.toString(),
+      error.runtimeType.toString(),
+      attributes,
+    );
+  }
+
+  void stopResourceWithErrorInfo(
+    DateTime timestamp,
+    String key,
+    String message,
+    String type,
+    Map<String, dynamic> attributes,
+  ) {
+    final resource = _resources[key];
+    if (resource == null) return;
+
+    final epochTime = timestamp.millisecondsSinceEpoch;
+    final eventTime = _webPlugin.getEventRelativeTime(timestamp);
+    final finalAttributes = resource.attributes.mergedWith(attributes);
+
+    final id = _uuid.v4();
+
+    _webPlugin.addEvent(
+      eventTime,
+      RumWebRawErrorEvent(
+        date: epochTime.toJS,
+        context: attributesToJs(finalAttributes, 'attributes'),
+        error: RumWebRawErrorData(
+          id: id.toString(),
+          message: message,
+          source: 'network',
+          type: type,
+          resource: RumWebRawErrorResource(
+            method: resource.method.name.toUpperCase(),
+            status_code: 0,
+            url: resource.url,
+          ),
+        ),
+      ),
+      RumWebErrorEventDomainContext(),
+    );
+  }
+
+  RumWebRawResourceDdData _extractDdData(Map<String, dynamic> attributes) {
+    final traceId =
+        attributes.remove(DatadogRumPlatformAttributeKey.traceID) as String?;
+    final spanId =
+        attributes.remove(DatadogRumPlatformAttributeKey.spanID) as String?;
+    final rulePsr =
+        attributes.remove(DatadogRumPlatformAttributeKey.rulePsr) as double?;
+
+    return RumWebRawResourceDdData(
+      trace_id: traceId,
+      span_id: spanId,
+      rule_psr: rulePsr?.toJS,
+      discarded: false,
+    );
+  }
+}
+
+class _ResourceInfo {
+  final DateTime timestamp;
+  final String key;
+  final RumHttpMethod method;
+  final String url;
+  final Map<String, dynamic> attributes;
+
+  _ResourceInfo({
+    required this.timestamp,
+    required this.key,
+    required this.method,
+    required this.url,
+    required this.attributes,
+  });
+}
+
+extension MapMerge<K, V> on Map<K, V> {
+  // Merge the current dictionary with the new dictionary,
+  // overwriting any duplicate keys. This does not do any
+  // 'recursive' merging, so maps will be overwritten.
+  Map<K, V> mergedWith(Map<K, V> other) {
+    final result = Map<K, V>.from(this);
+    for (final entry in other.entries) {
+      result[entry.key] = entry.value;
+    }
+
+    return result;
+  }
+}

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/resource_tracker.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/resource_tracker.dart
@@ -19,7 +19,7 @@ import 'rum_web_plugin.dart';
 /// See RUM-
 class ResourceTracker {
   final Uuid _uuid = Uuid();
-  final RumWebPlugin _webPlugin;
+  final RumWebPluginImpl _webPlugin;
   final Map<String, _ResourceInfo> _resources = {};
 
   ResourceTracker(this._webPlugin);

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/rum_web_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/rum_web_plugin.dart
@@ -1,0 +1,40 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
+import 'raw_events.dart';
+
+@JSExport()
+class RumWebPlugin {
+  final String name = 'DatadogFlutterWeb';
+
+  JSFunction? _addEvent;
+  int? _navigationStart;
+
+  void onRumStart(OnRumStartOptions options) {
+    _addEvent = options.addEvent;
+  }
+
+  void addEvent(
+      JSNumber time, RumWebRawEvent event, RumWebEventDomainContext context) {
+    _addEvent?.callAsFunction(null, time, event, context, null);
+  }
+
+  JSNumber getEventRelativeTime(DateTime time) {
+    _navigationStart ??= window.performance.timing.navigationStart;
+    if (_navigationStart == null) {
+      return time.millisecondsSinceEpoch.toJS;
+    }
+
+    return (time.millisecondsSinceEpoch - _navigationStart!).toJS;
+  }
+}
+
+@anonymous
+extension type OnRumStartOptions._(JSObject _) implements JSObject {
+  external JSFunction addEvent;
+}

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/rum_web_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/rum_web_plugin.dart
@@ -8,13 +8,35 @@ import 'package:web/web.dart';
 
 import 'raw_events.dart';
 
+/// Mirrors the `RumPlugin` interface from the Datadog Browser SDK:
+/// https://github.com/DataDog/browser-sdk/blob/bd6074ff1f33cb0b94acf7b6b7eae95180271475/packages/rum-core/src/domain/plugins.ts#L30
+///
+/// Keep this class updated to match the original interface.
 @JSExport()
-class RumWebPlugin {
-  final String name = 'DatadogFlutterWeb';
+abstract interface class RumWebPlugin {
+  String get name;
+
+  /// Get configuration information about how the SDK is set up to
+  /// send to telemetry.
+  ///
+  /// This should return a typescript Record%lt;String, JSAny%gt;
+  JSObject getConfigurationTelemetry() {
+    return JSObject();
+  }
+
+  // Sent when RUM is started. Replaces onInit from previous versions.
+  void onRumStart(OnRumStartOptions options) {}
+}
+
+@JSExport()
+class RumWebPluginImpl extends RumWebPlugin {
+  @override
+  String get name => 'DatadogFlutterWeb';
 
   JSFunction? _addEvent;
   int? _navigationStart;
 
+  @override
   void onRumStart(OnRumStartOptions options) {
     _addEvent = options.addEvent;
   }

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   json_annotation: ^4.9.0
   uuid: ^4.0.0
   meta: ^1.7.0
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
+@TestOn('vm')
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
+@TestOn('vm')
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
+@TestOn('vm')
 
 import 'dart:async';
 import 'dart:math';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -370,7 +370,8 @@ void main() {
       rum.timeProvider = mockTimeProvider;
     });
 
-    test('markViewFirstBuildComplete adds ns timestamp as view attribute', () {
+    test('markViewFirstBuildComplete adds ns timestamp as view attribute',
+        testOn: 'vm', () {
       final startTime = DateTime.now();
       final duration = random.nextInt(1 << 32);
       final timeAnswers = [

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -1,6 +1,8 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
+// TODO (RUM-): See if we can setup these tests to work on browser
+@TestOn('vm')
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';

--- a/packages/datadog_flutter_plugin/test/rum/web/error_event_matcher.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/error_event_matcher.dart
@@ -1,3 +1,0 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2025-Present Datadog, Inc.

--- a/packages/datadog_flutter_plugin/test/rum/web/error_event_matcher.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/error_event_matcher.dart
@@ -1,0 +1,3 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.

--- a/packages/datadog_flutter_plugin/test/rum/web/event_matchers.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/event_matchers.dart
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:datadog_flutter_plugin/src/rum/web/raw_events.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Custom Equality matchers
+Matcher equalsResourceEvent(Object object) {
+  return _ResourceEventMatcher(object);
+}
+
+class _ResourceEventMatcher extends Matcher {
+  final Object? _expected;
+
+  _ResourceEventMatcher(this._expected);
+
+  @override
+  Description describe(Description description) {
+    return description.addDescriptionOf(_expected);
+  }
+
+  @override
+  bool matches(Object? actual, Map<dynamic, dynamic> matchState) {
+    // ignore: invalid_runtime_check_with_js_interop_types
+    if (_expected is! JSObject || actual is! JSObject) return false;
+
+    final expectedResource = _expected as RumWebRawResourceEvent;
+    final actualResource = actual as RumWebRawResourceEvent;
+
+    StringBuffer mismatch = StringBuffer();
+
+    _compareProperties(
+        'date', expectedResource.date, actualResource.date, mismatch);
+    _compareProperties(
+        'type', expectedResource.type, actualResource.type, mismatch);
+    _compareProperties('resource.id', expectedResource.resource.id,
+        actualResource.resource.id, mismatch);
+    _compareProperties('resource.type', expectedResource.resource.type,
+        actualResource.resource.type, mismatch);
+    _compareProperties('resource.duration', expectedResource.resource.duration,
+        actualResource.resource.duration, mismatch);
+    _compareProperties('resource.url', expectedResource.resource.url,
+        actualResource.resource.url, mismatch);
+    _compareProperties('resource.method', expectedResource.resource.method,
+        actualResource.resource.method, mismatch);
+    _compareProperties(
+        'resource.statusCode',
+        expectedResource.resource.statusCode,
+        actualResource.resource.statusCode,
+        mismatch);
+    _compareProperties('resource.size', expectedResource.resource.size,
+        actualResource.resource.size, mismatch);
+    _compareProperties(
+        'resource.encodedBodySize',
+        expectedResource.resource.encodedBodySize,
+        actualResource.resource.encodedBodySize,
+        mismatch);
+    _compareProperties(
+        'resource.decodedBodySize',
+        expectedResource.resource.decodedBodySize,
+        actualResource.resource.decodedBodySize,
+        mismatch);
+    _compareProperties(
+        'resource.transferSize',
+        expectedResource.resource.transferSize,
+        actualResource.resource.transferSize,
+        mismatch);
+    _compareProperties(
+        'resource.renderBlockingStatus',
+        expectedResource.resource.renderBlockingStatus,
+        actualResource.resource.renderBlockingStatus,
+        mismatch);
+    _compareProperties('resource.protocol', expectedResource.resource.protocol,
+        actualResource.resource.protocol, mismatch);
+    _compareContext(
+        'context', expectedResource.context, actualResource.context, mismatch);
+    _compareProperties('dd.discarded', expectedResource.dd.discarded,
+        actualResource.dd.discarded, mismatch);
+    _compareProperties('dd.traceId', expectedResource.dd.traceId,
+        actualResource.dd.traceId, mismatch);
+    _compareProperties('dd.spanId', expectedResource.dd.spanId,
+        actualResource.dd.spanId, mismatch);
+    _compareProperties('dd.rulePsr', expectedResource.dd.rulePsr,
+        actualResource.dd.rulePsr, mismatch);
+
+    if (mismatch.isNotEmpty) {
+      matchState['mismatch'] = mismatch.toString();
+    }
+
+    return mismatch.isEmpty;
+  }
+
+  @override
+  Description describeMismatch(Object? item, Description mismatchDescription,
+      Map<dynamic, dynamic> matchState, bool verbose) {
+    Object? mismatch = matchState['mismatch'];
+    if (mismatch is String) {
+      mismatchDescription.add(mismatch);
+    }
+    return mismatchDescription;
+  }
+}
+
+Matcher equalsContext(Object context) {
+  return _ContextMatcher(context);
+}
+
+class _ContextMatcher extends Matcher {
+  final Object? _expected;
+
+  _ContextMatcher(this._expected);
+
+  @override
+  Description describe(Description description) {
+    return description.addDescriptionOf(_expected);
+  }
+
+  @override
+  bool matches(Object? actual, Map<dynamic, dynamic> matchState) {
+    // ignore: invalid_runtime_check_with_js_interop_types
+    if (_expected is! JSObject || actual is! JSObject) return false;
+
+    StringBuffer mismatch = StringBuffer();
+
+    _compareContext('context', _expected, actual, mismatch);
+
+    return mismatch.isEmpty;
+  }
+}
+
+void _compareProperties(String propertyName, Object? expected, Object? actual,
+    StringBuffer mismatch) {
+  if (expected != actual) {
+    mismatch.writeln('$propertyName is $actual instead of $expected');
+  }
+}
+
+void _compareContext(String propertyName, Object? expected, Object? actual,
+    StringBuffer mismatch) {
+  // ignore: invalid_runtime_check_with_js_interop_types
+  if (expected is! JSObject) {
+    mismatch.write('expected $propertyName is not a JSObject');
+    return;
+  }
+  // ignore: invalid_runtime_check_with_js_interop_types
+  if (actual is! JSObject) {
+    mismatch.write('actual $propertyName is not a JSObject');
+    return;
+  }
+
+  final expectedKeys = JSObjectUtil.keys(expected);
+  final actualKeys = JSObjectUtil.keys(actual);
+
+  if (expectedKeys.length != actualKeys.length) {
+    mismatch.writeln(
+        'expected $propertyName length is ${actualKeys.length} instead of ${expectedKeys.length}');
+  }
+
+  for (int i = 0; i < expectedKeys.length; ++i) {
+    final key = expectedKeys[i]!;
+    final expectedValue = expected.getProperty(key);
+    final actualValue = actual.getProperty(key);
+    if (actualValue == null) {
+      mismatch.writeln('expected $propertyName.$key is missing.');
+      continue;
+    }
+    if (expectedValue != actualValue) {
+      mismatch.writeln(
+          '$propertyName.$key is $actualValue instead of $expectedValue.');
+    }
+  }
+}
+
+@JS('Object')
+extension type JSObjectUtil._(JSObject _jsObject) implements JSAny {
+  external static JSArray keys(JSObject object);
+}

--- a/packages/datadog_flutter_plugin/test/rum/web/resource_tracker_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/resource_tracker_test.dart
@@ -1,0 +1,358 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+@TestOn('browser')
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart'
+    hide DurationHelpers;
+import 'package:datadog_flutter_plugin/src/rum/rum.dart';
+import 'package:datadog_flutter_plugin/src/rum/web/raw_events.dart';
+import 'package:datadog_flutter_plugin/src/rum/web/resource_tracker.dart';
+import 'package:datadog_flutter_plugin/src/rum/web/rum_web_plugin.dart';
+import 'package:datadog_flutter_plugin/src/web_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'event_matchers.dart';
+
+class MockWebPlugin extends Mock implements RumWebPlugin {}
+
+final navigationStart = DateTime.now();
+
+void main() {
+  late MockWebPlugin mockPlugin;
+
+  JSNumber getRelativeEventTime(DateTime dateTime) {
+    return (dateTime.difference(navigationStart).inMilliseconds).toJS;
+  }
+
+  setUp(() {
+    mockPlugin = MockWebPlugin();
+
+    when(() => mockPlugin.getEventRelativeTime(any())).thenAnswer((call) {
+      final timestamp = call.positionalArguments[0] as DateTime;
+      return getRelativeEventTime(timestamp);
+    });
+  });
+
+  test('startResource sends no events', () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+
+    // When
+    tracker.startResource(
+      DateTime.now(),
+      'fake_key',
+      RumHttpMethod.get,
+      'fake_url',
+      {},
+    );
+
+    // Then
+    verifyZeroInteractions(mockPlugin);
+  });
+
+  test('stopResource sends resource event', () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+    final size = randomInt();
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {},
+    );
+    tracker
+        .stopResource(endTime, keyName, 200, RumResourceType.image, size, {});
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    // Despite having a matcher, make sure all properties got transferred to this event manually
+    // to ensure the JS Interop is coded properly.
+    final actualEvent = captured[0] as RumWebRawResourceEvent;
+    expect(actualEvent.date, endTime.millisecondsSinceEpoch.toJS);
+    expect(actualEvent.resource.id, keyName);
+    expect(actualEvent.type, 'resource');
+    expect(actualEvent.resource.type, 'image');
+    expect(actualEvent.resource.url, url);
+    expect(actualEvent.resource.duration,
+        endTime.difference(startTime).inNanoseconds.toJS);
+    expect(actualEvent.resource.method, 'GET');
+    expect(actualEvent.resource.statusCode, 200.toJS);
+    expect(actualEvent.resource.transferSize, size.toJS);
+  });
+
+  test('stopResource sends resource event merges attributes to context', () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+    final size = randomInt();
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {'attribute_1': 'value', 'attribute_2': 'value_2'},
+    );
+    tracker.stopResource(endTime, keyName, 200, RumResourceType.image, size,
+        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'});
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final expectedEvent = RumWebRawResourceEvent(
+        date: endTime.millisecondsSinceEpoch.toJS,
+        resource: RumWebRawResourceData(
+          id: keyName,
+          type: 'image',
+          url: url,
+          duration: (endTime.difference(startTime).inNanoseconds).toJS,
+          method: 'GET',
+          status_code: 200.toJS,
+          transfer_size: size.toJS,
+        ),
+        dd: RumWebRawResourceDdData(discarded: false),
+        context: {
+          'attribute_1': 'value',
+          'attribute_2': 'finished_value',
+          'attribute_3': 'extra_value',
+        });
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    expect(captured[0], equalsResourceEvent(expectedEvent));
+  });
+
+  test('stopResourceWithError sends error event', () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {},
+    );
+    final error = FormatException('message');
+    tracker.stopResourceWithError(endTime, keyName, error, {});
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    final errorEvent = captured[0] as RumWebRawErrorEvent;
+    expect(errorEvent.date, endTime.millisecondsSinceEpoch.toJS);
+    expect(errorEvent.error.id, isNotNull);
+    expect(errorEvent.error.message, error.toString());
+    expect(errorEvent.error.source, 'network');
+    expect(errorEvent.error.type, 'FormatException');
+    expect(errorEvent.error.resource?.method, 'GET');
+    expect(errorEvent.error.resource?.statusCode, 0);
+    expect(errorEvent.error.resource?.url, url);
+  });
+
+  test(
+      'stopResourceWithError sends resource event with error merges attributes to context',
+      () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {'attribute_1': 'value', 'attribute_2': 'value_2'},
+    );
+    final error = FormatException('message');
+    tracker.stopResourceWithError(endTime, keyName, error,
+        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'});
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final expectedContext = attributesToJs({
+      'attribute_1': 'value',
+      'attribute_2': 'finished_value',
+      'attribute_3': 'extra_value',
+    }, 'attributes');
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    final errorEvent = captured[0] as RumWebRawErrorEvent;
+    expect(errorEvent.context, equalsContext(expectedContext));
+  });
+
+  test('stopResourceWithErrorInfo sends resource event with info', () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+    final errorType = randomString();
+    final errorMessage = randomString();
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {},
+    );
+    tracker.stopResourceWithErrorInfo(
+      endTime,
+      keyName,
+      errorMessage,
+      errorType,
+      {},
+    );
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    final errorEvent = captured[0] as RumWebRawErrorEvent;
+    expect(errorEvent.date, endTime.millisecondsSinceEpoch.toJS);
+    expect(errorEvent.error.id, isNotNull);
+    expect(errorEvent.error.message, errorMessage);
+    expect(errorEvent.error.source, 'network');
+    expect(errorEvent.error.type, errorType);
+    expect(errorEvent.error.resource?.method, 'GET');
+    expect(errorEvent.error.resource?.statusCode, 0);
+    expect(errorEvent.error.resource?.url, url);
+  });
+
+  test(
+      'stopResourceWithError sends resource event with error merges attributes to context',
+      () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+    final errorType = randomString();
+    final errorMessage = randomString();
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {'attribute_1': 'value', 'attribute_2': 'value_2'},
+    );
+    tracker.stopResourceWithErrorInfo(endTime, keyName, errorMessage, errorType,
+        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'});
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final expectedContext = attributesToJs({
+      'attribute_1': 'value',
+      'attribute_2': 'finished_value',
+      'attribute_3': 'extra_value',
+    }, 'attributes');
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    final errorEvent = captured[0] as RumWebRawErrorEvent;
+    expect(errorEvent.context, equalsContext(expectedContext));
+  });
+
+  test('stopResource transfers traceId and spanId to DdData', () {
+    // Given
+    final tracker = ResourceTracker(mockPlugin);
+    final startTime = DateTime.now();
+    final endTime = startTime.add(Duration(seconds: 20));
+    final keyName = randomString();
+    final url = randomString();
+    final size = randomInt();
+    // These are not real trace Ids, but proves the values get transferred
+    final traceId = randomString();
+    final spanId = randomString();
+    final rulePsr = randomDouble(min: 0.0, max: 1.0);
+
+    // When
+    tracker.startResource(
+      startTime,
+      keyName,
+      RumHttpMethod.get,
+      url,
+      {
+        DatadogRumPlatformAttributeKey.traceID: traceId,
+        DatadogRumPlatformAttributeKey.spanID: spanId,
+        DatadogRumPlatformAttributeKey.rulePsr: rulePsr.toJS,
+      },
+    );
+    tracker
+        .stopResource(endTime, keyName, 200, RumResourceType.image, size, {});
+
+    // Then
+    final expectedEventTime = getRelativeEventTime(endTime);
+    final captured = verify(() => mockPlugin.addEvent(
+          expectedEventTime,
+          captureAny(),
+          captureAny(),
+        )).captured;
+    final actualEvent = captured[0] as RumWebRawResourceEvent;
+    expect(
+        actualEvent.context
+            .getProperty(DatadogRumPlatformAttributeKey.traceID.toJS),
+        isNull);
+    expect(
+        actualEvent.context
+            .getProperty(DatadogRumPlatformAttributeKey.spanID.toJS),
+        isNull);
+    expect(
+        actualEvent.context
+            .getProperty(DatadogRumPlatformAttributeKey.rulePsr.toJS),
+        isNull);
+    expect(actualEvent.dd.traceId, traceId);
+    expect(actualEvent.dd.spanId, spanId);
+    expect(actualEvent.dd.rulePsr, rulePsr.toJS);
+  });
+}

--- a/packages/datadog_flutter_plugin/test/rum/web/resource_tracker_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/resource_tracker_test.dart
@@ -19,7 +19,7 @@ import 'package:mocktail/mocktail.dart';
 
 import 'event_matchers.dart';
 
-class MockWebPlugin extends Mock implements RumWebPlugin {}
+class MockWebPlugin extends Mock implements RumWebPluginImpl {}
 
 final navigationStart = DateTime.now();
 

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -7,32 +7,34 @@ import 'package:datadog_flutter_plugin/src/tracing/tracing_headers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  // if (!kIsWeb) {
-  //   test('TracingIdRepresentation generates proper values', () {
-  //     // Create a value in 128-bit hex that has leading zeros on both
-  //     // the low and high 64-bits, and ensure we get the proper values
-  //     const low = 0x01445feed89934bb;
-  //     const high = 0x01222f00d89934ba;
+  test('TracingIdRepresentation generates proper values', () {
+    // Create a value in 128-bit hex that has leading zeros on both
+    // the low and high 64-bits, and ensure we get the proper values
+    const low0 = 0xd89934bb;
+    const low32 = 0x01445fee;
+    const high0 = 0xd89934ba;
+    const high32 = 0x01222f00;
 
-  //     var combined = BigInt.from(high);
-  //     combined = (combined << 64) + BigInt.from(low);
+    var combined = BigInt.from(high32);
+    combined = (combined << 32) + BigInt.from(high0);
+    combined = (combined << 32) + BigInt.from(low32);
+    combined = (combined << 32) + BigInt.from(low0);
 
-  //     final tracingId = TracingId(combined);
+    final tracingId = TracingId(combined);
 
-  //     expect(tracingId.asString(TracingIdRepresentation.hex),
-  //         '1222f00d89934ba01445feed89934bb');
-  //     expect(tracingId.asString(TracingIdRepresentation.hex32Chars),
-  //         '01222f00d89934ba01445feed89934bb');
-  //     expect(tracingId.asString(TracingIdRepresentation.hex16Chars),
-  //         '01445feed89934bb');
-  //     expect(tracingId.asString(TracingIdRepresentation.highHex16Chars),
-  //         '01222f00d89934ba');
-  //     expect(tracingId.asString(TracingIdRepresentation.decimal),
-  //         '1506719429260448406838152867989763259');
-  //     expect(tracingId.asString(TracingIdRepresentation.lowDecimal),
-  //         '91303371895026875');
-  //   });
-  // }
+    expect(tracingId.asString(TracingIdRepresentation.hex),
+        '1222f00d89934ba01445feed89934bb');
+    expect(tracingId.asString(TracingIdRepresentation.hex32Chars),
+        '01222f00d89934ba01445feed89934bb');
+    expect(tracingId.asString(TracingIdRepresentation.hex16Chars),
+        '01445feed89934bb');
+    expect(tracingId.asString(TracingIdRepresentation.highHex16Chars),
+        '01222f00d89934ba');
+    expect(tracingId.asString(TracingIdRepresentation.decimal),
+        '1506719429260448406838152867989763259');
+    expect(tracingId.asString(TracingIdRepresentation.lowDecimal),
+        '91303371895026875');
+  });
 
   test('traceId generates proper values', () {
     final nowSeconds = (DateTime.now().millisecondsSinceEpoch ~/ 1000);

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -7,30 +7,32 @@ import 'package:datadog_flutter_plugin/src/tracing/tracing_headers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('TracingIdRepresentation generates proper values', () {
-    // Create a value in 128-bit hex that has leading zeros on both
-    // the low and high 64-bits, and ensure we get the proper values
-    const low = 0x01445feed89934bb;
-    const high = 0x01222f00d89934ba;
+  // if (!kIsWeb) {
+  //   test('TracingIdRepresentation generates proper values', () {
+  //     // Create a value in 128-bit hex that has leading zeros on both
+  //     // the low and high 64-bits, and ensure we get the proper values
+  //     const low = 0x01445feed89934bb;
+  //     const high = 0x01222f00d89934ba;
 
-    var combined = BigInt.from(high);
-    combined = (combined << 64) + BigInt.from(low);
+  //     var combined = BigInt.from(high);
+  //     combined = (combined << 64) + BigInt.from(low);
 
-    final tracingId = TracingId(combined);
+  //     final tracingId = TracingId(combined);
 
-    expect(tracingId.asString(TracingIdRepresentation.hex),
-        '1222f00d89934ba01445feed89934bb');
-    expect(tracingId.asString(TracingIdRepresentation.hex32Chars),
-        '01222f00d89934ba01445feed89934bb');
-    expect(tracingId.asString(TracingIdRepresentation.hex16Chars),
-        '01445feed89934bb');
-    expect(tracingId.asString(TracingIdRepresentation.highHex16Chars),
-        '01222f00d89934ba');
-    expect(tracingId.asString(TracingIdRepresentation.decimal),
-        '1506719429260448406838152867989763259');
-    expect(tracingId.asString(TracingIdRepresentation.lowDecimal),
-        '91303371895026875');
-  });
+  //     expect(tracingId.asString(TracingIdRepresentation.hex),
+  //         '1222f00d89934ba01445feed89934bb');
+  //     expect(tracingId.asString(TracingIdRepresentation.hex32Chars),
+  //         '01222f00d89934ba01445feed89934bb');
+  //     expect(tracingId.asString(TracingIdRepresentation.hex16Chars),
+  //         '01445feed89934bb');
+  //     expect(tracingId.asString(TracingIdRepresentation.highHex16Chars),
+  //         '01222f00d89934ba');
+  //     expect(tracingId.asString(TracingIdRepresentation.decimal),
+  //         '1506719429260448406838152867989763259');
+  //     expect(tracingId.asString(TracingIdRepresentation.lowDecimal),
+  //         '91303371895026875');
+  //   });
+  // }
 
   test('traceId generates proper values', () {
     final nowSeconds = (DateTime.now().millisecondsSinceEpoch ~/ 1000);

--- a/packages/datadog_tracking_http_client/example/ios/Podfile
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -22,10 +22,7 @@ dependencies:
     path: ../
   datadog_common_test:
     path: ../../datadog_common_test
-  dio: ^5.7.0
-  native_dio_adapter: ^1.5.0
-  cronet_http: ^1.4.0
-  cupertino_http: ^2.2.0
+  dio: ^5.7.0  
 
 dev_dependencies:
   flutter_test:

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -22,7 +22,10 @@ dependencies:
     path: ../
   datadog_common_test:
     path: ../../datadog_common_test
-  dio: ^5.7.0  
+  dio: ^5.7.0
+  native_dio_adapter: ^1.5.0
+  cronet_http: ^1.4.0
+  cupertino_http: ^2.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/datadog_tracking_http_client/example/web/index.html
+++ b/packages/datadog_tracking_http_client/example/web/index.html
@@ -33,8 +33,8 @@
   <link rel="manifest" href="manifest.json">
 
   <!-- Datadog -->
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script> 
-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"></script> 
+  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum-slim.js"></script> 
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
### What and why?

Manual resource tracking uses the new `addEvent` functionality provided by the Browser SDK. This PR utilizes this to improve the functionality of several features, but mostly resource tracking. 

This also adds initial work on addAction, which correctly supports non-`custom` action types. However sustained actions that use `start/stopAction` and tracking of events that occur close to specific actions is still not supported.

refs: RUM-10042

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
