### PR TITLE
fix: improve test and add locations.toList

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -249,7 +249,7 @@ class DatadogGqlLink extends Link {
             }),
         'path': e.path
       };
-    });
+    }).toList();
     return {
       '_dd': {
         'graphql': {

--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -243,10 +243,12 @@ class DatadogGqlLink extends Link {
     final serializedErrors = response.errors!.map((e) {
       return {
         'message': e.message,
-        'locations': e.locations?.map((l) => {
-              'line': l.line,
-              'column': l.column,
-            }),
+        'locations': e.locations
+            ?.map((l) => {
+                  'line': l.line,
+                  'column': l.column,
+                })
+            .toList(),
         'path': e.path
       };
     }).toList();

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -666,6 +666,8 @@ query UserInfo($id: ID!) {
       final captured = verify(() => mockRum.stopResource(
           any(), any(), RumResourceType.native, any(), captureAny()));
       final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
+      expect(capturedAttrs['_dd']['graphql']['errors'].runtimeType,
+          List<Map<String, Object?>>);
       expect(capturedAttrs['_dd']['graphql']['errors'], [
         {
           'message': 'GraphQL Error Message',

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -666,8 +666,7 @@ query UserInfo($id: ID!) {
       final captured = verify(() => mockRum.stopResource(
           any(), any(), RumResourceType.native, any(), captureAny()));
       final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
-      expect(capturedAttrs['_dd']['graphql']['errors'].runtimeType,
-          List<Map<String, Object?>>);
+      expect(findInvalidAttribute(capturedAttrs), null);
       expect(capturedAttrs['_dd']['graphql']['errors'], [
         {
           'message': 'GraphQL Error Message',


### PR DESCRIPTION
fix: GqlErrors causing stopResource ArgumentError

When handling gql response with errors, errors are serialized and passed to rum.stopResource as an attribute however, attributes must be of type Map<String, Object?> but when gqllink has an error an attribute of MappedListIterable<GraphQLError, Map<String, Object?>> is add. By calling toList() on the serialized errors stopResources will no longer throw an exception.

### What and why?

What changes does this pull request introduce and why is it necessary?
resolve MappedListIterable to list in serializeErrors function by calling `.toList()` avoiding a downstream exception in RUM.stopresource()

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
