### PR TITLE
fix(sr): Drop session replay Dart requirement to 3.6

### DIFF
--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ^3.7.2
+  sdk: ^3.6.0
   flutter: '>=3.3.0'
 
 dependencies:


### PR DESCRIPTION
### What and why?

We aren't using any feature from 3.7, and min version for v3 is likely to be 3.6, so downgrade this package to match.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
