### PR TITLE
feat: Support consistent sampling based on session id

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -6,6 +6,8 @@
 package com.datadoghq.flutter
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import com.datadog.android.api.SdkCore
 import com.datadog.android.core.configuration.BatchSize
@@ -21,6 +23,7 @@ import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
@@ -34,7 +37,7 @@ import java.lang.ClassCastException
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
-class DatadogRumPlugin : MethodChannel.MethodCallHandler {
+class DatadogRumPlugin : MethodChannel.MethodCallHandler, RumSessionListener {
     companion object {
         const val PARAM_AT = "at"
         const val PARAM_DURATION = "duration"
@@ -144,6 +147,19 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
         }
     }
 
+    override fun onSessionStarted(sessionId: String, isDiscarded: Boolean) {
+        val handler = Handler(Looper.getMainLooper())
+        handler.post {
+            channel.invokeMethod(
+                "onSessionChanged",
+                mapOf(
+                    "sessionId" to sessionId,
+                    "discarded" to isDiscarded
+                )
+            )
+        }
+    }
+
     private fun enable(call: MethodCall, result: Result) {
         val encodedConfig = call.argument<Map<String, Any?>>("configuration")
         val applicationId = encodedConfig?.get("applicationId") as? String
@@ -167,6 +183,7 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
                     .disableUserInteractionTracking()
                     .useViewTrackingStrategy(NoOpViewTrackingStrategy)
                     .setLastInteractionIdentifier(null)
+                    .setSessionListener(this)
 
                 // Mapper initialization
                 configBuilder = attachEventMappers(encodedConfig, configBuilder)

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/tracing_helpers_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/tracing_helpers_test.dart
@@ -49,7 +49,7 @@ void main() {
   testWidgets('generateTracingContext generates proper bit values',
       (WidgetTester tester) async {
     final mockRum = MockDdRum();
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
 
     final context = generateTracingContext(mockRum);
 
@@ -59,7 +59,7 @@ void main() {
   });
 
   // Check that our math works on web
-  test('Sampling decisions are deterministic', () async {
+  test('Sampling decisions are deterministic by traceId', () async {
     // Lots of extra setup to get a real version of RUM with a mock version of the Core
     final mockInternalLogger = MockInternalLogger();
     DdRumPlatform.instance = DdNoOpRumPlatform();
@@ -101,7 +101,108 @@ void main() {
       );
       final rum = await DatadogRum.enable(mockDatadogSdk, rumConfiguration);
       final tracingId = TracingId(identifier);
-      bool shouldSample = rum!.shouldSampleTrace(tracingId);
+      bool shouldSample = rum!.shouldSampleTrace(null, tracingId);
+      expect(shouldSample, expected);
+    }
+  });
+
+  // Check that our math works on web
+  test('Sampling decisions are deterministic by sessionId', () async {
+    // Lots of extra setup to get a real version of RUM with a mock version of the Core
+    final mockInternalLogger = MockInternalLogger();
+    DdRumPlatform.instance = DdNoOpRumPlatform();
+
+    final mockDatadogSdk = MockDatadogSdk();
+    registerFallbackValue(DatadogSdk.instance);
+    registerFallbackValue(DatadogRumConfiguration(applicationId: ''));
+    registerFallbackValue(RumErrorSource.source);
+    // ignore: invalid_use_of_internal_member
+    when(() => mockDatadogSdk.internalLogger).thenReturn(mockInternalLogger);
+
+    final mockDatadogPlatform = MockDatadogPlatform();
+    when(() => mockDatadogPlatform.updateTelemetryConfiguration(any(), any()))
+        .thenAnswer((_) => Future.value());
+    when(() => mockDatadogSdk.platform).thenReturn(mockDatadogPlatform);
+
+    final mockRumPlatform = MockRumPlatform();
+    when(() => mockRumPlatform.setInternalViewAttribute(any(), any()))
+        .thenAnswer((_) => Future.value());
+
+    // The numbers used in the session UUID are the same numbers truncated to 48 bits,
+    // which sometimes results in a different sampling decision. Created using this program:
+    // https://go.dev/play/p/lUl2SiOHxfZ
+    final inputs = <(String, BigInt, double, bool)>[
+      (
+        '11111111-2222-3333-4444-822107fcfd52',
+        BigInt.parse('5577006791947779410'),
+        94.050909,
+        true
+      ),
+      (
+        '11111111-2222-3333-4444-4dc76695721d',
+        BigInt.parse('15352856648520921629'),
+        43.771419,
+        true
+      ),
+      (
+        '11111111-2222-3333-4444-858149c6e2d1',
+        BigInt.parse('3916589616287113937'),
+        68.682307,
+        true
+      ),
+      (
+        '11111111-2222-3333-4444-cb397916001e',
+        BigInt.parse('9828766684487745566'),
+        15.651925,
+        false
+      ),
+      (
+        '11111111-2222-3333-4444-7f48392907a0',
+        BigInt.parse('894385949183117216'),
+        30.091186,
+        true
+      ),
+      (
+        '11111111-2222-3333-4444-7cc6f3875d04',
+        BigInt.parse('4751997750760398084'),
+        81.363996,
+        true
+      ),
+      (
+        '11111111-2222-3333-4444-ffa2ba517936',
+        BigInt.parse('11199607447739267382'),
+        38.065719,
+        true
+      ),
+      (
+        '11111111-2222-3333-4444-21587cb3ad0b',
+        BigInt.parse('12156940908066221323'),
+        46.888984,
+        false
+      ),
+      (
+        '11111111-2222-3333-4444-768b7c4e0b68',
+        BigInt.parse('11833901312327420776'),
+        29.310186,
+        false
+      ),
+      (
+        '11111111-2222-3333-4444-3f2525632186',
+        BigInt.parse('6263450610539110790'),
+        21.855305,
+        false
+      ),
+    ];
+
+    for (final (sessionId, identifier, sampleRate, expected) in inputs) {
+      final rumConfiguration = DatadogRumConfiguration(
+        applicationId: 'applicationId',
+        traceSampleRate: sampleRate,
+        detectLongTasks: false,
+      );
+      final rum = await DatadogRum.enable(mockDatadogSdk, rumConfiguration);
+      final tracingId = TracingId(identifier);
+      bool shouldSample = rum!.shouldSampleTrace(sessionId, tracingId);
       expect(shouldSample, expected);
     }
   });

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogLogsPlugin.swift
@@ -205,7 +205,11 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
     }
 
     // Returns true if this method was handled
-    private func handleGlobalMethod(call: FlutterMethodCall, arguments: [String: Any?], result: @escaping FlutterResult) -> Bool {
+    private func handleGlobalMethod(
+        call: FlutterMethodCall,
+        arguments: [String: Any?],
+        result: @escaping FlutterResult
+    ) -> Bool {
         if call.method == "enable" {
             enable(arguments: arguments, result: result)
             return true

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogRumPlugin.swift
@@ -354,6 +354,18 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                 attachEventMappers(configArg: configArg, config: &config)
                 // Disable INV as the Flutter calculations for it are different
                 config.nextViewActionPredicate = nil
+                config.onSessionStart = { sessionId, discarded in
+                    DispatchQueue.main.async {
+                        guard let methodChannel = DatadogRumPlugin.methodChannel else { return }
+                        methodChannel.invokeMethod(
+                            "onSessionChanged",
+                            arguments: [
+                                "sessionId": sessionId,
+                                "discarded": discarded
+                            ],
+                            result: nil)
+                    }
+                }
 
                 RUM.enable(with: config)
                 rum = RUMMonitor.shared()

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogSdkPlugin.swift
@@ -45,7 +45,7 @@ extension Datadog.Configuration {
     }
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable:next type_body_length
 public class DatadogSdkPlugin: NSObject, FlutterPlugin {
     let channel: FlutterMethodChannel
 
@@ -121,7 +121,8 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin {
                 } else {
                     consolePrint(
                         "🔥 The DatadogSDK is already initialized but no previous configuration exists. Did you mean" +
-                        " to use attachToExisting? Note: Datadog does not currently support multiple Flutter engines on iOS.",
+                        " to use attachToExisting? Note: Datadog does not currently support multiple Flutter engines" +
+                        " on iOS.",
                         .error
                     )
                 }

--- a/packages/datadog_flutter_plugin/lib/src/ios/ios_rum_event_mapper.dart
+++ b/packages/datadog_flutter_plugin/lib/src/ios/ios_rum_event_mapper.dart
@@ -16,11 +16,10 @@ import '../rum/rum_mapper_proxy.dart';
 ///
 /// We can revisit this when Objective-C ffi supports callbacks syncronously
 /// returning data.
-class IosRumEventMapper extends RumMapperProxy {
+class IosRumEventMapper extends RumMethodChannelMapperProxy {
   static const mapperError = {'_dd.mapper_error': 'mapper error'};
 
   final InternalLogger _internalLogger;
-  final MethodChannel _methodChannel = MethodChannel('datadog_sdk_flutter.rum');
 
   IosRumEventMapper(DatadogRumConfiguration config, InternalLogger logger)
     : _internalLogger = logger,
@@ -30,12 +29,9 @@ class IosRumEventMapper extends RumMapperProxy {
         resourceEventMapper: config.resourceEventMapper,
         errorEventMapper: config.errorEventMapper,
         longTaskEventMapper: config.longTaskEventMapper,
-      ) {
-    if (ServicesBinding.rootIsolateToken != null) {
-      _methodChannel.setMethodCallHandler(handleMethodCall);
-    }
-  }
+      );
 
+  @override
   Future<dynamic> handleMethodCall(MethodCall call) async {
     try {
       switch (call.method) {
@@ -50,7 +46,9 @@ class IosRumEventMapper extends RumMapperProxy {
         case 'mapLongTaskEvent':
           return _mapLongTaskEvent(call);
       }
-      // Ignore unknown methods
+      throw MissingPluginException(
+        'Could not find a method to call for ${call.method}',
+      );
     } catch (e, st) {
       _internalLogger.sendToDatadog(
         '${call.method} threw an exception: ${e.toString()}.',

--- a/packages/datadog_flutter_plugin/lib/src/ios/ios_rum_event_mapper.dart
+++ b/packages/datadog_flutter_plugin/lib/src/ios/ios_rum_event_mapper.dart
@@ -50,10 +50,7 @@ class IosRumEventMapper extends RumMapperProxy {
         case 'mapLongTaskEvent':
           return _mapLongTaskEvent(call);
       }
-
-      throw MissingPluginException(
-        'Could not find a method to call for ${call.method}',
-      );
+      // Ignore unknown methods
     } catch (e, st) {
       _internalLogger.sendToDatadog(
         '${call.method} threw an exception: ${e.toString()}.',

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -23,8 +23,9 @@ enum RumHttpMethod { post, get, head, put, delete, patch }
 
 RumHttpMethod rumMethodFromMethodString(String value) {
   var lowerValue = value.toLowerCase();
-  return RumHttpMethod.values
-      .firstWhere((e) => e.toString() == 'RumHttpMethod.$lowerValue');
+  return RumHttpMethod.values.firstWhere(
+    (e) => e.toString() == 'RumHttpMethod.$lowerValue',
+  );
 }
 
 /// Describes the type of a RUM Action.
@@ -60,7 +61,7 @@ enum RumResourceType {
   js,
   media,
   other,
-  native
+  native,
 }
 
 RumResourceType resourceTypeFromContentType(ContentType? type) {
@@ -128,8 +129,15 @@ class DatadogRum {
 
   final InvMetricProvider _invMetricProvider = InvMetricProvider();
 
+  /// For internal use only. If you want an accurate sessionId,
+  /// use [getCurrentSessionId].
+  @internal
+  String? get cachedSessionId => _platform.cachedSessionId;
+
   static Future<DatadogRum?> enable(
-      DatadogSdk core, DatadogRumConfiguration configuration) async {
+    DatadogSdk core,
+    DatadogRumConfiguration configuration,
+  ) async {
     DatadogRum? rum;
     await wrapAsync('rum.enable', core.internalLogger, null, () {
       DdRumPlatform.instance.enable(core, configuration);
@@ -141,10 +149,10 @@ class DatadogRum {
 
   @internal
   DatadogRum.fromExisting(DatadogSdk core, DatadogAttachConfiguration config)
-      : traceSampleRate = config.traceSampleRate,
-        _maxSampledTraceId = _getMaxTraceId(config.traceSampleRate),
-        traceContextInjection = config.traceContextInjection,
-        logger = core.internalLogger {
+    : traceSampleRate = config.traceSampleRate,
+      _maxSampledTraceId = _getMaxTraceId(config.traceSampleRate),
+      traceContextInjection = config.traceContextInjection,
+      logger = core.internalLogger {
     _init(
       core: core,
       detectLongTasks: config.detectLongTasks,
@@ -154,10 +162,10 @@ class DatadogRum {
   }
 
   DatadogRum._(DatadogSdk core, DatadogRumConfiguration configuration)
-      : traceSampleRate = configuration.traceSampleRate,
-        _maxSampledTraceId = _getMaxTraceId(configuration.traceSampleRate),
-        traceContextInjection = configuration.traceContextInjection,
-        logger = core.internalLogger {
+    : traceSampleRate = configuration.traceSampleRate,
+      _maxSampledTraceId = _getMaxTraceId(configuration.traceSampleRate),
+      traceContextInjection = configuration.traceContextInjection,
+      logger = core.internalLogger {
     _init(
       core: core,
       detectLongTasks: configuration.detectLongTasks,
@@ -172,8 +180,9 @@ class DatadogRum {
     required double longTaskThreshold,
     required bool reportFlutterPerformance,
   }) {
-    final isBackgroundIsolate =
-        kIsWeb ? false : ServicesBinding.rootIsolateToken == null;
+    final isBackgroundIsolate = kIsWeb
+        ? false
+        : ServicesBinding.rootIsolateToken == null;
     // Don't allow initialization of foreground stuff in background isolates
     if (!isBackgroundIsolate) {
       // Never use long task observer on web -- the Browser SDK should
@@ -186,20 +195,24 @@ class DatadogRum {
         _longTaskObserver!.init();
       }
       if (reportFlutterPerformance) {
-        ambiguate(SchedulerBinding.instance)
-            ?.addTimingsCallback(_timingsCallback);
+        ambiguate(
+          SchedulerBinding.instance,
+        )?.addTimingsCallback(_timingsCallback);
       }
 
       core.updateConfigurationInfo(
-          LateConfigurationProperty.trackFlutterPerformance,
-          reportFlutterPerformance);
+        LateConfigurationProperty.trackFlutterPerformance,
+        reportFlutterPerformance,
+      );
       core.updateConfigurationInfo(
-          LateConfigurationProperty.trackCrossPlatformLongTasks,
-          detectLongTasks);
+        LateConfigurationProperty.trackCrossPlatformLongTasks,
+        detectLongTasks,
+      );
     } else {
       if (detectLongTasks || reportFlutterPerformance) {
         logger.warn(
-            'Attaching to the DatadogSdk from a background isolate does not support detecting long tasks or reporting Flutter performance.');
+          'Attaching to the DatadogSdk from a background isolate does not support detecting long tasks or reporting Flutter performance.',
+        );
       }
     }
   }
@@ -216,8 +229,12 @@ class DatadogRum {
   /// Get the current active session ID. The session ID will be null if no
   /// session is active or if the session has been sampled out.
   Future<String?> getCurrentSessionId() {
-    return wrapAsync('rum.getCurrentSessionId', logger, null,
-        () => _platform.getCurrentSessionId());
+    return wrapAsync(
+      'rum.getCurrentSessionId',
+      logger,
+      null,
+      () => _platform.getCurrentSessionId(),
+    );
   }
 
   /// Notifies that the View identified by [key] starts being presented to the
@@ -226,8 +243,11 @@ class DatadogRum {
   /// who's values must be supported by [StandardMessageCodec].
   ///
   /// The [key] passed here must match the [key] passed to [stopView] later.
-  void startView(String key,
-      [String? name, Map<String, Object?> attributes = const {}]) {
+  void startView(
+    String key, [
+    String? name,
+    Map<String, Object?> attributes = const {},
+  ]) {
     name ??= key;
     final currentTime = timeProvider.now();
     _currentViewInfo = _ViewInfo(key, name, currentTime);
@@ -295,10 +315,13 @@ class DatadogRum {
     wrap('rum.addError', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.addError(
-          currentTime, error, source, stackTrace, errorType, {
-        DatadogPlatformAttributeKey.errorSourceType: 'flutter',
-        ...attributes
-      });
+        currentTime,
+        error,
+        source,
+        stackTrace,
+        errorType,
+        {DatadogPlatformAttributeKey.errorSourceType: 'flutter', ...attributes},
+      );
     });
   }
 
@@ -323,10 +346,13 @@ class DatadogRum {
     wrap('rum.addErrorInfo', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.addErrorInfo(
-          currentTime, message, source, stackTrace, errorType, {
-        DatadogPlatformAttributeKey.errorSourceType: 'flutter',
-        ...attributes
-      });
+        currentTime,
+        message,
+        source,
+        stackTrace,
+        errorType,
+        {DatadogPlatformAttributeKey.errorSourceType: 'flutter', ...attributes},
+      );
     });
   }
 
@@ -356,12 +382,21 @@ class DatadogRum {
   /// and should be sent to [stopResource] or
   /// [stopResourceWithError] / [stopResourceWithErrorInfo] when
   /// resource loading is complete.
-  void startResource(String key, RumHttpMethod httpMethod, String url,
-      [Map<String, Object?> attributes = const {}]) {
+  void startResource(
+    String key,
+    RumHttpMethod httpMethod,
+    String url, [
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.startResource', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.startResource(
-          currentTime, key, httpMethod, url, attributes);
+        currentTime,
+        key,
+        httpMethod,
+        url,
+        attributes,
+      );
     });
   }
 
@@ -369,36 +404,63 @@ class DatadogRum {
   /// successfully and supplies additional information about the Resource loaded,
   /// including its [kind], the [statusCode] of the response, the [size] of the
   /// Resource, and any other custom [attributes] to attach to the resource.
-  void stopResource(String key, int? statusCode, RumResourceType kind,
-      [int? size, Map<String, Object?> attributes = const {}]) {
+  void stopResource(
+    String key,
+    int? statusCode,
+    RumResourceType kind, [
+    int? size,
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.stopResource', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.stopResource(
-          currentTime, key, statusCode, kind, size, attributes);
+        currentTime,
+        key,
+        statusCode,
+        kind,
+        size,
+        attributes,
+      );
     });
   }
 
   /// Notifies that the Resource identified by [key] stopped being loaded with an
   /// Exception specified by [error]. You can optionally supply custom
   /// [attributes] to attach to this Resource.
-  void stopResourceWithError(String key, Exception error,
-      [Map<String, Object?> attributes = const {}]) {
+  void stopResourceWithError(
+    String key,
+    Exception error, [
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.stopResourceWithError', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.stopResourceWithError(
-          currentTime, key, error, attributes);
+        currentTime,
+        key,
+        error,
+        attributes,
+      );
     });
   }
 
   /// Notifies that the Resource identified by [key] stopped being loaded with
   /// the supplied [message]. You can optionally supply custom [attributes] to
   /// attach to this Resource.
-  void stopResourceWithErrorInfo(String key, String message, String type,
-      [Map<String, Object?> attributes = const {}]) {
+  void stopResourceWithErrorInfo(
+    String key,
+    String message,
+    String type, [
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.stopResourceWithErrorInfo', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.stopResourceWithErrorInfo(
-          currentTime, key, message, type, attributes);
+        currentTime,
+        key,
+        message,
+        type,
+        attributes,
+      );
     });
   }
 
@@ -407,13 +469,19 @@ class DatadogRum {
   /// This is used to a track discrete User Actions (e.g. "tap") specified by
   /// [type]. The [name] and [attributes] supplied will be associated with this
   /// user action.
-  void addAction(RumActionType type, String name,
-      [Map<String, Object?> attributes = const {}]) {
+  void addAction(
+    RumActionType type,
+    String name, [
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.addAction', logger, attributes, () {
       final currentTime = timeProvider.now();
       if (_currentViewInfo != null) {
         _invMetricProvider.trackAction(
-            _currentViewInfo!.viewKey, currentTime, type);
+          _currentViewInfo!.viewKey,
+          currentTime,
+          type,
+        );
       }
       return _platform.addAction(currentTime, type, name, attributes);
     });
@@ -424,8 +492,11 @@ class DatadogRum {
   /// Action must be stopped with [stopAction], and will be stopped
   /// automatically if it lasts for more than 10 seconds. You can optionally
   /// provide custom [attributes].
-  void startAction(RumActionType type, String name,
-      [Map<String, Object?> attributes = const {}]) {
+  void startAction(
+    RumActionType type,
+    String name, [
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.startAction', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.startAction(currentTime, type, name, attributes);
@@ -435,8 +506,11 @@ class DatadogRum {
   /// Notifies that the User Action of [type], named [name] has stopped.
   /// This is used to stop tracking long running user actions (e.g. "scroll"),
   /// started with [startAction].
-  void stopAction(RumActionType type, String name,
-      [Map<String, Object?> attributes = const {}]) {
+  void stopAction(
+    RumActionType type,
+    String name, [
+    Map<String, Object?> attributes = const {},
+  ]) {
     wrap('rum.stopAction', logger, attributes, () {
       final currentTime = timeProvider.now();
       return _platform.stopAction(currentTime, type, name, attributes);
@@ -489,7 +563,7 @@ class DatadogRum {
   ///
   /// This is used by Datadog tracing plugins like `datadog_tracing_http_client`
   /// to add the proper headers to network requests.
-  bool shouldSampleTrace(TracingId traceId) {
+  bool shouldSampleTrace(String? sessionId, TracingId traceId) {
     if (traceSampleRate >= 100) return true;
     if (traceSampleRate <= 0) return false;
 
@@ -497,11 +571,17 @@ class DatadogRum {
     //
     //   (identifier * knuthFactor) < max_trace_id
     //
-    // We use the low bits of the trace id in case it is 128 bits, to be consistent with the C++ implementation:
-    // https://github.com/DataDog/dd-trace-cpp/blob/159629edc438ae45f2bb318eb7bd51abd05e94b5/src/datadog/trace_sampler.cpp#L57
-    //
-    // The trace id also must be truncated back down to 64-bits after hashing.
-    final lowBits = traceId.value & _maxTraceId;
+    // We use the low 48 bits from the session id if it exists, or the low bits of the trace id if it doesn't
+    BigInt? lowBits;
+
+    if (sessionId != null) {
+      final uuidParts = sessionId.split('-');
+      if (uuidParts.length == 5) {
+        lowBits = BigInt.tryParse(uuidParts[4], radix: 16);
+      }
+    }
+
+    lowBits ??= traceId.value & _maxTraceId;
 
     return ((lowBits * _knuthFactor) & _maxTraceId) < _maxSampledTraceId;
   }
@@ -527,17 +607,22 @@ class DatadogRum {
     if (_currentViewInfo case final currentViewInfo?) {
       if (viewKey == currentViewInfo.viewKey) {
         final currentTime = timeProvider.now();
-        final fbcTime =
-            (currentTime.difference(currentViewInfo.viewStart)).inNanoseconds;
+        final fbcTime = (currentTime.difference(
+          currentViewInfo.viewStart,
+        )).inNanoseconds;
         wrap('rum.setInternalViewAttribute', logger, null, () {
           _platform.setInternalViewAttribute(
-              DatadogRumPlatformAttributeKey.firstBuildComplete, fbcTime);
+            DatadogRumPlatformAttributeKey.firstBuildComplete,
+            fbcTime,
+          );
           _invMetricProvider.trackViewFirstBuildComplete(viewKey, currentTime);
 
           final invValue = _invMetricProvider.valueForView(viewKey);
           if (invValue != null) {
             _platform.setInternalViewAttribute(
-                DatadogRumPlatformAttributeKey.customInvValue, invValue);
+              DatadogRumPlatformAttributeKey.customInvValue,
+              invValue,
+            );
           }
         });
       }
@@ -549,10 +634,12 @@ class DatadogRum {
       var buildTimes = <double>[];
       var rasterTimes = <double>[];
       for (final timing in timings) {
-        buildTimes.add(timing.buildDuration.inMicroseconds /
-            Duration.microsecondsPerSecond);
-        rasterTimes.add(timing.rasterDuration.inMicroseconds /
-            Duration.microsecondsPerSecond);
+        buildTimes.add(
+          timing.buildDuration.inMicroseconds / Duration.microsecondsPerSecond,
+        );
+        rasterTimes.add(
+          timing.rasterDuration.inMicroseconds / Duration.microsecondsPerSecond,
+        );
       }
 
       wrap('rum.updatePerformanceMetrics', logger, null, () {

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -343,10 +343,17 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @visibleForTesting
   Future<dynamic> handleMethodCall(MethodCall call) async {
+    if (call.method.startsWith('map')) {
+      if (_mapperProxy case final RumMethodChannelMapperProxy mapper) {
+        return mapper.handleMethodCall(call);
+      }
+    }
     switch (call.method) {
       case 'onSessionChanged':
         return _onSessionChanged(call);
     }
-    // Ignore unknown methods
+    throw MissingPluginException(
+      'Could not find a method to call for ${call.method}',
+    );
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -20,6 +20,10 @@ class DdRumMethodChannel extends DdRumPlatform {
   // ignore: unused_field
   RumMapperProxy? _mapperProxy;
 
+  String? _cachedSessionId;
+  @override
+  String? get cachedSessionId => _cachedSessionId;
+
   @override
   Future<void> enable(
     DatadogSdk core,
@@ -30,7 +34,11 @@ class DdRumMethodChannel extends DdRumPlatform {
       core.internalLogger,
     );
 
-    return methodChannel.invokeMethod('enable', {
+    if (ServicesBinding.rootIsolateToken != null) {
+      methodChannel.setMethodCallHandler(handleMethodCall);
+    }
+
+    await methodChannel.invokeMethod('enable', {
       'configuration': configuration.encode(),
     });
   }
@@ -42,7 +50,13 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<String?> getCurrentSessionId() async {
-    return methodChannel.invokeMethod<String>('getCurrentSessionId', {});
+    final sessionId = await methodChannel.invokeMethod<String>(
+      'getCurrentSessionId',
+      {},
+    );
+    // Pulling this directly means this is the most up to date it can be.
+    _cachedSessionId = sessionId;
+    return sessionId;
   }
 
   @override
@@ -295,6 +309,7 @@ class DdRumMethodChannel extends DdRumPlatform {
 
   @override
   Future<void> stopSession() {
+    _cachedSessionId = null;
     return methodChannel.invokeMethod('stopSession', <String, Object?>{});
   }
 
@@ -315,5 +330,23 @@ class DdRumMethodChannel extends DdRumPlatform {
       'buildTimes': buildTimes,
       'rasterTimes': rasterTimes,
     });
+  }
+
+  void _onSessionChanged(MethodCall call) {
+    if (call.arguments case final Map<dynamic, dynamic> arguments?) {
+      final sessionId = arguments['sessionId'];
+      if (sessionId is String) {
+        _cachedSessionId = sessionId;
+      }
+    }
+  }
+
+  @visibleForTesting
+  Future<dynamic> handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'onSessionChanged':
+        return _onSessionChanged(call);
+    }
+    // Ignore unknown methods
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -7,6 +7,9 @@ import 'ddrum_platform_interface.dart';
 
 class DdNoOpRumPlatform extends DdRumPlatform {
   @override
+  String? get cachedSessionId => null;
+
+  @override
   Future<String?> getCurrentSessionId() => Future.value(null);
 
   @override
@@ -17,23 +20,25 @@ class DdNoOpRumPlatform extends DdRumPlatform {
 
   @override
   Future<void> addError(
-      DateTime timestamp,
-      Object error,
-      RumErrorSource source,
-      StackTrace? stackTrace,
-      String? errorType,
-      Map<String, Object?> attributes) {
+    DateTime timestamp,
+    Object error,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
   Future<void> addErrorInfo(
-      DateTime timestamp,
-      String message,
-      RumErrorSource source,
-      StackTrace? stackTrace,
-      String? errorType,
-      Map<String, Object?> attributes) {
+    DateTime timestamp,
+    String message,
+    RumErrorSource source,
+    StackTrace? stackTrace,
+    String? errorType,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
@@ -53,8 +58,12 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> addAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, Object?> attributes) {
+  Future<void> addAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
@@ -77,38 +86,66 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> startResource(DateTime timestamp, String key,
-      RumHttpMethod httpMethod, String url, Map<String, Object?> attributes) {
+  Future<void> startResource(
+    DateTime timestamp,
+    String key,
+    RumHttpMethod httpMethod,
+    String url,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
-  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, Object?> attributes) {
+  Future<void> startAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
-  Future<void> startView(DateTime timestamp, String key, String name,
-      Map<String, Object?> attributes) {
+  Future<void> startView(
+    DateTime timestamp,
+    String key,
+    String name,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
-      RumResourceType kind, int? size, Map<String, Object?> attributes) {
+  Future<void> stopResource(
+    DateTime timestamp,
+    String key,
+    int? statusCode,
+    RumResourceType kind,
+    int? size,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResourceWithError(DateTime timestamp, String key,
-      Exception error, Map<String, Object?> attributes) {
+  Future<void> stopResourceWithError(
+    DateTime timestamp,
+    String key,
+    Exception error,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
-  Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
-      String message, String type, Map<String, Object?> attributes) {
+  Future<void> stopResourceWithErrorInfo(
+    DateTime timestamp,
+    String key,
+    String message,
+    String type,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
@@ -116,20 +153,29 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   Future<void> stopSession() => Future.value();
 
   @override
-  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, Object?> attributes) {
+  Future<void> stopAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
   Future<void> stopView(
-      DateTime timestamp, String key, Map<String, Object?> attributes) {
+    DateTime timestamp,
+    String key,
+    Map<String, Object?> attributes,
+  ) {
     return Future.value();
   }
 
   @override
   Future<void> updatePerformanceMetrics(
-      List<double> buildTimes, List<double> rasterTimes) {
+    List<double> buildTimes,
+    List<double> rasterTimes,
+  ) {
     return Future.value();
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -21,26 +21,55 @@ abstract class DdRumPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  String? get cachedSessionId;
+
   Future<void> enable(DatadogSdk core, DatadogRumConfiguration configuration);
   Future<void> deinitialize();
 
   Future<String?> getCurrentSessionId();
 
-  Future<void> startView(DateTime timestamp, String key, String name,
-      Map<String, Object?> attributes);
+  Future<void> startView(
+    DateTime timestamp,
+    String key,
+    String name,
+    Map<String, Object?> attributes,
+  );
   Future<void> stopView(
-      DateTime timestamp, String key, Map<String, Object?> attributes);
+    DateTime timestamp,
+    String key,
+    Map<String, Object?> attributes,
+  );
   Future<void> addTiming(DateTime timestamp, String name);
   Future<void> addViewLoadingTime(bool overwrite);
 
-  Future<void> startResource(DateTime timestamp, String key,
-      RumHttpMethod httpMethod, String url, Map<String, Object?> attributes);
-  Future<void> stopResource(DateTime timestamp, String key, int? statusCode,
-      RumResourceType kind, int? size, Map<String, Object?> attributes);
-  Future<void> stopResourceWithError(DateTime timestamp, String key,
-      Exception error, Map<String, Object?> attributes);
-  Future<void> stopResourceWithErrorInfo(DateTime timestamp, String key,
-      String message, String type, Map<String, Object?> attributes);
+  Future<void> startResource(
+    DateTime timestamp,
+    String key,
+    RumHttpMethod httpMethod,
+    String url,
+    Map<String, Object?> attributes,
+  );
+  Future<void> stopResource(
+    DateTime timestamp,
+    String key,
+    int? statusCode,
+    RumResourceType kind,
+    int? size,
+    Map<String, Object?> attributes,
+  );
+  Future<void> stopResourceWithError(
+    DateTime timestamp,
+    String key,
+    Exception error,
+    Map<String, Object?> attributes,
+  );
+  Future<void> stopResourceWithErrorInfo(
+    DateTime timestamp,
+    String key,
+    String message,
+    String type,
+    Map<String, Object?> attributes,
+  );
 
   Future<void> addError(
     DateTime timestamp,
@@ -59,12 +88,24 @@ abstract class DdRumPlatform extends PlatformInterface {
     Map<String, Object?> attributes,
   );
 
-  Future<void> addAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, Object?> attributes);
-  Future<void> startAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, Object?> attributes);
-  Future<void> stopAction(DateTime timestamp, RumActionType type, String name,
-      Map<String, Object?> attributes);
+  Future<void> addAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, Object?> attributes,
+  );
+  Future<void> startAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, Object?> attributes,
+  );
+  Future<void> stopAction(
+    DateTime timestamp,
+    RumActionType type,
+    String name,
+    Map<String, Object?> attributes,
+  );
 
   Future<void> addAttribute(String key, dynamic value);
   Future<void> removeAttribute(String key);
@@ -75,5 +116,7 @@ abstract class DdRumPlatform extends PlatformInterface {
 
   Future<void> reportLongTask(DateTime at, int durationMs);
   Future<void> updatePerformanceMetrics(
-      List<double> buildTimes, List<double> rasterTimes);
+    List<double> buildTimes,
+    List<double> rasterTimes,
+  );
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_mapper_proxy.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_mapper_proxy.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import '../../datadog_internal.dart';
 import '../android/android_rum_event_mapper.dart';
@@ -103,4 +104,16 @@ abstract class RumMapperProxy {
     }
     return null;
   }
+}
+
+abstract class RumMethodChannelMapperProxy extends RumMapperProxy {
+  RumMethodChannelMapperProxy({
+    super.viewEventMapper,
+    super.actionEventMapper,
+    super.resourceEventMapper,
+    super.errorEventMapper,
+    super.longTaskEventMapper,
+  }) : super();
+
+  Future<dynamic> handleMethodCall(MethodCall methodCall);
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_mapper_proxy_stub.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_mapper_proxy_stub.dart
@@ -3,6 +3,7 @@
 // Copyright 2025-Present Datadog, Inc.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import '../../datadog_flutter_plugin.dart';
 import '../../datadog_internal.dart';
@@ -21,4 +22,8 @@ class RumMapperProxy {
     }
     return null;
   }
+}
+
+class RumMethodChannelMapperProxy extends RumMapperProxy {
+  void handleMethodCall(MethodCall methodCall) {}
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -21,6 +21,10 @@ class DdRumWeb extends DdRumPlatform {
   RumWebPluginImpl? _webPlugin;
   ResourceTracker? _resourceTracker;
 
+  @override
+  // Can return this directly, don't need to use a cached version
+  String? get cachedSessionId => DD_RUM?.getInternalContext()?.session_id;
+
   // Because Web needs the full SDK configuration, we have a separate init method
   void initialize(
     DatadogConfiguration configuration,

--- a/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/tracing_headers.dart
@@ -188,12 +188,14 @@ class TracingContext {
   final TracingId traceId;
   final TracingId spanId;
   final TracingId? parentSpanId;
+  final String? rumSessionId;
   final bool sampled;
 
   const TracingContext(
     this.traceId,
     this.spanId,
     this.parentSpanId,
+    this.rumSessionId,
     this.sampled,
   );
 }
@@ -204,8 +206,9 @@ final Random _traceRandom = Random();
 TracingContext generateTracingContext(DatadogRum rum) {
   final traceId = TracingId.traceId();
   final spanId = TracingId.spanId();
-  bool sampled = rum.shouldSampleTrace(traceId);
-  return TracingContext(traceId, spanId, null, sampled);
+  final sessionId = rum.cachedSessionId;
+  bool sampled = rum.shouldSampleTrace(sessionId, traceId);
+  return TracingContext(traceId, spanId, null, sessionId, sampled);
 }
 
 Map<String, Object?> generateDatadogAttributes(

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -2,10 +2,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 @TestOn('vm')
-
 import 'dart:async';
 import 'dart:math';
 
+import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_method_channel.dart';
@@ -42,12 +42,12 @@ void main() {
     ambiguate(TestDefaultBinaryMessengerBinding.instance)
         ?.defaultBinaryMessenger
         .setMockMethodCallHandler(ddRumPlatform.methodChannel, (message) {
-      log.add(message);
-      if (message.method == 'getCurrentSessionId') {
-        return Future.value('fake-session-id');
-      }
-      return null;
-    });
+          log.add(message);
+          if (message.method == 'getCurrentSessionId') {
+            return Future.value('fake-session-id');
+          }
+          return null;
+        });
   });
 
   tearDown(() {
@@ -58,41 +58,78 @@ void main() {
     var sessionId = await ddRumPlatform.getCurrentSessionId();
 
     expect(sessionId, 'fake-session-id');
-    expect(log, [
-      isMethodCall('getCurrentSessionId', arguments: {}),
-    ]);
+    expect(log, [isMethodCall('getCurrentSessionId', arguments: {})]);
+  });
+
+  test('cachedSessionId starts null', () async {
+    var cachedSessionId = ddRumPlatform.cachedSessionId;
+
+    // Then
+    expect(cachedSessionId, isNull);
+  });
+
+  test('getCurrentSessionId sets cached sessionId', () async {
+    var _ = await ddRumPlatform.getCurrentSessionId();
+    var cachedSessionId = ddRumPlatform.cachedSessionId;
+
+    // Then
+    expect(cachedSessionId, 'fake-session-id');
+  });
+
+  test('onSessionChanged sets cachedSessionId', () async {
+    // Given
+    final sessionId = randomString();
+
+    // When
+    await ddRumPlatform.handleMethodCall(
+      MethodCall('onSessionChanged', {
+        'sessionId': sessionId,
+        'discarded': randomBool(),
+      }),
+    );
+
+    // Then
+    expect(ddRumPlatform.cachedSessionId, sessionId);
   });
 
   test('startView calls to platform', () async {
     final timestamp = randomTimestamp();
-    await ddRumPlatform
-        .startView(timestamp, 'my_key', 'my_name', {'attribute': 'value'});
+    await ddRumPlatform.startView(timestamp, 'my_key', 'my_name', {
+      'attribute': 'value',
+    });
 
     expect(log, [
-      isMethodCall('startView', arguments: {
-        'key': 'my_key',
-        'name': 'my_name',
-        'attributes': {
-          'attribute': 'value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'startView',
+        arguments: {
+          'key': 'my_key',
+          'name': 'my_name',
+          'attributes': {
+            'attribute': 'value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('stopView calls to platform', () async {
     final timestamp = randomTimestamp();
-    await ddRumPlatform
-        .stopView(timestamp, 'my_key', {'stop_attribute': 'my_value'});
+    await ddRumPlatform.stopView(timestamp, 'my_key', {
+      'stop_attribute': 'my_value',
+    });
 
     expect(log, [
-      isMethodCall('stopView', arguments: {
-        'key': 'my_key',
-        'attributes': {
-          'stop_attribute': 'my_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'stopView',
+        arguments: {
+          'key': 'my_key',
+          'attributes': {
+            'stop_attribute': 'my_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
@@ -101,7 +138,7 @@ void main() {
     await ddRumPlatform.addTiming(timestamp, 'my timing name');
 
     expect(log, [
-      isMethodCall('addTiming', arguments: {'name': 'my timing name'})
+      isMethodCall('addTiming', arguments: {'name': 'my timing name'}),
     ]);
   });
 
@@ -109,99 +146,133 @@ void main() {
     await ddRumPlatform.addViewLoadingTime(true);
 
     expect(log, [
-      isMethodCall('addViewLoadingTime', arguments: {'overwrite': true})
+      isMethodCall('addViewLoadingTime', arguments: {'overwrite': true}),
     ]);
   });
 
   test('startResource calls to platform', () async {
     final timestamp = randomTimestamp();
     await ddRumPlatform.startResource(
-        timestamp,
-        'resource_key',
-        RumHttpMethod.get,
-        'https://fakeresource.com/url',
-        {'attribute_key': 'attribute_value'});
+      timestamp,
+      'resource_key',
+      RumHttpMethod.get,
+      'https://fakeresource.com/url',
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('startResource', arguments: {
-        'key': 'resource_key',
-        'httpMethod': 'RumHttpMethod.get',
-        'url': 'https://fakeresource.com/url',
-        'attributes': {
-          'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'startResource',
+        arguments: {
+          'key': 'resource_key',
+          'httpMethod': 'RumHttpMethod.get',
+          'url': 'https://fakeresource.com/url',
+          'attributes': {
+            'attribute_key': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('stopResource calls to platform', () async {
     final timestamp = randomTimestamp();
-    await ddRumPlatform.stopResource(timestamp, 'resource_key', 202,
-        RumResourceType.image, 41123, {'attribute_key': 'attribute_value'});
+    await ddRumPlatform.stopResource(
+      timestamp,
+      'resource_key',
+      202,
+      RumResourceType.image,
+      41123,
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('stopResource', arguments: {
-        'key': 'resource_key',
-        'statusCode': 202,
-        'kind': 'RumResourceType.image',
-        'size': 41123,
-        'attributes': {
-          'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'stopResource',
+        arguments: {
+          'key': 'resource_key',
+          'statusCode': 202,
+          'kind': 'RumResourceType.image',
+          'size': 41123,
+          'attributes': {
+            'attribute_key': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('stopResourceWithError calls to platform with info', () async {
     final timestamp = randomTimestamp();
     final exception = TimeoutException(
-        'Timeout retrieving resource', const Duration(seconds: 5));
-    await ddRumPlatform.stopResourceWithError(timestamp, 'resource_key',
-        exception, {'attribute_key': 'attribute_value'});
+      'Timeout retrieving resource',
+      const Duration(seconds: 5),
+    );
+    await ddRumPlatform.stopResourceWithError(
+      timestamp,
+      'resource_key',
+      exception,
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('stopResourceWithError', arguments: {
-        'key': 'resource_key',
-        'message': exception.toString(),
-        'type': exception.runtimeType.toString(),
-        'attributes': {
-          'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'stopResourceWithError',
+        arguments: {
+          'key': 'resource_key',
+          'message': exception.toString(),
+          'type': exception.runtimeType.toString(),
+          'attributes': {
+            'attribute_key': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('stopResourceWithErrorInfo calls to platform', () async {
     final timestamp = randomTimestamp();
     await ddRumPlatform.stopResourceWithErrorInfo(
-        timestamp,
-        'resource_key',
-        'Exception message',
-        'Exception type',
-        {'attribute_key': 'attribute_value'});
+      timestamp,
+      'resource_key',
+      'Exception message',
+      'Exception type',
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('stopResourceWithError', arguments: {
-        'key': 'resource_key',
-        'message': 'Exception message',
-        'type': 'Exception type',
-        'attributes': {
-          'attribute_key': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'stopResourceWithError',
+        arguments: {
+          'key': 'resource_key',
+          'message': 'Exception message',
+          'type': 'Exception type',
+          'attributes': {
+            'attribute_key': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('addError calls to platform with info', () async {
     final timestamp = randomTimestamp();
     final exception = TimeoutException(
-        'Timeout retrieving resource', const Duration(seconds: 5));
-    await ddRumPlatform.addError(timestamp, exception, RumErrorSource.source,
-        null, 'error_type', {'attribute_key': 'attribute_value'});
+      'Timeout retrieving resource',
+      const Duration(seconds: 5),
+    );
+    await ddRumPlatform.addError(
+      timestamp,
+      exception,
+      RumErrorSource.source,
+      null,
+      'error_type',
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log.length, 1);
     final call = log.first;
@@ -219,12 +290,13 @@ void main() {
   test('addErrorInfo calls to platform with info', () async {
     final timestamp = randomTimestamp();
     await ddRumPlatform.addErrorInfo(
-        timestamp,
-        'Exception message',
-        RumErrorSource.source,
-        null,
-        'error_type',
-        {'attribute_key': 'attribute_value'});
+      timestamp,
+      'Exception message',
+      RumErrorSource.source,
+      null,
+      'error_type',
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log.length, 1);
     final call = log.first;
@@ -243,9 +315,17 @@ void main() {
     final timestamp = randomTimestamp();
     final stackTrace = StackTrace.current;
     final exception = TimeoutException(
-        'Timeout retrieving resource', const Duration(seconds: 5));
-    await ddRumPlatform.addError(timestamp, exception, RumErrorSource.source,
-        stackTrace, null, {'attribute_key': 'attribute_value'});
+      'Timeout retrieving resource',
+      const Duration(seconds: 5),
+    );
+    await ddRumPlatform.addError(
+      timestamp,
+      exception,
+      RumErrorSource.source,
+      stackTrace,
+      null,
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log.length, 1);
     final call = log.first;
@@ -264,12 +344,13 @@ void main() {
     final timestamp = randomTimestamp();
     final stackTrace = StackTrace.current;
     await ddRumPlatform.addErrorInfo(
-        timestamp,
-        'Exception message',
-        RumErrorSource.source,
-        stackTrace,
-        'error_type',
-        {'attribute_key': 'attribute_value'});
+      timestamp,
+      'Exception message',
+      RumErrorSource.source,
+      stackTrace,
+      'error_type',
+      {'attribute_key': 'attribute_value'},
+    );
 
     expect(log.length, 1);
     final call = log.first;
@@ -286,54 +367,73 @@ void main() {
 
   test('addAction calls to platform', () async {
     final timestamp = randomTimestamp();
-    await ddRumPlatform
-        .addAction(timestamp, RumActionType.tap, 'fake_user_action', {
-      'attribute_name': 'attribute_value',
-    });
+    await ddRumPlatform.addAction(
+      timestamp,
+      RumActionType.tap,
+      'fake_user_action',
+      {'attribute_name': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('addAction', arguments: {
-        'type': 'RumActionType.tap',
-        'name': 'fake_user_action',
-        'attributes': {
-          'attribute_name': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'addAction',
+        arguments: {
+          'type': 'RumActionType.tap',
+          'name': 'fake_user_action',
+          'attributes': {
+            'attribute_name': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('startAction calls to platform', () async {
     final timestamp = randomTimestamp();
-    await ddRumPlatform.startAction(timestamp, RumActionType.scroll,
-        'user_action_scroll', {'attribute_name': 'attribute_value'});
+    await ddRumPlatform.startAction(
+      timestamp,
+      RumActionType.scroll,
+      'user_action_scroll',
+      {'attribute_name': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('startAction', arguments: {
-        'type': 'RumActionType.scroll',
-        'name': 'user_action_scroll',
-        'attributes': {
-          'attribute_name': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'startAction',
+        arguments: {
+          'type': 'RumActionType.scroll',
+          'name': 'user_action_scroll',
+          'attributes': {
+            'attribute_name': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
   test('stopAction calls to platform', () async {
     final timestamp = randomTimestamp();
-    await ddRumPlatform.stopAction(timestamp, RumActionType.swipe,
-        'user_action_swipe', {'attribute_name': 'attribute_value'});
+    await ddRumPlatform.stopAction(
+      timestamp,
+      RumActionType.swipe,
+      'user_action_swipe',
+      {'attribute_name': 'attribute_value'},
+    );
 
     expect(log, [
-      isMethodCall('stopAction', arguments: {
-        'type': 'RumActionType.swipe',
-        'name': 'user_action_swipe',
-        'attributes': {
-          'attribute_name': 'attribute_value',
-          '_dd.timestamp': timestamp.millisecondsSinceEpoch,
-        }
-      })
+      isMethodCall(
+        'stopAction',
+        arguments: {
+          'type': 'RumActionType.swipe',
+          'name': 'user_action_swipe',
+          'attributes': {
+            'attribute_name': 'attribute_value',
+            '_dd.timestamp': timestamp.millisecondsSinceEpoch,
+          },
+        },
+      ),
     ]);
   });
 
@@ -341,8 +441,10 @@ void main() {
     await ddRumPlatform.addAttribute('attribute_key', 'my attribute value');
 
     expect(log, [
-      isMethodCall('addAttribute',
-          arguments: {'key': 'attribute_key', 'value': 'my attribute value'})
+      isMethodCall(
+        'addAttribute',
+        arguments: {'key': 'attribute_key', 'value': 'my attribute value'},
+      ),
     ]);
   });
 
@@ -350,7 +452,7 @@ void main() {
     await ddRumPlatform.removeAttribute('attribute_key');
 
     expect(log, [
-      isMethodCall('removeAttribute', arguments: {'key': 'attribute_key'})
+      isMethodCall('removeAttribute', arguments: {'key': 'attribute_key'}),
     ]);
   });
 
@@ -358,10 +460,10 @@ void main() {
     await ddRumPlatform.addFeatureFlagEvaluation('key_name', 'key_value');
 
     expect(log, [
-      isMethodCall('addFeatureFlagEvaluation', arguments: {
-        'name': 'key_name',
-        'value': 'key_value',
-      })
+      isMethodCall(
+        'addFeatureFlagEvaluation',
+        arguments: {'name': 'key_name', 'value': 'key_value'},
+      ),
     ]);
   });
 
@@ -378,10 +480,10 @@ void main() {
     await ddRumPlatform.reportLongTask(now, duration);
 
     expect(log, [
-      isMethodCall('reportLongTask', arguments: {
-        'at': now.millisecondsSinceEpoch,
-        'duration': duration,
-      }),
+      isMethodCall(
+        'reportLongTask',
+        arguments: {'at': now.millisecondsSinceEpoch, 'duration': duration},
+      ),
     ]);
   });
 
@@ -389,10 +491,13 @@ void main() {
     await ddRumPlatform.updatePerformanceMetrics([0.2, 0.3], [0.11, 0.25]);
 
     expect(log, [
-      isMethodCall('updatePerformanceMetrics', arguments: {
-        'buildTimes': [0.2, 0.3],
-        'rasterTimes': [0.11, 0.25],
-      }),
+      isMethodCall(
+        'updatePerformanceMetrics',
+        arguments: {
+          'buildTimes': [0.2, 0.3],
+          'rasterTimes': [0.11, 0.25],
+        },
+      ),
     ]);
   });
 }

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:uuid/v4.dart';
 
 class MockInternalLogger extends Mock implements InternalLogger {}
 
@@ -46,13 +47,15 @@ void main() {
     when(() => mockDatadogSdk.internalLogger).thenReturn(mockInternalLogger);
 
     mockDatadogPlatform = MockDatadogPlatform();
-    when(() => mockDatadogPlatform.updateTelemetryConfiguration(any(), any()))
-        .thenAnswer((_) => Future.value());
+    when(
+      () => mockDatadogPlatform.updateTelemetryConfiguration(any(), any()),
+    ).thenAnswer((_) => Future.value());
     when(() => mockDatadogSdk.platform).thenReturn(mockDatadogPlatform);
 
     mockRumPlatform = MockRumPlatform();
-    when(() => mockRumPlatform.setInternalViewAttribute(any(), any()))
-        .thenAnswer((_) => Future.value());
+    when(
+      () => mockRumPlatform.setInternalViewAttribute(any(), any()),
+    ).thenAnswer((_) => Future.value());
   });
 
   test('RumResourceType parses simple mimeTypes from ContentType', () {
@@ -192,7 +195,8 @@ void main() {
 
     for (int i = 0; i < 10; ++i) {
       final trace = TracingId.traceId();
-      expect(rum!.shouldSampleTrace(trace), isTrue);
+      final sessionId = UuidV4().toString();
+      expect(rum!.shouldSampleTrace(sessionId, trace), isTrue);
     }
   });
 
@@ -206,7 +210,8 @@ void main() {
 
     for (int i = 0; i < 10; ++i) {
       final trace = TracingId.traceId();
-      expect(rum!.shouldSampleTrace(trace), isFalse);
+      final sessionId = UuidV4().toString();
+      expect(rum!.shouldSampleTrace(sessionId, trace), isFalse);
     }
   });
 
@@ -222,7 +227,8 @@ void main() {
     var noSampleCount = 0;
     for (int i = 0; i < numSamples; ++i) {
       final trace = TracingId.traceId();
-      if (rum!.shouldSampleTrace(trace)) {
+      final sessionId = UuidV4().toString();
+      if (rum!.shouldSampleTrace(sessionId, trace)) {
         sampleCount++;
       } else {
         noSampleCount++;
@@ -245,7 +251,8 @@ void main() {
     var noSampleCount = 0;
     for (int i = 0; i < numSamples; ++i) {
       final trace = TracingId.traceId();
-      if (rum!.shouldSampleTrace(trace)) {
+      final sessionId = UuidV4().toString();
+      if (rum!.shouldSampleTrace(sessionId, trace)) {
         sampleCount++;
       } else {
         noSampleCount++;
@@ -256,7 +263,7 @@ void main() {
     expect(noSampleCount, greaterThanOrEqualTo(1));
   });
 
-  test('Sampling decisions are deterministic', () async {
+  test('Sampling decisions are deterministic for traceId', () async {
     // Generated using the dd-trace-go implementation with the following program: https://go.dev/play/p/CUrDJtze8E_e
     final inputs = <(BigInt, double, bool)>[
       (BigInt.parse('5577006791947779410'), 94.0509, true),
@@ -279,7 +286,87 @@ void main() {
       );
       final rum = await DatadogRum.enable(mockDatadogSdk, rumConfiguration);
       final tracingId = TracingId(identifier);
-      bool shouldSample = rum!.shouldSampleTrace(tracingId);
+      bool shouldSample = rum!.shouldSampleTrace(null, tracingId);
+      expect(shouldSample, expected);
+    }
+  });
+
+  test('Sampling decisions are deterministic for sessionId', () async {
+    // The numbers used in the session UUID are the same numbers truncated to 48 bits,
+    // which sometimes results in a different sampling decision. Created using this program:
+    // https://go.dev/play/p/lUl2SiOHxfZ
+    final inputs = <(String, BigInt, double, bool)>[
+      (
+        '11111111-2222-3333-4444-822107fcfd52',
+        BigInt.parse('5577006791947779410'),
+        94.050909,
+        true,
+      ),
+      (
+        '11111111-2222-3333-4444-4dc76695721d',
+        BigInt.parse('15352856648520921629'),
+        43.771419,
+        true,
+      ),
+      (
+        '11111111-2222-3333-4444-858149c6e2d1',
+        BigInt.parse('3916589616287113937'),
+        68.682307,
+        true,
+      ),
+      (
+        '11111111-2222-3333-4444-cb397916001e',
+        BigInt.parse('9828766684487745566'),
+        15.651925,
+        false,
+      ),
+      (
+        '11111111-2222-3333-4444-7f48392907a0',
+        BigInt.parse('894385949183117216'),
+        30.091186,
+        true,
+      ),
+      (
+        '11111111-2222-3333-4444-7cc6f3875d04',
+        BigInt.parse('4751997750760398084'),
+        81.363996,
+        true,
+      ),
+      (
+        '11111111-2222-3333-4444-ffa2ba517936',
+        BigInt.parse('11199607447739267382'),
+        38.065719,
+        true,
+      ),
+      (
+        '11111111-2222-3333-4444-21587cb3ad0b',
+        BigInt.parse('12156940908066221323'),
+        46.888984,
+        false,
+      ),
+      (
+        '11111111-2222-3333-4444-768b7c4e0b68',
+        BigInt.parse('11833901312327420776'),
+        29.310186,
+        false,
+      ),
+      (
+        '11111111-2222-3333-4444-3f2525632186',
+        BigInt.parse('6263450610539110790'),
+        21.855305,
+        false,
+      ),
+    ];
+
+    for (final (sessionId, identifier, sampleRate, expected) in inputs) {
+      final rumConfiguration = DatadogRumConfiguration(
+        applicationId: 'applicationId',
+        traceSampleRate: sampleRate,
+        detectLongTasks: false,
+      );
+      final rum = await DatadogRum.enable(mockDatadogSdk, rumConfiguration);
+      final tracingId = TracingId(identifier);
+      bool shouldSample = rum!.shouldSampleTrace(sessionId, tracingId);
       expect(shouldSample, expected);
     }
   });
@@ -288,16 +375,19 @@ void main() {
     // Given
     final fakeSessionId = randomString(length: 12);
     DdRumPlatform.instance = mockRumPlatform;
-    when(() => mockRumPlatform.enable(any(), any()))
-        .thenAnswer((_) => Future.value());
-    when(() => mockRumPlatform.getCurrentSessionId())
-        .thenAnswer((_) => Future.value(fakeSessionId));
+    when(
+      () => mockRumPlatform.enable(any(), any()),
+    ).thenAnswer((_) => Future.value());
+    when(
+      () => mockRumPlatform.getCurrentSessionId(),
+    ).thenAnswer((_) => Future.value(fakeSessionId));
     final rum = await DatadogRum.enable(
-        mockDatadogSdk,
-        DatadogRumConfiguration(
-          applicationId: 'applicationId',
-          detectLongTasks: false,
-        ));
+      mockDatadogSdk,
+      DatadogRumConfiguration(
+        applicationId: 'applicationId',
+        detectLongTasks: false,
+      ),
+    );
 
     // When
     var sessionId = await rum!.getCurrentSessionId();
@@ -309,16 +399,19 @@ void main() {
   test('addAttribute with null calls remove attribute instead', () async {
     // Given
     DdRumPlatform.instance = mockRumPlatform;
-    when(() => mockRumPlatform.enable(any(), any()))
-        .thenAnswer((_) => Future.value());
-    when(() => mockRumPlatform.removeAttribute(any()))
-        .thenAnswer((_) => Future.value());
+    when(
+      () => mockRumPlatform.enable(any(), any()),
+    ).thenAnswer((_) => Future.value());
+    when(
+      () => mockRumPlatform.removeAttribute(any()),
+    ).thenAnswer((_) => Future.value());
     final rum = await DatadogRum.enable(
-        mockDatadogSdk,
-        DatadogRumConfiguration(
-          applicationId: 'applicationId',
-          detectLongTasks: false,
-        ));
+      mockDatadogSdk,
+      DatadogRumConfiguration(
+        applicationId: 'applicationId',
+        detectLongTasks: false,
+      ),
+    );
 
     // when
     rum!.addAttribute('attribute-key', null);
@@ -328,55 +421,81 @@ void main() {
     verifyNever(() => mockRumPlatform.addAttribute(any(), any()));
   });
 
-  test('addError does not forward to platform on MissingPluginException',
-      () async {
-    // Given
-    DdRumPlatform.instance = mockRumPlatform;
-    when(() => mockRumPlatform.enable(any(), any()))
-        .thenAnswer((_) => Future.value());
-    when(() => mockRumPlatform.removeAttribute(any()))
-        .thenAnswer((_) => Future.value());
-    final rum = await DatadogRum.enable(
+  test(
+    'addError does not forward to platform on MissingPluginException',
+    () async {
+      // Given
+      DdRumPlatform.instance = mockRumPlatform;
+      when(
+        () => mockRumPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.removeAttribute(any()),
+      ).thenAnswer((_) => Future.value());
+      final rum = await DatadogRum.enable(
         mockDatadogSdk,
         DatadogRumConfiguration(
           applicationId: 'applicationId',
           detectLongTasks: false,
-        ));
+        ),
+      );
 
-    // when
-    final exception = MissingPluginException(
-        'No implementation found for method addError on channel datadog_sdk_flutter.rum');
-    rum!.addError(exception, RumErrorSource.source);
+      // when
+      final exception = MissingPluginException(
+        'No implementation found for method addError on channel datadog_sdk_flutter.rum',
+      );
+      rum!.addError(exception, RumErrorSource.source);
 
-    // Then
-    verifyNever(() => rum.addError(any(), any(),
-        stackTrace: any(), errorType: any(), attributes: any()));
-  });
+      // Then
+      verifyNever(
+        () => rum.addError(
+          any(),
+          any(),
+          stackTrace: any(),
+          errorType: any(),
+          attributes: any(),
+        ),
+      );
+    },
+  );
 
-  test('addErrorInfo does not forward to platform on MissingPluginException',
-      () async {
-    // Given
-    DdRumPlatform.instance = mockRumPlatform;
-    when(() => mockRumPlatform.enable(any(), any()))
-        .thenAnswer((_) => Future.value());
-    when(() => mockRumPlatform.removeAttribute(any()))
-        .thenAnswer((_) => Future.value());
-    final rum = await DatadogRum.enable(
+  test(
+    'addErrorInfo does not forward to platform on MissingPluginException',
+    () async {
+      // Given
+      DdRumPlatform.instance = mockRumPlatform;
+      when(
+        () => mockRumPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.removeAttribute(any()),
+      ).thenAnswer((_) => Future.value());
+      final rum = await DatadogRum.enable(
         mockDatadogSdk,
         DatadogRumConfiguration(
           applicationId: 'applicationId',
           detectLongTasks: false,
-        ));
+        ),
+      );
 
-    // when
-    final exception = MissingPluginException(
-        'No implementation found for method addError on channel datadog_sdk_flutter.rum');
-    rum!.addErrorInfo(exception.toString(), RumErrorSource.source);
+      // when
+      final exception = MissingPluginException(
+        'No implementation found for method addError on channel datadog_sdk_flutter.rum',
+      );
+      rum!.addErrorInfo(exception.toString(), RumErrorSource.source);
 
-    // Then
-    verifyNever(() => rum.addError(any(), any(),
-        stackTrace: any(), errorType: any(), attributes: any()));
-  });
+      // Then
+      verifyNever(
+        () => rum.addError(
+          any(),
+          any(),
+          stackTrace: any(),
+          errorType: any(),
+          attributes: any(),
+        ),
+      );
+    },
+  );
 
   group('markViewFirstBuildComplete', () {
     late DatadogRum rum;
@@ -391,54 +510,77 @@ void main() {
         detectLongTasks: false,
       );
 
-      when(() => mockRumPlatform.enable(any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.startView(any(), any(), any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.stopView(any(), any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.addAttribute(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.startView(any(), any(), any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.stopView(any(), any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.addAttribute(any(), any()),
+      ).thenAnswer((_) => Future.value());
 
       rum = (await DatadogRum.enable(mockDatadogSdk, rumConfiguration))!;
       rum.timeProvider = mockTimeProvider;
     });
 
-    test('markViewFirstBuildComplete adds ns timestamp as view attribute',
-        testOn: 'vm', () {
-      final startTime = DateTime.now();
-      final duration = random.nextInt(1 << 32);
-      final timeAnswers = [
-        startTime,
-        startTime.add(Duration(microseconds: duration)),
-      ];
-      when(() => mockTimeProvider.now())
-          .thenAnswer((_) => timeAnswers.removeAt(0));
-      rum.startView('test_view');
-      rum.markViewFirstBuildComplete('test_view');
+    test(
+      'markViewFirstBuildComplete adds ns timestamp as view attribute',
+      testOn: 'vm',
+      () {
+        final startTime = DateTime.now();
+        final duration = random.nextInt(1 << 32);
+        final timeAnswers = [
+          startTime,
+          startTime.add(Duration(microseconds: duration)),
+        ];
+        when(
+          () => mockTimeProvider.now(),
+        ).thenAnswer((_) => timeAnswers.removeAt(0));
+        rum.startView('test_view');
+        rum.markViewFirstBuildComplete('test_view');
 
-      verify(() => mockRumPlatform.setInternalViewAttribute(
-          '_dd.performance.first_build_complete', duration * 1000));
-    });
-
-    test('markViewFirstBuildComplete adds no attribute if view not started',
-        () {
-      rum.markViewFirstBuildComplete('test_view');
-
-      verifyNever(() => mockRumPlatform.setInternalViewAttribute(
-          '_dd.performance.first_build_complete', any()));
-    });
+        verify(
+          () => mockRumPlatform.setInternalViewAttribute(
+            '_dd.performance.first_build_complete',
+            duration * 1000,
+          ),
+        );
+      },
+    );
 
     test(
-        'markViewFirstBuildComplete adds no attribute if different view started',
-        () {
-      when(() => mockTimeProvider.now()).thenAnswer((_) => DateTime.now());
-      rum.startView('test_view');
-      rum.markViewFirstBuildComplete('second_view');
+      'markViewFirstBuildComplete adds no attribute if view not started',
+      () {
+        rum.markViewFirstBuildComplete('test_view');
 
-      verifyNever(() => mockRumPlatform.setInternalViewAttribute(
-          '_dd.performance.first_build_complete', any()));
-    });
+        verifyNever(
+          () => mockRumPlatform.setInternalViewAttribute(
+            '_dd.performance.first_build_complete',
+            any(),
+          ),
+        );
+      },
+    );
+
+    test(
+      'markViewFirstBuildComplete adds no attribute if different view started',
+      () {
+        when(() => mockTimeProvider.now()).thenAnswer((_) => DateTime.now());
+        rum.startView('test_view');
+        rum.markViewFirstBuildComplete('second_view');
+
+        verifyNever(
+          () => mockRumPlatform.setInternalViewAttribute(
+            '_dd.performance.first_build_complete',
+            any(),
+          ),
+        );
+      },
+    );
 
     test('markViewFirstBuildComplete adds no attribute if view stopped', () {
       when(() => mockTimeProvider.now()).thenAnswer((_) => DateTime.now());
@@ -446,8 +588,12 @@ void main() {
       rum.stopView('test_view');
       rum.markViewFirstBuildComplete('test_view');
 
-      verifyNever(() => mockRumPlatform.setInternalViewAttribute(
-          '_dd.performance.first_build_complete', any()));
+      verifyNever(
+        () => mockRumPlatform.setInternalViewAttribute(
+          '_dd.performance.first_build_complete',
+          any(),
+        ),
+      );
     });
   });
 
@@ -466,16 +612,21 @@ void main() {
 
       registerFallbackValue(RumActionType.custom);
 
-      when(() => mockRumPlatform.enable(any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.startView(any(), any(), any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.stopView(any(), any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.addAction(any(), any(), any(), any()))
-          .thenAnswer((_) => Future.value());
-      when(() => mockRumPlatform.addAttribute(any(), any()))
-          .thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.startView(any(), any(), any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.stopView(any(), any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.addAction(any(), any(), any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(
+        () => mockRumPlatform.addAttribute(any(), any()),
+      ).thenAnswer((_) => Future.value());
 
       rum = (await DatadogRum.enable(mockDatadogSdk, rumConfiguration))!;
       rum.timeProvider = mockTimeProvider;
@@ -486,16 +637,13 @@ void main() {
       final startTime = DateTime.now();
       final actionTime = startTime.add(Duration(seconds: 1));
       final startTime2 = actionTime.add(Duration(milliseconds: 10));
-      final fbcTime =
-          startTime2.add(Duration(microseconds: random.nextInt(1 << 8)));
-      final timeAnswers = [
-        startTime,
-        actionTime,
-        startTime2,
-        fbcTime,
-      ];
-      when(() => mockTimeProvider.now())
-          .thenAnswer((_) => timeAnswers.removeAt(0));
+      final fbcTime = startTime2.add(
+        Duration(microseconds: random.nextInt(1 << 8)),
+      );
+      final timeAnswers = [startTime, actionTime, startTime2, fbcTime];
+      when(
+        () => mockTimeProvider.now(),
+      ).thenAnswer((_) => timeAnswers.removeAt(0));
 
       // When
       rum.startView('test_view');
@@ -503,33 +651,40 @@ void main() {
       rum.startView('test_view_2');
       rum.markViewFirstBuildComplete('test_view_2');
 
-      verify(() => mockRumPlatform.setInternalViewAttribute(
+      verify(
+        () => mockRumPlatform.setInternalViewAttribute(
           '_dd.view.custom_inv_value',
-          (fbcTime.difference(actionTime)).inNanoseconds));
+          (fbcTime.difference(actionTime)).inNanoseconds,
+        ),
+      );
     });
 
-    test('markViewFirstBuildComplete does not set inv attribute if missing',
-        () {
-      // Given
-      final startTime = DateTime.now();
-      final startTime2 = startTime.add(Duration(seconds: 10));
-      final fbcTime =
-          startTime2.add(Duration(microseconds: random.nextInt(1 << 8)));
-      final timeAnswers = [
-        startTime,
-        startTime2,
-        fbcTime,
-      ];
-      when(() => mockTimeProvider.now())
-          .thenAnswer((_) => timeAnswers.removeAt(0));
+    test(
+      'markViewFirstBuildComplete does not set inv attribute if missing',
+      () {
+        // Given
+        final startTime = DateTime.now();
+        final startTime2 = startTime.add(Duration(seconds: 10));
+        final fbcTime = startTime2.add(
+          Duration(microseconds: random.nextInt(1 << 8)),
+        );
+        final timeAnswers = [startTime, startTime2, fbcTime];
+        when(
+          () => mockTimeProvider.now(),
+        ).thenAnswer((_) => timeAnswers.removeAt(0));
 
-      // When
-      rum.startView('test_view');
-      rum.startView('test_view_2');
-      rum.markViewFirstBuildComplete('test_view_2');
+        // When
+        rum.startView('test_view');
+        rum.startView('test_view_2');
+        rum.markViewFirstBuildComplete('test_view_2');
 
-      verifyNever(() => mockRumPlatform.setInternalViewAttribute(
-          '_dd.view.custom_inv_value', any()));
-    });
+        verifyNever(
+          () => mockRumPlatform.setInternalViewAttribute(
+            '_dd.view.custom_inv_value',
+            any(),
+          ),
+        );
+      },
+    );
   });
 }

--- a/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
+++ b/packages/datadog_flutter_plugin/test/tracing/tracing_headers_test.dart
@@ -16,7 +16,7 @@ void main() {
     registerFallbackValue(TracingId(BigInt.one));
 
     mockRum = MockDdRum();
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
   });
 
   test('TracingIdRepresentation generates proper values', () {
@@ -96,7 +96,7 @@ void main() {
   });
 
   test('Unsampled context does not generate datadog attributes', () {
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
     final context = generateTracingContext(mockRum);
 
     final attributes = generateDatadogAttributes(context, 30.0);
@@ -214,7 +214,7 @@ void main() {
   test(
     'Datadog tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -243,7 +243,7 @@ void main() {
   test(
     'Datadog tracing headers are generated correctly { TraceContextInjection.sampled, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -260,7 +260,7 @@ void main() {
   );
 
   test('Default for tracing headers is TraceContextInjection.sampled', () {
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
     final context = generateTracingContext(mockRum);
 
     final headers = getTracingHeaders(context, TracingHeaderType.datadog);
@@ -274,7 +274,7 @@ void main() {
   test(
     'b3 tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -290,7 +290,7 @@ void main() {
   test(
     'b3 tracing headers are generated correctly { TraceContextInjection.sampled, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -306,7 +306,7 @@ void main() {
   test(
     'b3multi tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -325,7 +325,7 @@ void main() {
   test(
     'b3multi tracing headers are generated correctly { TraceContextInjection.sampled, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -344,7 +344,7 @@ void main() {
   test(
     'traceparent tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(
@@ -370,7 +370,7 @@ void main() {
   test(
     'traceparent tracing headers are generated correctly { TraceContextInjection.all, unsampled }',
     () {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       final context = generateTracingContext(mockRum);
 
       final headers = getTracingHeaders(

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -76,7 +76,7 @@ query UserInfo($id: ID!) {
     when(() => mockDatadog.internalLogger).thenReturn(MockInternalLogger());
 
     mockRum = MockDdRum();
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(50.0);
   });
 
@@ -751,7 +751,7 @@ query UserInfo($id: ID!) {
         // ignore: invalid_use_of_internal_member
         when(() => mockDatadog.internalLogger).thenReturn(MockInternalLogger());
 
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
         when(() => mockRum.traceSampleRate).thenReturn(50.0);
         when(() => mockDatadog.rum).thenReturn(mockRum);
       });
@@ -759,7 +759,7 @@ query UserInfo($id: ID!) {
       test('does not set trace attributes when should sample returns false',
           () {
         // Given
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
         final link =
             DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
         final request = Request(
@@ -781,7 +781,7 @@ query UserInfo($id: ID!) {
 
       test('start resource loading sets tracing attributes', () {
         // Given
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
         final link =
             DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
         final request = Request(
@@ -811,7 +811,7 @@ query UserInfo($id: ID!) {
 
       // This should not happen as links are url specific, but we should check anyway.
       test('does not set trace headers for third party urls', () async {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
         final link = DatadogGqlLink(
             mockDatadog, Uri.parse('https://non_first_party/graphql'));
         final request = Request(
@@ -843,7 +843,7 @@ query UserInfo($id: ID!) {
       test(
           'sets trace headers for first party urls { sampled, TraceContextInjection.all }',
           () {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
         when(() => mockRum.contextInjectionSetting)
             .thenReturn(TraceContextInjection.all);
         final link =
@@ -866,7 +866,7 @@ query UserInfo($id: ID!) {
       test(
           'sets trace headers for first party urls { sampled, TraceContextInjection.sampled }',
           () {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
         when(() => mockRum.contextInjectionSetting)
             .thenReturn(TraceContextInjection.sampled);
         final link =
@@ -889,7 +889,7 @@ query UserInfo($id: ID!) {
       test(
           'sets trace headers for first party urls { unsampled, TraceContextInjection.all }, ',
           () {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
         when(() => mockRum.contextInjectionSetting)
             .thenReturn(TraceContextInjection.all);
         final link =
@@ -912,7 +912,7 @@ query UserInfo($id: ID!) {
       test(
           'does not sets trace headers for first party urls { unsampled, TraceContextInjection.sampled }, ',
           () {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
         when(() => mockRum.contextInjectionSetting)
             .thenReturn(TraceContextInjection.sampled);
         final link =

--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -158,7 +158,7 @@ void main() {
       mockDatadog = DatadogSdkMock();
       mockRum = RumMock();
       when(() => mockDatadog.rum).thenReturn(mockRum);
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
       when(() => mockRum.contextInjectionSetting)
           .thenReturn(TraceContextInjection.all);
       when(() => mockRum.traceSampleRate).thenReturn(12);
@@ -228,7 +228,7 @@ void main() {
             () async {
           when(() => mockDatadog.headerTypesForHost(any()))
               .thenReturn({tracingType});
-          when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+          when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
@@ -303,7 +303,7 @@ void main() {
               .thenReturn({tracingType});
           when(() => mockRum.contextInjectionSetting)
               .thenReturn(TraceContextInjection.all);
-          when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+          when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
@@ -327,7 +327,7 @@ void main() {
               .thenReturn({tracingType});
           when(() => mockRum.contextInjectionSetting)
               .thenReturn(TraceContextInjection.sampled);
-          when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+          when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
 
           final interceptor = DatadogGrpcInterceptor(
             mockDatadog,
@@ -383,7 +383,7 @@ void main() {
     mockDatadog = DatadogSdkMock();
     mockRum = RumMock();
     when(() => mockDatadog.rum).thenReturn(mockRum);
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
     when(() => mockRum.traceSampleRate).thenReturn(12);
     when(() => mockRum.contextInjectionSetting)
         .thenReturn(TraceContextInjection.all);
@@ -432,7 +432,7 @@ void main() {
     mockDatadog = DatadogSdkMock();
     mockRum = RumMock();
     when(() => mockDatadog.rum).thenReturn(mockRum);
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(12);
     when(() => mockRum.contextInjectionSetting)
         .thenReturn(TraceContextInjection.all);
@@ -476,7 +476,7 @@ void main() {
     mockDatadog = DatadogSdkMock();
     mockRum = RumMock();
     when(() => mockDatadog.rum).thenReturn(mockRum);
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(12);
     when(() => mockRum.contextInjectionSetting)
         .thenReturn(TraceContextInjection.all);

--- a/packages/datadog_tracking_http_client/example/android/app/build.gradle
+++ b/packages/datadog_tracking_http_client/example/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 23
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -107,7 +107,7 @@ void main() {
 
     setUp(() {
       mockRum = MockDdRum();
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
       when(() => mockRum.contextInjectionSetting)
           .thenReturn(TraceContextInjection.all);
       when(() => mockRum.traceSampleRate).thenReturn(50.0);
@@ -444,7 +444,7 @@ void main() {
         test(
             'adds tracing headers to request { unsampled, TraceContextInjection.all }',
             () async {
-          when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+          when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
           final client = DatadogClient(
             datadogSdk: mockDatadog,
             innerClient: mockClient,
@@ -465,7 +465,7 @@ void main() {
         test(
             'does not add tracing headers to request { unsampled, TraceContextInjection.sampled }',
             () async {
-          when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+          when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
           when(() => mockRum.contextInjectionSetting)
               .thenReturn(TraceContextInjection.sampled);
           final client = DatadogClient(

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -78,7 +78,7 @@ void main() {
     when(() => mockDatadog.internalLogger).thenReturn(InternalLogger());
 
     mockRum = MockDdRum();
-    when(() => mockRum.shouldSampleTrace(any())).thenReturn(true);
+    when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
     when(() => mockRum.contextInjectionSetting)
         .thenReturn(TraceContextInjection.all);
     when(() => mockRum.traceSampleRate).thenReturn(50.0);
@@ -440,7 +440,7 @@ void main() {
       var url = Uri.parse('https://test_url/path');
       final completer = setupMockRequest(url);
 
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       when(() => mockRum.traceSampleRate).thenReturn(12.0);
 
       var request = await client.openUrl('get', url);
@@ -684,7 +684,7 @@ void main() {
       test(
           'sets trace headers for first party urls { unsampled, TraceContextInjection.all }',
           () async {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
         var url = Uri.parse('https://test_url/path');
         var completer = setupMockRequest(url);
         var mockResponse = setupMockClientResponse(200);
@@ -733,7 +733,7 @@ void main() {
       test(
           'sets trace headers for first party urls { unsampled, TraceContextInjection.sampled }',
           () async {
-        when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
         when(() => mockRum.contextInjectionSetting)
             .thenReturn(TraceContextInjection.sampled);
         var url = Uri.parse('https://test_url/path');
@@ -905,7 +905,7 @@ void main() {
 
     test('does not set trace headers when should sample returns false',
         () async {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       var url = Uri.parse('https://test_url/path');
       var completer = setupMockRequest(url);
       var mockResponse = setupMockClientResponse(200);
@@ -937,7 +937,7 @@ void main() {
 
     test('does not set trace headers when should sample returns false',
         () async {
-      when(() => mockRum.shouldSampleTrace(any())).thenReturn(false);
+      when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(false);
       var url = Uri.parse('https://test_url/path');
       var completer = setupMockRequest(url);
       var mockResponse = setupMockClientResponse(200);


### PR DESCRIPTION
### What and why?

Consistent trace sampling based on RUM Session ID allows RUM clients and the backend to come to a the same decision about sampling without relying on randomness for each trace.

This adds a listener for Session changes to RUM, and changes the `shouldSampleTrace` method to check the RUM session id first, before using the trace sampling if no session can be found.

refs: RUM-12492

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
