### PR TITLE
chore: Pin iOS version to last 2.x release

### DIFF
--- a/packages/datadog_common_test/lib/src/request_log.dart
+++ b/packages/datadog_common_test/lib/src/request_log.dart
@@ -20,12 +20,15 @@ class RequestLog {
 
   Map<String, String> get tags {
     var tagMap = <String, String>{};
-    for (var tag in queryParameters['ddtags']!.split(',')) {
-      var colon = tag.indexOf(':');
-      if (colon == -1) {
-        tagMap[tag] = '';
-      } else {
-        tagMap[tag.substring(0, colon)] = tag.substring(colon + 1);
+    final queryTags = queryParameters['ddtags'];
+    if (queryTags != null) {
+      for (var tag in queryTags.split(',')) {
+        var colon = tag.indexOf(':');
+        if (colon == -1) {
+          tagMap[tag] = '';
+        } else {
+          tagMap[tag.substring(0, colon)] = tag.substring(colon + 1);
+        }
       }
     }
     return tagMap;

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
@@ -33,11 +33,11 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
   # End Datadog Pod Overrides
   
 end

--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -36,11 +36,11 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -110,23 +110,26 @@ extension Waiter on WidgetTester {
 
 void verifyCommonTags(
     RequestLog request, String service, String version, String? variant) {
-  final sdkVersion = request.tags['sdk_version'];
-  if (kIsWeb) {
-    // Returning the browser version of the SDK.
-    expect(sdkVersion?.startsWith('5.'), true);
-  } else {
-    expect(sdkVersion, DatadogSdk.sdkVersion);
-  }
+  // TODO: These tags were moved to events and should be checked there.
+  if (request.tags.isNotEmpty) {
+    final sdkVersion = request.tags['sdk_version'];
+    if (kIsWeb) {
+      // Returning the browser version of the SDK.
+      expect(sdkVersion?.startsWith('5.'), true);
+    } else {
+      expect(sdkVersion, DatadogSdk.sdkVersion);
+    }
 
-  expect(request.tags['service'], service);
+    expect(request.tags['service'], service);
 
-  if (!kIsWeb) {
-    // Currently coming back as 'browser' on web
-    expect(request.queryParameters['ddsource'], 'flutter');
+    if (!kIsWeb) {
+      // Currently coming back as 'browser' on web
+      expect(request.queryParameters['ddsource'], 'flutter');
 
-    // Not sent as a tag on web
-    expect(request.tags['version'], version);
-    expect(request.tags['variant'], variant);
+      // Not sent as a tag on web
+      expect(request.tags['version'], version);
+      expect(request.tags['variant'], variant);
+    }
   }
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
@@ -33,11 +33,11 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-flutter-plugin", targets: ["datadog_flutter_plugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", branch: "develop"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
         .package(url: "https://github.com/almazrafi/DictionaryCoder.git", from: "1.2.0")
     ],
     targets: [

--- a/packages/datadog_inappwebview_tracking/example/ios/Podfile
+++ b/packages/datadog_inappwebview_tracking/example/ios/Podfile
@@ -36,12 +36,12 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking/Package.swift
+++ b/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-inappwebview-tracking", targets: ["datadog_inappwebview_tracking"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "2.20.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
     ],
     targets: [
         .target(

--- a/packages/datadog_session_replay/example/ios/Podfile
+++ b/packages/datadog_session_replay/example/ios/Podfile
@@ -36,11 +36,11 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-session-replay", targets: ["datadog_session_replay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "2.20.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
     ],
     targets: [
         .target(

--- a/packages/datadog_tracking_http_client/example/ios/Podfile
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile
@@ -34,11 +34,11 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_webview_tracking/example/ios/Podfile
+++ b/packages/datadog_webview_tracking/example/ios/Podfile
@@ -36,12 +36,12 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
   # End Datadog Pod Overridess
 end
 

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-webview-tracking", targets: ["datadog_webview_tracking"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "2.20.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

v3 changes have been merged into develop in iOS, which breaks Flutter builds. Flutter will pin to the last available version of v2 until full development of v3 starts.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
