### PR TITLE
feat[web]: Support logger tags and global attributes

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -79,73 +79,55 @@ void main() {
 
     expect(firstLoggerLogs[0].status, 'debug');
     expect(firstLoggerLogs[0].message, 'debug message');
-    // JS SDK doesn't support tags
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[0].tags, contains('tag1:tag-value'));
-      expect(firstLoggerLogs[0].tags, contains('my-tag'));
-    }
+    expect(firstLoggerLogs[0].tags, contains('tag1:tag-value'));
+    expect(firstLoggerLogs[0].tags, contains('my-tag'));
     expect(firstLoggerLogs[0].log['logger-attribute1'], 'string value');
     expect(firstLoggerLogs[0].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[0].log['stringAttribute'], 'string');
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[0].log['global-attribute'], isNull);
-    }
+    expect(firstLoggerLogs[0].log['global-attribute'], isNull);
 
     expect(firstLoggerLogs[1].status, 'info');
     expect(firstLoggerLogs[1].message, 'info message');
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[1].tags, isNot(contains('my-tag')));
-      expect(firstLoggerLogs[1].tags, contains('tag1:tag-value'));
-    }
+    expect(firstLoggerLogs[1].tags, isNot(contains('my-tag')));
+    expect(firstLoggerLogs[1].tags, contains('tag1:tag-value'));
     expect(firstLoggerLogs[1].log['logger-attribute1'], 'string value');
     expect(firstLoggerLogs[1].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[1].log['nestedAttribute'],
         containsPair('internal', 'test'));
     expect(firstLoggerLogs[1].log['nestedAttribute'],
         containsPair('isValid', true));
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[1].log['global-attribute'], isNull);
-    }
+    expect(firstLoggerLogs[1].log['global-attribute'], isNull);
 
     expect(firstLoggerLogs[2].status, 'warn');
     expect(firstLoggerLogs[2].message, 'warn message');
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[2].tags, isNot(contains('my-tag')));
-      expect(firstLoggerLogs[2].tags, contains('tag1:tag-value'));
-    }
+    expect(firstLoggerLogs[2].tags, isNot(contains('my-tag')));
+    expect(firstLoggerLogs[2].tags, contains('tag1:tag-value'));
     expect(firstLoggerLogs[2].log['logger-attribute1'], 'string value');
     expect(firstLoggerLogs[2].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[2].log['doubleAttribute'], 10.34);
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[2].log['global-attribute'], isNull);
-    }
+    expect(firstLoggerLogs[2].log['global-attribute'], isNull);
 
     expect(firstLoggerLogs[3].status, 'error');
     expect(firstLoggerLogs[3].message, 'error message');
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[3].tags, isNot(contains('my-tag')));
-      expect(firstLoggerLogs[3].tags, isNot(contains('tag1:tag-value')));
-    }
+    expect(firstLoggerLogs[3].tags, isNot(contains('my-tag')));
+    expect(firstLoggerLogs[3].tags, isNot(contains('tag1:tag-value')));
     expect(firstLoggerLogs[3].log['logger-attribute1'], isNull);
     expect(firstLoggerLogs[3].log['logger-attribute2'], 1000);
     expect(firstLoggerLogs[3].log['attribute'], 'value');
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[3].log['global-attribute'], 'global value');
-    }
+    expect(firstLoggerLogs[3].log['global-attribute'], 'global value');
 
     expect(firstLoggerLogs[4].status, 'error');
     expect(firstLoggerLogs[4].message, 'Encountered an error');
     expect(firstLoggerLogs[4].errorMessage, isNotNull);
     if (!kIsWeb) {
+      // Errors from web will always be `browser`
       expect(firstLoggerLogs[4].errorSourceType, 'flutter');
-      expect(firstLoggerLogs[4].tags, isNot(contains('my-tag')));
-      expect(firstLoggerLogs[4].tags, isNot(contains('tag1:tag-value')));
     }
+    expect(firstLoggerLogs[4].tags, isNot(contains('my-tag')));
+    expect(firstLoggerLogs[4].tags, isNot(contains('tag1:tag-value')));
     expect(firstLoggerLogs[4].log['logger-attribute1'], isNull);
     expect(firstLoggerLogs[4].log['logger-attribute2'], 1000);
