### PR TITLE
chore: Add stale issue workflow.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: 'Automatically close stale issues'
+
+on:
+  # schedule:
+  # Runs every day at 7:00 AM GMT
+  #  - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity and has the `awaiting response` label.
+            
+            It will be closed if no further activity occurs within 3 days.
+        
+          # The label that will be added to the issues when automatically marked as stale
+          stale-issue-label: 'stale'
+          # The label that will be added to the issues when automatically marked as stale
+          close-issue-label: 'automatically closed'
+          # Only target issues with 'awaiting-response' label
+          only-labels: 'awaiting response'
+          # Mark issues as stale after 14 days
+          days-before-issue-stale: 14
+          # Close issues after 3 days of being marked stale
+          days-before-issue-close: 3
+          # Automatically remove the stale label when the issues or the pull requests are updated
+          remove-stale-when-updated: true
+          # Specify the reason used when closing issues: `completed` or `not_planned`
+          close-issue-reason: completed
+          # Run the stale workflow as dry-run.
+          # No GitHub API calls that can alter the issues and pull requests will happen.
+          # Useful to debug or when you want to configure the stale workflow safely. 
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |


### PR DESCRIPTION
### What and why?

Adding a workflow that will automatically tag issues as `stale` if they are tagged as `awaiting response` for more than 14 days.

After 3 days of being marked `stale`, the workflow will close these issues automatically.

This PR sets this workflow as a debug workflow with no schedule as an initial test.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
