### PR TITLE
fix: Support properly stopping Dio's `badResponse` exceptions

### DIFF
--- a/packages/datadog_dio/example/integration_test/dio_interceptor_test.dart
+++ b/packages/datadog_dio/example/integration_test/dio_interceptor_test.dart
@@ -29,7 +29,7 @@ Future<void> performRumUserFlow(WidgetTester tester) async {
   await tester.pumpAndSettle();
 
   var nextButton = find.widgetWithText(ElevatedButton, 'Next Page');
-  await tester.waitFor(nextButton, const Duration(seconds: 5),
+  await tester.waitFor(nextButton, const Duration(seconds: 100),
       (e) => (e.widget as ElevatedButton).enabled);
   await tester.tap(nextButton);
   await tester.pumpAndSettle();
@@ -55,7 +55,7 @@ void main() {
       firstPartyBadUrl: 'https://foo.bar',
       thirdPartyGetUrl: 'https://httpbingo.org/get',
       thirdPartyPostUrl: 'https://httpbingo.org/post',
-      enableIoHttpTracking: true,
+      thirdPartyMissingUrl: 'https://httpbingo.org/status/404',
     );
     RumAutoInstrumentationScenarioConfig.instance = scenarioConfig;
 
@@ -179,5 +179,15 @@ void main() {
     expect(secondThirdPartyResource.duration, greaterThan(0));
     expect(secondThirdPartyResource.dd.traceId, isNull);
     expect(secondThirdPartyResource.dd.spanId, isNull);
+
+    final missingThirdPartyResource = view2.resourceEvents.firstWhereOrNull(
+        (e) => e.url.contains(scenarioConfig.thirdPartyMissingUrl));
+    expect(missingThirdPartyResource, isNotNull);
+    expect(missingThirdPartyResource!.url,
+        startsWith(scenarioConfig.thirdPartyMissingUrl));
+    expect(missingThirdPartyResource.method, 'GET');
+    expect(missingThirdPartyResource.duration, greaterThan(0));
+    expect(missingThirdPartyResource.dd.traceId, isNull);
+    expect(missingThirdPartyResource.dd.spanId, isNull);
   });
 }

