### PR TITLE
feat: Improve capture performance

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
@@ -16,6 +16,9 @@ class ContainerRecorder implements ElementRecorder {
   const ContainerRecorder(this.keyGenerator);
 
   @override
+  List<Type> get handlesTypes => [ColoredBox, Material, DecoratedBox];
+
+  @override
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
@@ -18,6 +18,9 @@ class CustomPaintRecorder implements ElementRecorder {
   const CustomPaintRecorder(this.keyGenerator);
 
   @override
+  List<Type> get handlesTypes => [CustomPaint];
+
+  @override
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
@@ -30,6 +30,9 @@ class EditableTextRecorder implements ElementRecorder {
   EditableTextRecorder(this.keyGenerator);
 
   @override
+  List<Type> get handlesTypes => [EditableText];
+
+  @override
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
@@ -103,6 +106,9 @@ class InputDecoratorRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   InputDecoratorRecorder(this.keyGenerator);
+
+  @override
+  List<Type> get handlesTypes => [InputDecorator];
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
@@ -29,6 +29,9 @@ class ImageRecorder implements ElementRecorder {
   const ImageRecorder(this.keyGenerator);
 
   @override
+  List<Type> get handlesTypes => [RawImage, Image];
+
+  @override
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/privacy_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/privacy_recorder.dart
@@ -21,6 +21,9 @@ class PrivacyRecorder implements ElementRecorder {
   PrivacyRecorder(this.keyGenerator);
 
   @override
+  List<Type> get handlesTypes => [SessionReplayPrivacy];
+
+  @override
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
@@ -19,6 +19,9 @@ class TextElementRecorder implements ElementRecorder {
   const TextElementRecorder(this.keyGenerator);
 
   @override
+  List<Type> get handlesTypes => [RichText];
+
+  @override
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -108,7 +108,6 @@ class CaptureResult {
 
 class SessionReplayRecorder {
   final DatadogTimeProvider _timeProvider;
-  // final List<ElementRecorder> _elementRecorders;
   final Map<Type, ElementRecorder> _elementRecordersByType = {};
 
   final Map<Key, Element> _elements = {};
@@ -142,7 +141,7 @@ class SessionReplayRecorder {
     this._defaultTreeCapturePrivacy,
     this._touchPrivacyLevel,
   ) {
-    _sortElementRecorders([
+    _populateElementRecorderMap([
       ContainerRecorder(keyGenerator),
       TextElementRecorder(keyGenerator),
       EditableTextRecorder(keyGenerator),
@@ -162,7 +161,7 @@ class SessionReplayRecorder {
   }) : _timeProvider = timeProvider,
        _defaultTreeCapturePrivacy = defaultCapturePrivacy,
        _touchPrivacyLevel = touchPrivacyLevel {
-    _sortElementRecorders(elementRecorders);
+    _populateElementRecorderMap(elementRecorders);
   }
 
   void updateContext(RUMContext? context) {
@@ -269,7 +268,7 @@ class SessionReplayRecorder {
     }
   }
 
-  void _sortElementRecorders(List<ElementRecorder> recorders) {
+  void _populateElementRecorderMap(List<ElementRecorder> recorders) {
     for (final recorder in recorders) {
       for (final type in recorder.handlesTypes) {
         _elementRecordersByType[type] = recorder;

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -1,6 +1,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+import 'dart:developer';
 import 'dart:ui' as ui;
 
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
@@ -48,6 +49,8 @@ class TreeCapturePrivacy {
 }
 
 abstract interface class ElementRecorder {
+  List<Type> get handlesTypes;
+
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
@@ -105,7 +108,8 @@ class CaptureResult {
 
 class SessionReplayRecorder {
   final DatadogTimeProvider _timeProvider;
-  final List<ElementRecorder> _elementRecorders;
+  // final List<ElementRecorder> _elementRecorders;
+  final Map<Type, ElementRecorder> _elementRecordersByType = {};
 
   final Map<Key, Element> _elements = {};
   RUMContext? _currentContext;
@@ -137,25 +141,29 @@ class SessionReplayRecorder {
     this._timeProvider,
     this._defaultTreeCapturePrivacy,
     this._touchPrivacyLevel,
-  ) : _elementRecorders = [
-        ContainerRecorder(keyGenerator),
-        TextElementRecorder(keyGenerator),
-        EditableTextRecorder(keyGenerator),
-        InputDecoratorRecorder(keyGenerator),
-        ImageRecorder(keyGenerator),
-        CustomPaintRecorder(keyGenerator),
-        PrivacyRecorder(keyGenerator),
-      ];
+  ) {
+    _sortElementRecorders([
+      ContainerRecorder(keyGenerator),
+      TextElementRecorder(keyGenerator),
+      EditableTextRecorder(keyGenerator),
+      InputDecoratorRecorder(keyGenerator),
+      ImageRecorder(keyGenerator),
+      CustomPaintRecorder(keyGenerator),
+      PrivacyRecorder(keyGenerator),
+    ]);
+  }
 
   @visibleForTesting
   SessionReplayRecorder.withCustomRecorders(
-    this._elementRecorders, {
+    List<ElementRecorder> elementRecorders, {
     DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
     required TreeCapturePrivacy defaultCapturePrivacy,
     required TouchPrivacyLevel touchPrivacyLevel,
   }) : _timeProvider = timeProvider,
        _defaultTreeCapturePrivacy = defaultCapturePrivacy,
-       _touchPrivacyLevel = touchPrivacyLevel;
+       _touchPrivacyLevel = touchPrivacyLevel {
+    _sortElementRecorders(elementRecorders);
+  }
 
   void updateContext(RUMContext? context) {
     _currentContext = context;
@@ -180,45 +188,60 @@ class SessionReplayRecorder {
     if (_captureInProgress) return null;
 
     _captureInProgress = true;
-    DateTime now = _timeProvider.now();
     List<CaptureNodeSemantics> capturedSemantics = [];
     List<PointerSnapshot> pointerSnapshots = [];
+    DateTime now = _timeProvider.now();
     var size = Size.zero;
-    for (final e in _elements.values) {
-      final renderObject = e.renderObject;
-      if (kDebugMode) {
-        // During hot reload, elements can be inserted that still need layout, and
-        // these will throw when we get their size. Avoid capturing these
-        if (renderObject?.debugNeedsLayout == true) continue;
-      }
 
-      // In debug mode, Flutter will assert if you attempt to access the size of an
-      // object that shouldn't have size. We can skip elements that have no size for
-      // whatever reason.
-      if (renderObject is RenderBox && !renderObject.hasSize) continue;
+    Timeline.timeSync('Datadog SR Tree Capture', () {
+      for (final e in _elements.values) {
+        final renderObject = e.renderObject;
+        if (kDebugMode) {
+          // During hot reload, elements can be inserted that still need layout, and
+          // these will throw when we get their size. Avoid capturing these
+          if (renderObject?.debugNeedsLayout == true) continue;
+        }
 
-      final elementSize = e.size;
-      if (elementSize != null) {
-        // Need to copy this value because the size class
-        // returned by the element is not serializable over the isolate
-        size = Size(elementSize.width, elementSize.height);
+        // In debug mode, Flutter will assert if you attempt to access the size of an
+        // object that shouldn't have size. We can skip elements that have no size for
+        // whatever reason.
+        if (renderObject is RenderBox && !renderObject.hasSize) continue;
+
+        final elementSize = e.size;
+        if (elementSize != null) {
+          // Need to copy this value because the size class
+          // returned by the element is not serializable over the isolate
+          size = Size(elementSize.width, elementSize.height);
+        }
+        _captureElement(
+          e,
+          capturedSemantics,
+          pointerSnapshots,
+          _defaultTreeCapturePrivacy,
+        );
       }
-      _captureElement(
-        e,
-        capturedSemantics,
-        pointerSnapshots,
-        _defaultTreeCapturePrivacy,
-      );
-    }
+    });
+
+    final addedProcessingTimelineTask =
+        TimelineTask()..start('Datadog SR Capture Processing');
 
     // Process anything that needs additional processing
     final nodes = <CaptureNode>[];
     for (var s in capturedSemantics) {
-      if (s is AdditionalProcessingElement) {
-        s = await s.process();
+      try {
+        if (s is AdditionalProcessingElement) {
+          s = await s.process();
+        }
+        nodes.addAll(s.nodes);
+      } catch (e, st) {
+        DatadogSessionReplayPlatform.instance.telemetryError(
+          'Exception during session replay capture: $e',
+          e.runtimeType.toString(),
+          st.toString(),
+        );
       }
-      nodes.addAll(s.nodes);
     }
+    addedProcessingTimelineTask.finish();
 
     _captureInProgress = false;
 
@@ -246,17 +269,28 @@ class SessionReplayRecorder {
     }
   }
 
+  void _sortElementRecorders(List<ElementRecorder> recorders) {
+    for (final recorder in recorders) {
+      for (final type in recorder.handlesTypes) {
+        _elementRecordersByType[type] = recorder;
+      }
+    }
+  }
+
   // Certain elements will cause everything under the element to be invisible, such
   // as Visibility or FadeTransition. Ignore these trees.
   bool _shouldIgnoreTree(Element e) {
-    if (e.widget case final Visibility visibility) {
-      if (!visibility.visible) return true;
-    }
-    if (e.widget case final SliverVisibility visilbity) {
-      if (!visilbity.visible) return true;
-    }
-    if (e.widget case final FadeTransition transition) {
-      if (transition.opacity.value <= 0.0) return true;
+    final widget = e.widget;
+    switch (widget) {
+      case final Visibility visibility:
+        if (!visibility.visible) return true;
+        break;
+      case final SliverVisibility visibility:
+        if (!visibility.visible) return true;
+        break;
+      case final FadeTransition transition:
+        if (transition.opacity.value <= 0.0) return true;
+        break;
     }
 
     return false;
@@ -290,39 +324,50 @@ class SessionReplayRecorder {
       //   return;
       // }
 
-      final transformMatrix = renderObject.getTransformTo(
-        topElement.renderObject,
-      );
       final untransformedPaintBounds = renderObject.paintBounds;
-
-      final paintBounds = MatrixUtils.transformRect(
-        transformMatrix,
-        renderObject.paintBounds,
-      );
       // Don't capture things that take up no space.
-      if (paintBounds.width == 0 && paintBounds.height == 0) return;
-
-      final scaleX = paintBounds.width / untransformedPaintBounds.width;
-      final scaleY = paintBounds.height / untransformedPaintBounds.height;
-      final viewAttributes = CapturedViewAttributes(
-        paintBounds: paintBounds,
-        scaleX: scaleX,
-        scaleY: scaleY,
-      );
-
-      final elementSemantics = _elementSemantics(
-        e,
-        viewAttributes,
-        capturePrivacy,
-      );
-      if (elementSemantics.subtreePrivacy case final newCapturePrivacy?) {
-        capturePrivacy = newCapturePrivacy;
+      if (untransformedPaintBounds.width == 0 &&
+          untransformedPaintBounds.height == 0) {
+        return;
       }
 
-      capturedSemantics.add(elementSemantics);
+      final widget = e.widget;
+      final recorder = _elementRecordersByType[widget.runtimeType];
+      var subtreeStrategy = CaptureNodeSubtreeStrategy.record;
+      if (recorder != null) {
+        final transformMatrix = renderObject.getTransformTo(
+          topElement.renderObject,
+        );
 
-      if (elementSemantics.subtreeStrategy ==
-          CaptureNodeSubtreeStrategy.record) {
+        final paintBounds = MatrixUtils.transformRect(
+          transformMatrix,
+          renderObject.paintBounds,
+        );
+
+        final scaleX = paintBounds.width / untransformedPaintBounds.width;
+        final scaleY = paintBounds.height / untransformedPaintBounds.height;
+        final viewAttributes = CapturedViewAttributes(
+          paintBounds: paintBounds,
+          scaleX: scaleX,
+          scaleY: scaleY,
+        );
+        final semantics = recorder.captureSemantics(
+          e,
+          viewAttributes,
+          capturePrivacy,
+        );
+
+        if (semantics != null) {
+          subtreeStrategy = semantics.subtreeStrategy;
+          if (semantics.subtreePrivacy case final newCapturePrivacy?) {
+            capturePrivacy = newCapturePrivacy;
+          }
+
+          capturedSemantics.add(semantics);
+        }
+      }
+
+      if (subtreeStrategy == CaptureNodeSubtreeStrategy.record) {
         e.visitChildElements((child) {
           final renderObject = child.renderObject;
           if (renderObject == null) return;
@@ -333,31 +378,5 @@ class SessionReplayRecorder {
     }
 
     visit(topElement, capturePrivacy, 0);
-  }
-
-  CaptureNodeSemantics _elementSemantics(
-    Element element,
-    CapturedViewAttributes viewAttributes,
-    TreeCapturePrivacy capturePrivacy,
-  ) {
-    CaptureNodeSemantics semantics = const UnknownElement();
-
-    for (final recorder in _elementRecorders) {
-      final nextSemantics = recorder.captureSemantics(
-        element,
-        viewAttributes,
-        capturePrivacy,
-      );
-      if (nextSemantics == null) continue;
-
-      if (nextSemantics.importance >= semantics.importance) {
-        semantics = nextSemantics;
-        if (semantics.importance == CaptureNodeSemantics.maxImporance) {
-          break;
-        }
-      }
-    }
-
-    return semantics;
   }
 }

--- a/packages/datadog_session_replay/lib/src/capture/view_tree_snapshot.dart
+++ b/packages/datadog_session_replay/lib/src/capture/view_tree_snapshot.dart
@@ -27,16 +27,11 @@ enum CaptureNodeSubtreeStrategy { record, ignore }
 
 @immutable
 abstract class CaptureNodeSemantics {
-  static const maxImporance = 1000000;
-  static const minImportance = -1000000;
-
-  final int importance;
   final CaptureNodeSubtreeStrategy subtreeStrategy;
   final TreeCapturePrivacy? subtreePrivacy;
   final List<CaptureNode> nodes;
 
   const CaptureNodeSemantics({
-    required this.importance,
     required this.subtreeStrategy,
     this.subtreePrivacy,
     required this.nodes,
@@ -47,7 +42,6 @@ abstract class CaptureNodeSemantics {
 class UnknownElement extends CaptureNodeSemantics {
   const UnknownElement({super.subtreePrivacy})
     : super(
-        importance: CaptureNodeSemantics.minImportance,
         subtreeStrategy: CaptureNodeSubtreeStrategy.record,
         nodes: const [],
       );
@@ -56,7 +50,7 @@ class UnknownElement extends CaptureNodeSemantics {
 @immutable
 class InvisibleElement extends CaptureNodeSemantics {
   const InvisibleElement({required super.subtreeStrategy, super.subtreePrivacy})
-    : super(importance: 0, nodes: const []);
+    : super(nodes: const []);
 }
 
 @immutable
@@ -65,7 +59,7 @@ class IgnoredElement extends CaptureNodeSemantics {
     required super.subtreeStrategy,
     super.subtreePrivacy,
     super.nodes = const [],
-  }) : super(importance: CaptureNodeSemantics.maxImporance);
+  }) : super();
 }
 
 @immutable
@@ -74,7 +68,7 @@ class AmbiguousElement extends CaptureNodeSemantics {
     super.subtreeStrategy = CaptureNodeSubtreeStrategy.record,
     super.subtreePrivacy,
     required super.nodes,
-  }) : super(importance: 0);
+  }) : super();
 }
 
 @immutable
@@ -83,7 +77,7 @@ class SpecificElement extends CaptureNodeSemantics {
     required super.subtreeStrategy,
     super.subtreePrivacy,
     required super.nodes,
-  }) : super(importance: CaptureNodeSemantics.maxImporance);
+  }) : super();
 }
 
 /// This node needs additional async processing in order to provide
@@ -96,5 +90,5 @@ class AdditionalProcessingElement extends CaptureNodeSemantics {
     required super.subtreeStrategy,
     super.subtreePrivacy,
     required this.process,
-  }) : super(importance: CaptureNodeSemantics.maxImporance, nodes: const []);
+  }) : super(nodes: const []);
 }

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -17,6 +17,13 @@ import 'processor/processor.dart';
 import 'rum_context.dart';
 
 class DatadogSessionReplay {
+  // The minimum amount of time that needs to pass before we perform another
+  // tree capture.
+  static const minCaptureTiming = Duration(milliseconds: 100);
+  // The number of times in quick succession thar SR capture can throw before
+  // we shut it down completely.
+  static const errorTollerance = 10;
+
   static DatadogSessionReplay? _instance;
   static DatadogSessionReplay? get instance => _instance;
 
@@ -27,11 +34,15 @@ class DatadogSessionReplay {
   final SessionReplayProcessor _processor = SessionReplayProcessor();
   final SessionReplayRecorder _recorder;
 
+  int _errorCounter = 0;
+  bool _needCapture = true;
+
   @internal
   static Future<DatadogSessionReplay> init(
     DatadogSessionReplayConfiguration configuration,
-    InternalLogger logger,
-  ) async {
+    InternalLogger logger, {
+    DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
+  }) async {
     _instance = DatadogSessionReplay._(configuration, logger);
     await _instance!._start();
     return _instance!;
@@ -66,22 +77,25 @@ class DatadogSessionReplay {
     });
 
     if (success) {
-      // The number of times in quick succession thar SR capture can throw before
-      // we shut it down completely.
-      const errorTollerance = 10;
-
       await _processor.start();
 
-      const timerDuration = Duration(milliseconds: 100);
-      var errorCounter = 0;
-      // TODO(RUM-10155): See if we can be smarter about how often we perform tree captures
-      Timer.periodic(timerDuration, (timer) async {
+      _startPeriodicCapture();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _needCapture = true;
+      });
+    }
+  }
+
+  void _startPeriodicCapture() async {
+    Timer.periodic(minCaptureTiming, (timer) async {
+      bool shouldScheduleNextCapture = true;
+      if (_needCapture) {
         try {
           final captureResult = await _recorder.performCapture();
           if (captureResult != null) {
             _processor.process(captureResult);
           }
-          errorCounter = max(0, errorCounter - 1);
+          _errorCounter = max(0, _errorCounter - 1);
         } catch (e, st) {
           internalLogger.sendToDatadog(
             'Exception during session replay capture: $e',
@@ -92,17 +106,25 @@ class DatadogSessionReplay {
             CoreLoggerLevel.warn,
             'Exception during session replay capture: $e',
           );
-          errorCounter += 1;
-          if (errorCounter > errorTollerance) {
+          _errorCounter += 1;
+          if (_errorCounter > errorTollerance) {
             internalLogger.sendToDatadog(
               'Flutter SR has exceeded its error tollerance of $errorTollerance. Shutting down.',
               null,
               null,
             );
             timer.cancel();
+            shouldScheduleNextCapture = false;
           }
         }
-      });
-    }
+        _needCapture = false;
+      }
+
+      if (shouldScheduleNextCapture) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _needCapture = true;
+        });
+      }
+    });
   }
 }

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -35,7 +35,7 @@ class DatadogSessionReplay {
   final SessionReplayRecorder _recorder;
 
   int _errorCounter = 0;
-  bool _needCapture = true;
+  bool _newFrameBuilt = true;
 
   @internal
   static Future<DatadogSessionReplay> init(
@@ -81,15 +81,22 @@ class DatadogSessionReplay {
 
       _startPeriodicCapture();
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        _needCapture = true;
+        // Let capture know that a new element tree is available for capture.
+        _newFrameBuilt = true;
       });
     }
   }
 
   void _startPeriodicCapture() async {
+    /// This timer periodically checks if a tree capture is necessary, which it
+    /// only is if _newFrameBuilt has been set by a call to `postFrameCallback`
+    ///
+    /// Using the timer (instead of as part of addPostFrameCallback) allows
+    /// Flutter to schedule this outside of the build phase, which means our
+    /// tree capture shouldn't affect tree build time.
     Timer.periodic(minCaptureTiming, (timer) async {
-      bool shouldScheduleNextCapture = true;
-      if (_needCapture) {
+      bool shouldWatchForNextFrame = true;
+      if (_newFrameBuilt) {
         try {
           final captureResult = await _recorder.performCapture();
           if (captureResult != null) {
@@ -113,16 +120,19 @@ class DatadogSessionReplay {
               null,
               null,
             );
+            // Too many errors, cancel this periodic timer and don't schedule
+            // another post frame callback
             timer.cancel();
-            shouldScheduleNextCapture = false;
+            shouldWatchForNextFrame = false;
           }
         }
-        _needCapture = false;
+        _newFrameBuilt = false;
       }
 
-      if (shouldScheduleNextCapture) {
+      // If we've received too many errors, don't request any more post frame callbacks
+      if (shouldWatchForNextFrame) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          _needCapture = true;
+          _newFrameBuilt = true;
         });
       }
     });

--- a/packages/datadog_session_replay/test/capture/recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/recorder_test.dart
@@ -25,7 +25,10 @@ class MockElement extends Mock implements Element {
   }
 }
 
-class MockElementRecorder extends Mock implements ElementRecorder {}
+class MockElementRecorder extends Mock implements ElementRecorder {
+  @override
+  List<Type> get handlesTypes => [SimpleTestCapture, Placeholder, Center];
+}
 
 class MockCaptureNode extends Mock implements CaptureNode {}
 
@@ -195,7 +198,6 @@ void main() {
         final testedTree = SimpleTestCapture(
           key: UniqueKey(),
           recorder: recorder,
-          child: Container(),
         );
         await tester.pumpWidget(testedTree);
         final capture = await recorder.performCapture();


### PR DESCRIPTION
### What and why?

Instead of asking for semantics from every recorder, bind recorders to types so only the relevant ones are asked for capture semantics. This allows us to avoid capturing paint bounds and doing matrix translations for every element in the tree, only the ones that we need to capture semantics for.

Additionally, use `addPostFrameCallback` to make it so we only capture the tree if there was a change to the widget tree.

refs: RUM-11123

### More detail

One of the first frames after boot is usually the worst. Prior to optimization in Shopist, which could also include a GC pass.
<img width="376" height="222" alt="image" src="https://github.com/user-attachments/assets/2e6c0e85-2952-4a41-a060-e3a1b9126943" />

A more representative sample without a GC pass registers at 11ms or so:
<img width="442" height="217" alt="image" src="https://github.com/user-attachments/assets/2eee600c-9706-4771-95e9-b008087f22e6" />

Post optimization, since we create less garbage (fewer Semantics objects and Matrix objects) we see fewer GC passes and faster results:
<img width="538" height="230" alt="image" src="https://github.com/user-attachments/assets/c04ee2bd-9965-41b5-90ee-bb7cb6fd6e32" />

And this is the worst case with a GC trigger:
<img width="506" height="254" alt="image" src="https://github.com/user-attachments/assets/35b85799-250d-43c9-8a93-4e63faee1a6c" />

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
