### PR TITLE
fix(sr): Don't capture elements with width OR height of zero

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -129,11 +129,11 @@ class SessionReplayRecorder {
     required TreeCapturePrivacy defaultCapturePrivacy,
     required TouchPrivacyLevel touchPrivacyLevel,
   }) : this._(
-         KeyGenerator(),
-         timeProvider,
-         defaultCapturePrivacy,
-         touchPrivacyLevel,
-       );
+          KeyGenerator(),
+          timeProvider,
+          defaultCapturePrivacy,
+          touchPrivacyLevel,
+        );
 
   SessionReplayRecorder._(
     KeyGenerator keyGenerator,
@@ -158,9 +158,9 @@ class SessionReplayRecorder {
     DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
     required TreeCapturePrivacy defaultCapturePrivacy,
     required TouchPrivacyLevel touchPrivacyLevel,
-  }) : _timeProvider = timeProvider,
-       _defaultTreeCapturePrivacy = defaultCapturePrivacy,
-       _touchPrivacyLevel = touchPrivacyLevel {
+  })  : _timeProvider = timeProvider,
+        _defaultTreeCapturePrivacy = defaultCapturePrivacy,
+        _touchPrivacyLevel = touchPrivacyLevel {
     _populateElementRecorderMap(elementRecorders);
   }
 
@@ -221,8 +221,8 @@ class SessionReplayRecorder {
       }
     });
 
-    final addedProcessingTimelineTask =
-        TimelineTask()..start('Datadog SR Capture Processing');
+    final addedProcessingTimelineTask = TimelineTask()
+      ..start('Datadog SR Capture Processing');
 
     // Process anything that needs additional processing
     final nodes = <CaptureNode>[];
@@ -325,7 +325,7 @@ class SessionReplayRecorder {
 
       final untransformedPaintBounds = renderObject.paintBounds;
       // Don't capture things that take up no space.
-      if (untransformedPaintBounds.width == 0 &&
+      if (untransformedPaintBounds.width == 0 ||
           untransformedPaintBounds.height == 0) {
         return;
       }


### PR DESCRIPTION
### What and why?

We're seeing some telemetry when trying to multiply Infinity or NaN when doing text scaling. I believe this is because we're dividing by zero when calculating scale. While we check to see if the element takes up no space with a width and height of zero, we should be checking if either one is zero, and exiting out early.

Most of the changes are formatting performed automatically by a new version of `dartfmt`. Only relevant line changes the `&&` check to `||`

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
