### PR TITLE
chore(tools): Add Session Replay packages to release override removal

### DIFF
--- a/tools/releaser/lib/package_list.dart
+++ b/tools/releaser/lib/package_list.dart
@@ -10,6 +10,7 @@ final podfileList = [
   'packages/datadog_tracking_http_client/example/ios/Podfile',
   'packages/datadog_webview_tracking/example/ios/Podfile',
   'packages/datadog_inappwebview_tracking/example/ios/Podfile',
+  'packages/datadog_session_replay/example/ios/Podfile',
 ];
 
 // Location of gradle files
@@ -19,5 +20,6 @@ final gradleList = [
   'packages/datadog_flutter_plugin/integration_test_app/android/app/build.gradle',
   'packages/datadog_webview_tracking/android/build.gradle',
   'packages/datadog_inappwebview_tracking/android/build.gradle',
+  'packages/datadog_session_replay/android/build.gradle',
   'examples/native-hybrid-app/android/app/build.gradle',
 ];


### PR DESCRIPTION
### What and why?

The native package version overrides weren't being removed from Session Replay build files as part of the release script. Fix it so they are.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
