### PR TITLE
fix(web): Support user info in logs on web.

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
@@ -14,6 +14,12 @@ class LogDecoder {
   String get message => log['message'] as String;
   String get serviceName => log['service'] as String;
   String get tags => log['ddtags'] as String;
+
+  String? get userAnonymousId => getNestedProperty('usr.anonymous_id', log);
+  String? get userId => getNestedProperty('usr.id', log);
+  String? get userName => getNestedProperty('usr.name', log);
+  String? get userEmail => getNestedProperty('usr.email', log);
+
   List<String> get tagValues => (log['ddtags'] as String).split(',');
   String get applicationVersion => log['version'] as String;
   String get loggerName => getNestedProperty('logger.name', log);

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -194,6 +194,10 @@ void main() {
     for (final log in logs) {
       expect(log.serviceName,
           equalsIgnoringCase('com.datadoghq.flutter.integration'));
+      expect(log.userId, 'bits');
+      expect(log.userName, 'Bits Dawoof');
+      expect(log.userEmail, 'bits@datadoghq.com');
+
       if (!kIsWeb) {
         if (Platform.isIOS) {
           expect(log.applicationVersion, '1.2.3-555');

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -43,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -21,6 +21,9 @@ class _LoggingScenarioState extends State<LoggingScenario> {
   void initState() {
     super.initState();
 
+    DatadogSdk.instance.setUserInfo(
+        id: 'bits', name: 'Bits Dawoof', email: 'bits@datadoghq.com');
+
     // Create a logger that will not send to Datadog
     var silentLogger = DatadogSdk.instance.logs!.createLogger(
       DatadogLoggerConfiguration(

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: unused_element
 
 import 'dart:async';
+import 'dart:js_interop';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -15,6 +16,19 @@ import 'src/logs/ddlogs_platform_interface.dart';
 import 'src/logs/ddlogs_web.dart';
 import 'src/rum/ddrum_platform_interface.dart';
 import 'src/rum/ddrum_web.dart';
+
+@anonymous
+extension type JsUser._(JSObject _) implements JSObject {
+  external String? get id;
+  external String? get email;
+  external String? get name;
+
+  external factory JsUser({
+    String? id,
+    String? email,
+    String? name,
+  });
+}
 
 /// A web implementation of the DatadogSdk plugin.
 class DatadogSdkWeb extends DatadogSdkPlatform {
@@ -35,11 +49,13 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   Future<void> setUserInfo(String? id, String? name, String? email,
       Map<String, dynamic> extraInfo) async {
     // TODO: Extra user properties
-    DD_RUM?.setUser(JsUser(
+    final jsUser = JsUser(
       id: id,
       name: name,
       email: email,
-    ));
+    );
+    DD_LOGS?.setUser(jsUser);
+    DD_RUM?.setUser(jsUser);
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -8,6 +8,7 @@ import 'dart:js_interop';
 import 'package:meta/meta.dart';
 
 import '../../datadog_flutter_plugin.dart';
+import '../../datadog_flutter_plugin_web.dart';
 import '../../datadog_internal.dart';
 import '../web_helpers.dart';
 import 'ddlogs_platform_interface.dart';
@@ -17,7 +18,7 @@ class DdLogsWeb extends DdLogsPlatform {
   final Map<String, Logger> _activeLoggers = {};
 
   static void initLogs(DatadogConfiguration configuration) {
-    DD_LOGS.init(_LogInitOptions(
+    DD_LOGS?.init(_LogInitOptions(
       clientToken: configuration.clientToken,
       env: configuration.env,
       proxy: configuration.loggingConfiguration?.customEndpoint,
@@ -46,7 +47,7 @@ class DdLogsWeb extends DdLogsPlatform {
     var loggerHandlers = [
       'http'.toJS,
     ];
-    var logger = DD_LOGS.createLogger(
+    var logger = DD_LOGS?.createLogger(
       config.name ?? 'default',
       _JsLoggerConfiguration(),
     );
@@ -185,6 +186,8 @@ extension type _DdLogs._(JSObject _) implements JSObject {
 
   external Logger? getLogger(String name);
 
+  external void setUser(JsUser userInfo);
+
   @internal
   external Logger? createLogger(
       String name, _JsLoggerConfiguration? configuration);
@@ -192,7 +195,7 @@ extension type _DdLogs._(JSObject _) implements JSObject {
 
 @JS()
 // ignore: non_constant_identifier_names
-external _DdLogs DD_LOGS;
+external _DdLogs? DD_LOGS;
 
 extension type Logger._(JSObject _) implements JSObject {
   external void log(

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -5,9 +5,8 @@
 
 import 'dart:js_interop';
 
-import 'package:meta/meta.dart';
-
 import '../../datadog_flutter_plugin.dart';
+import '../../datadog_flutter_plugin_web.dart';
 import '../../datadog_internal.dart';
 import '../logs/ddweb_helpers.dart';
 import '../web_helpers.dart';
@@ -307,20 +306,6 @@ extension type _RumInternalContext._(JSObject _) implements JSObject {
   external String? application_id;
   // ignore: non_constant_identifier_names
   external String? session_id;
-}
-
-@anonymous
-@internal
-extension type JsUser._(JSObject _) implements JSObject {
-  external String? get id;
-  external String? get email;
-  external String? get name;
-
-  external factory JsUser({
-    String? id,
-    String? email,
-    String? name,
-  });
 }
 
 extension type _DdRum._(JSObject _) implements JSObject {


### PR DESCRIPTION
### What and why?

`setUserInfo` only set user info on RUM, not Logs This was an unintentional oversight.

Web still does not support extra user info. This will be tracked as a separate issue and may be part of some changes coming in v3.

refs: #781

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
