### PR TITLE
feat(web): Support source, variant, and sdkVersion

### DIFF
--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -117,19 +117,12 @@ void verifyCommonEventTags(
   final sdkVersion = tags['sdk_version'];
   expect(sdkVersion, DatadogSdk.sdkVersion);
   expect(tags['service'], service);
-
-  if (!kIsWeb) {
-    // Not sent as a tag on web
-    expect(tags['version'], version);
-    expect(tags['variant'], variant);
-  }
+  expect(tags['version'], version);
+  expect(tags['variant'], variant);
 }
 
 void verifyCommonRequestTags(RequestLog log) {
-  if (!kIsWeb) {
-    // Currently coming back as 'browser' on web
-    expect(log.queryParameters['ddsource'], 'flutter');
-  }
+  expect(log.queryParameters['ddsource'], 'flutter');
 }
 
 void verifyUser(RumEventDecoder decoder) {

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -110,29 +110,18 @@ extension Waiter on WidgetTester {
 
 void verifyCommonEventTags(
     RumEventDecoder log, String service, String version, String? variant) {
-  // Tags moved to events in v6. We should be able to remove this check
-  // for dd-sdk-flutter-v3
+  final tags = log.ddtags;
+  // Likely telemetry
+  if (tags.isEmpty) return;
+
+  final sdkVersion = tags['sdk_version'];
+  expect(sdkVersion, DatadogSdk.sdkVersion);
+  expect(tags['service'], service);
+
   if (!kIsWeb) {
-    final tags = log.ddtags;
-    // Likely telemetry
-    if (tags.isEmpty) return;
-
-    final sdkVersion = tags['sdk_version'];
-    if (kIsWeb) {
-      // Returning the browser version of the SDK.
-      expect(sdkVersion?.startsWith('5.'), true);
-    } else {
-      expect(sdkVersion, DatadogSdk.sdkVersion);
-    }
-
-
-    expect(tags['service'], service);
-
-    if (!kIsWeb) {
-      // Not sent as a tag on web
-      expect(tags['version'], version);
-      expect(tags['variant'], variant);
-    }
+    // Not sent as a tag on web
+    expect(tags['version'], version);
+    expect(tags['variant'], variant);
   }
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -181,12 +181,12 @@ void main() {
           expect(log.applicationVersion, '1.2.3-555');
         }
         expect(log.threadName, 'main');
-
-        // Verify expected tags
-        expect(log.tagValues.contains('env:prod'), isTrue);
-        expect(log.tagValues.contains('version:1.2.3-555'), isTrue);
-        expect(log.tagValues.contains('variant:integration'), isTrue);
       }
+
+      // Verify expected tags
+      expect(log.tagValues.contains('env:prod'), isTrue);
+      expect(log.tagValues.contains('version:1.2.3-555'), isTrue);
+      expect(log.tagValues.contains('variant:integration'), isTrue);
     }
   });
 }

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -25,6 +25,9 @@ class DdLogsWeb extends DdLogsPlatform {
       site: siteStringForSite(configuration.site),
       service: configuration.service,
       version: configuration.versionTag,
+      variant: configuration.flavor,
+      source: 'flutter',
+      sdkVersion: DatadogSdk.sdkVersion,
     ));
   }
 
@@ -166,6 +169,9 @@ extension type _LogInitOptions._(JSObject _) implements JSObject {
   external String? get proxy;
   external String? get service;
   external String? get version;
+  external String? get source;
+  external String? get sdkVersion;
+  external String? get variant;
 
   external factory _LogInitOptions({
     String clientToken,
@@ -174,6 +180,9 @@ extension type _LogInitOptions._(JSObject _) implements JSObject {
     String? service,
     String? proxy,
     String? version,
+    String? source,
+    String? sdkVersion,
+    String? variant,
   });
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -79,6 +79,9 @@ class DdRumWeb extends DdRumPlatform {
         // TODO(RUM-11211): Support and document web configuration options.
         compressIntakeRequests: false,
         plugins: plugins,
+        variant: configuration.flavor,
+        source: 'flutter',
+        sdkVersion: DatadogSdk.sdkVersion,
       ),
     );
   }
@@ -402,6 +405,9 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
   external JSArray get enableExperimentalFeatures;
   external bool get compressIntakeRequests;
   external JSArray? get plugins;
+  external String? get source;
+  external String? get sdkVersion;
+  external String? get variant;
 
   external factory _RumInitOptions({
     String applicationId,
@@ -429,6 +435,9 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
     JSArray enableExperimentalFeatures,
     bool compressIntakeRequests,
     JSArray? plugins,
+    String? source,
+    String? sdkVersion,
+    String? variant,
   });
 }
 


### PR DESCRIPTION
### What and why?

New versions of the Browser SDK support overriding `source`, `sdkVersion` and `variant`. Set them properly for Logs and RUM.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
