### PR TITLE
feat(web): implement tracking consent support

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -40,7 +40,11 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   Future<void> setSdkVerbosity(CoreLoggerLevel verbosity) async {}
 
   @override
-  Future<void> setTrackingConsent(TrackingConsent trackingConsent) async {}
+  Future<void> setTrackingConsent(TrackingConsent trackingConsent) async {
+    final consentString = trackingConsentToWeb(trackingConsent);
+    DD_LOGS?.setTrackingConsent(consentString);
+    DD_RUM?.setTrackingConsent(consentString);
+  }
 
   @override
   Future<void> setUserInfo(
@@ -75,7 +79,7 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
     bool logsInitialized = false;
     try {
       if (configuration.loggingConfiguration != null) {
-        DdLogsWeb.initLogs(configuration);
+        DdLogsWeb.initLogs(configuration, trackingConsent);
         logsInitialized = true;
       }
     } catch (e) {
@@ -93,6 +97,7 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
           configuration,
           configuration.rumConfiguration!,
           internalLogger,
+          trackingConsent,
         );
         rumInitialized = true;
       }

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -41,9 +41,8 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
 
   @override
   Future<void> setTrackingConsent(TrackingConsent trackingConsent) async {
-    final consentString = trackingConsentToWeb(trackingConsent);
-    DD_LOGS?.setTrackingConsent(consentString);
-    DD_RUM?.setTrackingConsent(consentString);
+    DD_LOGS?.setTrackingConsent(trackingConsent.webValue());
+    DD_RUM?.setTrackingConsent(trackingConsent.webValue());
   }
 
   @override

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -17,7 +17,10 @@ import 'ddweb_helpers.dart';
 class DdLogsWeb extends DdLogsPlatform {
   final Map<String, Logger> _activeLoggers = {};
 
-  static void initLogs(DatadogConfiguration configuration) {
+  static void initLogs(
+    DatadogConfiguration configuration,
+    TrackingConsent trackingConsent,
+  ) {
     DD_LOGS?.init(
       _LogInitOptions(
         clientToken: configuration.clientToken,
@@ -26,6 +29,7 @@ class DdLogsWeb extends DdLogsPlatform {
         site: siteStringForSite(configuration.site),
         service: configuration.service,
         version: configuration.versionTag,
+        trackingConsent: trackingConsentToWeb(trackingConsent),
       ),
     );
   }
@@ -161,6 +165,7 @@ extension type _LogInitOptions._(JSObject _) implements JSObject {
   external String? get proxy;
   external String? get service;
   external String? get version;
+  external String? get trackingConsent;
 
   external factory _LogInitOptions({
     String clientToken,
@@ -169,6 +174,7 @@ extension type _LogInitOptions._(JSObject _) implements JSObject {
     String? service,
     String? proxy,
     String? version,
+    String? trackingConsent,
   });
 }
 
@@ -201,6 +207,8 @@ extension type _DdLogs._(JSObject _) implements JSObject {
     String name,
     _JsLoggerConfiguration? configuration,
   );
+
+  external void setTrackingConsent(String consent);
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -29,7 +29,7 @@ class DdLogsWeb extends DdLogsPlatform {
         site: siteStringForSite(configuration.site),
         service: configuration.service,
         version: configuration.versionTag,
-        trackingConsent: trackingConsentToWeb(trackingConsent),
+        trackingConsent: trackingConsent.webValue(),
       ),
     );
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -61,7 +61,7 @@ class DdRumWeb extends DdRumPlatform {
         trackFrustrations: rumConfiguration.trackFrustrations,
         trackLongTasks: rumConfiguration.detectLongTasks,
         enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
-        trackingConsent: trackingConsentToWeb(trackingConsent),
+        trackingConsent: trackingConsent.webValue(),
       ),
     );
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_web.dart
@@ -18,6 +18,7 @@ class DdRumWeb extends DdRumPlatform {
     DatadogConfiguration configuration,
     DatadogRumConfiguration rumConfiguration,
     InternalLogger logger,
+    TrackingConsent trackingConsent,
   ) {
     bool trackResources =
         configuration.additionalConfig[trackResourcesConfigKey] == true;
@@ -60,6 +61,7 @@ class DdRumWeb extends DdRumPlatform {
         trackFrustrations: rumConfiguration.trackFrustrations,
         trackLongTasks: rumConfiguration.detectLongTasks,
         enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
+        trackingConsent: trackingConsentToWeb(trackingConsent),
       ),
     );
   }
@@ -313,6 +315,7 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
   external String? get proxy;
   external JSArray get allowedTracingUrls;
   external JSArray get enableExperimentalFeatures;
+  external String? get trackingConsent;
 
   external factory _RumInitOptions({
     String applicationId,
@@ -338,6 +341,7 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
     num? traceSampleRate,
     String? traceContextInjection,
     JSArray enableExperimentalFeatures,
+    String? trackingConsent,
   });
 }
 
