### PR TITLE
chore(android): Pin android to last stable v2 release.

### DIFF
--- a/examples/native-hybrid-app/android/app/build.gradle
+++ b/examples/native-hybrid-app/android/app/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.26.0"
 }
 
 plugins {

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -10,7 +10,7 @@ version "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "1.8.22"
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.26.0"
 
     repositories {
         google()

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 buildscript {
-    ext.datadog_version = "2+"
+    ext.datadog_version = "2.26.0"
 }
 
 plugins {


### PR DESCRIPTION
### What and why?

Android `develop` has merged in changes for v3 but didn't update the published version for snapshots, so Flutter builds that rely on snapshots are currently broken.

Pin `develop` to the last stable version of the Android SDK.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
