### PR TITLE
chore: Changes from shipping session replay preview 4

### DIFF
--- a/packages/datadog_session_replay/CHANGELOG.md
+++ b/packages/datadog_session_replay/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-preview.4
+
+* Fix an issue with custom endpoints on iOS.
+* Drop session replay Dart requirement to 3.6.
+
 ## 1.0.0-preview.3
 
 * Add classes to Proguard rules to prevent stripping. See [#851](https://github.com/DataDog/dd-sdk-flutter/issues/851).

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_session_replay
 description: "Support for Flutter Session Replay in Datadog"
-version: 1.0.0-preview.4
+version: 1.0.0-preview.5
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

Changes associated with shipping `datadog_session_replay` preview 4.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
