### PR TITLE
chore: Minor fix to properly create releases on github

### DIFF
--- a/tools/releaser/lib/github_cmd_wrapper.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.dart
@@ -92,6 +92,8 @@ class GithubCommandWrapper {
       [
         'release',
         'create',
+        tag,
+        '--title',
         name,
         '--notes',
         changelog,


### PR DESCRIPTION
### What and why?

Releases from the deployer script were using the name instead of the tag, and weren't providing a title.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