@@ -367,6 +371,7 @@ extension type _DdRum._(JSObject _) implements JSObject {
   external void stopSession();
   external void setUser(JsUser newUser);
   external void setUserProperty(String key, JSAny? value);
+  external void setTrackingConsent(String consent);
 }
 
 @JS()

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -110,3 +110,13 @@ String? convertWebStackTrace(StackTrace? stackTrace) {
 
   return stackTraceString;
 }
+
+String trackingConsentToWeb(TrackingConsent consent) {
+  switch (consent) {
+    case TrackingConsent.granted:
+      return 'granted';
+    case TrackingConsent.notGranted:
+    case TrackingConsent.pending:
+      return 'not-granted';
+  }
+}

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -111,12 +111,14 @@ String? convertWebStackTrace(StackTrace? stackTrace) {
   return stackTraceString;
 }
 
-String trackingConsentToWeb(TrackingConsent consent) {
-  switch (consent) {
-    case TrackingConsent.granted:
-      return 'granted';
-    case TrackingConsent.notGranted:
-    case TrackingConsent.pending:
-      return 'not-granted';
+extension TrackingConsentWebValue on TrackingConsent {
+  String webValue() {
+    switch (this) {
+      case TrackingConsent.granted:
+        return 'granted';
+      case TrackingConsent.notGranted:
+      case TrackingConsent.pending:
+        return 'not-granted';
+    }
   }
 }

--- a/packages/datadog_flutter_plugin/test/web_helpers_test.dart
+++ b/packages/datadog_flutter_plugin/test/web_helpers_test.dart
@@ -14,15 +14,15 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('trackingConsentToWeb', () {
     test('converts granted to "granted"', () {
-      expect(trackingConsentToWeb(TrackingConsent.granted), 'granted');
+      expect(TrackingConsent.granted.webValue(), 'granted');
     });
 
     test('converts notGranted to "not-granted"', () {
-      expect(trackingConsentToWeb(TrackingConsent.notGranted), 'not-granted');
+      expect(TrackingConsent.notGranted.webValue(), 'not-granted');
     });
 
     test('converts pending to "not-granted"', () {
-      expect(trackingConsentToWeb(TrackingConsent.pending), 'not-granted');
+      expect(TrackingConsent.pending.webValue(), 'not-granted');
     });
   });
   group('value to js', () {

--- a/packages/datadog_flutter_plugin/test/web_helpers_test.dart
+++ b/packages/datadog_flutter_plugin/test/web_helpers_test.dart
@@ -7,10 +7,24 @@
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/src/web_helpers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('trackingConsentToWeb', () {
+    test('converts granted to "granted"', () {
+      expect(trackingConsentToWeb(TrackingConsent.granted), 'granted');
+    });
+
+    test('converts notGranted to "not-granted"', () {
+      expect(trackingConsentToWeb(TrackingConsent.notGranted), 'not-granted');
+    });
+
+    test('converts pending to "not-granted"', () {
+      expect(trackingConsentToWeb(TrackingConsent.pending), 'not-granted');
+    });
+  });
   group('value to js', () {
     test('converts simple values', () {
       expect(1, (valueToJs(1, 'integer') as JSNumber).toDartInt);


### PR DESCRIPTION
Implement tracking consent for web platform to match native (iOS/Android) behavior. Tracking consent is now passed during SDK initialization and can be updated at runtime via setTrackingConsent().

Changes:
- Add trackingConsentToWeb() converter that maps TrackingConsent enum to JavaScript SDK strings ('granted' or 'not-granted')
- Treat TrackingConsent.pending as 'not-granted' on web since the Browser SDK doesn't support a pending state
- Extend RUM JavaScript interop (_RumInitOptions and _DdRum) to include trackingConsent parameter and setTrackingConsent() method
- Extend Logs JavaScript interop (_LogInitOptions and _DdLogs) to include trackingConsent parameter and setTrackingConsent() method
- Update DatadogSdkWeb.initialize() to pass tracking consent to both RUM and Logs initialization
- Implement DatadogSdkWeb.setTrackingConsent() to update consent on both DD_RUM and DD_LOGS at runtime
- Add unit tests for trackingConsentToWeb() converter function

Following the native platform pattern, tracking consent is set SDK-wide and affects both RUM and Logs features.

Refs: https://docs.datadoghq.com/real_user_monitoring/application_monitoring/browser/advanced_configuration/?tab=npm#user-tracking-consent

### What and why?

This pull request implements tracking consent for web both at initialization and also allows to update the tracking consent after initialization.

### How?

We take the consent passed by the plugin and provide it to the Datadog JavaScript RUM and log initialization.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
