### PR TITLE
Revert "chore: Pin iOS version to last 2.x release"

### DIFF
--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/e2e_test_app/ios/Podfile
@@ -33,11 +33,11 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overrides
   
 end

--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -36,11 +36,11 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
+++ b/packages/datadog_flutter_plugin/integration_test_app/ios/Podfile
@@ -33,11 +33,11 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-flutter-plugin", targets: ["datadog_flutter_plugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", branch: "develop"),
         .package(url: "https://github.com/almazrafi/DictionaryCoder.git", from: "1.2.0")
     ],
     targets: [

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogSdkPlugin.swift
@@ -155,7 +155,7 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
                 let name = arguments["name"] as? String
                 let email = arguments["email"] as? String
                 let encodedAttributes = castFlutterAttributesToSwift(extraInfo)
-                Datadog.setUserInfo(id: id, name: name, email: email, extraInfo: encodedAttributes)
+                Datadog.setUserInfo(id: id!, name: name, email: email, extraInfo: encodedAttributes)
                 result(nil)
             } else {
                 result(FlutterError.missingParameter(methodName: call.method))

--- a/packages/datadog_inappwebview_tracking/example/ios/Podfile
+++ b/packages/datadog_inappwebview_tracking/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_inappwebview_tracking/example/ios/Podfile
+++ b/packages/datadog_inappwebview_tracking/example/ios/Podfile
@@ -36,12 +36,12 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking/Package.swift
+++ b/packages/datadog_inappwebview_tracking/ios/datadog_inappwebview_tracking/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-inappwebview-tracking", targets: ["datadog_inappwebview_tracking"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "2.20.0"),
     ],
     targets: [
         .target(

--- a/packages/datadog_session_replay/example/ios/Podfile
+++ b/packages/datadog_session_replay/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_session_replay/example/ios/Podfile
+++ b/packages/datadog_session_replay/example/ios/Podfile
@@ -36,11 +36,11 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -29,11 +29,11 @@ PODS:
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_session_replay (from `.symlinks/plugins/datadog_session_replay/ios`)
-  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
+  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
+  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
 
@@ -48,20 +48,20 @@ EXTERNAL SOURCES:
   datadog_session_replay:
     :path: ".symlinks/plugins/datadog_session_replay/ios"
   DatadogCore:
+    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogCrashReporting:
+    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogInternal:
+    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogLogs:
+    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogRUM:
+    :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   Flutter:
     :path: Flutter
   integration_test:
@@ -69,20 +69,20 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogCore:
+    :commit: eeffc34909aa2aaff8e1f2774cf716832c74cb19
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogCrashReporting:
+    :commit: eeffc34909aa2aaff8e1f2774cf716832c74cb19
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogInternal:
+    :commit: eeffc34909aa2aaff8e1f2774cf716832c74cb19
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogLogs:
+    :commit: eeffc34909aa2aaff8e1f2774cf716832c74cb19
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
   DatadogRUM:
+    :commit: eeffc34909aa2aaff8e1f2774cf716832c74cb19
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: dae31b2f0e5755d091601d8c8108fe86528085fd
@@ -97,6 +97,6 @@ SPEC CHECKSUMS:
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 
-PODFILE CHECKSUM: 17b6b9e9b2b841f11a725f239fc06ce7386c1cf4
+PODFILE CHECKSUM: 357bc2de26f249c9e5dd52e99a556d5704fbd68b
 
 COCOAPODS: 1.16.2

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -5,22 +5,22 @@ PODS:
     - DatadogInternal (~> 2)
     - DatadogLogs (~> 2)
     - DatadogRUM (~> 2)
-    - DictionaryCoder (= 1.0.8)
+    - DictionaryCoder (= 1.2.0)
     - Flutter
   - datadog_session_replay (0.0.1):
     - DatadogCore (~> 2)
     - Flutter
-  - DatadogCore (2.29.0):
-    - DatadogInternal (= 2.29.0)
-  - DatadogCrashReporting (2.29.0):
-    - DatadogInternal (= 2.29.0)
+  - DatadogCore (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DatadogCrashReporting (2.30.0):
+    - DatadogInternal (= 2.30.0)
     - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (2.29.0)
-  - DatadogLogs (2.29.0):
-    - DatadogInternal (= 2.29.0)
-  - DatadogRUM (2.29.0):
-    - DatadogInternal (= 2.29.0)
-  - DictionaryCoder (1.0.8)
+  - DatadogInternal (2.30.0)
+  - DatadogLogs (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DatadogRUM (2.30.0):
+    - DatadogInternal (= 2.30.0)
+  - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
@@ -29,16 +29,16 @@ PODS:
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_session_replay (from `.symlinks/plugins/datadog_session_replay/ios`)
+  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
+  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
+  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
+  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
+  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
 
 SPEC REPOS:
   trunk:
-    - DatadogCore
-    - DatadogCrashReporting
-    - DatadogInternal
-    - DatadogLogs
-    - DatadogRUM
     - DictionaryCoder
     - PLCrashReporter
 
@@ -47,24 +47,56 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
   datadog_session_replay:
     :path: ".symlinks/plugins/datadog_session_replay/ios"
+  DatadogCore:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogCrashReporting:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogInternal:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogLogs:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogRUM:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
   Flutter:
     :path: Flutter
   integration_test:
     :path: ".symlinks/plugins/integration_test/ios"
 
+CHECKOUT OPTIONS:
+  DatadogCore:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogCrashReporting:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogInternal:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogLogs:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+  DatadogRUM:
+    :git: https://github.com/DataDog/dd-sdk-ios
+    :tag: 2.30.0
+
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: cbf61c8c2dd346d83683cca8f2450c1b7ab1f1dd
+  datadog_flutter_plugin: dae31b2f0e5755d091601d8c8108fe86528085fd
   datadog_session_replay: 65da9f52202889d5299b83c32da652b4442b8079
-  DatadogCore: 919080d4ba0bf172f42e8cf49a6ea33a79bdeb9a
-  DatadogCrashReporting: 3de14c873c0492803eca0373769791fde30639f6
-  DatadogInternal: f98c60cc5b44db688692e2b560ea273182cde022
-  DatadogLogs: c314b15a97bfc7e0728ea253d3638b0513032d88
-  DatadogRUM: 6ec371f477a1022fd5aad6ccb5407b85a04db399
-  DictionaryCoder: 5f84fff69f54cb806071538430bdafe04a89d658
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  DatadogCore: 5c01290a3b60b27bf49aa958f2e339c738364d9e
+  DatadogCrashReporting: 11286d48ab61baeb2b41b945c7c0d4ef23db317d
+  DatadogInternal: 7aeb48e254178a0c462c3953dc0a8a8d64499a93
+  DatadogLogs: 4324739de62a6059e07d70bf6ceceed78764edeb
+  DatadogRUM: f36949a38285f3b240a7be577d425f8518e087d4
+  DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 
-PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5
+PODFILE CHECKSUM: 17b6b9e9b2b841f11a725f239fc06ce7386c1cf4
 
 COCOAPODS: 1.16.2

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-session-replay", targets: ["datadog_session_replay"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "2.20.0"),
     ],
     targets: [
         .target(

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Feature/RequestBuilder/RequestBuilder.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Feature/RequestBuilder/RequestBuilder.swift
@@ -43,7 +43,12 @@ internal struct RequestBuilder: FeatureRequestBuilder {
             queryItems: [],
             headers: [
                 .contentTypeHeader(contentType: .multipartFormData(boundary: multipart.boundary)),
-                .userAgentHeader(appName: context.applicationName, appVersion: context.version, device: context.device),
+                .userAgentHeader(
+                    appName: context.applicationName,
+                    appVersion: context.version,
+                    device: context.device,
+                    os: context.os
+                ),
                 .ddAPIKeyHeader(clientToken: context.clientToken),
                 .ddEVPOriginHeader(source: context.source),
                 .ddEVPOriginVersionHeader(sdkVersion: context.sdkVersion),

--- a/packages/datadog_tracking_http_client/example/ios/Podfile
+++ b/packages/datadog_tracking_http_client/example/ios/Podfile
@@ -34,11 +34,11 @@ target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_webview_tracking/example/ios/Podfile
+++ b/packages/datadog_webview_tracking/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/packages/datadog_webview_tracking/example/ios/Podfile
+++ b/packages/datadog_webview_tracking/example/ios/Podfile
@@ -36,12 +36,12 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '2.30.0'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogWebViewTracking', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
   # End Datadog Pod Overridess
 end
 

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "datadog-webview-tracking", targets: ["datadog_webview_tracking"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "2.30.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "2.20.0"),
     ],
     targets: [
         .target(

--- a/test_apps/stress_test/ios/Podfile
+++ b/test_apps/stress_test/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'


### PR DESCRIPTION
### What and why?

Revert "Fix e2e and integration test app pins"

v3 branch should be back on develop. Pins came in when develop was merged into the v3 branch.

This also fixes some build errors incurred from a Flutter update and from v3 changes.

This reverts commit 758370e4830a27fd3295b9cb577df161ef3e38be, 339dbd2f313ff24eafa5dac854beb4d350c7e6bb.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
