### PR TITLE
chore: Fix web / wasm flakey test

### DIFF
--- a/packages/datadog_flutter_plugin/test/rum/rum_long_task_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_long_task_observer_test.dart
@@ -140,15 +140,15 @@ void main() {
 
     observer.didChangeAppLifecycleState(AppLifecycleState.inactive);
     await tester.runAsync(() async {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
     });
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 300));
 
     observer.didChangeAppLifecycleState(AppLifecycleState.resumed);
     await tester.runAsync(() async {
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await Future<void>.delayed(const Duration(milliseconds: 150));
     });
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 300));
 
     verify(() => mockRum.reportLongTask(any())).called(1);
 


### PR DESCRIPTION
### What and why?

Adjust timing for detecting long tasks, as I think `delayed` can trigger inside the 100ms window causing a long task to not be reported.

Tested in chrome with and without `--wasm` several hundred times without a flake.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
