### PR TITLE
fix(sr): Don't capture unmounted widgets.

### DIFF
--- a/packages/datadog_session_replay/example/lib/app.dart
+++ b/packages/datadog_session_replay/example/lib/app.dart
@@ -28,46 +28,58 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final captureKey = GlobalKey();
+  var captureKey = GlobalKey();
+  GoRouter? router;
 
-  final router = GoRouter(
-    observers: [DatadogNavigationObserver(datadogSdk: DatadogSdk.instance)],
-    routes: [
-      GoRoute(path: '/', builder: (context, state) => const MainScreen()),
-      GoRoute(
-        path: Routes.simpleContainers,
-        builder: (context, state) => const SimpleContainersScreen(),
-      ),
-      GoRoute(
-        path: Routes.textRecording,
-        builder: (context, state) => TextRecordingScreen(),
-      ),
-      GoRoute(
-        path: Routes.cupertinoWidgets,
-        builder: (context, state) => CupertinoWidgetsScreen(),
-      ),
-      GoRoute(
-        path: Routes.materialWidgets,
-        builder: (context, state) => MaterialWidgetsScreen(),
-      ),
-      GoRoute(
-        path: Routes.textFieldWidgets,
-        builder: (context, state) => TextFieldsScreen(),
-      ),
-      GoRoute(
-        path: Routes.slivers,
-        builder: (context, state) => SliversScreen(),
-      ),
-      GoRoute(
-        path: Routes.imageWidgets,
-        builder: (context, state) => ImagesScreen(),
-      ),
-      GoRoute(
-        path: Routes.touchPrivacy,
-        builder: (context, state) => TouchPrivacyScreen(),
-      ),
-    ],
-  );
+  _MyAppState() {
+    router = GoRouter(
+      observers: [DatadogNavigationObserver(datadogSdk: DatadogSdk.instance)],
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => MainScreen(onRecreateKey: _recreateKey),
+        ),
+        GoRoute(
+          path: Routes.simpleContainers,
+          builder: (context, state) => const SimpleContainersScreen(),
+        ),
+        GoRoute(
+          path: Routes.textRecording,
+          builder: (context, state) => TextRecordingScreen(),
+        ),
+        GoRoute(
+          path: Routes.cupertinoWidgets,
+          builder: (context, state) => CupertinoWidgetsScreen(),
+        ),
+        GoRoute(
+          path: Routes.materialWidgets,
+          builder: (context, state) => MaterialWidgetsScreen(),
+        ),
+        GoRoute(
+          path: Routes.textFieldWidgets,
+          builder: (context, state) => TextFieldsScreen(),
+        ),
+        GoRoute(
+          path: Routes.slivers,
+          builder: (context, state) => SliversScreen(),
+        ),
+        GoRoute(
+          path: Routes.imageWidgets,
+          builder: (context, state) => ImagesScreen(),
+        ),
+        GoRoute(
+          path: Routes.touchPrivacy,
+          builder: (context, state) => TouchPrivacyScreen(),
+        ),
+      ],
+    );
+  }
+
+  void _recreateKey() {
+    setState(() {
+      captureKey = GlobalKey();
+    });
+  }
 
   @override
   void initState() {

--- a/packages/datadog_session_replay/example/lib/screens/main_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/main_screen.dart
@@ -17,7 +17,9 @@ class _RouteScreen {
 }
 
 class MainScreen extends StatefulWidget {
-  const MainScreen({super.key});
+  final VoidCallback onRecreateKey;
+
+  const MainScreen({super.key, required this.onRecreateKey});
 
   @override
   State<MainScreen> createState() => _MainScreenState();
@@ -71,6 +73,10 @@ class _MainScreenState extends State<MainScreen> {
               child: Text('Stop Session'),
             ),
             for (final route in routes) _routeButton(context, route),
+            ElevatedButton(
+              onPressed: widget.onRecreateKey,
+              child: Text('Recreate Capture Widget'),
+            ),
           ],
         ),
       ),

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -201,6 +201,10 @@ class SessionReplayRecorder {
           if (renderObject?.debugNeedsLayout == true) continue;
         }
 
+        /// This shouldn't happen as we now remove widgets from capture requests during
+        /// dispose. But, just in case, let's skip any widgets that are in a defunct state.
+        if (!e.mounted) continue;
+
         // In debug mode, Flutter will assert if you attempt to access the size of an
         // object that shouldn't have size. We can skip elements that have no size for
         // whatever reason.

--- a/packages/datadog_session_replay/lib/src/widgets.dart
+++ b/packages/datadog_session_replay/lib/src/widgets.dart
@@ -48,6 +48,12 @@ class _SessionReplayCaptureState extends State<SessionReplayCapture> {
   }
 
   @override
+  void dispose() {
+    widget.sessionReplay.removeElement(widget.key!);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     Widget builtChild = RumUserActionDetector(
       rum: widget.rum,


### PR DESCRIPTION
### What and why?

If, for some reason, the SessionReplayCapture widget is recreated and its key is changed, the element we're trying to capture will be in a defunct state, causing capture to throw and halting Session Replay

To prevent this, both remove disposed `SessionReplayCapture` elements from capture consideration, and also skip any elements we find that are not `mounted` as a failsafe.

refs: RUMS-5150

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
