### PR TITLE
fix(sr): Fix an issue with custom endpoints on iOS

### DIFF
--- a/packages/datadog_session_replay/example/lib/screens/main_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/main_screen.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -34,36 +35,43 @@ class _MainScreenState extends State<MainScreen> {
     _RouteScreen('Touch Privacy', Routes.touchPrivacy),
   ];
 
+  void _stopSession() {
+    DatadogSdk.instance.rum?.stopSession();
+  }
+
+  Widget _routeButton(BuildContext context, _RouteScreen route) {
+    final theme = Theme.of(context);
+    return InkWell(
+      child: Padding(
+        padding: EdgeInsets.all(8),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(route.title, style: theme.textTheme.headlineSmall),
+            ),
+            Icon(Icons.arrow_right_sharp),
+          ],
+        ),
+      ),
+      onTap: () {
+        context.push(route.route);
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(title: const Text('Session Replay Example')),
       body: Center(
-        child: ListView.builder(
-          itemCount: routes.length,
-          itemBuilder: (context, index) {
-            final route = routes[index];
-            return InkWell(
-              child: Padding(
-                padding: EdgeInsets.all(8),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        route.title,
-                        style: theme.textTheme.headlineSmall,
-                      ),
-                    ),
-                    Icon(Icons.arrow_right_sharp),
-                  ],
-                ),
-              ),
-              onTap: () {
-                context.push(route.route);
-              },
-            );
-          },
+        child: Column(
+          children: [
+            ElevatedButton(
+              onPressed: _stopSession,
+              child: Text('Stop Session'),
+            ),
+            for (final route in routes) _routeButton(context, route),
+          ],
         ),
       ),
     );

--- a/packages/datadog_session_replay/lib/src/ios/datadog_session_replay_platform_ios.dart
+++ b/packages/datadog_session_replay/lib/src/ios/datadog_session_replay_platform_ios.dart
@@ -22,7 +22,7 @@ class DatadogSessionReplayPlatformIos extends DatadogSessionReplayPlatform {
   }
 
   DatadogSessionReplayPlatformIos.fromObjCRef(ObjCObjectBase ref)
-    : _iosBridge = FlutterSessionReplay.castFrom(ref);
+      : _iosBridge = FlutterSessionReplay.castFrom(ref);
 
   @override
   Object? get isolateToken => _iosBridge;
@@ -34,7 +34,7 @@ class DatadogSessionReplayPlatformIos extends DatadogSessionReplayPlatform {
   ) {
     NSURL? url;
     if (configuration.customEndpoint case final customEndpoint?) {
-      url = NSURL().initWithString(NSString(customEndpoint));
+      url = NSURL.alloc().initWithString(NSString(customEndpoint));
       if (url == null) {
         final message =
             'Failed to parse custom endpoint $customEndpoint. Session replay was not initialized.';
@@ -50,22 +50,22 @@ class DatadogSessionReplayPlatformIos extends DatadogSessionReplayPlatform {
 
     final contextChangedListener =
         ObjCBlock_ffiVoid_FlutterRUMCoreContext.listener((context) {
-          RUMContext? dartContext;
-          if (context != null) {
-            dartContext = RUMContext(
-              applicationId: context.applicationID.toDartString(),
-              sessionId: context.sessionID.toDartString(),
-              viewId: context.viewID?.toDartString(),
-            );
-            onContextChanged(dartContext);
-          }
-        });
-
-    final iOsConfiguration =
-        FlutterSessionReplayConfiguration.alloc()..initWithCustomEndpoint(
-          url,
-          onContextChanged: contextChangedListener,
+      RUMContext? dartContext;
+      if (context != null) {
+        dartContext = RUMContext(
+          applicationId: context.applicationID.toDartString(),
+          sessionId: context.sessionID.toDartString(),
+          viewId: context.viewID?.toDartString(),
         );
+        onContextChanged(dartContext);
+      }
+    });
+
+    final iOsConfiguration = FlutterSessionReplayConfiguration.alloc()
+      ..initWithCustomEndpoint(
+        url,
+        onContextChanged: contextChangedListener,
+      );
     _iosBridge.enableWith(iOsConfiguration);
 
     return true;
@@ -146,13 +146,12 @@ class DatadogSessionReplayPlatformIos extends DatadogSessionReplayPlatform {
 }
 
 @ffi.Native<
-  ffi.Pointer<ObjCObject> Function(
-    ffi.Pointer<ObjCObject>,
-    ffi.Pointer<ObjCSelector>,
-    ffi.Pointer<ffi.Void>,
-    ffi.UnsignedLong,
-  )
->(symbol: 'objc_msgSend', isLeaf: true)
+    ffi.Pointer<ObjCObject> Function(
+      ffi.Pointer<ObjCObject>,
+      ffi.Pointer<ObjCSelector>,
+      ffi.Pointer<ffi.Void>,
+      ffi.UnsignedLong,
+    )>(symbol: 'objc_msgSend', isLeaf: true)
 // ignore: non_constant_identifier_names
 external ffi.Pointer<ObjCObject> objc_msgSend_3nbx5e(
   ffi.Pointer<ObjCObject> object,


### PR DESCRIPTION
### What and why?

Custom endpoints were crashing on iOS because of incorrectly using `NSRUL()` over `NSURL.alloc()` when creating the URL.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
