### PR TITLE
fix(web): Fix conversion of List to JSArray for Flutter Web

### DIFF
--- a/packages/datadog_flutter_plugin/example/lib/rum_user_actions_screen.dart
+++ b/packages/datadog_flutter_plugin/example/lib/rum_user_actions_screen.dart
@@ -112,24 +112,22 @@ class _RumUserActionsScreenState extends State<RumUserActionsScreen> {
             });
           }),
         ),
-        Row(
-          children: [
-            Radio<int>(
-              value: 0,
-              groupValue: _radioValue,
-              onChanged: _updateRadioValue,
-            ),
-            Radio<int>(
-              value: 1,
-              groupValue: _radioValue,
-              onChanged: _updateRadioValue,
-            ),
-            Radio<int>(
-              value: 2,
-              groupValue: _radioValue,
-              onChanged: _updateRadioValue,
-            )
-          ],
+        RadioGroup(
+          groupValue: _radioValue,
+          onChanged: _updateRadioValue,
+          child: const Row(
+            children: [
+              Radio<int>(
+                value: 0,
+              ),
+              Radio<int>(
+                value: 1,
+              ),
+              Radio<int>(
+                value: 2,
+              )
+            ],
+          ),
         ),
         Switch(
           value: _switchValue,

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 
 import 'datadog_internal.dart';
 import 'src/datadog_configuration.dart';

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -61,11 +61,15 @@ JSAny? valueToJs(Object? value, String parameterName) {
   }
 
   if (value is List) {
-    final jsList = JSArray();
+    final jsArray = JSArray<JSAny?>();
     for (int i = 0; i < value.length; ++i) {
-      jsList.add(valueToJs(value[i], '$parameterName[$i]'));
+      // Indexing operations on JSArray in js_interop weren't added until Dart 3.6
+      // and a properly supported `add` method wasn't added until Dart 3.10, so
+      // call `push` directly to create the array.
+      jsArray.callMethod(
+          'push'.toJS, valueToJs(value[i], '$parameterName[$i]'));
     }
-    return jsList;
+    return jsArray;
   }
 
   throw ArgumentError(

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -390,10 +390,12 @@ void main() {
 
     await tester.pumpWidget(_buildSimpleApp(
       mockRum,
-      Radio(
-        value: 1,
+      RadioGroup(
         groupValue: 0,
         onChanged: (value) {},
+        child: Radio(
+          value: 1,
+        ),
       ),
     ));
 
@@ -412,10 +414,12 @@ void main() {
       mockRum,
       RumUserActionAnnotation(
         description: annotation,
-        child: Radio(
-          value: 1,
+        child: RadioGroup(
           groupValue: 0,
           onChanged: (value) {},
+          child: Radio(
+            value: 1,
+          ),
         ),
       ),
     ));

--- a/packages/datadog_flutter_plugin/test/web_helpers_test.dart
+++ b/packages/datadog_flutter_plugin/test/web_helpers_test.dart
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+// ignore: library_annotations
+@TestOn('browser')
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:datadog_flutter_plugin/src/web_helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('value to js', () {
+    test('converts simple values', () {
+      expect(1, (valueToJs(1, 'integer') as JSNumber).toDartInt);
+      expect(3.1415, (valueToJs(3.1415, 'double') as JSNumber).toDartDouble);
+      expect('Test String',
+          (valueToJs('Test String', 'string') as JSString).toDart);
+      expect(false, (valueToJs(false, 'bool') as JSBoolean).toDart);
+    });
+
+    test('converts map values', () {
+      final mapValue = {
+        'integer': 1,
+        'double': 3.1415,
+        'bool': false,
+        'string': 'Test String',
+      };
+
+      final jsMap = valueToJs(mapValue, 'map') as JSObject;
+      expect(1, (jsMap.getProperty('integer'.toJS) as JSNumber).toDartInt);
+      expect(
+          3.1415, (jsMap.getProperty('double'.toJS) as JSNumber).toDartDouble);
+      expect(false, (jsMap.getProperty('bool'.toJS) as JSBoolean).toDart);
+      expect(
+          'Test String', (jsMap.getProperty('string'.toJS) as JSString).toDart);
+    });
+
+    test('converts nested map values', () {
+      final mapValue = {
+        'object': {
+          'integer': 1,
+          'double': 3.1415,
+          'bool': false,
+          'string': 'Test String',
+        },
+      };
+
+      final jsMap = valueToJs(mapValue, 'map') as JSObject;
+      final innerMap = jsMap.getProperty('object'.toJS) as JSObject;
+      expect(1, (innerMap.getProperty('integer'.toJS) as JSNumber).toDartInt);
+      expect(3.1415,
+          (innerMap.getProperty('double'.toJS) as JSNumber).toDartDouble);
+      expect(false, (innerMap.getProperty('bool'.toJS) as JSBoolean).toDart);
+      expect('Test String',
+          (innerMap.getProperty('string'.toJS) as JSString).toDart);
+    });
+
+    test('converts integer array', () {
+      final array = [1, 2, 22, 45];
+
+      final jsArray = valueToJs(array, 'array') as JSArray;
+      final jsDartArray = jsArray.toDart;
+      expect(1, (jsDartArray[0] as JSNumber).toDartInt);
+      expect(2, (jsDartArray[1] as JSNumber).toDartInt);
+      expect(22, (jsDartArray[2] as JSNumber).toDartInt);
+      expect(45, (jsDartArray[3] as JSNumber).toDartInt);
+    });
+
+    test('converts string array', () {
+      final array = ['a', 'b', 'long string', 'longer string'];
+
+      final jsArray = valueToJs(array, 'array') as JSArray;
+      final jsDartArray = jsArray.toDart;
+      expect('a', (jsDartArray[0] as JSString).toDart);
+      expect('b', (jsDartArray[1] as JSString).toDart);
+      expect('long string', (jsDartArray[2] as JSString).toDart);
+      expect('longer string', (jsDartArray[3] as JSString).toDart);
+    });
+
+    test('converts complex object', () {
+      final mapValue = {
+        'integer': 1,
+        'double': 3.1415,
+        'object': {
+          'array_test': [14, 23, 11],
+          'string': 'test string'
+        },
+        'flags': ['my_flag', 'another_flag']
+      };
+
+      final jsMap = valueToJs(mapValue, 'map') as JSObject;
+      expect(1, (jsMap.getProperty('integer'.toJS) as JSNumber).toDartInt);
+      expect(
+          3.1415, (jsMap.getProperty('double'.toJS) as JSNumber).toDartDouble);
+      final innerMap = jsMap.getProperty('object'.toJS) as JSObject;
+      final testArray =
+          (innerMap.getProperty('array_test'.toJS) as JSArray).toDart;
+      expect(14, (testArray[0] as JSNumber).toDartInt);
+      expect(23, (testArray[1] as JSNumber).toDartInt);
+      expect(11, (testArray[2] as JSNumber).toDartInt);
+      expect('test string',
+          (innerMap.getProperty('string'.toJS) as JSString).toDart);
+
+      final flagsArray = (jsMap.getProperty('flags'.toJS) as JSArray).toDart;
+      expect('my_flag', (flagsArray[0] as JSString).toDart);
+      expect('another_flag', (flagsArray[1] as JSString).toDart);
+    });
+  });
+}

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_gql_link
 description: A package for tracking GraphQL calls in Datadog compatible with gql_link 
-homepage: http://datadoghq.com
+homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 version: 1.2.0
 

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -151,7 +151,7 @@ void main() {
         ),
       );
       loggingService = LoggingGreeterService();
-      server = Server([loggingService]);
+      server = Server.create(services: [loggingService]);
       await server.serve(port: port);
 
       mockDatadog = DatadogSdkMock();
@@ -376,7 +376,7 @@ void main() {
       ),
     );
     loggingService = LoggingGreeterService();
-    final server = Server([loggingService]);
+    final server = Server.create(services: [loggingService]);
     await server.serve(port: port);
 
     mockDatadog = DatadogSdkMock();
@@ -425,7 +425,7 @@ void main() {
       ),
     );
     loggingService = LoggingGreeterService();
-    final server = Server([loggingService]);
+    final server = Server.create(services: [loggingService]);
     await server.serve(port: port);
 
     mockDatadog = DatadogSdkMock();
@@ -469,7 +469,7 @@ void main() {
       ),
     );
     loggingService = LoggingGreeterService();
