### PR TITLE
fix(android): Fix compileSdk to be 35 on main package

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,6 +163,11 @@ build-web:
     - !reference [.pre-web, script]
     - melos run build:web
     - melos run unit_test:web
+  artifacts:
+    when: always
+    expire_in: "30 days"
+    reports:
+      junit: $CI_PROJECT_DIR/.build/test-results/*.xml
 
 # Integration Tests
 

--- a/examples/simple_example/android/app/build.gradle
+++ b/examples/simple_example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
     namespace 'com.example.test_app'
 

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -44,7 +44,7 @@ apply plugin: "kotlin-android"
 
 android {
     namespace "com.datadoghq.flutter"
-    compileSdkVersion 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/app/build.gradle
@@ -30,7 +30,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.e2e_test_app"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/datadog_flutter_plugin/example/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/app/build.gradle
@@ -32,7 +32,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -55,7 +55,7 @@ android {
 
     defaultConfig {
         applicationId "com.datadoghq.example.flutter"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle
@@ -29,7 +29,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.datadoghq.flutter.integrationtestapp"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/packages/datadog_tracking_http_client/example/android/app/build.gradle
+++ b/packages/datadog_tracking_http_client/example/android/app/build.gradle
@@ -29,7 +29,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
     namespace "com.example.example"
 

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "com.datadoghq.flutter.webview"
-    compileSdkVersion 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/datadog_webview_tracking/example/android/app/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/app/build.gradle
@@ -30,7 +30,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.example.datadog_webview_tracking"
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/test_apps/stress_test/android/app/build.gradle
+++ b/test_apps/stress_test/android/app/build.gradle
@@ -33,7 +33,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion flutter.compileSdkVersion
+    compileSdk flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {


### PR DESCRIPTION
### What and why?

The `datadog_flutter_plugin` and `datadog_webview_tracking` packages need a minimum `compileSdk` of 35 (currently 34).

Modify all other gradle files to use `compileSdk` over `compileSdkVersion`.

ref: #834

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