--- a/packages/datadog_dio/example/lib/main.dart
+++ b/packages/datadog_dio/example/lib/main.dart
@@ -75,7 +75,9 @@ Future<void> main() async {
   }
 
   await DatadogSdk.runApp(configuration, TrackingConsent.granted, () async {
-    final dio = Dio()
+    final dio = Dio(BaseOptions(
+      validateStatus: (status) => status != null && status < 300,
+    ))
       ..addDatadogInterceptor(
         DatadogSdk.instance,
       );

--- a/packages/datadog_dio/example/lib/scenario_config.dart
+++ b/packages/datadog_dio/example/lib/scenario_config.dart
@@ -8,7 +8,7 @@ class RumAutoInstrumentationScenarioConfig {
   final String firstPartyBadUrl;
   final String thirdPartyGetUrl;
   final String thirdPartyPostUrl;
-  final bool enableIoHttpTracking;
+  final String thirdPartyMissingUrl;
 
   RumAutoInstrumentationScenarioConfig({
     this.firstPartyHosts = const ['foo.bar'],
@@ -17,7 +17,7 @@ class RumAutoInstrumentationScenarioConfig {
     this.firstPartyBadUrl = 'https://foo.bar',
     this.thirdPartyGetUrl = 'https://httpbingo.org/get',
     this.thirdPartyPostUrl = 'https://httpbingo.org/post',
-    this.enableIoHttpTracking = true,
+    this.thirdPartyMissingUrl = 'https://httpbingo.org/status/404',
   });
 
   static RumAutoInstrumentationScenarioConfig? _instance;

--- a/packages/datadog_dio/example/lib/screens/instrumentation_second_screen.dart
+++ b/packages/datadog_dio/example/lib/screens/instrumentation_second_screen.dart
@@ -64,6 +64,15 @@ class _InstrumentationSecondScreenState
     });
     await widget.dio.postUri(Uri.parse(_config.thirdPartyPostUrl));
 
+    setState(() {
+      _buttonText = 'Third party missing url';
+    });
+    try {
+      await widget.dio.getUri(Uri.parse(_config.thirdPartyMissingUrl));
+    } catch (_) {
+      // Do nothing, this will throw from Dio
+    }
+
     await Future.delayed(const Duration(milliseconds: 100));
     setState(() {
       _buttonText = 'All Done';

--- a/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
+++ b/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
@@ -49,26 +49,7 @@ class DatadogDioInterceptor extends Interceptor {
     final rumKey = response.requestOptions.extra[datadogRumExtraKey];
     if (!kIsWeb && rum != null && rumKey is String) {
       try {
-        final contentTypeHeader =
-            response.headers[Headers.contentTypeHeader]?.firstOrNull;
-        final contentType = contentTypeHeader != null
-            ? ContentType.parse(contentTypeHeader)
-            : ContentType.text;
-        final resourceType = resourceTypeFromContentType(contentType);
-        int? contentLength;
-        final contentLengthHeader =
-            response.headers[Headers.contentLengthHeader]?.firstOrNull;
-        if (contentLengthHeader != null) {
-          contentLength = int.tryParse(contentLengthHeader);
-        }
-        final attributes = attributesProvider?.onResponse(response) ?? {};
-        rum.stopResource(
-          rumKey,
-          response.statusCode,
-          resourceType,
-          contentLength,
-          attributes,
-        );
+        _stopWithResponse(rum, rumKey, response);
       } catch (e, st) {
         datadogSdk.internalLogger.sendToDatadog(
           '$DatadogDioInterceptor encountered an error while attempting'
@@ -87,9 +68,18 @@ class DatadogDioInterceptor extends Interceptor {
     final rumKey = err.requestOptions.extra[datadogRumExtraKey];
     if (!kIsWeb && rum != null && rumKey is String) {
       try {
-        final attributes = attributesProvider?.onError(err) ?? {};
-        rum.stopResourceWithErrorInfo(
-            rumKey, err.toString(), err.type.toString(), attributes);
+        if (err.type == DioExceptionType.badResponse &&
+            err.response?.statusCode != null) {
+          // Response completed successfully, but Dio throws an exception for
+          // certain status codes if ValidateStatus is configured. This breaks
+          // distributed tracing, so we stop our resource properly instead of
+          // adding it as an error.
+          _stopWithResponse(rum, rumKey, err.response!);
+        } else {
+          final attributes = attributesProvider?.onError(err) ?? {};
+          rum.stopResourceWithErrorInfo(
+              rumKey, err.toString(), err.type.toString(), attributes);
+        }
       } catch (e, st) {
         datadogSdk.internalLogger.sendToDatadog(
           '$DatadogDioInterceptor encountered an error while attempting'
@@ -100,6 +90,30 @@ class DatadogDioInterceptor extends Interceptor {
       }
     }
     super.onError(err, handler);
+  }
+
+  void _stopWithResponse(
+      DatadogRum rum, String rumKey, Response<dynamic> response) {
+    final contentTypeHeader =
+        response.headers[Headers.contentTypeHeader]?.firstOrNull;
+    final contentType = contentTypeHeader != null
+        ? ContentType.parse(contentTypeHeader)
+        : ContentType.text;
+    final resourceType = resourceTypeFromContentType(contentType);
+    int? contentLength;
+    final contentLengthHeader =
+        response.headers[Headers.contentLengthHeader]?.firstOrNull;
+    if (contentLengthHeader != null) {
+      contentLength = int.tryParse(contentLengthHeader);
+    }
+    final attributes = attributesProvider?.onResponse(response) ?? {};
+    rum.stopResource(
+      rumKey,
+      response.statusCode,
+      resourceType,
+      contentLength,
+      attributes,
+    );
   }
 
   void _trackRequest(RequestOptions options, DatadogRum rum) {

--- a/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
+++ b/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
@@ -412,6 +412,54 @@ void main() {
           rumKey, dioErrorString, dioErrorTypeString, {'my_attribute': 100}));
     });
 
+    test('the interceptor stops resources as non-errors on badResponse', () {
+      // Given
+      final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);
+      final requestOptions =
+          RequestOptions(path: 'https://test_uri', method: 'POST', headers: {});
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+      final response =
+          Response(requestOptions: requestOptions, statusCode: 404);
+
+      // When
+      final dioException = DioException.badResponse(
+          statusCode: 404, requestOptions: requestOptions, response: response);
+      final handler = ErrorInterceptorHandlerMock();
+      interceptor.onError(dioException, handler);
+
+      // Then
+      verify(() => mockRum.stopResource(rumKey, 404, any()));
+      verify(() => handler.next(dioException));
+    });
+
+    test('the interceptor adds provided attributes as non-error on badResponse',
+        () {
+      // Given
+      final attributeProvider = DatadogDioAttributeProviderMock();
+      when(() => attributeProvider.onResponse(any()))
+          .thenReturn({'my_attribute': 100});
+      final interceptor = DatadogDioInterceptor(
+          datadogSdk: mockDatadog, attributesProvider: attributeProvider);
+      final requestOptions =
+          RequestOptions(path: 'https://test_uri', method: 'POST', headers: {});
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+      final response =
+          Response(requestOptions: requestOptions, statusCode: 404);
+
+      // When
+      final dioException = DioException.badResponse(
+          statusCode: 404, requestOptions: requestOptions, response: response);
+      final handler = ErrorInterceptorHandlerMock();
+      interceptor.onError(dioException, handler);
+
+      // Then
+      verify(() => mockRum
+          .stopResource(rumKey, 404, any(), any(), {'my_attribute': 100}));
+      verify(() => handler.next(dioException));
+    });
+
     test('the interceptor ignores requests that match a regex', () {
       // Given
       final interceptor = DatadogDioInterceptor(


### PR DESCRIPTION
### What and why?

Dio can throw an exception when it encounters certain user defined error codes in `validateStatus`. However, we need to stop these resources as non-errors in RUM for them to show properly.

Detect `badResponse` exceptions and properly stop them before forwarding the error to other Dio handlers.

refs RUM-12688

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