-    if (!kIsWeb) {
-      expect(firstLoggerLogs[4].log['global-attribute'], 'global value');
-    }
+    expect(firstLoggerLogs[4].log['global-attribute'], 'global value');
 
     List<LogDecoder> secondLoggerLogs =
         logs.where((l) => l.loggerName == 'second_logger').toList();
@@ -164,9 +146,7 @@ void main() {
     expect(secondLoggerLogs[0].log['second-logger-attribute'], 'second-value');
     expect(secondLoggerLogs[0].log['logger-attribute1'], isNull);
     expect(secondLoggerLogs[0].log['logger-attribute2'], isNull);
-    if (!kIsWeb) {
-      expect(secondLoggerLogs[0].log['global-attribute'], 'global value');
-    }
+    expect(secondLoggerLogs[0].log['global-attribute'], 'global value');
     expect(getNestedProperty<String>('logger.name', secondLoggerLogs[1].log),
         'second_logger');
 
@@ -175,9 +155,7 @@ void main() {
     expect(secondLoggerLogs[1].log['second-logger-attribute'], 'second-value');
     expect(secondLoggerLogs[1].log['logger-attribute1'], isNull);
     expect(secondLoggerLogs[1].log['logger-attribute2'], isNull);
-    if (!kIsWeb) {
-      expect(secondLoggerLogs[1].log['global-attribute'], 'global value');
-    }
+    expect(secondLoggerLogs[1].log['global-attribute'], 'global value');
     expect(secondLoggerLogs[1].errorMessage, 'Error Message');
     expect(secondLoggerLogs[1].errorStack, isNotNull);
     expect(secondLoggerLogs[1].errorFingerprint, 'custom-fingerprint');

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -33,10 +33,14 @@ class DdLogsWeb extends DdLogsPlatform {
       DatadogSdk core, DatadogLoggingConfiguration config) async {}
 
   @override
-  Future<void> addGlobalAttribute(String key, Object value) async {}
+  Future<void> addGlobalAttribute(String key, Object value) async {
+    DD_LOGS?.setGlobalContextProperty(key, valueToJs(value, 'value'));
+  }
 
   @override
-  Future<void> removeGlobalAttribute(String key) async {}
+  Future<void> removeGlobalAttribute(String key) async {
+    DD_LOGS?.removeGlobalContextProperty(key);
+  }
 
   @override
   Future<void> deinitialize() async {}
@@ -75,7 +79,10 @@ class DdLogsWeb extends DdLogsPlatform {
   }
 
   @override
-  Future<void> addTag(String loggerHandle, String tag, [String? value]) async {}
+  Future<void> addTag(String loggerHandle, String tag, [String? value]) async {
+    final logger = _activeLoggers[loggerHandle];
+    logger?.addTag(tag, value);
+  }
 
   @override
   Future<void> removeAttribute(String loggerHandle, String key) async {
@@ -84,10 +91,15 @@ class DdLogsWeb extends DdLogsPlatform {
   }
 
   @override
-  Future<void> removeTag(String loggerHandle, String tag) async {}
+  Future<void> removeTag(String loggerHandle, String tag) {
+    return removeTagWithKey(loggerHandle, tag);
+  }
 
   @override
-  Future<void> removeTagWithKey(String loggerHandle, String key) async {}
+  Future<void> removeTagWithKey(String loggerHandle, String key) async {
+    final logger = _activeLoggers[loggerHandle];
+    logger?.removeTagsWithKey(key);
+  }
 
   @override
   Future<void> log(
@@ -191,6 +203,9 @@ extension type _DdLogs._(JSObject _) implements JSObject {
   @internal
   external Logger? createLogger(
       String name, _JsLoggerConfiguration? configuration);
+
+  external void setGlobalContextProperty(String key, JSAny? property);
+  external void removeGlobalContextProperty(String key);
 }
 
 @JS()
@@ -200,6 +215,9 @@ external _DdLogs? DD_LOGS;
 extension type Logger._(JSObject _) implements JSObject {
   external void log(
       String message, JSAny? messageContext, String status, JSError? error);
+
+  external void addTag(String key, String? value);
+  external void removeTagsWithKey(String key);
 
   external void setContextProperty(String key, JSAny? value);
   external void removeContextProperty(String key);


### PR DESCRIPTION
### What and why?

Browser SDK added support for tags on loggers. This bridges that support to Flutter.

refs: RUM-10042

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
