### PR TITLE
chore: Disable wasm unit testing

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -115,8 +115,8 @@ scripts:
   unit_test:web:
     run:
       mkdir -p .build/test-results &&
-      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"'" &&
-      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"'" 
+      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"'"
+      # melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"'" 
     packageFilters:
       scope: 'datadog_flutter_plugin'
 


### PR DESCRIPTION
### What and why?

Flutter shipped a regression in Flutter 3.38 that stalls loading WASM tests on Mac. As a result we need to disable WASM testing until it is fixed.

This is tracked in the Flutter issue tracker as https://github.com/flutter/flutter/issues/177008

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
