### PR TITLE
chore: Remove FVM cache before nightlies builds.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -321,6 +321,7 @@ nightly-beta-test:
     - !reference [.pre-ios, script]
     - brew tap leoafarias/fvm
     - brew install fvm
+    - fvm destroy
     - fvm install beta
     - fvm use beta
     - fvm flutter upgrade


### PR DESCRIPTION
### What and why?

We're getting an error on beta nightlies complaining of an invalid SDK hash, which is causing the builds to timeout, then fail. Try clearing the Flutter Version Manager cache before building the nightly to see if that fixes the issue.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
