### PR TITLE
fix(web): Use UUID for resource key over id

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/web/resource_tracker.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/resource_tracker.dart
@@ -63,12 +63,14 @@ class ResourceTracker {
 
     final ddData = _extractDdData(finalAttributes);
 
+    var id = _uuid.v4().toString();
+
     _webPlugin.addEvent(
       eventTime,
       RumWebRawResourceEvent(
         date: epochTime.toJS,
         resource: RumWebRawResourceData(
-          id: key,
+          id: id,
           type: kind.name,
           url: resource.url,
           duration: duration.toJS,

--- a/packages/datadog_flutter_plugin/test/rum/web/event_matchers.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/event_matchers.dart
@@ -34,58 +34,113 @@ class _ResourceEventMatcher extends Matcher {
     StringBuffer mismatch = StringBuffer();
 
     _compareProperties(
-        'date', expectedResource.date, actualResource.date, mismatch);
+      'date',
+      expectedResource.date,
+      actualResource.date,
+      mismatch,
+    );
     _compareProperties(
-        'type', expectedResource.type, actualResource.type, mismatch);
-    _compareProperties('resource.id', expectedResource.resource.id,
-        actualResource.resource.id, mismatch);
-    _compareProperties('resource.type', expectedResource.resource.type,
-        actualResource.resource.type, mismatch);
-    _compareProperties('resource.duration', expectedResource.resource.duration,
-        actualResource.resource.duration, mismatch);
-    _compareProperties('resource.url', expectedResource.resource.url,
-        actualResource.resource.url, mismatch);
-    _compareProperties('resource.method', expectedResource.resource.method,
-        actualResource.resource.method, mismatch);
+      'type',
+      expectedResource.type,
+      actualResource.type,
+      mismatch,
+    );
     _compareProperties(
-        'resource.statusCode',
-        expectedResource.resource.statusCode,
-        actualResource.resource.statusCode,
-        mismatch);
-    _compareProperties('resource.size', expectedResource.resource.size,
-        actualResource.resource.size, mismatch);
+      'resource.type',
+      expectedResource.resource.type,
+      actualResource.resource.type,
+      mismatch,
+    );
     _compareProperties(
-        'resource.encodedBodySize',
-        expectedResource.resource.encodedBodySize,
-        actualResource.resource.encodedBodySize,
-        mismatch);
+      'resource.duration',
+      expectedResource.resource.duration,
+      actualResource.resource.duration,
+      mismatch,
+    );
     _compareProperties(
-        'resource.decodedBodySize',
-        expectedResource.resource.decodedBodySize,
-        actualResource.resource.decodedBodySize,
-        mismatch);
+      'resource.url',
+      expectedResource.resource.url,
+      actualResource.resource.url,
+      mismatch,
+    );
     _compareProperties(
-        'resource.transferSize',
-        expectedResource.resource.transferSize,
-        actualResource.resource.transferSize,
-        mismatch);
+      'resource.method',
+      expectedResource.resource.method,
+      actualResource.resource.method,
+      mismatch,
+    );
     _compareProperties(
-        'resource.renderBlockingStatus',
-        expectedResource.resource.renderBlockingStatus,
-        actualResource.resource.renderBlockingStatus,
-        mismatch);
-    _compareProperties('resource.protocol', expectedResource.resource.protocol,
-        actualResource.resource.protocol, mismatch);
+      'resource.statusCode',
+      expectedResource.resource.statusCode,
+      actualResource.resource.statusCode,
+      mismatch,
+    );
+    _compareProperties(
+      'resource.size',
+      expectedResource.resource.size,
+      actualResource.resource.size,
+      mismatch,
+    );
+    _compareProperties(
+      'resource.encodedBodySize',
+      expectedResource.resource.encodedBodySize,
+      actualResource.resource.encodedBodySize,
+      mismatch,
+    );
+    _compareProperties(
+      'resource.decodedBodySize',
+      expectedResource.resource.decodedBodySize,
+      actualResource.resource.decodedBodySize,
+      mismatch,
+    );
+    _compareProperties(
+      'resource.transferSize',
+      expectedResource.resource.transferSize,
+      actualResource.resource.transferSize,
+      mismatch,
+    );
+    _compareProperties(
+      'resource.renderBlockingStatus',
+      expectedResource.resource.renderBlockingStatus,
+      actualResource.resource.renderBlockingStatus,
+      mismatch,
+    );
+    _compareProperties(
+      'resource.protocol',
+      expectedResource.resource.protocol,
+      actualResource.resource.protocol,
+      mismatch,
+    );
     _compareContext(
-        'context', expectedResource.context, actualResource.context, mismatch);
-    _compareProperties('dd.discarded', expectedResource.dd.discarded,
-        actualResource.dd.discarded, mismatch);
-    _compareProperties('dd.traceId', expectedResource.dd.traceId,
-        actualResource.dd.traceId, mismatch);
-    _compareProperties('dd.spanId', expectedResource.dd.spanId,
-        actualResource.dd.spanId, mismatch);
-    _compareProperties('dd.rulePsr', expectedResource.dd.rulePsr,
-        actualResource.dd.rulePsr, mismatch);
+      'context',
+      expectedResource.context,
+      actualResource.context,
+      mismatch,
+    );
+    _compareProperties(
+      'dd.discarded',
+      expectedResource.dd.discarded,
+      actualResource.dd.discarded,
+      mismatch,
+    );
+    _compareProperties(
+      'dd.traceId',
+      expectedResource.dd.traceId,
+      actualResource.dd.traceId,
+      mismatch,
+    );
+    _compareProperties(
+      'dd.spanId',
+      expectedResource.dd.spanId,
+      actualResource.dd.spanId,
+      mismatch,
+    );
+    _compareProperties(
+      'dd.rulePsr',
+      expectedResource.dd.rulePsr,
+      actualResource.dd.rulePsr,
+      mismatch,
+    );
 
     if (mismatch.isNotEmpty) {
       matchState['mismatch'] = mismatch.toString();
@@ -95,8 +150,12 @@ class _ResourceEventMatcher extends Matcher {
   }
 
   @override
-  Description describeMismatch(Object? item, Description mismatchDescription,
-      Map<dynamic, dynamic> matchState, bool verbose) {
+  Description describeMismatch(
+    Object? item,
+    Description mismatchDescription,
+    Map<dynamic, dynamic> matchState,
+    bool verbose,
+  ) {
     Object? mismatch = matchState['mismatch'];
     if (mismatch is String) {
       mismatchDescription.add(mismatch);
@@ -132,15 +191,23 @@ class _ContextMatcher extends Matcher {
   }
 }
 
-void _compareProperties(String propertyName, Object? expected, Object? actual,
-    StringBuffer mismatch) {
+void _compareProperties(
+  String propertyName,
+  Object? expected,
+  Object? actual,
+  StringBuffer mismatch,
+) {
   if (expected != actual) {
     mismatch.writeln('$propertyName is $actual instead of $expected');
   }
 }
 
-void _compareContext(String propertyName, Object? expected, Object? actual,
-    StringBuffer mismatch) {
+void _compareContext(
+  String propertyName,
+  Object? expected,
+  Object? actual,
+  StringBuffer mismatch,
+) {
   // ignore: invalid_runtime_check_with_js_interop_types
   if (expected is! JSObject) {
     mismatch.write('expected $propertyName is not a JSObject');
@@ -157,7 +224,8 @@ void _compareContext(String propertyName, Object? expected, Object? actual,
 
   if (expectedKeys.length != actualKeys.length) {
     mismatch.writeln(
-        'expected $propertyName length is ${actualKeys.length} instead of ${expectedKeys.length}');
+      'expected $propertyName length is ${actualKeys.length} instead of ${expectedKeys.length}',
+    );
   }
 
   for (int i = 0; i < expectedKeys.length; ++i) {
@@ -170,7 +238,8 @@ void _compareContext(String propertyName, Object? expected, Object? actual,
     }
     if (expectedValue != actualValue) {
       mismatch.writeln(
-          '$propertyName.$key is $actualValue instead of $expectedValue.');
+        '$propertyName.$key is $actualValue instead of $expectedValue.',
+      );
     }
   }
 }

--- a/packages/datadog_flutter_plugin/test/rum/web/resource_tracker_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/web/resource_tracker_test.dart
@@ -2,7 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 @TestOn('browser')
-
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
@@ -66,33 +65,33 @@ void main() {
     final size = randomInt();
 
     // When
-    tracker.startResource(
-      startTime,
+    tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {});
+    tracker.stopResource(
+      endTime,
       keyName,
-      RumHttpMethod.get,
-      url,
+      200,
+      RumResourceType.image,
+      size,
       {},
     );
-    tracker
-        .stopResource(endTime, keyName, 200, RumResourceType.image, size, {});
 
     // Then
     final expectedEventTime = getRelativeEventTime(endTime);
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
+    final captured = verify(
+      () => mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+    ).captured;
     // Despite having a matcher, make sure all properties got transferred to this event manually
     // to ensure the JS Interop is coded properly.
     final actualEvent = captured[0] as RumWebRawResourceEvent;
     expect(actualEvent.date, endTime.millisecondsSinceEpoch.toJS);
-    expect(actualEvent.resource.id, keyName);
+    expect(actualEvent.resource.id, isNotNull);
     expect(actualEvent.type, 'resource');
     expect(actualEvent.resource.type, 'image');
     expect(actualEvent.resource.url, url);
-    expect(actualEvent.resource.duration,
-        endTime.difference(startTime).inNanoseconds.toJS);
+    expect(
+      actualEvent.resource.duration,
+      endTime.difference(startTime).inNanoseconds.toJS,
+    );
     expect(actualEvent.resource.method, 'GET');
     expect(actualEvent.resource.statusCode, 200.toJS);
     expect(actualEvent.resource.transferSize, size.toJS);
@@ -108,40 +107,38 @@ void main() {
     final size = randomInt();
 
     // When
-    tracker.startResource(
-      startTime,
-      keyName,
-      RumHttpMethod.get,
-      url,
-      {'attribute_1': 'value', 'attribute_2': 'value_2'},
-    );
-    tracker.stopResource(endTime, keyName, 200, RumResourceType.image, size,
-        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'});
+    tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {
+      'attribute_1': 'value',
+      'attribute_2': 'value_2',
+    });
+    tracker.stopResource(endTime, keyName, 200, RumResourceType.image, size, {
+      'attribute_2': 'finished_value',
+      'attribute_3': 'extra_value',
+    });
 
     // Then
     final expectedEventTime = getRelativeEventTime(endTime);
     final expectedEvent = RumWebRawResourceEvent(
-        date: endTime.millisecondsSinceEpoch.toJS,
-        resource: RumWebRawResourceData(
-          id: keyName,
-          type: 'image',
-          url: url,
-          duration: (endTime.difference(startTime).inNanoseconds).toJS,
-          method: 'GET',
-          status_code: 200.toJS,
-          transfer_size: size.toJS,
-        ),
-        dd: RumWebRawResourceDdData(discarded: false),
-        context: {
-          'attribute_1': 'value',
-          'attribute_2': 'finished_value',
-          'attribute_3': 'extra_value',
-        });
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
+      date: endTime.millisecondsSinceEpoch.toJS,
+      resource: RumWebRawResourceData(
+        id: 'any',
+        type: 'image',
+        url: url,
+        duration: (endTime.difference(startTime).inNanoseconds).toJS,
+        method: 'GET',
+        status_code: 200.toJS,
+        transfer_size: size.toJS,
+      ),
+      dd: RumWebRawResourceDdData(discarded: false),
+      context: {
+        'attribute_1': 'value',
+        'attribute_2': 'finished_value',
+        'attribute_3': 'extra_value',
+      },
+    );
+    final captured = verify(
+      () => mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+    ).captured;
     expect(captured[0], equalsResourceEvent(expectedEvent));
   });
 
@@ -154,23 +151,15 @@ void main() {
     final url = randomString();
 
     // When
-    tracker.startResource(
-      startTime,
-      keyName,
-      RumHttpMethod.get,
-      url,
-      {},
-    );
+    tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {});
     final error = FormatException('message');
     tracker.stopResourceWithError(endTime, keyName, error, {});
 
     // Then
     final expectedEventTime = getRelativeEventTime(endTime);
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
+    final captured = verify(
+      () => mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+    ).captured;
     final errorEvent = captured[0] as RumWebRawErrorEvent;
     expect(errorEvent.date, endTime.millisecondsSinceEpoch.toJS);
     expect(errorEvent.error.id, isNotNull);
@@ -183,42 +172,41 @@ void main() {
   });
 
   test(
-      'stopResourceWithError sends resource event with error merges attributes to context',
-      () {
-    // Given
-    final tracker = ResourceTracker(mockPlugin);
-    final startTime = DateTime.now();
-    final endTime = startTime.add(Duration(seconds: 20));
-    final keyName = randomString();
-    final url = randomString();
+    'stopResourceWithError sends resource event with error merges attributes to context',
+    () {
+      // Given
+      final tracker = ResourceTracker(mockPlugin);
+      final startTime = DateTime.now();
+      final endTime = startTime.add(Duration(seconds: 20));
+      final keyName = randomString();
+      final url = randomString();
 
-    // When
-    tracker.startResource(
-      startTime,
-      keyName,
-      RumHttpMethod.get,
-      url,
-      {'attribute_1': 'value', 'attribute_2': 'value_2'},
-    );
-    final error = FormatException('message');
-    tracker.stopResourceWithError(endTime, keyName, error,
-        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'});
+      // When
+      tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {
+        'attribute_1': 'value',
+        'attribute_2': 'value_2',
+      });
+      final error = FormatException('message');
+      tracker.stopResourceWithError(endTime, keyName, error, {
+        'attribute_2': 'finished_value',
+        'attribute_3': 'extra_value',
+      });
 
-    // Then
-    final expectedEventTime = getRelativeEventTime(endTime);
-    final expectedContext = attributesToJs({
-      'attribute_1': 'value',
-      'attribute_2': 'finished_value',
-      'attribute_3': 'extra_value',
-    }, 'attributes');
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
-    final errorEvent = captured[0] as RumWebRawErrorEvent;
-    expect(errorEvent.context, equalsContext(expectedContext));
-  });
+      // Then
+      final expectedEventTime = getRelativeEventTime(endTime);
+      final expectedContext = attributesToJs({
+        'attribute_1': 'value',
+        'attribute_2': 'finished_value',
+        'attribute_3': 'extra_value',
+      }, 'attributes');
+      final captured = verify(
+        () =>
+            mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+      ).captured;
+      final errorEvent = captured[0] as RumWebRawErrorEvent;
+      expect(errorEvent.context, equalsContext(expectedContext));
+    },
+  );
 
   test('stopResourceWithErrorInfo sends resource event with info', () {
     // Given
@@ -231,13 +219,7 @@ void main() {
     final errorMessage = randomString();
 
     // When
-    tracker.startResource(
-      startTime,
-      keyName,
-      RumHttpMethod.get,
-      url,
-      {},
-    );
+    tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {});
     tracker.stopResourceWithErrorInfo(
       endTime,
       keyName,
@@ -248,11 +230,9 @@ void main() {
 
     // Then
     final expectedEventTime = getRelativeEventTime(endTime);
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
+    final captured = verify(
+      () => mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+    ).captured;
     final errorEvent = captured[0] as RumWebRawErrorEvent;
     expect(errorEvent.date, endTime.millisecondsSinceEpoch.toJS);
     expect(errorEvent.error.id, isNotNull);
@@ -265,43 +245,45 @@ void main() {
   });
 
   test(
-      'stopResourceWithError sends resource event with error merges attributes to context',
-      () {
-    // Given
-    final tracker = ResourceTracker(mockPlugin);
-    final startTime = DateTime.now();
-    final endTime = startTime.add(Duration(seconds: 20));
-    final keyName = randomString();
-    final url = randomString();
-    final errorType = randomString();
-    final errorMessage = randomString();
+    'stopResourceWithError sends resource event with error merges attributes to context',
+    () {
+      // Given
+      final tracker = ResourceTracker(mockPlugin);
+      final startTime = DateTime.now();
+      final endTime = startTime.add(Duration(seconds: 20));
+      final keyName = randomString();
+      final url = randomString();
+      final errorType = randomString();
+      final errorMessage = randomString();
 
-    // When
-    tracker.startResource(
-      startTime,
-      keyName,
-      RumHttpMethod.get,
-      url,
-      {'attribute_1': 'value', 'attribute_2': 'value_2'},
-    );
-    tracker.stopResourceWithErrorInfo(endTime, keyName, errorMessage, errorType,
-        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'});
+      // When
+      tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {
+        'attribute_1': 'value',
+        'attribute_2': 'value_2',
+      });
+      tracker.stopResourceWithErrorInfo(
+        endTime,
+        keyName,
+        errorMessage,
+        errorType,
+        {'attribute_2': 'finished_value', 'attribute_3': 'extra_value'},
+      );
 
-    // Then
-    final expectedEventTime = getRelativeEventTime(endTime);
-    final expectedContext = attributesToJs({
-      'attribute_1': 'value',
-      'attribute_2': 'finished_value',
-      'attribute_3': 'extra_value',
-    }, 'attributes');
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
-    final errorEvent = captured[0] as RumWebRawErrorEvent;
-    expect(errorEvent.context, equalsContext(expectedContext));
-  });
+      // Then
+      final expectedEventTime = getRelativeEventTime(endTime);
+      final expectedContext = attributesToJs({
+        'attribute_1': 'value',
+        'attribute_2': 'finished_value',
+        'attribute_3': 'extra_value',
+      }, 'attributes');
+      final captured = verify(
+        () =>
+            mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+      ).captured;
+      final errorEvent = captured[0] as RumWebRawErrorEvent;
+      expect(errorEvent.context, equalsContext(expectedContext));
+    },
+  );
 
   test('stopResource transfers traceId and spanId to DdData', () {
     // Given
@@ -317,40 +299,44 @@ void main() {
     final rulePsr = randomDouble(min: 0.0, max: 1.0);
 
     // When
-    tracker.startResource(
-      startTime,
+    tracker.startResource(startTime, keyName, RumHttpMethod.get, url, {
+      DatadogRumPlatformAttributeKey.traceID: traceId,
+      DatadogRumPlatformAttributeKey.spanID: spanId,
+      DatadogRumPlatformAttributeKey.rulePsr: rulePsr.toJS,
+    });
+    tracker.stopResource(
+      endTime,
       keyName,
-      RumHttpMethod.get,
-      url,
-      {
-        DatadogRumPlatformAttributeKey.traceID: traceId,
-        DatadogRumPlatformAttributeKey.spanID: spanId,
-        DatadogRumPlatformAttributeKey.rulePsr: rulePsr.toJS,
-      },
+      200,
+      RumResourceType.image,
+      size,
+      {},
     );
-    tracker
-        .stopResource(endTime, keyName, 200, RumResourceType.image, size, {});
 
     // Then
     final expectedEventTime = getRelativeEventTime(endTime);
-    final captured = verify(() => mockPlugin.addEvent(
-          expectedEventTime,
-          captureAny(),
-          captureAny(),
-        )).captured;
+    final captured = verify(
+      () => mockPlugin.addEvent(expectedEventTime, captureAny(), captureAny()),
+    ).captured;
     final actualEvent = captured[0] as RumWebRawResourceEvent;
     expect(
-        actualEvent.context
-            .getProperty(DatadogRumPlatformAttributeKey.traceID.toJS),
-        isNull);
+      actualEvent.context.getProperty(
+        DatadogRumPlatformAttributeKey.traceID.toJS,
+      ),
+      isNull,
+    );
     expect(
-        actualEvent.context
-            .getProperty(DatadogRumPlatformAttributeKey.spanID.toJS),
-        isNull);
+      actualEvent.context.getProperty(
+        DatadogRumPlatformAttributeKey.spanID.toJS,
+      ),
+      isNull,
+    );
     expect(
-        actualEvent.context
-            .getProperty(DatadogRumPlatformAttributeKey.rulePsr.toJS),
-        isNull);
+      actualEvent.context.getProperty(
+        DatadogRumPlatformAttributeKey.rulePsr.toJS,
+      ),
+      isNull,
+    );
     expect(actualEvent.dd.traceId, traceId);
     expect(actualEvent.dd.spanId, spanId);
     expect(actualEvent.dd.rulePsr, rulePsr.toJS);


### PR DESCRIPTION
### What and why?

Minor mistake when sending a resource event to the Browser SDK, using the resource `id` instead of a newly generated UUID.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
