### PR TITLE
chore: Changes associated with shipping session replay preview.7

### DIFF
--- a/packages/datadog_session_replay/CHANGELOG.md
+++ b/packages/datadog_session_replay/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0-preview.7
 
-* [Session Replay] Fix using BoxShape.circle in BoxDecoration.
+* [Session Replay] Fix using `BoxShape.circle` in `BoxDecoration`.
 * [Session Replay] Don't attempt to capture unmounted widgets.
 
 ## 1.0.0-preview.6

--- a/packages/datadog_session_replay/CHANGELOG.md
+++ b/packages/datadog_session_replay/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-preview.7
+
+* [Session Replay] Fix using BoxShape.circle in BoxDecoration.
+* [Session Replay] Don't attempt to capture unmounted widgets.
+
 ## 1.0.0-preview.6
 
 * [Session Replay] Don't capture elements with width or height of zero.

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_session_replay
 description: "Support for Flutter Session Replay in Datadog"
-version: 1.0.0-preview.7
+version: 1.0.0-preview.8
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

Changes associated with shipping `datadog_session_replay` `preview.7`.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