-    final server = Server([loggingService]);
+    final server = Server.create(services: [loggingService]);
     await server.serve(port: port);
 
     mockDatadog = DatadogSdkMock();

--- a/packages/datadog_session_replay/example/lib/screens/material_widgets_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/material_widgets_screen.dart
@@ -107,29 +107,15 @@ class _MaterialWidgetsScreenState extends State<MaterialWidgetsScreen> {
               _WidgetDisplay(
                 name: 'Radio',
                 builder:
-                    (_) => Column(
-                      children: [
-                        Row(
-                          children: [
-                            Radio<String>(
-                              value: 'a',
-                              groupValue: _radioValue,
-                              onChanged: _onRadioChanged,
-                            ),
-                            Text('A'),
-                          ],
-                        ),
-                        Row(
-                          children: [
-                            Radio<String>(
-                              value: 'b',
-                              groupValue: _radioValue,
-                              onChanged: _onRadioChanged,
-                            ),
-                            Text('B'),
-                          ],
-                        ),
-                      ],
+                    (_) => RadioGroup(
+                      groupValue: _radioValue,
+                      onChanged: _onRadioChanged,
+                      child: Column(
+                        children: [
+                          Row(children: [Radio<String>(value: 'a'), Text('A')]),
+                          Row(children: [Radio<String>(value: 'b'), Text('B')]),
+                        ],
+                      ),
                     ),
               ),
               _WidgetDisplay(

--- a/packages/datadog_session_replay/test/capture/text_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/text_recorder_test.dart
@@ -161,7 +161,7 @@ void main() {
           children: [
             Text(textData),
             Transform(
-              transform: Matrix4.identity()..scale(0.5),
+              transform: Matrix4.identity()..scaleByDouble(0.5, 0.5, 0.5, 1.0),
               child: Text(textData),
             ),
           ],

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ^2.0.1
+  collection: ^1.19.1
   
 flutter:
   uses-material-design: true

--- a/tools/ci/lib/web_helpers.dart
+++ b/tools/ci/lib/web_helpers.dart
@@ -17,7 +17,8 @@ Future<void> downloadChromeAndDriver() async {
   final chromeVersionsResponse = await http.get(Uri.parse(chromeForTestingUrl));
   if (!chromeVersionsResponse.ok) {
     print(
-        "❌ Failed getting chrome for testing info. Response was: $chromeVersionsResponse");
+      "❌ Failed getting chrome for testing info. Response was: $chromeVersionsResponse",
+    );
     return;
   }
 
@@ -25,8 +26,9 @@ Future<void> downloadChromeAndDriver() async {
   final chrome = jsonDecode(resultStirng);
 
   final stableDownloads = chrome['channels']['Stable']['downloads'];
-  final chromeDownload = (stableDownloads['chrome'] as List)
-      .firstWhereOrNull((e) => e['platform'] == platform);
+  final chromeDownload = (stableDownloads['chrome'] as List).firstWhereOrNull(
+    (e) => e['platform'] == platform,
+  );
   if (chromeDownload == null) {
     print("❌ Could not find Chrome download matching platform $platform");
     return;
@@ -47,13 +49,15 @@ Future<void> downloadChromeAndDriver() async {
 
   print('⬇️ Downloading chromedriver to .tmp/chromedriver.zip');
   await _getUrlTo(
-      Uri.parse(chromeDriverDownload['url']), '.tmp/chromedriver.zip');
+    Uri.parse(chromeDriverDownload['url']),
+    '.tmp/chromedriver.zip',
+  );
   print('\n✅ Done.');
 }
 
 Future<void> _getUrlTo(Uri uri, String toPath) async {
   var contentLength = 0;
-  var bytesRecieved = 0;
+  var bytesReceived = 0;
 
   final client = HttpClient();
   final chromeFile = File(toPath);
@@ -65,9 +69,9 @@ Future<void> _getUrlTo(Uri uri, String toPath) async {
   try {
     await chromeResponse.listen((event) {
       chromeFileSink.add(event);
-      bytesRecieved += event.length;
+      bytesReceived += event.length;
 
-      stdout.write(' --- $bytesRecieved / $contentLength\r');
+      stdout.write(' --- $bytesReceived / $contentLength\r');
     }).asFuture();
   } finally {
     chromeFileSink.close();


### PR DESCRIPTION
### What and why?

Creation of JSArray was using JSArray.add, which translated to a Javascript `+` operator, which is incorrect. `.add` on JSArray in Dart 3.10 correctly translates to `Array.push`, but we are targeting Dart 3.3+, so we need to call `push` manually.

This was discovered because Dart 3.10's analyzer (currently in beta) complained that using `add` was only supported in Dart 3.10+, and we're targeting Dart 3.3. So this will also fix our analyzer issue in current Flutter beta checks.

To prevent further issues, I've add tests for `valueToJs` that run on browser (though `develop` does not currently run browser checks).

Fix multiple other analyzer errors.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
