### PR TITLE
chore: Make web integration tests more resilient

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,8 @@ variables:
   IS_ON_CI: $CI
   SLACK_CHANNEL: "#mobile-sdk-ops"
 
-  KUBERNETES_MEMORY_REQUEST: "12Gi"
-  KUBERNETES_MEMORY_LIMIT: "16Gi"
+  KUBERNETES_MEMORY_REQUEST: "16Gi"
+  KUBERNETES_MEMORY_LIMIT: "32Gi"
 
 stages:
   - ci-image

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -70,8 +70,6 @@ class RumSessionDecoder {
           break;
         case 'resource':
           final resourceEvent = RumResourceEventDecoder(e.rumEvent);
-          // Filter resource events looking for $dwdsSseHandler?
-          if (resourceEvent.url.contains('\$dwdsSseHandler?')) continue;
           visit.resourceEvents.add(resourceEvent);
           break;
         case 'error':

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_dio_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_dio_test.dart
@@ -3,6 +3,7 @@
 // Copyright 2019-2022 Datadog, Inc.
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_tracking_http_client_example/main.dart' as app;
 import 'package:datadog_tracking_http_client_example/scenario_config.dart';
@@ -34,157 +35,164 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   // TODO: Figure out why
-  testWidgets(
-    'test auto instrumentation',
-    (WidgetTester tester) async {
-      final sessionRecorder = await startMockServer();
+  testWidgets('test auto instrumentation', (WidgetTester tester) async {
+    final sessionRecorder = await startMockServer();
 
-      const clientToken = bool.hasEnvironment('DD_CLIENT_TOKEN')
-          ? String.fromEnvironment('DD_CLIENT_TOKEN')
-          : null;
-      const applicationId = bool.hasEnvironment('DD_APPLICATION_ID')
-          ? String.fromEnvironment('DD_APPLICATION_ID')
-          : null;
+    const clientToken = bool.hasEnvironment('DD_CLIENT_TOKEN')
+        ? String.fromEnvironment('DD_CLIENT_TOKEN')
+        : null;
+    const applicationId = bool.hasEnvironment('DD_APPLICATION_ID')
+        ? String.fromEnvironment('DD_APPLICATION_ID')
+        : null;
 
-      final scenarioConfig = RumAutoInstrumentationScenarioConfig(
-        firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
-        firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
-        firstPartyPostUrl:
-            '${sessionRecorder.sessionEndpoint}/integration_post',
-        firstPartyBadUrl: 'https://foo.bar',
-        thirdPartyGetUrl: 'https://httpbin.org/get',
-        thirdPartyPostUrl: 'https://httpbin.org/post',
-        // TODO(RUM-7120): The only way to enable resource tracking for Dio at the moment
-        // is to call `enableHttpTracking`, which enables it globally. This isn't
-        // in line with what's expected from package:http or Dio, which expect
-        // to track only the calls from their clients.
-        enableIoHttpTracking: true,
-      );
-      RumAutoInstrumentationScenarioConfig.instance = scenarioConfig;
+    final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
+      firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
+      firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',
+      firstPartyBadUrl: 'https://foo.bar',
+      thirdPartyGetUrl: 'https://httpbin.org/get',
+      thirdPartyPostUrl: 'https://httpbin.org/post',
+      // TODO(RUM-7120): The only way to enable resource tracking for Dio at the moment
+      // is to call `enableHttpTracking`, which enables it globally. This isn't
+      // in line with what's expected from package:http or Dio, which expect
+      // to track only the calls from their clients.
+      enableIoHttpTracking: true,
+    );
+    RumAutoInstrumentationScenarioConfig.instance = scenarioConfig;
 
-      app.testingConfiguration = TestingConfiguration(
-          customEndpoint: sessionRecorder.sessionEndpoint,
-          clientToken: clientToken,
-          applicationId: applicationId,
-          firstPartyHosts: ['localhost']);
-      await app.main();
-      await tester.pumpAndSettle();
+    app.testingConfiguration = TestingConfiguration(
+        customEndpoint: sessionRecorder.sessionEndpoint,
+        clientToken: clientToken,
+        applicationId: applicationId,
+        firstPartyHosts: ['localhost']);
+    await app.main();
+    await tester.pumpAndSettle();
 
-      await performRumUserFlow(tester);
+    await performRumUserFlow(tester);
 
-      final requestLog = <RequestLog>[];
-      final rumLog = <RumEventDecoder>[];
-      final testRequests = <RequestLog>[];
-      await sessionRecorder.pollSessionRequests(
-        const Duration(seconds: 50),
-        (requests) {
-          requestLog.addAll(requests);
-          for (var request in requests) {
-            if (request.requestedUrl.contains('integration')) {
-              if (!request.requestHeaders
-                  .containsKey('access-control-request-method')) {
-                testRequests.add(request);
-              }
-            } else {
-              request.data.split('\n').forEach((e) {
-                var jsonValue = json.decode(e);
-                if (jsonValue is Map<String, dynamic>) {
-                  rumLog.add(RumEventDecoder(jsonValue));
-                }
-              });
+    final requestLog = <RequestLog>[];
+    final rumLog = <RumEventDecoder>[];
+    final testRequests = <RequestLog>[];
+    await sessionRecorder.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        requestLog.addAll(requests);
+        for (var request in requests) {
+          if (request.requestedUrl.contains('integration')) {
+            if (!request.requestHeaders
+                .containsKey('access-control-request-method')) {
+              testRequests.add(request);
             }
+          } else {
+            request.data.split('\n').forEach((e) {
+              var jsonValue = json.decode(e);
+              if (jsonValue is Map<String, dynamic>) {
+                rumLog.add(RumEventDecoder(jsonValue));
+              }
+            });
           }
-          return RumSessionDecoder.fromEvents(rumLog).visits.length >= 4;
-        },
-      );
-
-      final session = RumSessionDecoder.fromEvents(rumLog);
-      expect(session.visits.length, greaterThanOrEqualTo(3));
-
-      final view1 = session.visits[1];
-
-      // For now, completely ignore resource checking on web for Dio, its
-      // being incredibly flakey and it is in the process of being rewritten
-      if (!kIsWeb) {
-        expect(view1.viewEvents.last.view.resourceCount, greaterThan(1));
-        // After redirects, we don't end up with a picsum.photos url.
-        expect(view1.resourceEvents[0].url.contains('picsum.photos'), isTrue);
-        expect(view1.resourceEvents[1].url,
-            'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png');
-        // Allow this to fail since we don't have as much control over them
-        if (view1.resourceEvents[1].statusCode == 200) {
-          expect(
-              view1.resourceEvents[1].resourceType, kIsWeb ? 'xhr' : 'image');
         }
-      }
+        return RumSessionDecoder.fromEvents(rumLog).visits.length >= 4;
+      },
+    );
 
-      final view2 = session.visits[2];
-      if (!kIsWeb) {
-        expect(view2.viewEvents.last.view.resourceCount, kIsWeb ? 5 : 4);
-        expect(view2.viewEvents.last.view.errorCount, 1);
-      }
+    final session = RumSessionDecoder.fromEvents(rumLog);
+    expect(session.visits.length, greaterThanOrEqualTo(3));
 
-      // Check first party requests
-      for (var testRequest in testRequests) {
-        expect(testRequest.requestHeaders['x-datadog-sampling-priority']?.first,
-            '1');
-        expect(testRequest.requestHeaders['x-datadog-origin']?.first, 'rum');
-      }
+    final view1 = session.visits[1];
 
-      final getEvent = view2.resourceEvents[0];
-      final getTraceId = extractDatadogTraceId(testRequests[0].requestHeaders);
-      final getSpanId =
-          testRequests[0].requestHeaders['x-datadog-parent-id']?.first;
-      expect(getEvent.url, scenarioConfig.firstPartyGetUrl);
-      expect(getEvent.statusCode, 200);
-      expect(getEvent.method, 'GET');
-      expect(getEvent.duration, greaterThan(0));
-      expect(getEvent.dd.traceId, getTraceId?.toRadixString(kIsWeb ? 10 : 16));
-      expect(getEvent.dd.spanId, getSpanId!);
+    expect(
+        view1.viewEvents.last.view.resourceCount, view1.resourceEvents.length);
 
-      final postTraceId = extractDatadogTraceId(testRequests[1].requestHeaders);
-      final postSpanId =
-          testRequests[1].requestHeaders['x-datadog-parent-id']?.first;
-      final postEvent = view2.resourceEvents[1];
-      expect(postEvent.url, scenarioConfig.firstPartyPostUrl);
-      expect(postEvent.statusCode, 200);
-      expect(postEvent.method, 'POST');
-      expect(postEvent.duration, greaterThan(0));
+    // After redirects, we don't end up with a picsum.photos url.
+    final picsumResource = view1.resourceEvents
+        .firstWhereOrNull((e) => e.url.contains('picsum.photos'));
+    expect(picsumResource, isNotNull);
+
+    final datadogResource = view1.resourceEvents
+        .firstWhereOrNull((e) => e.url.contains('imgix.datadoghq.com'));
+    expect(datadogResource, isNotNull);
+    expect(datadogResource!.url,
+        'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png');
+    // Allow this to fail since we don't have as much control over them
+    if (datadogResource.statusCode == 200) {
+      expect(view1.resourceEvents[1].resourceType, kIsWeb ? 'xhr' : 'image');
+    }
+
+    final view2 = session.visits[2];
+    expect(
+        view2.viewEvents.last.view.resourceCount, view2.resourceEvents.length);
+    if (!kIsWeb) {
+      // Web doesn't report the failed resource as an error
+      expect(view2.viewEvents.last.view.errorCount, 1);
+    }
+
+    // Check first party requests
+    for (var testRequest in testRequests) {
+      expect(testRequest.requestHeaders['x-datadog-sampling-priority']?.first,
+          '1');
+      expect(testRequest.requestHeaders['x-datadog-origin']?.first, 'rum');
+    }
+
+    final getEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyGetUrl);
+    expect(getEvent, isNotNull);
+    final getRequest = testRequests
+        .firstWhere((e) => e.requestedUrl == scenarioConfig.firstPartyGetUrl);
+    final getTraceId = extractDatadogTraceId(getRequest.requestHeaders);
+    final getSpanId = getRequest.requestHeaders['x-datadog-parent-id']?.first;
+    expect(getEvent!.url, scenarioConfig.firstPartyGetUrl);
+    expect(getEvent.statusCode, 200);
+    expect(getEvent.method, 'GET');
+    expect(getEvent.duration, greaterThan(0));
+    expect(getEvent.dd.traceId, getTraceId?.toRadixString(kIsWeb ? 10 : 16));
+    expect(getEvent.dd.spanId, getSpanId!);
+
+    final postEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyPostUrl);
+    expect(postEvent, isNotNull);
+    final postRequest = testRequests
+        .firstWhere((e) => e.requestedUrl == scenarioConfig.firstPartyPostUrl);
+    final postTraceId = extractDatadogTraceId(postRequest.requestHeaders);
+    final postSpanId = postRequest.requestHeaders['x-datadog-parent-id']?.first;
+    expect(postEvent!.url, scenarioConfig.firstPartyPostUrl);
+    expect(postEvent.statusCode, 200);
+    expect(postEvent.method, 'POST');
+    expect(postEvent.duration, greaterThan(0));
+    expect(postEvent.dd.traceId, postTraceId?.toRadixString(kIsWeb ? 10 : 16));
+    expect(postEvent.dd.spanId, postSpanId!);
+
+    // Third party requests
+    if (!kIsWeb) {
+      expect(view2.errorEvents[0].resourceUrl,
+          startsWith(scenarioConfig.firstPartyBadUrl));
+      expect(view2.errorEvents[0].resourceMethod, 'GET');
+    } else {
+      final errorResourceEvent = view2.resourceEvents.firstWhereOrNull(
+          (e) => e.url.contains(scenarioConfig.firstPartyBadUrl));
       expect(
-          postEvent.dd.traceId, postTraceId?.toRadixString(kIsWeb ? 10 : 16));
-      expect(postEvent.dd.spanId, postSpanId!);
+          errorResourceEvent!.url, startsWith(scenarioConfig.firstPartyBadUrl));
+      expect(errorResourceEvent.method, 'GET');
+    }
 
-      // Third party requests
-      int thirdPartyResourceIndex = 2;
-      if (!kIsWeb) {
-        expect(view2.errorEvents[0].resourceUrl,
-            startsWith(scenarioConfig.firstPartyBadUrl));
-        expect(view2.errorEvents[0].resourceMethod, 'GET');
-      } else {
-        expect(view2.resourceEvents[2].url,
-            startsWith(scenarioConfig.firstPartyBadUrl));
-        expect(view2.resourceEvents[2].method, 'GET');
-        thirdPartyResourceIndex = 3;
-      }
+    final firstThirdPartyResource = view2.resourceEvents.firstWhereOrNull(
+        (e) => e.url.contains(scenarioConfig.thirdPartyGetUrl));
+    expect(firstThirdPartyResource, isNotNull);
+    expect(firstThirdPartyResource!.url,
+        startsWith(scenarioConfig.thirdPartyGetUrl));
+    expect(firstThirdPartyResource.method, 'GET');
+    expect(firstThirdPartyResource.duration, greaterThan(0));
+    expect(firstThirdPartyResource.dd.traceId, isNull);
+    expect(firstThirdPartyResource.dd.spanId, isNull);
 
-      final firstThirdPartyResource =
-          view2.resourceEvents[thirdPartyResourceIndex];
-      expect(firstThirdPartyResource.url,
-          startsWith(scenarioConfig.thirdPartyGetUrl));
-      expect(firstThirdPartyResource.method, 'GET');
-      expect(firstThirdPartyResource.duration, greaterThan(0));
-      expect(firstThirdPartyResource.dd.traceId, isNull);
-      expect(firstThirdPartyResource.dd.spanId, isNull);
-
-      final secondThirdPartyResource =
-          view2.resourceEvents[thirdPartyResourceIndex + 1];
-      expect(secondThirdPartyResource.url,
-          startsWith(scenarioConfig.thirdPartyPostUrl));
-      expect(secondThirdPartyResource.method, 'POST');
-      expect(secondThirdPartyResource.duration, greaterThan(0));
-      expect(secondThirdPartyResource.dd.traceId, isNull);
-      expect(secondThirdPartyResource.dd.spanId, isNull);
-    },
-    skip: kIsWeb, // TODO: Figure out why this integration test is flakey on web
-  );
+    final secondThirdPartyResource = view2.resourceEvents.firstWhereOrNull(
+        (e) => e.url.contains(scenarioConfig.thirdPartyPostUrl));
+    expect(secondThirdPartyResource, isNotNull);
+    expect(secondThirdPartyResource!.url,
+        startsWith(scenarioConfig.thirdPartyPostUrl));
+    expect(secondThirdPartyResource.method, 'POST');
+    expect(secondThirdPartyResource.duration, greaterThan(0));
+    expect(secondThirdPartyResource.dd.traceId, isNull);
+    expect(secondThirdPartyResource.dd.spanId, isNull);
+  });
 }

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_tracking_http_client_example/main.dart' as app;
 import 'package:datadog_tracking_http_client_example/scenario_config.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -153,5 +154,5 @@ void main() {
     expect(secondThirdPartyResource.duration, greaterThan(0));
     expect(secondThirdPartyResource.dd.traceId, isNull);
     expect(secondThirdPartyResource.dd.spanId, isNull);
