### PR TITLE
chore: Fix trailing space in yaml

### DIFF
--- a/packages/datadog_common_test/analysis_options.yaml
+++ b/packages/datadog_common_test/analysis_options.yaml
@@ -13,4 +13,4 @@ linter:
   rules:
     prefer_single_quotes: true
     prefer_relative_imports: true
-    unawaited_futures: true 
+    unawaited_futures: true


### PR DESCRIPTION
### What and why?

Fixes beta nightlies which became more strict about yaml formatting.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
