### PR TITLE
chore(ci): Fix a flake in SR.

### DIFF
--- a/packages/datadog_session_replay/test/capture/editable_text_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/editable_text_recorder_test.dart
@@ -55,7 +55,7 @@ void main() {
     final x = randomDouble(min: 10, max: 50);
     final y = randomDouble(min: 10, max: 50);
     final width = randomDouble(min: 10, max: 50);
-    final height = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 20, max: 50);
 
     final controller = TextEditingController();
     final focusNode = FocusNode();
@@ -104,7 +104,7 @@ void main() {
     final x = randomDouble(min: 10, max: 50);
     final y = randomDouble(min: 10, max: 50);
     final width = randomDouble(min: 10, max: 50);
-    final height = randomDouble(min: 10, max: 50);
+    final height = randomDouble(min: 20, max: 50);
     final tree = MaterialApp(
       home: SimpleTestCapture(
         key: Key('key'),


### PR DESCRIPTION
### What and why?

There is a flake with recent changes in Session Replay that would cause the decorator field in EditableText to not be captured, but only when the size of the field was too small to fit it.

Require the text field to be at least of the height to support rendering the decorator.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
