### PR TITLE
chore: Minor pubspec fix

### DIFF
--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_session_replay
 description: "Support for Flutter Session Replay in Datadog"
-version: 1.0.0-preview.1
+version: 1.0.0
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
@@ -18,6 +18,7 @@ dependencies:
   objective_c: ^8.1.0
   web: ^1.0.0
   meta: ^1.16.0  
+  plugin_platform_interface: ^2.1.8
   datadog_flutter_plugin: ^2.13.1
   json_annotation: ^4.9.0
 


### PR DESCRIPTION
### What and why?

Accidentally removed `plugin_platform_interface` as a direct dependency at some point, it needs to be added back in to avoid linting issues.

Change the committed version (as it will make updating it from the release easier).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
