### PR TITLE
fix(sr): Downgrade packages that required Dart versions above 3.6

### DIFF
--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -10,16 +10,16 @@ PODS:
   - datadog_session_replay (0.0.1):
     - DatadogCore (~> 2)
     - Flutter
-  - DatadogCore (2.30.0):
-    - DatadogInternal (= 2.30.0)
-  - DatadogCrashReporting (2.30.0):
-    - DatadogInternal (= 2.30.0)
+  - DatadogCore (2.30.1):
+    - DatadogInternal (= 2.30.1)
+  - DatadogCrashReporting (2.30.1):
+    - DatadogInternal (= 2.30.1)
     - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (2.30.0)
-  - DatadogLogs (2.30.0):
-    - DatadogInternal (= 2.30.0)
-  - DatadogRUM (2.30.0):
-    - DatadogInternal (= 2.30.0)
+  - DatadogInternal (2.30.1)
+  - DatadogLogs (2.30.1):
+    - DatadogInternal (= 2.30.1)
+  - DatadogRUM (2.30.1):
+    - DatadogInternal (= 2.30.1)
   - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -31,11 +31,11 @@ PODS:
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
   - datadog_session_replay (from `.symlinks/plugins/datadog_session_replay/ios`)
-  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
-  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.0`)
+  - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.1`)
+  - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.1`)
+  - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.1`)
+  - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.1`)
+  - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, tag `2.30.1`)
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - objective_c (from `.symlinks/plugins/objective_c/ios`)
@@ -52,19 +52,19 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/datadog_session_replay/ios"
   DatadogCore:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogCrashReporting:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogInternal:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogLogs:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogRUM:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   Flutter:
     :path: Flutter
   integration_test:
@@ -75,34 +75,34 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   DatadogCore:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogCrashReporting:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogInternal:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogLogs:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
   DatadogRUM:
     :git: https://github.com/DataDog/dd-sdk-ios
-    :tag: 2.30.0
+    :tag: 2.30.1
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: dae31b2f0e5755d091601d8c8108fe86528085fd
-  datadog_session_replay: 65da9f52202889d5299b83c32da652b4442b8079
-  DatadogCore: 5c01290a3b60b27bf49aa958f2e339c738364d9e
-  DatadogCrashReporting: 11286d48ab61baeb2b41b945c7c0d4ef23db317d
-  DatadogInternal: 7aeb48e254178a0c462c3953dc0a8a8d64499a93
-  DatadogLogs: 4324739de62a6059e07d70bf6ceceed78764edeb
-  DatadogRUM: f36949a38285f3b240a7be577d425f8518e087d4
+  datadog_session_replay: d13ea731f09b529de9c9660019e75da6fbac20b7
+  DatadogCore: c09c6b3345d200ad8df6b8424562afc4c274d85e
+  DatadogCrashReporting: 19c67670fe9ee01cc4cbc3c859d6c69dc6344e9e
+  DatadogInternal: a712490b2c285095d748ccb437a9a630df949d7f
+  DatadogLogs: 084f7974d6dbe053b5fbabc07a245a700c1514f7
+  DatadogRUM: c9356f806db3599386f854bdb53494216600d2ae
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
   PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 
-PODFILE CHECKSUM: 17b6b9e9b2b841f11a725f239fc06ce7386c1cf4
+PODFILE CHECKSUM: c0f7518304348c7e1fd19e84dd7cb3cf85de0527
 
 COCOAPODS: 1.16.2

--- a/packages/datadog_session_replay/example/lib/screens/material_widgets_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/material_widgets_screen.dart
@@ -86,48 +86,53 @@ class _MaterialWidgetsScreenState extends State<MaterialWidgetsScreen> {
             children: [
               _WidgetDisplay(
                 name: 'Button',
-                builder:
-                    (_) =>
-                        ElevatedButton(child: Text('Button'), onPressed: () {}),
+                builder: (_) =>
+                    ElevatedButton(child: Text('Button'), onPressed: () {}),
               ),
               _WidgetDisplay(
                 name: 'Switch',
-                builder:
-                    (_) =>
-                        Switch(value: _switchOn, onChanged: _onSwitchChanged),
+                builder: (_) =>
+                    Switch(value: _switchOn, onChanged: _onSwitchChanged),
               ),
               _WidgetDisplay(
                 name: 'Checkbox',
-                builder:
-                    (_) => Checkbox(
-                      value: _checkboxOn,
-                      onChanged: _onCheckboxChanged,
-                    ),
+                builder: (_) => Checkbox(
+                  value: _checkboxOn,
+                  onChanged: _onCheckboxChanged,
+                ),
               ),
               _WidgetDisplay(
                 name: 'Radio',
-                builder:
-                    (_) => RadioGroup(
-                      groupValue: _radioValue,
-                      onChanged: _onRadioChanged,
-                      child: Column(
-                        children: [
-                          Row(children: [Radio<String>(value: 'a'), Text('A')]),
-                          Row(children: [Radio<String>(value: 'b'), Text('B')]),
-                        ],
+                builder: (_) => Column(
+                  children: [
+                    Row(children: [
+                      Radio<String>(
+                        value: 'a',
+                        groupValue: _radioValue,
+                        onChanged: _onRadioChanged,
                       ),
-                    ),
+                      Text('A')
+                    ]),
+                    Row(children: [
+                      Radio<String>(
+                        value: 'b',
+                        groupValue: _radioValue,
+                        onChanged: _onRadioChanged,
+                      ),
+                      Text('B')
+                    ]),
+                  ],
+                ),
               ),
               _WidgetDisplay(
                 name: 'Slider',
-                builder:
-                    (_) => Slider(
-                      min: 0,
-                      max: 100,
-                      divisions: 100,
-                      value: _sliderValue,
-                      onChanged: _onSliderChanged,
-                    ),
+                builder: (_) => Slider(
+                  min: 0,
+                  max: 100,
+                  divisions: 100,
+                  value: _sliderValue,
+                  onChanged: _onSliderChanged,
+                ),
               ),
               _WidgetDisplay(
                 name: 'Segmened Button',

--- a/packages/datadog_session_replay/example/lib/screens/touch_privacy_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/touch_privacy_screen.dart
@@ -34,7 +34,7 @@ class _TouchPrivacyScreenState extends State<TouchPrivacyScreen> {
     return SessionReplayPrivacy(
       touchPrivacyLevel: TouchPrivacyLevel.hide,
       child: Padding(
-        padding: EdgeInsetsGeometry.all(10),
+        padding: EdgeInsets.all(10),
         child: Column(
           spacing: 20.0,
           children: [

--- a/packages/datadog_session_replay/ios/datadog_session_replay.podspec
+++ b/packages/datadog_session_replay/ios/datadog_session_replay.podspec
@@ -16,7 +16,7 @@ Support for Datadog Session Replay in Flutter.
   s.source_files = 'datadog_session_replay/Sources/**/*'
   s.dependency 'Flutter'
   s.dependency 'DatadogCore', '~> 2'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
@@ -18,7 +18,6 @@ const _sensitiveInputTypes = [
   TextInputType.phone,
   TextInputType.emailAddress,
   TextInputType.streetAddress,
-  TextInputType.twitter,
   TextInputType.visiblePassword,
 ];
 
@@ -129,15 +128,15 @@ class InputDecoratorRecorder implements ElementRecorder {
 
     return containerStyle != null
         ? SpecificElement(
-          subtreeStrategy: CaptureNodeSubtreeStrategy.record,
-          nodes: [
-            ContainerNode(
-              attributes,
-              wireframeId: keyGenerator.keyForElement(element),
-              style: containerStyle,
-            ),
-          ],
-        )
+            subtreeStrategy: CaptureNodeSubtreeStrategy.record,
+            nodes: [
+              ContainerNode(
+                attributes,
+                wireframeId: keyGenerator.keyForElement(element),
+                style: containerStyle,
+              ),
+            ],
+          )
         : null;
   }
 }

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  ffi: ^2.1.4
+  ffi: ^2.1.3
   jni: ^0.14.2
-  objective_c: ^8.1.0
+  objective_c: ^8.0.0
   web: ^1.0.0
-  meta: ^1.16.0  
+  meta: ^1.15.0  
   plugin_platform_interface: ^2.1.8
   datadog_flutter_plugin: ^2.13.1
   json_annotation: ^4.9.0
@@ -29,7 +29,7 @@ dev_dependencies:
   mocktail: ^1.0.4
   json_serializable: '>=6.7.0 <6.10.0'
   build_runner: ^2.4.15
-  ffigen: ^19.1.0
+  ffigen: ^19.0.0
   jnigen: ^0.14.2
   datadog_common_test:
     path: ../datadog_common_test

--- a/packages/datadog_session_replay/test/capture/editable_text_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/editable_text_recorder_test.dart
@@ -272,7 +272,6 @@ void main() {
     TextInputType.phone,
     TextInputType.emailAddress,
     TextInputType.streetAddress,
-    TextInputType.twitter,
     TextInputType.visiblePassword,
   ];
   for (final inputType in maskedTextInputTypes) {


### PR DESCRIPTION
### What and why?

SR had some dependencies on packages that required Dart versions above 3.6. Downgrade them to the 3.6 versions.

Note that the example and test portions are still at higher versions of Flutter, because `golden_tests` requires a higher flutter version.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
