### PR TITLE
feat(sr): Implement touch privacy

### DIFF
--- a/packages/datadog_session_replay/example/lib/app.dart
+++ b/packages/datadog_session_replay/example/lib/app.dart
@@ -16,6 +16,7 @@ import 'screens/simple_containers_screen.dart';
 import 'screens/slivers_screen.dart';
 import 'screens/text_fields_screen.dart';
 import 'screens/text_recording_screen.dart';
+import 'screens/touch_privacy_screen.dart';
 
 const Color datadogPurple = Color.fromARGB(255, 99, 44, 166);
 
@@ -56,10 +57,14 @@ class _MyAppState extends State<MyApp> {
       GoRoute(
         path: Routes.slivers,
         builder: (context, state) => SliversScreen(),
-	  ),
+      ),
       GoRoute(
         path: Routes.imageWidgets,
         builder: (context, state) => ImagesScreen(),
+      ),
+      GoRoute(
+        path: Routes.touchPrivacy,
+        builder: (context, state) => TouchPrivacyScreen(),
       ),
     ],
   );

--- a/packages/datadog_session_replay/example/lib/main.dart
+++ b/packages/datadog_session_replay/example/lib/main.dart
@@ -33,6 +33,7 @@ void main() async {
   )..enableSessionReplay(
     DatadogSessionReplayConfiguration(
       textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+      touchPrivacyLevel: TouchPrivacyLevel.show,
       replaySampleRate: 1.0,
     ),
   );

--- a/packages/datadog_session_replay/example/lib/routes.dart
+++ b/packages/datadog_session_replay/example/lib/routes.dart
@@ -11,4 +11,5 @@ abstract final class Routes {
   static const String textFieldWidgets = '/text_fields';
   static const String slivers = '/slivers';
   static const String imageWidgets = '/images';
+  static const String touchPrivacy = '/touch_privacy';
 }

--- a/packages/datadog_session_replay/example/lib/screens/main_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/main_screen.dart
@@ -31,6 +31,7 @@ class _MainScreenState extends State<MainScreen> {
     _RouteScreen('Text Fields', Routes.textFieldWidgets),
     _RouteScreen('Slivers', Routes.slivers),
     _RouteScreen('Images', Routes.imageWidgets),
+    _RouteScreen('Touch Privacy', Routes.touchPrivacy),
   ];
 
   @override

