### PR TITLE
feat: Add trackBackgroundEvents to RUM

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -507,6 +507,9 @@ fun RumConfiguration.Builder.withEncoded(encoded: Map<String, Any?>): RumConfigu
     (encoded["trackAnonymousUser"] as? Boolean)?.let {
         builder = builder.trackAnonymousUser(it)
     }
+    (encoded["trackBackgroundEvents"] as? Boolean)?.let {
+        builder = builder.trackBackgroundEvents(it)
+    }
     (encoded["initialResourceThreshold"] as? Number)?.let {
         val milliseconds = it.toDouble().seconds.inWholeMilliseconds
         builder = builder.setInitialResourceIdentifier(

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -35,6 +35,7 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
@@ -171,6 +172,7 @@ class DatadogRumPluginTest {
         // GIVEN
         val trackNonFatalAnrs = forge.aNullable { forge.aBool() }
         val trackAnonymousUser = forge.aBool()
+        val trackBackgroundEvents = forge.aBool()
         val attributes = forge.exhaustiveAttributes()
         val configArg = mapOf(
             "sessionSampleRate" to sessionSampleRate,
@@ -178,6 +180,7 @@ class DatadogRumPluginTest {
             "trackFrustrations" to trackFrustration,
             "trackNonFatalAnrs" to trackNonFatalAnrs,
             "trackAnonymousUser" to trackAnonymousUser,
+            "trackBackgroundEvents" to trackBackgroundEvents,
             "initialResourceThreshold" to initialResourceThreshold,
             "customEndpoint" to endpoint,
             "vitalsUpdateFrequency" to "VitalsFrequency.frequent",
@@ -201,6 +204,7 @@ class DatadogRumPluginTest {
             assertThat(featureConfiguration.getPrivate("trackNonFatalAnrs")).isEqualTo(true)
         }
         assertThat(featureConfiguration.getPrivate("trackAnonymousUser")).isEqualTo(trackAnonymousUser)
+        assertThat(featureConfiguration.getPrivate("backgroundEventTracking")).isEqualTo(trackBackgroundEvents)
         val initialResourceIdentifier = featureConfiguration.getPrivate("initialResourceIdentifier") as? TimeBasedInitialResourceIdentifier
         assertThat(initialResourceIdentifier).isNotNull()
         // The threshold is converted to configured in milliseconds, but held in nanoseconds.

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -206,6 +206,17 @@ class DatadogRumPluginTests: XCTestCase {
         XCTAssertEqual(config?.trackAnonymousUser, trackAnonymousUser)
     }
 
+    func testRumConfiguration_WithTrackBackgroundEvents_IsSetCorrectly() {
+        let trackBackgroundEvents = Bool.mockRandom()
+        let encoded: [String: Any?] = [
+            "applicationId": "fake-application-id",
+            "trackBackgroundEvents": trackBackgroundEvents
+        ]
+
+        let config = RUM.Configuration.init(fromEncoded: encoded)
+        XCTAssertEqual(config?.trackBackgroundEvents, trackBackgroundEvents)
+    }
+
     func testRepeatEnable_FromMethodChannelSameOptions_DoesNothing() {
         // Uninitialize plugin
         plugin?.inject(rum: nil)

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogRumPlugin.swift
@@ -23,6 +23,7 @@ public extension RUM.Configuration {
         longTaskThreshold = (encoded["longTaskThreshold"] as? NSNumber)?.doubleValue ?? 0.1
         trackFrustrations = (encoded["trackFrustrations"] as? NSNumber)?.boolValue ?? true
         trackAnonymousUser = (encoded["trackAnonymousUser"] as? NSNumber)?.boolValue ?? true
+        trackBackgroundEvents = (encoded["trackBackgroundEvents"] as? NSNumber)?.boolValue ?? false
         if let appHangThreshold = (encoded["appHangThreshold"] as? NSNumber)?.doubleValue {
             self.appHangThreshold = appHangThreshold
         }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -165,6 +165,16 @@ class DatadogRumConfiguration {
   /// Defaults to `true`.
   bool trackAnonymousUser = true;
 
+  /// Whether to track RUM events when no view is active, including when the app is in the background.
+  ///
+  /// When enabled, RUM will attach events (such as crashes and network requests) to an automatically
+  /// created "background" view. This includes events that occur when the application is in the background.
+  ///
+  /// Note: Enabling this option may result in additional sessions, which could impact billing.
+  ///
+  /// Defaults to `false`.
+  bool trackBackgroundEvents;
+
   /// The amount of time after a view starts where a Resource should be
   /// considered when calculating Time to Network-Settled (TNS). TNS will be
   /// calculated using all resources that start withing the specified threshold,
@@ -214,6 +224,7 @@ class DatadogRumConfiguration {
     this.trackNonFatalAnrs,
     this.appHangThreshold,
     this.trackAnonymousUser = true,
+    this.trackBackgroundEvents = false,
     this.initialResourceThreshold = 0.1,
     this.customEndpoint,
     this.telemetrySampleRate = 20.0,
@@ -239,6 +250,7 @@ class DatadogRumConfiguration {
       'trackNonFatalAnrs': trackNonFatalAnrs,
       'appHangThreshold': appHangThreshold,
       'trackAnonymousUser': trackAnonymousUser,
+      'trackBackgroundEvents': trackBackgroundEvents,
       'initialResourceThreshold': initialResourceThreshold,
       'customEndpoint': customEndpoint,
       'telemetrySampleRate': telemetrySampleRate,

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -98,6 +98,7 @@ void main() {
       trackNonFatalAnrs: false,
       appHangThreshold: 0.332,
       trackAnonymousUser: false,
+      trackBackgroundEvents: true,
       initialResourceThreshold: 1.23,
       customEndpoint: customEndpoint,
     );
@@ -111,6 +112,7 @@ void main() {
     expect(encoded['vitalsUpdateFrequency'], vitalUpdateFrequency.toString());
     expect(encoded['trackNonFatalAnrs'], false);
     expect(encoded['trackAnonymousUser'], false);
+    expect(encoded['trackBackgroundEvents'], true);
     expect(encoded['appHangThreshold'], 0.332);
     expect(encoded['customEndpoint'], customEndpoint);
     expect(encoded['initialResourceThreshold'], 1.23);


### PR DESCRIPTION
### What and why?

`trackBackgroundEvents` allows users to track events when no view is active or when the application is in the background.

Not having it was an oversight in the original configuration.

refs: #795

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
