### PR TITLE
chore: Update min versions to be more accurate

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -288,12 +288,9 @@ nightly-min-version-test:
     - fvm install $FLUTTER_MIN_VERSION
     - fvm use $FLUTTER_MIN_VERSION
     - fvm exec dart pub global activate melos
-    - pod repo update
+    - export MELOS_PACKAGES="datadog_flutter_plugin"
     - fvm exec melos pub:get
-    - fvm exec melos pod_update --no-select
-    - fvm exec melos run analyze
-    - fvm exec melos run build
-    - fvm exec melos run unit_test:all
+    - fvm exec melos analyze:dart    
   artifacts:
     when: always
     expire_in: "30 days"

--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: "^3.3.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/datadog_flutter_plugin/test/rum/inv_metric_provider_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/inv_metric_provider_test.dart
@@ -7,7 +7,7 @@ import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/inv_metric_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-const defaultFirstBuildTime = Duration(milliseconds: 38);
+const defaultFirstBuildTime = const Duration(milliseconds: 38);
 
 void main() {
   final baseStartTime = DateTime.now();
@@ -41,7 +41,7 @@ void main() {
       final provider = InvMetricProvider();
       startView(provider, 'view1', baseStartTime);
       final secondViewStart =
-          baseStartTime.add(Duration(minutes: 1, seconds: 10));
+          baseStartTime.add(const Duration(minutes: 1, seconds: 10));
       startView(provider, 'view2', secondViewStart);
 
       // When
@@ -55,8 +55,8 @@ void main() {
       // Given
       final provider = InvMetricProvider();
       startView(provider, 'view1', baseStartTime);
-      final actionTime = baseStartTime.add(Duration(seconds: 4));
-      final nextViewTime = actionTime.add(Duration(milliseconds: 10));
+      final actionTime = baseStartTime.add(const Duration(seconds: 4));
+      final nextViewTime = actionTime.add(const Duration(milliseconds: 10));
       provider.trackAction('view1', actionTime, RumActionType.tap);
       startView(provider, 'view2', nextViewTime);
 
@@ -90,9 +90,9 @@ void main() {
       // Given
       final provider = InvMetricProvider();
       startView(provider, 'view1', baseStartTime);
-      final actionTime = baseStartTime.add(Duration(seconds: 4));
-      final stopTime = actionTime.add(Duration(milliseconds: 10));
-      final nextViewTime = stopTime.add(Duration(milliseconds: 10));
+      final actionTime = baseStartTime.add(const Duration(seconds: 4));
+      final stopTime = actionTime.add(const Duration(milliseconds: 10));
+      final nextViewTime = stopTime.add(const Duration(milliseconds: 10));
       provider.trackAction('view1', actionTime, RumActionType.tap);
       provider.trackViewStop('view1', stopTime);
       startView(provider, 'view2', nextViewTime);
@@ -111,7 +111,7 @@ void main() {
       // Given
       final provider = InvMetricProvider();
       startView(provider, 'view1', baseStartTime);
-      final actionTime = baseStartTime.add(Duration(seconds: 5));
+      final actionTime = baseStartTime.add(const Duration(seconds: 5));
       final nextViewTime = actionTime
           .add(Duration(seconds: (defaultMaxTimeToNextView + 1).toInt()));
       provider.trackAction('view1', actionTime, RumActionType.tap);
@@ -128,7 +128,7 @@ void main() {
       // Given
       final provider = InvMetricProvider();
       startView(provider, 'view1', baseStartTime);
-      final actionTime = baseStartTime.add(Duration(seconds: 5));
+      final actionTime = baseStartTime.add(const Duration(seconds: 5));
       final nextViewTime = actionTime
           .add(Duration(seconds: (defaultMaxTimeToNextView + 1).toInt()));
       provider.trackAction('view1', actionTime, RumActionType.tap);
@@ -151,7 +151,7 @@ void main() {
           .add(Duration(seconds: (defaultMaxTimeToNextView + 1).toInt()));
       provider.trackAction('view1', actionTime, RumActionType.tap);
       startView(provider, 'view2', secondViewTime);
-      final thirdViewTime = secondViewTime.add(Duration(seconds: 1));
+      final thirdViewTime = secondViewTime.add(const Duration(seconds: 1));
       startView(provider, 'view3', thirdViewTime);
 
       // When

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -48,13 +48,13 @@ Widget _buildSimpleApp(DatadogRum rum, Widget innerWidget) {
     rum: rum,
     customGestureDetector: (widget) {
       if (widget is _DescriptiveWidget) {
-        return RumGestureDetectorInfo(
+        return const RumGestureDetectorInfo(
           'DescriptiveWidget',
           searchForText: false,
           searchForBetter: false,
         );
       } else if (widget is _VagueWidget) {
-        return RumGestureDetectorInfo(
+        return const RumGestureDetectorInfo(
           'VagueWidget',
           searchForBetter: true,
           searchForText: true,
@@ -390,13 +390,11 @@ void main() {
 
     await tester.pumpWidget(_buildSimpleApp(
       mockRum,
-      RadioGroup(
+      Radio(
         groupValue: 0,
         onChanged: (value) {},
-        child: Radio(
-          value: 1,
-        ),
-      ),
+        value: 1,
+      ),      
     ));
 
     final text = find.byType(Radio<int>);
@@ -414,12 +412,10 @@ void main() {
       mockRum,
       RumUserActionAnnotation(
         description: annotation,
-        child: RadioGroup(
+        child: Radio(
           groupValue: 0,
           onChanged: (value) {},
-          child: Radio(
-            value: 1,
-          ),
+          value: 1,          
         ),
       ),
     ));
@@ -688,7 +684,7 @@ void main() {
 
       await tester.pumpWidget(_buildSimpleApp(
         mockRum,
-        _DescriptiveWidget(),
+        const _DescriptiveWidget(),
       ));
 
       final button = find.byType(_DescriptiveWidget);
@@ -769,7 +765,7 @@ void main() {
         mockRum,
         RumUserActionAnnotation(
           description: annotation,
-          child: _DescriptiveWidget(),
+          child: const _DescriptiveWidget(),
         ),
       ));
 
@@ -795,7 +791,7 @@ void main() {
               description: annotation,
               attributes: attributes,
               child: Semantics(
-                child: SizedBox.shrink(),
+                child: const SizedBox.shrink(),
               ),
             ),
           ),

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/DataDog/dd-sdk-flutter
 version: 1.2.0
 
 environment:
-  sdk: '>=3.1.0 <4.0.0'
-  flutter: ">=1.17.0"
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/datadog_inappwebview_tracking/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: '>=3.3.0'
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: '>=3.19.0'
 
 dependencies:
   flutter:

--- a/packages/datadog_tracking_http_client/example/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/example/pubspec.yaml
@@ -30,7 +30,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-  collection: ^1.19.1
+  collection: ^1.18.0
   
 flutter:
   uses-material-design: true

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### What and why?

Some pubspecs were specifying min versions well bellow what we actually support, update them to all be more accurate.

Additionally, update the 'min version' test to only test the main plugin for now, as other packages depend on packages that are only available in newer versions of Flutter. The update for v3 will likely enable min-version testing in all packages.

Cleanup some linter infos.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