-  });
+  }, skip: kIsWeb);
 }

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_tracking_http_client_example/main.dart' as app;
 import 'package:datadog_tracking_http_client_example/scenario_config.dart';
@@ -106,8 +107,10 @@ void main() {
     }
 
     final view2 = session.visits[2];
-    expect(view2.viewEvents.last.view.resourceCount, kIsWeb ? 5 : 4);
+    expect(
+        view2.viewEvents.last.view.resourceCount, view2.resourceEvents.length);
     if (!kIsWeb) {
+      // Web doesn't report the failed resource as an error
       expect(view2.viewEvents.last.view.errorCount, 1);
     }
 
@@ -118,22 +121,28 @@ void main() {
       expect(testRequest.requestHeaders['x-datadog-origin']?.first, 'rum');
     }
 
-    final getEvent = view2.resourceEvents[0];
-    final getTraceId = extractDatadogTraceId(testRequests[0].requestHeaders);
-    final getSpanId =
-        testRequests[0].requestHeaders['x-datadog-parent-id']?.first;
-    expect(getEvent.url, scenarioConfig.firstPartyGetUrl);
+    final getEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyGetUrl);
+    expect(getEvent, isNotNull);
+    final getRequest = testRequests
+        .firstWhere((e) => e.requestedUrl == scenarioConfig.firstPartyGetUrl);
+    final getTraceId = extractDatadogTraceId(getRequest.requestHeaders);
+    final getSpanId = getRequest.requestHeaders['x-datadog-parent-id']?.first;
+    expect(getEvent!.url, scenarioConfig.firstPartyGetUrl);
     expect(getEvent.statusCode, 200);
     expect(getEvent.method, 'GET');
     expect(getEvent.duration, greaterThan(0));
     expect(getEvent.dd.traceId, getTraceId?.toRadixString(kIsWeb ? 10 : 16));
     expect(getEvent.dd.spanId, getSpanId!);
 
