### PR TITLE
feat(web): Add extra user info support

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/log_decoder.dart
@@ -36,4 +36,8 @@ class LogDecoder {
       return log['error.fingerprint'] as String?;
     }
   }
+
+  Object? getUserProperty(String name) {
+    return getNestedProperty('usr.$name', log);
+  }
 }

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -7,17 +7,18 @@ import 'dart:io';
 import '../../datadog_common_test.dart';
 
 class RumUser {
+  Map<String, Object?> raw;
   String? email;
   String? id;
   String? name;
 
-  RumUser(this.email, this.id, this.name);
+  RumUser(this.raw, this.email, this.id, this.name);
 
   static RumUser fromJson(Map<String, dynamic> json) {
     final email = json['email'] is String ? json['email'] as String : null;
     final id = json['id'] is String ? json['id'] as String : null;
     final name = json['name'] is String ? json['name'] as String : null;
-    return RumUser(email, id, name);
+    return RumUser(json, email, id, name);
   }
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/common.dart
@@ -148,4 +148,6 @@ void verifyUser(RumEventDecoder decoder) {
   expect(user?.email, 'fake@datadoghq.com');
   expect(user?.id, 'fake-id');
   expect(user?.name, 'Johnny Silverhand');
+  expect(user?.raw['type'], 'customer');
+  expect(user?.raw['profession'], 'rocker');
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/logging_test.dart
@@ -197,6 +197,8 @@ void main() {
       expect(log.userId, 'bits');
       expect(log.userName, 'Bits Dawoof');
       expect(log.userEmail, 'bits@datadoghq.com');
+      expect(log.getUserProperty('type'), 'dog');
+      expect(log.getUserProperty('department'), 'data');
 
       if (!kIsWeb) {
         if (Platform.isIOS) {

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/logging_scenario.dart
@@ -22,7 +22,13 @@ class _LoggingScenarioState extends State<LoggingScenario> {
     super.initState();
 
     DatadogSdk.instance.setUserInfo(
-        id: 'bits', name: 'Bits Dawoof', email: 'bits@datadoghq.com');
+        id: 'bits',
+        name: 'Bits Dawoof',
+        email: 'bits@datadoghq.com',
+        extraInfo: {
+          'type': 'dog',
+          'department': 'data',
+        });
 
     // Create a logger that will not send to Datadog
     var silentLogger = DatadogSdk.instance.logs!.createLogger(

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -98,7 +98,10 @@ class _RumManualInstrumentationScenarioState
     DatadogSdk.instance.rum?.addViewLoadingTime();
 
     DatadogSdk.instance.setUserInfo(
-        id: 'fake-id', name: 'Johnny Silverhand', email: 'fake@datadoghq.com');
+        id: 'fake-id',
+        name: 'Johnny Silverhand',
+        email: 'fake@datadoghq.com',
+        extraInfo: {'type': 'customer', 'profession': 'rocker'});
   }
 
   void _simulateResourceDownload() async {

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -16,6 +16,7 @@ import 'src/logs/ddlogs_platform_interface.dart';
 import 'src/logs/ddlogs_web.dart';
 import 'src/rum/ddrum_platform_interface.dart';
 import 'src/rum/ddrum_web.dart';
+import 'src/web_helpers.dart';
 
 @anonymous
 extension type JsUser._(JSObject _) implements JSObject {
@@ -23,11 +24,7 @@ extension type JsUser._(JSObject _) implements JSObject {
   external String? get email;
   external String? get name;
 
-  external factory JsUser({
-    String? id,
-    String? email,
-    String? name,
-  });
+  external factory JsUser({String? id, String? email, String? name});
 }
 
 /// A web implementation of the DatadogSdk plugin.
@@ -46,20 +43,27 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   Future<void> setTrackingConsent(TrackingConsent trackingConsent) async {}
 
   @override
-  Future<void> setUserInfo(String? id, String? name, String? email,
-      Map<String, dynamic> extraInfo) async {
-    // TODO: Extra user properties
-    final jsUser = JsUser(
-      id: id,
-      name: name,
-      email: email,
-    );
+  Future<void> setUserInfo(
+    String? id,
+    String? name,
+    String? email,
+    Map<String, dynamic> extraInfo,
+  ) async {
+    final jsUser = JsUser(id: id, name: name, email: email);
     DD_LOGS?.setUser(jsUser);
     DD_RUM?.setUser(jsUser);
+    await addUserExtraInfo(extraInfo);
   }
 
   @override
-  Future<void> addUserExtraInfo(Map<String, Object?> extraInfo) async {}
+  Future<void> addUserExtraInfo(Map<String, Object?> extraInfo) async {
+    for (final entry in extraInfo.entries) {
+      DD_LOGS?.setUserProperty(entry.key, valueToJs(entry.value, 'extraInfo'));
+    }
+    for (final entry in extraInfo.entries) {
+      DD_RUM?.setUserProperty(entry.key, valueToJs(entry.value, 'extraInfo'));
+    }
+  }
 
   @override
   Future<PlatformInitializationResult> initialize(
@@ -76,8 +80,9 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
       }
     } catch (e) {
       internalLogger.warn('DatadogSdk failed to initialize logging: $e');
-      internalLogger
-          .warn('Did you remember to add "datadog-logs" to your scripts?');
+      internalLogger.warn(
+        'Did you remember to add "datadog-logs" to your scripts?',
+      );
     }
 
     bool rumInitialized = false;
@@ -93,12 +98,15 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
       }
     } catch (e) {
       internalLogger.warn('DatadogSdk failed to initialize RUM: $e');
-      internalLogger
-          .warn('Did you remember to add "datadog-rum-slim" to your scripts?');
+      internalLogger.warn(
+        'Did you remember to add "datadog-rum-slim" to your scripts?',
+      );
     }
 
     return PlatformInitializationResult(
-        logs: logsInitialized, rum: rumInitialized);
+      logs: logsInitialized,
+      rum: rumInitialized,
+    );
   }
 
   @override
@@ -116,7 +124,10 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
 
   @override
   Future<void> sendTelemetryError(
-      String message, String? stack, String? kind) async {
+    String message,
+    String? stack,
+    String? kind,
+  ) async {
     // Not currently supported
   }
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -18,19 +18,23 @@ class DdLogsWeb extends DdLogsPlatform {
   final Map<String, Logger> _activeLoggers = {};
 
   static void initLogs(DatadogConfiguration configuration) {
-    DD_LOGS?.init(_LogInitOptions(
-      clientToken: configuration.clientToken,
-      env: configuration.env,
-      proxy: configuration.loggingConfiguration?.customEndpoint,
-      site: siteStringForSite(configuration.site),
-      service: configuration.service,
-      version: configuration.versionTag,
-    ));
+    DD_LOGS?.init(
+      _LogInitOptions(
+        clientToken: configuration.clientToken,
+        env: configuration.env,
+        proxy: configuration.loggingConfiguration?.customEndpoint,
+        site: siteStringForSite(configuration.site),
+        service: configuration.service,
+        version: configuration.versionTag,
+      ),
+    );
   }
 
   @override
   Future<void> enable(
-      DatadogSdk core, DatadogLoggingConfiguration config) async {}
+    DatadogSdk core,
+    DatadogLoggingConfiguration config,
+  ) async {}
 
   @override
   Future<void> addGlobalAttribute(String key, Object value) async {}
@@ -43,10 +47,10 @@ class DdLogsWeb extends DdLogsPlatform {
 
   @override
   Future<void> createLogger(
-      String loggerHandle, DatadogLoggerConfiguration config) async {
-    var loggerHandlers = [
-      'http'.toJS,
-    ];
+    String loggerHandle,
+    DatadogLoggerConfiguration config,
+  ) async {
+    var loggerHandlers = ['http'.toJS];
     var logger = DD_LOGS?.createLogger(
       config.name ?? 'default',
       _JsLoggerConfiguration(),
@@ -69,7 +73,10 @@ class DdLogsWeb extends DdLogsPlatform {
 
   @override
   Future<void> addAttribute(
-      String loggerHandle, String key, Object value) async {
+    String loggerHandle,
+    String key,
+    Object value,
+  ) async {
     final logger = _activeLoggers[loggerHandle];
     logger?.setContextProperty(key, valueToJs(value, 'value'));
   }
@@ -187,10 +194,13 @@ extension type _DdLogs._(JSObject _) implements JSObject {
   external Logger? getLogger(String name);
 
   external void setUser(JsUser userInfo);
+  external void setUserProperty(String key, JSAny? value);
 
   @internal
   external Logger? createLogger(
-      String name, _JsLoggerConfiguration? configuration);
+    String name,
+    _JsLoggerConfiguration? configuration,
+  );
 }
 
 @JS()
@@ -199,7 +209,11 @@ external _DdLogs? DD_LOGS;
 
 extension type Logger._(JSObject _) implements JSObject {
   external void log(
-      String message, JSAny? messageContext, String status, JSError? error);
+    String message,
+    JSAny? messageContext,
+    String status,
+    JSError? error,
+  );
 
   external void setContextProperty(String key, JSAny? value);
   external void removeContextProperty(String key);

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -14,49 +14,61 @@ import 'ddrum_platform_interface.dart';
 
 class DdRumWeb extends DdRumPlatform {
   // Because Web needs the full SDK configuration, we have a separate init method
-  void initialize(DatadogConfiguration configuration,
-      DatadogRumConfiguration rumConfiguration, InternalLogger logger) {
+  void initialize(
+    DatadogConfiguration configuration,
+    DatadogRumConfiguration rumConfiguration,
+    InternalLogger logger,
+  ) {
     bool trackResources =
         configuration.additionalConfig[trackResourcesConfigKey] == true;
 
     final sanitizedFirstPartyHosts = FirstPartyHost.createSanitized(
-        configuration.firstPartyHostsWithTracingHeaders, logger);
+      configuration.firstPartyHostsWithTracingHeaders,
+      logger,
+    );
 
-    DD_RUM?.init(_RumInitOptions(
-      applicationId: rumConfiguration.applicationId,
-      clientToken: configuration.clientToken,
-      site: siteStringForSite(configuration.site),
-      sessionSampleRate: rumConfiguration.sessionSamplingRate,
-      sessionReplaySampleRate: 0,
-      service: configuration.service,
-      env: configuration.env,
-      version: configuration.versionTag,
-      proxy: rumConfiguration.customEndpoint,
-      allowedTracingUrls: [
-        for (final host in sanitizedFirstPartyHosts)
-          _TracingUrl(
-            match: ((String check) {
-              final uri = Uri.parse(check);
-              return host.regExp.hasMatch(uri.host);
-            }).toJS,
-            propagatorTypes:
-                host.headerTypes.map(_headerTypeToPropagatorType).toList().toJS,
-          )
-      ].toJS,
-      traceSampleRate: rumConfiguration.traceSampleRate,
-      traceContextInjection:
-          _contextInjectionString(rumConfiguration.traceContextInjection),
-      trackViewsManually: true,
-      trackResources: trackResources,
-      trackFrustrations: rumConfiguration.trackFrustrations,
-      trackLongTasks: rumConfiguration.detectLongTasks,
-      enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
-    ));
+    DD_RUM?.init(
+      _RumInitOptions(
+        applicationId: rumConfiguration.applicationId,
+        clientToken: configuration.clientToken,
+        site: siteStringForSite(configuration.site),
+        sessionSampleRate: rumConfiguration.sessionSamplingRate,
+        sessionReplaySampleRate: 0,
+        service: configuration.service,
+        env: configuration.env,
+        version: configuration.versionTag,
+        proxy: rumConfiguration.customEndpoint,
+        allowedTracingUrls: [
+          for (final host in sanitizedFirstPartyHosts)
+            _TracingUrl(
+              match: ((String check) {
+                final uri = Uri.parse(check);
+                return host.regExp.hasMatch(uri.host);
+              }).toJS,
+              propagatorTypes: host.headerTypes
+                  .map(_headerTypeToPropagatorType)
+                  .toList()
+                  .toJS,
+            ),
+        ].toJS,
+        traceSampleRate: rumConfiguration.traceSampleRate,
+        traceContextInjection: _contextInjectionString(
+          rumConfiguration.traceContextInjection,
+        ),
+        trackViewsManually: true,
+        trackResources: trackResources,
+        trackFrustrations: rumConfiguration.trackFrustrations,
+        trackLongTasks: rumConfiguration.detectLongTasks,
+        enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
+      ),
+    );
   }
 
   @override
   Future<void> enable(
-      DatadogSdk core, DatadogRumConfiguration configuration) async {}
+    DatadogSdk core,
+    DatadogRumConfiguration configuration,
+  ) async {}
 
   @override
   Future<void> deinitialize() async {}
@@ -131,8 +143,12 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, dynamic> attributes) async {
+  Future<void> addAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, dynamic> attributes,
+  ) async {
     DD_RUM?.addAction(name, attributesToJs(attributes, 'attributes'));
   }
 
@@ -143,53 +159,84 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> startResource(
-      DateTime timestamp,
-      String key,
-      RumHttpMethod httpMethod,
-      String url,
-      Map<String, dynamic> attributes) async {
+    DateTime timestamp,
+    String key,
+    RumHttpMethod httpMethod,
+    String url,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
   @override
-  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, dynamic> attributes) async {
+  Future<void> startAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
   @override
-  Future<void> startView(DateTime timestamp, String key, String name,
-      Map<String, dynamic> attributes) async {
+  Future<void> startView(
+    DateTime timestamp,
+    String key,
+    String name,
+    Map<String, dynamic> attributes,
+  ) async {
     DD_RUM?.startView(name);
   }
 
   @override
-  Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
-      RumResourceType kind, int? size, Map<String, dynamic> attributes) async {
+  Future<void> stopResource(
+    DateTime timestamp,
+    String key,
+    int? statusCode,
+    RumResourceType kind,
+    int? size,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
   @override
-  Future<void> stopResourceWithError(DateTime timestamp, String key,
-      Exception error, Map<String, dynamic> attributes) async {
+  Future<void> stopResourceWithError(
+    DateTime timestamp,
+    String key,
+    Exception error,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
   @override
-  Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
-      String message, String type, Map<String, dynamic> attributes) async {
+  Future<void> stopResourceWithErrorInfo(
+    DateTime timestamp,
+    String key,
+    String message,
+    String type,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
   @override
-  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, dynamic> attributes) async {
+  Future<void> stopAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
   @override
   Future<void> stopView(
-      DateTime timestamp, String key, Map<String, dynamic> attributes) async {
+    DateTime timestamp,
+    String key,
+    Map<String, dynamic> attributes,
+  ) async {
     // NOOP
   }
 
@@ -210,7 +257,9 @@ class DdRumWeb extends DdRumPlatform {
 
   @override
   Future<void> updatePerformanceMetrics(
-      List<double> buildTimes, List<double> rasterTimes) async {
+    List<double> buildTimes,
+    List<double> rasterTimes,
+  ) async {
     // NOOP - Not supported by the Browser SDK
   }
 }
@@ -242,10 +291,7 @@ extension type _TracingUrl._(JSObject _) implements JSObject {
   external JSRegExp match;
   external JSArray propagatorTypes;
 
-  external factory _TracingUrl({
-    JSFunction match,
-    JSArray propagatorTypes,
-  });
+  external factory _TracingUrl({JSFunction match, JSArray propagatorTypes});
 }
 
 @anonymous
@@ -320,6 +366,7 @@ extension type _DdRum._(JSObject _) implements JSObject {
   external void addFeatureFlagEvaluation(String name, JSAny? value);
   external void stopSession();
   external void setUser(JsUser newUser);
+  external void setUserProperty(String key, JSAny? value);
 }
 
 @JS()


### PR DESCRIPTION
### What and why?

While web supported setting user info, it did not support "extraInfo." Added support to have logs and rum call `setUserProperty` for each piece of extra info.

Add integration tests that check for user extra info.

Formatting changes due to dartfmt updates.

refs: #852

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
