### PR TITLE
fix(web): Fix `valueToJs` for WASM builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,6 @@ build-flutter:
     - melos run analyze:dart
     - melos run unit_test:flutter
     - melos run golden_test:flutter
-    - melos run build:web
   artifacts:
     when: always
     expire_in: "30 days"
@@ -152,6 +151,7 @@ build-web:
   script:
     - !reference [.pre, script]
     - melos run build:web
+    - melos run unit_test:web
 
 # Integration Tests
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ stages:
     - export PATH=$PATH:$HOME/.pub-cache/bin
     - flutter upgrade
     - flutter --version
+    - flutter doctor
     # SPM is the exception, make sure its disabled before starting the build
     - flutter config --no-enable-swift-package-manager
     - dart pub global activate melos

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,6 +61,14 @@ stages:
     - melos pub:get
     - flutter doctor
 
+.pre-web:
+  script:
+    - pushd tools/ci && dart pub get && dart run ci_helpers chrome_driver --extract && popd
+    - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --version
+    - ./tools/ci/.tmp/chrome-linux64/chrome --version    
+    - export CHROME_EXECUTABLE=${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/chrome
+    - export PATH="$PATH:${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/"
+    - echo $CHROME_EXECUTABLE 
   
 ci-image:
   when: manual
@@ -147,11 +155,12 @@ build-ios:
 build-web:
   stage: build
   except: [ schedules ]
+  image: $CI_IMAGE_DOCKER
   tags:
-    - macos:sonoma
-    - specific:true
+    [ "arch:amd64" ]
   script:
     - !reference [.pre, script]
+    - !reference [.pre-web, script]
     - melos run build:web
     - melos run unit_test:web
 
@@ -211,14 +220,8 @@ web-integration-test:
     [ "arch:amd64" ]
   script:
     - !reference [.pre, script]
-    - pushd tools/ci && dart pub get && dart run ci_helpers chrome_driver --extract && popd
-    - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --version
-    - ./tools/ci/.tmp/chrome-linux64/chrome --version
+    - !reference [.pre-web, script]
     - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --port=4444 &
-    - export CHROME_EXECUTABLE=${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/chrome
-    - export PATH="$PATH:${CI_PROJECT_DIR}/tools/ci/.tmp/chrome-linux64/"
-    - echo $CHROME_EXECUTABLE
-    - flutter doctor
     - melos run integration_test:web
 
 # Notify

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,8 +146,9 @@ build-ios:
 build-web:
   stage: build
   except: [ schedules ]
-  tags: [ "arch:amd64" ]
-  image: $CI_IMAGE_DOCKER
+  tags:
+    - macos:sonoma
+    - specific:true
   script:
     - !reference [.pre, script]
     - melos run build:web

--- a/melos.yaml
+++ b/melos.yaml
@@ -62,7 +62,7 @@ scripts:
         - "*e2e_test_app*"
 
   unit_test:all:
-    run: melos unit_test:flutter && melos unit_test:ios && melos unit_test:android
+    run: melos unit_test:flutter && melos unit_test:ios && melos unit_test:android && melos unit_test:web
 
   unit_test:flutter:
     run: 
@@ -77,6 +77,14 @@ scripts:
       melos exec -c 1 -- "set -e -o pipefail && flutter test golden_test --machine | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_golden.xml\"" 
     packageFilters:
       dirExists: 'golden_test'
+
+  unit_test:web:
+    run:
+      mkdir -p .build/test-results &&
+      melos exec -c 1 -- "set -euxo pipefail && flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"" &&
+      melos exec -c 1 -- "set -euxo pipefail && flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"" 
+    packageFilters:
+      scope: 'datadog_flutter_plugin'
 
   unit_test:ios:
     exec:

--- a/melos.yaml
+++ b/melos.yaml
@@ -81,8 +81,8 @@ scripts:
   unit_test:web:
     run:
       mkdir -p .build/test-results &&
-      melos exec -c 1 -- "set -euxo pipefail && flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"" &&
-      melos exec -c 1 -- "set -euxo pipefail && flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"" 
+      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"'" &&
+      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"'" 
     packageFilters:
       scope: 'datadog_flutter_plugin'
 

--- a/packages/datadog_flutter_plugin/analysis_options.yaml
+++ b/packages/datadog_flutter_plugin/analysis_options.yaml
@@ -4,6 +4,8 @@ include: package:flutter_lints/flutter.yaml
 # https://dart.dev/guides/language/analysis-options
 
 analyzer:
+  errors:
+    library_annotations: ignore
   exclude:
     - "**/*.mocks.dart"
     - "**/*.g.dart"

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -51,11 +51,11 @@ JSAny? valueToJs(Object? value, String parameterName) {
     return value.toJS;
   }
 
-  if (value is Map) {
+  if (value is Map<String, Object>) {
     final jsMap = JSObject();
     for (final item in value.entries) {
       jsMap.setProperty(
-          item.key, valueToJs(item.value, '$parameterName.${item.key}'));
+          item.key.toJS, valueToJs(item.value, '$parameterName.${item.key}'));
     }
     return jsMap;
   }

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -51,11 +51,12 @@ JSAny? valueToJs(Object? value, String parameterName) {
     return value.toJS;
   }
 
-  if (value is Map<String, Object>) {
+  if (value is Map) {
     final jsMap = JSObject();
     for (final item in value.entries) {
+      String key = item.key is String ? item.key : item.key.toString();
       jsMap.setProperty(
-          item.key.toJS, valueToJs(item.value, '$parameterName.${item.key}'));
+          key.toJS, valueToJs(item.value, '$parameterName.${item.key}'));
     }
     return jsMap;
   }

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
+@TestOn('vm')
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/logs/ddlogs_method_channel_test.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
+@TestOn('vm')
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
+@TestOn('vm')
 
 import 'dart:async';
 import 'dart:math';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -356,7 +356,8 @@ void main() {
       rum.timeProvider = mockTimeProvider;
     });
 
-    test('markViewFirstBuildComplete adds ns timestamp as view attribute', () {
+    test('markViewFirstBuildComplete adds ns timestamp as view attribute',
+        testOn: 'vm', () {
       final startTime = DateTime.now();
       final duration = random.nextInt(1 << 32);
       final timeAnswers = [

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -1,6 +1,8 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-2022 Datadog, Inc.
+// TODO (RUM-): See if we can setup these tests to work on browser
+@TestOn('vm')
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -10,11 +10,15 @@ void main() {
   test('TracingIdRepresentation generates proper values', () {
     // Create a value in 128-bit hex that has leading zeros on both
     // the low and high 64-bits, and ensure we get the proper values
-    const low = 0x01445feed89934bb;
-    const high = 0x01222f00d89934ba;
+    const low0 = 0xd89934bb;
+    const low32 = 0x01445fee;
+    const high0 = 0xd89934ba;
+    const high32 = 0x01222f00;
 
-    var combined = BigInt.from(high);
-    combined = (combined << 64) + BigInt.from(low);
+    var combined = BigInt.from(high32);
+    combined = (combined << 32) + BigInt.from(high0);
+    combined = (combined << 32) + BigInt.from(low32);
+    combined = (combined << 32) + BigInt.from(low0);
 
     final tracingId = TracingId(combined);
 
@@ -174,11 +178,11 @@ void main() {
     );
 
     expect(headers['x-datadog-trace-id'],
-          context.traceId.asString(TracingIdRepresentation.lowDecimal));
-      expect(headers['x-datadog-tags'],
-          '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
-      expect(headers['x-datadog-parent-id'],
-          context.spanId.asString(TracingIdRepresentation.decimal));
+        context.traceId.asString(TracingIdRepresentation.lowDecimal));
+    expect(headers['x-datadog-tags'],
+        '_dd.p.tid=${context.traceId.asString(TracingIdRepresentation.highHex16Chars)}');
+    expect(headers['x-datadog-parent-id'],
+        context.spanId.asString(TracingIdRepresentation.decimal));
     expect(headers['x-datadog-sampling-priority'], '0');
     expect(headers['x-datadog-origin'], 'rum');
   });


### PR DESCRIPTION
### What and why?

`valueToJs` was broken on WASM web builds because of  differences in implicit type conversion between dart2js and dart2wasm which can be fixed with an explicit type conversion.

Cherry pick web unit tests from v3, and add WASM unit tests on top.

refs #820

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
