### PR TITLE
fix(sr): Add classes to proguard rules to prevent stripping.

### DIFF
--- a/packages/datadog_session_replay/android/consumer-rules.pro
+++ b/packages/datadog_session_replay/android/consumer-rules.pro
@@ -1,1 +1,2 @@
--keep class com.datadoghq.flutter.sessionreplay.FlutterSessionReplayBridge { *; }
+-keep class com.datadoghq.flutter.sessionreplay.** { *; }
+-keep class com.datadog.android.api.feature.FeatureSdkCore** { *; }


### PR DESCRIPTION
### What and why?

Proguard in release builds was stripping internal classes as well as the FeatureSdkCore which was preventing JNI from using them during initialization.

refs: #851

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