--- a/packages/datadog_session_replay/example/lib/screens/touch_privacy_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/touch_privacy_screen.dart
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_session_replay/datadog_session_replay.dart';
+import 'package:flutter/material.dart';
+
+class TouchPrivacyScreen extends StatefulWidget {
+  const TouchPrivacyScreen({super.key});
+
+  @override
+  State<TouchPrivacyScreen> createState() => _ImagesScreenState();
+}
+
+class _ImagesScreenState extends State<TouchPrivacyScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Touch Privacy')),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            Text('Here touch recording should work'),
+            SizedBox(height: 20.0),
+            Text('The below pin pad should not show touches'),
+            _pinPad(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _pinPad() {
+    return SessionReplayPrivacy(
+      touchPrivacyLevel: TouchPrivacyLevel.hide,
+      child: Padding(
+        padding: EdgeInsetsGeometry.all(10),
+        child: Column(
+          spacing: 20.0,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _PinButton(text: '1'),
+                _PinButton(text: '2'),
+                _PinButton(text: '3'),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _PinButton(text: '4'),
+                _PinButton(text: '5'),
+                _PinButton(text: '6'),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _PinButton(text: '7'),
+                _PinButton(text: '8'),
+                _PinButton(text: '9'),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class _PinButton extends StatelessWidget {
+  final String text;
+
+  const _PinButton({required this.text}) : super();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialButton(
+      color: Colors.lightBlueAccent,
+      onPressed: () {},
+      padding: EdgeInsets.all(20.0),
+      shape: CircleBorder(),
+      child: Text(text),
+    );
+  }
+}

--- a/packages/datadog_session_replay/example/lib/screens/touch_privacy_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/touch_privacy_screen.dart
@@ -9,10 +9,10 @@ class TouchPrivacyScreen extends StatefulWidget {
   const TouchPrivacyScreen({super.key});
 
   @override
-  State<TouchPrivacyScreen> createState() => _ImagesScreenState();
+  State<TouchPrivacyScreen> createState() => _TouchPrivacyScreenState();
 }
 
-class _ImagesScreenState extends State<TouchPrivacyScreen> {
+class _TouchPrivacyScreenState extends State<TouchPrivacyScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
@@ -47,6 +47,8 @@ class ContainerRecorder implements ElementRecorder {
         break;
     }
 
+    attributes = _adjustAttributesForShape(widget, attributes);
+
     final key = keyGenerator.keyForElement(element);
     final node = ContainerNode(attributes, wireframeId: key, style: style!);
     return AmbiguousElement(nodes: [node]);
@@ -79,5 +81,37 @@ class ContainerRecorder implements ElementRecorder {
       borderWidth: borderStyle?.width,
       cornerRadius: borderStyle?.cornerRadius ?? 0.0,
     );
+  }
+
+  CapturedViewAttributes _adjustAttributesForShape(
+    Widget widget,
+    CapturedViewAttributes attributes,
+  ) {
+    CircleBorder? circleBorder;
+    switch (widget) {
+      case Material widget:
+        if (widget.shape case final CircleBorder circle) {
+          circleBorder = circle;
+        }
+        break;
+      case DecoratedBox box:
+        final decoration = box.decoration;
+        if (decoration is ShapeDecoration && decoration.shape is CircleBorder) {
+          circleBorder = decoration.shape as CircleBorder;
+        }
+        break;
+    }
+    if (circleBorder != null) {
+      // Need to adjust position, width, and height so that this actually appears as
+      // a circle in Session Replay
+      final center = attributes.paintBounds.center;
+      final shortSide = attributes.paintBounds.shortestSide;
+      attributes = CapturedViewAttributes(
+        paintBounds: Rect.fromCircle(center: center, radius: shortSide / 2),
+        scaleX: attributes.scaleX,
+        scaleY: attributes.scaleY,
+      );
+    }
+    return attributes;
   }
 }

--- a/packages/datadog_session_replay/lib/src/capture/pointer_capture.dart
+++ b/packages/datadog_session_replay/lib/src/capture/pointer_capture.dart
@@ -3,7 +3,7 @@
 // Copyright 2025-Present Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/widgets.dart';
 
 import '../sr_data_models.dart';
 
@@ -32,10 +32,34 @@ class PointerCapture {
   });
 }
 
+/// Provides a PointerSnapshotRecorder to other classes that need it.
+/// This is used primarily by [SessionReplayPrivacy] to cancel pointer
+/// tracking that occurs in its subtree if [TouchPrivacyLevel ]
+class PointerSnapshotRecorderProvider extends InheritedWidget {
+  final PointerSnapshotRecorder recorder;
+
+  const PointerSnapshotRecorderProvider({
+    super.key,
+    required super.child,
+    required this.recorder,
+  }) : super();
+
+  @override
+  bool updateShouldNotify(
+    covariant PointerSnapshotRecorderProvider oldWidget,
+  ) => recorder != oldWidget.recorder;
+
+  static PointerSnapshotRecorderProvider? of(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<PointerSnapshotRecorderProvider>();
+  }
+}
+
 class PointerSnapshotRecorder {
   final DatadogTimeProvider timeProvider;
 
   List<PointerCapture> _pointerBuffer = [];
+  final Set<int> _hiddenPointers = {};
 
   PointerSnapshotRecorder(this.timeProvider);
 
@@ -47,6 +71,10 @@ class PointerSnapshotRecorder {
   ) {
     final now = timeProvider.now();
 
+    if (_hiddenPointers.contains(pointerId)) {
+      return;
+    }
+
     _pointerBuffer.add(
       PointerCapture(
         date: now,
@@ -57,6 +85,20 @@ class PointerSnapshotRecorder {
       ),
     );
   }
+  
+  // Uncapturing a pointer removes any previous events from the pointer, and
+  // flags it as hidden until the next snapshot. This is partially to support
+  // 'hover' events that don't have up / down that are trackable, and because
+  // "up" triggers occur in reverse tree order, which means we can't 'uncapture'
+  // the tracking that happens at the root of the tree
+  //
+  // This may result in some touches being ignored if they alternate between a
+  // hidden area and a non-hidden area in between tree captures, but we'd rather
+  // miss a few pointer events than capture private ones.
+  void uncapturePointer(int pointerId) {
+    _hiddenPointers.add(pointerId);
+    _pointerBuffer.removeWhere((c) => c.pointerId == pointerId);
+  }
 
   PointerSnapshot? takeSnapshot() {
     if (_pointerBuffer.isEmpty) {
@@ -65,6 +107,7 @@ class PointerSnapshotRecorder {
 
     final copy = _pointerBuffer;
     _pointerBuffer = [];
+    _hiddenPointers.clear();
     return PointerSnapshot(copy.first.date, copy);
   }
 }

--- a/packages/datadog_session_replay/lib/src/capture/pointer_capture.dart
+++ b/packages/datadog_session_replay/lib/src/capture/pointer_capture.dart
@@ -34,7 +34,7 @@ class PointerCapture {
 
 /// Provides a PointerSnapshotRecorder to other classes that need it.
 /// This is used primarily by [SessionReplayPrivacy] to cancel pointer
-/// tracking that occurs in its subtree if [TouchPrivacyLevel ]
+/// tracking that occurs in its subtree if [TouchPrivacyLevel] is set
 class PointerSnapshotRecorderProvider extends InheritedWidget {
   final PointerSnapshotRecorder recorder;
 
@@ -90,7 +90,7 @@ class PointerSnapshotRecorder {
   // flags it as hidden until the next snapshot. This is partially to support
   // 'hover' events that don't have up / down that are trackable, and because
   // "up" triggers occur in reverse tree order, which means we can't 'uncapture'
-  // the tracking that happens at the root of the tree
+  // the tracking that happens at the root of the tree.
   //
   // This may result in some touches being ignored if they alternate between a
   // hidden area and a non-hidden area in between tree captures, but we'd rather

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -303,7 +303,7 @@ class SessionReplayRecorder {
   ) {
     void visit(Element e, TreeCapturePrivacy capturePrivacy, int depth) {
       if (e.widget case final PointerRecorder snapshotWidget) {
-        if (snapshotWidget.snapshotRecorder.takeSnapshot()
+        if (snapshotWidget.pointerRecorder.takeSnapshot()
             case final snapshot?) {
           pointerSnapshots.add(snapshot);
         }

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -34,6 +34,8 @@ class DatadogSessionReplay {
   final SessionReplayProcessor _processor = SessionReplayProcessor();
   final SessionReplayRecorder _recorder;
 
+  final TouchPrivacyLevel defaultTouchPrivacyLevel;
+
   int _errorCounter = 0;
   bool _newFrameBuilt = true;
 
@@ -49,7 +51,8 @@ class DatadogSessionReplay {
   }
 
   DatadogSessionReplay._(this._configuration, this.internalLogger)
-    : _recorder = SessionReplayRecorder(
+    : defaultTouchPrivacyLevel = _configuration.touchPrivacyLevel,
+      _recorder = SessionReplayRecorder(
         defaultCapturePrivacy: TreeCapturePrivacy(
           textAndInputPrivacyLevel: _configuration.textAndInputPrivacyLevel,
           imagePrivacyLevel: _configuration.imagePrivacyLevel,

--- a/packages/datadog_session_replay/lib/src/widgets.dart
+++ b/packages/datadog_session_replay/lib/src/widgets.dart
@@ -3,7 +3,7 @@
 // Copyright 2025-Present Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
-import 'package:flutter/gestures.dart';
+import 'package:flutter/gestures.dart' hide PointerEvent;
 import 'package:flutter/widgets.dart';
 
 import '../datadog_session_replay.dart';
@@ -15,19 +15,12 @@ class SessionReplayCapture extends StatefulWidget {
   final DatadogSessionReplay sessionReplay;
   final Widget child;
 
-  SessionReplayCapture({
-    super.key,
+  const SessionReplayCapture({
+    required Key key,
     required this.child,
     required this.rum,
     required this.sessionReplay,
-  }) {
-    if (key == null) {
-      sessionReplay.internalLogger.log(
-        CoreLoggerLevel.warn,
-        'SessionReplayCapture has a null Key value. A Key is required for Session Replay to work.',
-      );
-    }
-  }
+  }) : super(key: key);
 
   @override
   StatefulElement createElement() {
@@ -44,13 +37,34 @@ class SessionReplayCapture extends StatefulWidget {
 }
 
 class _SessionReplayCaptureState extends State<SessionReplayCapture> {
+  late PointerSnapshotRecorder pointerRecorder;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // ignore: invalid_use_of_internal_member
+    pointerRecorder = PointerSnapshotRecorder(widget.rum.timeProvider);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return PointerRecorder(
-      // ignore: invalid_use_of_internal_member
-      snapshotRecorder: PointerSnapshotRecorder(widget.rum.timeProvider),
-      child: RumUserActionDetector(rum: widget.rum, child: widget.child),
+    Widget builtChild = RumUserActionDetector(
+      rum: widget.rum,
+      child: widget.child,
     );
+
+    if (widget.sessionReplay.defaultTouchPrivacyLevel ==
+        TouchPrivacyLevel.show) {
+      builtChild = PointerSnapshotRecorderProvider(
+        recorder: pointerRecorder,
+        child: PointerRecorder(
+          pointerRecorder: pointerRecorder,
+          child: builtChild,
+        ),
+      );
+    }
+    return builtChild;
   }
 }
 
@@ -60,14 +74,21 @@ class _SessionReplayCaptureState extends State<SessionReplayCapture> {
 ///
 /// The privacy overrides specified continue for the entire tree below this
 /// widget. Privacy overrides include setting a tree's
-/// [TextAndInputPrivacyLevel], [ImagePrivacyLevel], and whether a tree should
-/// be hidden from Session Replay
+/// [TextAndInputPrivacyLevel], [ImagePrivacyLevel], and [TouchPrivacyLevel],
+/// and whether a tree should be hidden from Session Replay
 ///
-/// Privacy overrides can be modified multiple times in a widget tree, however,
-/// when a widget is hidden, it is replaced by a placeholder labeled as "Hidden"
+/// Privacy overrides can be modified multiple times in a widget tree. However,
+/// setting [hide] to `true` or seeting [touchPrivacyLevel] to
+/// [TouchPrivacyLevel.hide] will affect the entire subtree.
+///
+/// When a tree is hidden, it is replaced by a placeholder labeled as "Hidden"
 /// in the replay, and its subviews are not processed or recorded. Therefore, it
 /// is not possible to "unhide" a widget that is deeper in the tree of a hidden
 /// widget.
+///
+/// When [touchPrivacyLevel] is set to [TouchPrivacyLevel.hide], touch recording
+/// is cancelled for the entire subtree, and so it is not possible to "un-cancel"
+/// recording.
 @immutable
 class SessionReplayPrivacy extends StatelessWidget {
   final Widget child;
@@ -83,28 +104,50 @@ class SessionReplayPrivacy extends StatelessWidget {
   /// leaves the privacy level unchanged.
   final ImagePrivacyLevel? imagePrivacyLevel;
 
+  /// The new touch privacy level for this tree. Setting this to null
+  /// leaves the privacy level unchanged.
+  final TouchPrivacyLevel? touchPrivacyLevel;
+
   const SessionReplayPrivacy({
     super.key,
     required this.child,
     this.hide,
     this.textAndInputPrivacyLevel,
     this.imagePrivacyLevel,
+    this.touchPrivacyLevel,
   }) : super();
 
   @override
   Widget build(BuildContext context) {
-    return child;
+    var builtWidget = child;
+    if (touchPrivacyLevel == TouchPrivacyLevel.hide) {
+      builtWidget = RumUserActionAnnotation(
+        description: 'Hidden',
+        child: builtWidget,
+      );
+      final pointerRecorderProvider = PointerSnapshotRecorderProvider.of(
+        context,
+      );
+      if (pointerRecorderProvider != null) {
+        builtWidget = PointerUnrecorder(
+          pointerRecorder: pointerRecorderProvider.recorder,
+          child: builtWidget,
+        );
+      }
+    }
+
+    return builtWidget;
   }
 }
 
 @immutable
 class PointerRecorder extends StatelessWidget {
-  final PointerSnapshotRecorder snapshotRecorder;
+  final PointerSnapshotRecorder pointerRecorder;
   final Widget child;
 
   const PointerRecorder({
     super.key,
-    required this.snapshotRecorder,
+    required this.pointerRecorder,
     required this.child,
   });
 
@@ -124,12 +167,56 @@ class PointerRecorder extends StatelessWidget {
       _capturePointerEvent(SRPointerEventType.up, event);
 
   void _capturePointerEvent(SRPointerEventType type, PointerEvent event) {
-    snapshotRecorder.capturePointer(
+    pointerRecorder.capturePointer(
       event.pointer,
       type,
       event.position.dx,
       event.position.dy,
     );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerCancel: _onPointerCancel,
+      onPointerHover: _onPointerHover,
+      onPointerUp: _onPointerUp,
+      child: child,
+    );
+  }
+}
+
+@immutable
+class PointerUnrecorder extends StatelessWidget {
+  final PointerSnapshotRecorder pointerRecorder;
+  final Widget child;
+
+  const PointerUnrecorder({
+    super.key,
+    required this.pointerRecorder,
+    required this.child,
+  });
+
+  void _onPointerDown(PointerDownEvent event) =>
+      _uncapturePointerEvent(SRPointerEventType.down, event);
+
+  void _onPointerMove(PointerMoveEvent event) =>
+      _uncapturePointerEvent(SRPointerEventType.move, event);
+
+  void _onPointerCancel(PointerCancelEvent event) =>
+      _uncapturePointerEvent(SRPointerEventType.up, event);
+
+  void _onPointerHover(PointerHoverEvent event) =>
+      _uncapturePointerEvent(SRPointerEventType.move, event);
+
+  void _onPointerUp(PointerUpEvent event) =>
+      _uncapturePointerEvent(SRPointerEventType.up, event);
+
+  void _uncapturePointerEvent(SRPointerEventType type, PointerEvent event) {
+    pointerRecorder.uncapturePointer(event.pointer);
   }
 
   @override

--- a/packages/datadog_session_replay/test/capture/pointer_capture_test.dart
+++ b/packages/datadog_session_replay/test/capture/pointer_capture_test.dart
@@ -1,0 +1,428 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_session_replay/datadog_session_replay.dart';
+import 'package:datadog_session_replay/src/capture/capture_node.dart';
+import 'package:datadog_session_replay/src/capture/element_recorders/container_recorder.dart';
+import 'package:datadog_session_replay/src/capture/pointer_capture.dart';
+import 'package:datadog_session_replay/src/capture/recorder.dart';
+import 'package:datadog_session_replay/src/rum_context.dart';
+import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:datadog_session_replay/src/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'simple_test_capture.dart';
+
+class MockTimeProvider extends Mock implements DatadogTimeProvider {}
+
+void main() {
+  group('PointerSnapshotRecorder', () {
+    late MockTimeProvider mockTimeProvider;
+
+    setUp(() {
+      mockTimeProvider = MockTimeProvider();
+    });
+
+    group('capturePointer', () {
+      test('adds pointer event to snapshot', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        final x = randomDouble();
+        final y = randomDouble();
+        recorder.capturePointer(1, SRPointerEventType.down, x, y);
+
+        // Then
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(1));
+        expect(snapshot.pointerEvents[0].pointerId, 1);
+        expect(snapshot.pointerEvents[0].eventType, SRPointerEventType.down);
+        expect(snapshot.pointerEvents[0].x, x);
+        expect(snapshot.pointerEvents[0].y, y);
+        expect(snapshot.pointerEvents[0].date, mockTime);
+      });
+
+      test('captures multiple events in order', () {
+        // Given
+        final time1 = DateTime(2023, 1, 1, 12, 0, 0);
+        final time2 = DateTime(2023, 1, 1, 12, 0, 1);
+        final time3 = DateTime(2023, 1, 1, 12, 0, 2);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        when(() => mockTimeProvider.now()).thenReturn(time1);
+        final x = randomDouble();
+        final y = randomDouble();
+        recorder.capturePointer(1, SRPointerEventType.down, x, y);
+
+        when(() => mockTimeProvider.now()).thenReturn(time2);
+        recorder.capturePointer(1, SRPointerEventType.move, x + 10.0, y + 10.0);
+
+        when(() => mockTimeProvider.now()).thenReturn(time3);
+        recorder.capturePointer(1, SRPointerEventType.up, x + 10.0, y + 10.0);
+
+        // When
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(3));
+        expect(snapshot.firstRecord, time1);
+
+        // Then
+        expect(snapshot.pointerEvents[0].eventType, SRPointerEventType.down);
+        expect(snapshot.pointerEvents[0].date, time1);
+        expect(snapshot.pointerEvents[0].x, x);
+        expect(snapshot.pointerEvents[0].y, y);
+
+        expect(snapshot.pointerEvents[1].eventType, SRPointerEventType.move);
+        expect(snapshot.pointerEvents[1].date, time2);
+        expect(snapshot.pointerEvents[1].x, x + 10.0);
+        expect(snapshot.pointerEvents[1].y, y + 10.0);
+
+        expect(snapshot.pointerEvents[2].eventType, SRPointerEventType.up);
+        expect(snapshot.pointerEvents[2].date, time3);
+        expect(snapshot.pointerEvents[2].x, x + 10.0);
+        expect(snapshot.pointerEvents[2].y, y + 10.0);
+      });
+
+      test('captures events from multiple pointers', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        final x1 = randomDouble();
+        final y1 = randomDouble();
+        final x2 = randomDouble();
+        final y2 = randomDouble();
+        recorder.capturePointer(1, SRPointerEventType.down, x1, y1);
+        recorder.capturePointer(2, SRPointerEventType.down, x2, y2);
+
+        // Then
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(2));
+
+        expect(snapshot.pointerEvents[0].pointerId, 1);
+        expect(snapshot.pointerEvents[0].x, x1);
+        expect(snapshot.pointerEvents[0].y, y1);
+        expect(snapshot.pointerEvents[0].eventType, SRPointerEventType.down);
+        expect(snapshot.pointerEvents[1].pointerId, 2);
+        expect(snapshot.pointerEvents[1].x, x2);
+        expect(snapshot.pointerEvents[1].y, y2);
+        expect(snapshot.pointerEvents[1].eventType, SRPointerEventType.down);
+      });
+
+      test('handles all pointer event types correctly', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        recorder.capturePointer(
+          1,
+          SRPointerEventType.down,
+          randomDouble(),
+          randomDouble(),
+        );
+        recorder.capturePointer(
+          2,
+          SRPointerEventType.move,
+          randomDouble(),
+          randomDouble(),
+        );
+        recorder.capturePointer(
+          3,
+          SRPointerEventType.up,
+          randomDouble(),
+          randomDouble(),
+        );
+        final snapshot = recorder.takeSnapshot();
+
+        // Then
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(3));
+
+        expect(snapshot.pointerEvents[0].eventType, SRPointerEventType.down);
+        expect(snapshot.pointerEvents[1].eventType, SRPointerEventType.move);
+        expect(snapshot.pointerEvents[2].eventType, SRPointerEventType.up);
+      });
+    });
+
+    group('uncapturePointer', () {
+      test('adds pointer to hidden set', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        final x = randomDouble();
+        final y = randomDouble();
+        recorder.capturePointer(1, SRPointerEventType.down, x, y);
+        recorder.uncapturePointer(1);
+        recorder.capturePointer(1, SRPointerEventType.move, x, y);
+
+        // Assert - should have no events since pointer 1 is hidden
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNull);
+      });
+
+      test('removes existing events from hidden pointer', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        recorder.capturePointer(1, SRPointerEventType.down, 100.0, 200.0);
+        recorder.capturePointer(2, SRPointerEventType.down, 300.0, 400.0);
+        recorder.capturePointer(1, SRPointerEventType.move, 110.0, 210.0);
+
+        // Hide pointer 1
+        recorder.uncapturePointer(1);
+
+        // Then
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(1));
+        expect(snapshot.pointerEvents[0].pointerId, 2);
+      });
+
+      test('can hide pointer that does not exist in buffer', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // Hide a pointer that was never captured
+        expect(() => recorder.uncapturePointer(999), returnsNormally);
+
+        // Should still be able to capture other events
+        recorder.capturePointer(1, SRPointerEventType.down, 100.0, 200.0);
+
+        // Then
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(1));
+      });
+
+      test('can hide multiple pointers', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // Capture events from multiple pointers
+        recorder.capturePointer(1, SRPointerEventType.down, 100.0, 200.0);
+        recorder.capturePointer(2, SRPointerEventType.down, 200.0, 300.0);
+        recorder.capturePointer(3, SRPointerEventType.down, 300.0, 400.0);
+
+        // Hide multiple pointers
+        recorder.uncapturePointer(1);
+        recorder.uncapturePointer(3);
+
+        // Then - should only have events from pointer 2
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.pointerEvents, hasLength(1));
+        expect(snapshot.pointerEvents[0].pointerId, 2);
+      });
+    });
+
+    group('takeSnapshot', () {
+      test('returns null when buffer is empty', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        final snapshot = recorder.takeSnapshot();
+
+        // Then
+        expect(snapshot, isNull);
+      });
+
+      test('returns snapshot with correct first record time', () {
+        // Given
+        final time1 = DateTime(2023, 1, 1, 12, 0, 0);
+        final time2 = DateTime(2023, 1, 1, 12, 0, 5);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        when(() => mockTimeProvider.now()).thenReturn(time1);
+        recorder.capturePointer(1, SRPointerEventType.down, 100.0, 200.0);
+
+        when(() => mockTimeProvider.now()).thenReturn(time2);
+        recorder.capturePointer(1, SRPointerEventType.up, 110.0, 210.0);
+
+        // Then
+        final snapshot = recorder.takeSnapshot();
+        expect(snapshot, isNotNull);
+        expect(snapshot!.firstRecord, time1); // Should be time of first event
+      });
+
+      test('clears buffer after taking snapshot', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        recorder.capturePointer(1, SRPointerEventType.down, 100.0, 200.0);
+
+        final snapshot1 = recorder.takeSnapshot();
+        expect(snapshot1, isNotNull);
+        expect(snapshot1!.pointerEvents, hasLength(1));
+
+        // Then
+        final snapshot2 = recorder.takeSnapshot();
+        expect(snapshot2, isNull);
+      });
+
+      test('clears hidden pointers set after taking snapshot', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // Hide a pointer
+        recorder.uncapturePointer(1);
+
+        // Capture an event from another pointer
+        recorder.capturePointer(2, SRPointerEventType.down, 100.0, 200.0);
+
+        // Take snapshot (this should clear hidden pointers)
+        final snapshot1 = recorder.takeSnapshot();
+        expect(snapshot1, isNotNull);
+
+        // Now pointer 1 should no longer be hidden
+        recorder.capturePointer(1, SRPointerEventType.down, 200.0, 300.0);
+
+        final snapshot2 = recorder.takeSnapshot();
+        expect(snapshot2, isNotNull);
+        expect(snapshot2!.pointerEvents, hasLength(1));
+        expect(snapshot2.pointerEvents[0].pointerId, 1);
+      });
+
+      test('returns copy of buffer, not reference', () {
+        // Given
+        final mockTime = DateTime(2024, 1, 2, 3, 0, 0);
+        when(() => mockTimeProvider.now()).thenReturn(mockTime);
+        final recorder = PointerSnapshotRecorder(mockTimeProvider);
+
+        // When
+        recorder.capturePointer(1, SRPointerEventType.down, 100.0, 200.0);
+        final snapshot = recorder.takeSnapshot();
+
+        // Modify the returned list
+        snapshot!.pointerEvents.clear();
+
+        // Then
+        final snapshot2 = recorder.takeSnapshot();
+        expect(snapshot2, isNull);
+      });
+    });
+  });
+
+  group('widget tests', () {
+    late SessionReplayRecorder recorder;
+    late RUMContext context;
+
+    setUp(() {
+      final keyGenerator = KeyGenerator();
+      recorder = SessionReplayRecorder.withCustomRecorders(
+        [ContainerRecorder(keyGenerator)],
+        defaultCapturePrivacy: TreeCapturePrivacy(
+          textAndInputPrivacyLevel:
+              TextAndInputPrivacyLevel.maskSensitiveInputs,
+          imagePrivacyLevel: ImagePrivacyLevel.maskNonAssetsOnly,
+        ),
+        touchPrivacyLevel: TouchPrivacyLevel.show,
+      );
+
+      registerFallbackValue(
+        CapturedViewAttributes(
+          paintBounds: Rect.zero,
+          scaleX: 1.0,
+          scaleY: 1.0,
+        ),
+      );
+
+      context = RUMContext(
+        applicationId: randomString(),
+        sessionId: randomString(),
+      );
+      recorder.updateContext(context);
+    });
+
+    testWidgets('records taps on widgets', (tester) async {
+      // Given
+      final x = randomDouble(min: 10, max: 50);
+      final y = randomDouble(min: 10, max: 50);
+      final pointerRecorder = PointerSnapshotRecorder(DefaultTimeProvider());
+
+      bool didTapButton = false;
+      final tree = MaterialApp(
+        home: SimpleTestCapture(
+          key: Key('key'),
+          recorder: recorder,
+          child: PointerRecorder(
+            pointerRecorder: pointerRecorder,
+            child: Stack(
+              children: [
+                Positioned(
+                  top: y,
+                  left: x,
+                  width: 50.0,
+                  height: 50.0,
+                  child: MaterialButton(
+                    onPressed: () {
+                      didTapButton = true;
+                    },
+                    child: Text('Test Button'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpWidget(tree);
+      await tester.tap(find.byType(MaterialButton));
+      await tester.pumpAndSettle();
+
+      // When
+      CaptureResult? capture;
+      await tester.runAsync(() async {
+        capture = await recorder.performCapture();
+      });
+
+      // Then
+      expect(didTapButton, isTrue);
+      expect(capture!.pointerSnapshot, isNotNull);
+      final pointerEvents = capture!.pointerSnapshot!.pointerEvents;
+      expect(pointerEvents.length, 2);
+
+      final firstPointer = capture!.pointerSnapshot!.pointerEvents[0];
+      expect(firstPointer.eventType, SRPointerEventType.down);
+      expect(firstPointer.x, greaterThan(x));
+      expect(firstPointer.y, greaterThan(y));
+
+      final secondPointer = capture!.pointerSnapshot!.pointerEvents[1];
+      expect(secondPointer.eventType, SRPointerEventType.up);
+      expect(secondPointer.x, greaterThan(x));
+      expect(secondPointer.y, greaterThan(y));
+    });
+  });
+}

--- a/packages/datadog_session_replay/test/capture/privacy_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/privacy_recorder_test.dart
@@ -5,16 +5,19 @@
 import 'dart:ui' as ui;
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/capture/capture_node.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/image_recorder.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/privacy_recorder.dart';
 import 'package:datadog_session_replay/src/capture/element_recorders/text_recorder.dart';
+import 'package:datadog_session_replay/src/capture/pointer_capture.dart';
 import 'package:datadog_session_replay/src/capture/recorder.dart';
 import 'package:datadog_session_replay/src/capture/text_masking.dart';
 import 'package:datadog_session_replay/src/capture/view_tree_snapshot.dart';
 import 'package:datadog_session_replay/src/rum_context.dart';
 import 'package:datadog_session_replay/src/sr_data_models.dart';
+import 'package:datadog_session_replay/src/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -325,6 +328,61 @@ void main() {
       expect(builtWireframes.length, 1);
       final wireframe = builtWireframes.first as SRPlaceholderWireframe;
       expect(wireframe.label, 'Image');
+    });
+
+    testWidgets('overriding touch privacy prevents touch recording', (
+      tester,
+    ) async {
+      // Given
+      final x = randomDouble(min: 10, max: 50);
+      final y = randomDouble(min: 10, max: 50);
+      final pointerRecorder = PointerSnapshotRecorder(DefaultTimeProvider());
+
+      bool wasTapped = false;
+      final tree = MaterialApp(
+        home: SimpleTestCapture(
+          key: Key('key'),
+          recorder: recorder,
+          child: PointerSnapshotRecorderProvider(
+            recorder: pointerRecorder,
+            child: PointerRecorder(
+              pointerRecorder: pointerRecorder,
+              child: Stack(
+                children: [
+                  Positioned(
+                    top: y,
+                    left: x,
+                    width: 50.0,
+                    height: 50.0,
+                    child: SessionReplayPrivacy(
+                      touchPrivacyLevel: TouchPrivacyLevel.hide,
+                      child: MaterialButton(
+                        onPressed: () {
+                          wasTapped = true;
+                        },
+                        child: Text('Test Button'),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpWidget(tree);
+      await tester.tap(find.byType(MaterialButton));
+      await tester.pumpAndSettle();
+
+      // When
+      CaptureResult? capture;
+      await tester.runAsync(() async {
+        capture = await recorder.performCapture();
+      });
+
+      // Then
+      expect(wasTapped, isTrue);
+      expect(capture!.pointerSnapshot, isNull);
     });
   });
 }

--- a/packages/datadog_session_replay/test/capture/recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/recorder_test.dart
@@ -481,7 +481,7 @@ void main() {
         key: UniqueKey(),
         recorder: recorder,
         child: PointerRecorder(
-          snapshotRecorder: mockPointerRecorder,
+          pointerRecorder: mockPointerRecorder,
           child: Placeholder(),
         ),
       );

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
@@ -17,7 +17,7 @@ A Flutter plugin for use with the Datadog Flutter Plugin to track webviews as pa
   s.dependency 'Flutter'
   s.dependency 'DatadogWebViewTracking', '~> 2'
   s.dependency 'webview_flutter_wkwebview'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "datadog_webview_tracking",
     platforms: [
-        .iOS("12.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "datadog-webview-tracking", targets: ["datadog_webview_tracking"])


### PR DESCRIPTION
### What and why?

The `SessionReplayPrivacy` widget can now override touch privacy for a tree. It does this by canceling touch events from a given pointer until the next capture. This can mean we might miss some taps if they are moving in and out of a private area within a capture period.

Add tests for both pointer recorder and associated widgets.

refs: RUM-11681

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
