### PR TITLE
fix: Revert changes specific to flutter_inappwebview 6.2 beta

### DIFF
--- a/packages/datadog_inappwebview_tracking/example/ios/Podfile.lock
+++ b/packages/datadog_inappwebview_tracking/example/ios/Podfile.lock
@@ -5,22 +5,24 @@ PODS:
     - DatadogInternal (~> 2)
     - DatadogLogs (~> 2)
     - DatadogRUM (~> 2)
-    - DictionaryCoder (= 1.0.8)
+    - DictionaryCoder (= 1.2.0)
     - Flutter
   - datadog_inappwebview_tracking (0.0.1):
     - DatadogCore (~> 2.20)
     - Flutter
-  - DatadogCore (2.29.0):
-    - DatadogInternal (= 2.29.0)
-  - DatadogCrashReporting (2.29.0):
-    - DatadogInternal (= 2.29.0)
+  - DatadogCore (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DatadogCrashReporting (2.30.0):
+    - DatadogInternal (= 2.30.0)
     - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (2.29.0)
-  - DatadogLogs (2.29.0):
-    - DatadogInternal (= 2.29.0)
-  - DatadogRUM (2.29.0):
-    - DatadogInternal (= 2.29.0)
-  - DictionaryCoder (1.0.8)
+  - DatadogInternal (2.30.0)
+  - DatadogLogs (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DatadogRUM (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DatadogWebViewTracking (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - flutter_inappwebview_ios (0.0.1):
     - Flutter
@@ -37,17 +39,18 @@ PODS:
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_inappwebview_tracking (from `.symlinks/plugins/datadog_inappwebview_tracking/ios`)
+  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogWebViewTracking (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `Flutter`)
   - flutter_inappwebview_ios (from `.symlinks/plugins/flutter_inappwebview_ios/ios`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
 
 SPEC REPOS:
   trunk:
-    - DatadogCore
-    - DatadogCrashReporting
-    - DatadogInternal
-    - DatadogLogs
-    - DatadogRUM
     - DictionaryCoder
     - OrderedSet
     - PLCrashReporter
@@ -57,6 +60,24 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
   datadog_inappwebview_tracking:
     :path: ".symlinks/plugins/datadog_inappwebview_tracking/ios"
+  DatadogCore:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogCrashReporting:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogInternal:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogLogs:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogRUM:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogWebViewTracking:
+    :branch: develop
+    :git: https://github.com/DataDog/dd-sdk-ios
   Flutter:
     :path: Flutter
   flutter_inappwebview_ios:
@@ -64,21 +85,42 @@ EXTERNAL SOURCES:
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
 
+CHECKOUT OPTIONS:
+  DatadogCore:
+    :commit: c018e077f7f5b79e954a18c69aa8182d233477f8
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogCrashReporting:
+    :commit: c018e077f7f5b79e954a18c69aa8182d233477f8
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogInternal:
+    :commit: c018e077f7f5b79e954a18c69aa8182d233477f8
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogLogs:
+    :commit: c018e077f7f5b79e954a18c69aa8182d233477f8
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogRUM:
+    :commit: c018e077f7f5b79e954a18c69aa8182d233477f8
+    :git: https://github.com/DataDog/dd-sdk-ios
+  DatadogWebViewTracking:
+    :commit: c018e077f7f5b79e954a18c69aa8182d233477f8
+    :git: https://github.com/DataDog/dd-sdk-ios
+
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: cbf61c8c2dd346d83683cca8f2450c1b7ab1f1dd
+  datadog_flutter_plugin: dae31b2f0e5755d091601d8c8108fe86528085fd
   datadog_inappwebview_tracking: 5e209d7e4e9997f5a7422314e3be6406e5499eb9
-  DatadogCore: 919080d4ba0bf172f42e8cf49a6ea33a79bdeb9a
-  DatadogCrashReporting: 3de14c873c0492803eca0373769791fde30639f6
-  DatadogInternal: f98c60cc5b44db688692e2b560ea273182cde022
-  DatadogLogs: c314b15a97bfc7e0728ea253d3638b0513032d88
-  DatadogRUM: 6ec371f477a1022fd5aad6ccb5407b85a04db399
-  DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
+  DatadogCore: 5c01290a3b60b27bf49aa958f2e339c738364d9e
+  DatadogCrashReporting: 11286d48ab61baeb2b41b945c7c0d4ef23db317d
+  DatadogInternal: 7aeb48e254178a0c462c3953dc0a8a8d64499a93
+  DatadogLogs: 4324739de62a6059e07d70bf6ceceed78764edeb
+  DatadogRUM: f36949a38285f3b240a7be577d425f8518e087d4
+  DatadogWebViewTracking: 78c20d8e5f1ade506f4aadaec5690c1a63283fe2
+  DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 
-PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
+PODFILE CHECKSUM: e14c78365f04ac6601585f31d6be7fa90881512d
 
 COCOAPODS: 1.16.2

--- a/packages/datadog_inappwebview_tracking/example/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
 
   flutter_dotenv: ^5.2.1
-  flutter_inappwebview: ^6.2.0-beta
+  flutter_inappwebview: ^6.1.0
   go_router: ^14.5.0
   datadog_flutter_plugin: ^2.10.0
   datadog_inappwebview_tracking:

--- a/packages/datadog_inappwebview_tracking/lib/src/datadog_inappwebview_user_script.dart
+++ b/packages/datadog_inappwebview_tracking/lib/src/datadog_inappwebview_user_script.dart
@@ -76,9 +76,9 @@ extension DatadogInAppWebViewControllerExtension on InAppWebViewController {
   void trackDatadogEvents(DatadogSdk datadog, {double logSampleRate = 100.0}) {
     addJavaScriptHandler(
       handlerName: handlerName,
-      callback: (JavaScriptHandlerFunctionData data) {
-        if (data.args.isNotEmpty) {
-          final message = data.args.first;
+      callback: (data) {
+        if (data.isNotEmpty) {
+          final message = data[0];
           if (message is String) {
             // ignore: invalid_use_of_internal_member
             wrap('handleWebMessage', datadog.internalLogger, {}, () {

--- a/packages/datadog_inappwebview_tracking/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_inappwebview_tracking
 description: "A package for tracking Datadog sessions in webviews create with flutter_inappwebview"
-version: 1.1.0-beta.2
+version: 1.2.0
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   datadog_flutter_plugin: ^2.10.0
   plugin_platform_interface: ^2.0.2
-  flutter_inappwebview: ^6.2.0-beta
+  flutter_inappwebview: ^6.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What and why?

Changes were made to better support `flutter_inappwebview` 6.2, but this is still in beta and may never ship, so we need to revert the changes in develop for it.

However, there are changes in 6.2 that are needed for proper support of android, so we will need to re-add this support in our next beta release (likely 1.4.0-beta.1), but we'll make these changes in a separate release branch.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