-    final postTraceId = extractDatadogTraceId(testRequests[1].requestHeaders);
-    final postSpanId =
-        testRequests[1].requestHeaders['x-datadog-parent-id']?.first;
-    final postEvent = view2.resourceEvents[1];
-    expect(postEvent.url, scenarioConfig.firstPartyPostUrl);
+    final postEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyPostUrl);
+    expect(postEvent, isNotNull);
+    final postRequest = testRequests
+        .firstWhere((e) => e.requestedUrl == scenarioConfig.firstPartyPostUrl);
+    final postTraceId = extractDatadogTraceId(postRequest.requestHeaders);
+    final postSpanId = postRequest.requestHeaders['x-datadog-parent-id']?.first;
+    expect(postEvent!.url, scenarioConfig.firstPartyPostUrl);
     expect(postEvent.statusCode, 200);
     expect(postEvent.method, 'POST');
     expect(postEvent.duration, greaterThan(0));
@@ -141,30 +150,32 @@ void main() {
     expect(postEvent.dd.spanId, postSpanId!);
 
     // Third party requests
-    int thirdPartyResourceIndex = 2;
     if (!kIsWeb) {
       expect(view2.errorEvents[0].resourceUrl,
           startsWith(scenarioConfig.firstPartyBadUrl));
       expect(view2.errorEvents[0].resourceMethod, 'GET');
     } else {
-      expect(view2.resourceEvents[2].url,
-          startsWith(scenarioConfig.firstPartyBadUrl));
-      expect(view2.resourceEvents[2].method, 'GET');
-      thirdPartyResourceIndex = 3;
+      final errorResourceEvent = view2.resourceEvents.firstWhereOrNull(
+          (e) => e.url.contains(scenarioConfig.firstPartyBadUrl));
+      expect(
+          errorResourceEvent!.url, startsWith(scenarioConfig.firstPartyBadUrl));
+      expect(errorResourceEvent.method, 'GET');
     }
 
-    final firstThirdPartyResource =
-        view2.resourceEvents[thirdPartyResourceIndex];
-    expect(firstThirdPartyResource.url,
+    final firstThirdPartyResource = view2.resourceEvents.firstWhereOrNull(
+        (e) => e.url.contains(scenarioConfig.thirdPartyGetUrl));
+    expect(firstThirdPartyResource, isNotNull);
+    expect(firstThirdPartyResource!.url,
         startsWith(scenarioConfig.thirdPartyGetUrl));
     expect(firstThirdPartyResource.method, 'GET');
     expect(firstThirdPartyResource.duration, greaterThan(0));
     expect(firstThirdPartyResource.dd.traceId, isNull);
     expect(firstThirdPartyResource.dd.spanId, isNull);
 
-    final secondThirdPartyResource =
-        view2.resourceEvents[thirdPartyResourceIndex + 1];
-    expect(secondThirdPartyResource.url,
+    final secondThirdPartyResource = view2.resourceEvents.firstWhereOrNull(
+        (e) => e.url.contains(scenarioConfig.thirdPartyPostUrl));
+    expect(secondThirdPartyResource, isNotNull);
+    expect(secondThirdPartyResource!.url,
         startsWith(scenarioConfig.thirdPartyPostUrl));
     expect(secondThirdPartyResource.method, 'POST');
     expect(secondThirdPartyResource.duration, greaterThan(0));


### PR DESCRIPTION
### What and why?

Instead of assuming requests in a certain order, we search for the correct request. This is because web can download more resources on a webpage than we expect, and we can't really know what order they'll come in.

Also, up memory request for Android CI machines, hopefully preventing gradle daemon from disappearing.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
