### PR TITLE
chore: Set stale workflow to non-debug

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,4 +38,4 @@ jobs:
           # Run the stale workflow as dry-run.
           # No GitHub API calls that can alter the issues and pull requests will happen.
           # Useful to debug or when you want to configure the stale workflow safely. 
-          debug-only: true
+          debug-only: false


### PR DESCRIPTION
### What and why?

Set `debug` to `false` for the stale issue workflow to let it make actual modifications.


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
