### PR TITLE
feat: Support background isolate tracking.

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -100,11 +100,11 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler, RumSessionListener {
     override fun onMethodCall(call: MethodCall, result: Result) {
         if (call.method == "enable") {
             enable(call, result)
-            return;
+            return
         }
 
         if (!ensureRumEnabled(call, result)) {
-            return;
+            return
         }
 
         try {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -91,10 +91,6 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler, RumSessionListener {
         channel.setMethodCallHandler(this)
 
         binding = flutterPluginBinding
-
-        if (GlobalRumMonitor.isRegistered()) {
-            rum = GlobalRumMonitor.get()
-        }
     }
 
     fun detachFromEngine() {
@@ -102,16 +98,17 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler, RumSessionListener {
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
-        if (call.method != "enable" && rum == null) {
-            result.invalidOperation(
-                "Attempting to call ${call.method} on RUM when it has not been enabled"
-            )
-            return
+        if (call.method == "enable") {
+            enable(call, result)
+            return;
+        }
+
+        if (!ensureRumEnabled(call, result)) {
+            return;
         }
 
         try {
             when (call.method) {
-                "enable" -> enable(call, result)
                 "deinitialize" -> deinitialize(call, result)
                 "getCurrentSessionId" -> getCurrentSessionId(call, result)
                 "startView" -> startView(call, result)
@@ -145,6 +142,22 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler, RumSessionListener {
                 )
             )
         }
+    }
+
+    private fun ensureRumEnabled(call: MethodCall, result: Result): Boolean {
+        // Because multiple Flutter Engines, Flutter Isolates, and Hybrid applications
+        // can initialize RUM in any order, we check to see if RUM already exists on every
+        // call and associate it properly if it does.
+        if (rum == null) {
+            if (GlobalRumMonitor.isRegistered()) {
+                rum = GlobalRumMonitor.get()
+            } else {
+                result.invalidOperation(
+                    "Attempting to call ${call.method} on RUM when it has not been enabled"
+                )
+            }
+        }
+        return rum != null
     }
 
     override fun onSessionStarted(sessionId: String, isDiscarded: Boolean) {
@@ -213,10 +226,6 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler, RumSessionListener {
                 result.success(sessionId)
             }
         }
-    }
-
-    fun attachToExistingSdk(monitor: RumMonitor) {
-        rum = monitor
     }
 
     private fun mapTelemetryConfiguration(

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogSdkPlugin.kt
@@ -295,9 +295,6 @@ class DatadogSdkPlugin : FlutterPlugin, MethodCallHandler {
     private fun attachToExisting(): Map<String, Any> {
         val loggingEnabled = Logs.isEnabled()
         val rumEnabled = GlobalRumMonitor.isRegistered()
-        if (rumEnabled) {
-            rumPlugin.attachToExistingSdk(GlobalRumMonitor.get())
-        }
 
         return mapOf<String, Any>(
             "loggingEnabled" to loggingEnabled,

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -10,6 +10,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import com.datadog.android.Datadog
+import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumConfiguration
@@ -36,7 +37,6 @@ import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
@@ -62,6 +62,7 @@ class DatadogRumPluginTest {
         DatadogRumPlugin.resetConfig();
         unmockkStatic(Log::class)
         unmockkStatic(Rum::class)
+        unmockkStatic(GlobalRumMonitor::class)
     }
 
     @Test
@@ -221,6 +222,9 @@ class DatadogRumPluginTest {
     @Test
     fun `M return invalidOperation W method called { !enabled }`() {
         //GIVEN
+        mockkStatic(GlobalRumMonitor::class)
+        every { GlobalRumMonitor.isRegistered(any()) } returns false
+
         val plugin = DatadogRumPlugin()
         val call = MethodCall(
             "startView",

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ReflectUtils.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/ReflectUtils.kt
@@ -25,7 +25,7 @@ fun <T : Any> T.invokeMethod(
         params[it]?.javaClass
     }
 
-    val method = getDeclaredMethodRecursively(methodName, true, declarationParams)
+    val method = getDeclaredMethodRecursively(methodName, false, declarationParams)
     val wasAccessible = method.isAccessible
 
     val output: Any?

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/isolate_tracking_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/isolate_tracking_test.dart
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('test background isolate scenario', (WidgetTester tester) async {
+    var recordedSession = await openTestScenario(
+      tester,
+      menuTitle: 'Isolate Tracking Scenario',
+    );
+
+    var requestLog = <RequestLog>[];
+    var rumLog = <RumEventDecoder>[];
+    var logLog = <LogDecoder>[];
+    await recordedSession.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        requestLog.addAll(requests);
+        for (var e in requests) {
+          final asLogs = e.asLogs();
+          if (asLogs != null && asLogs.isNotEmpty) {
+            logLog.addAll(asLogs);
+          } else {
+            e.data.split('\n').forEach((e) {
+              dynamic jsonValue = json.decode(e);
+              if (jsonValue is Map<String, Object?>) {
+                final rumEvent = RumEventDecoder.fromJson(jsonValue);
+                if (rumEvent != null) {
+                  rumLog.add(rumEvent);
+                }
+              }
+            });
+          }
+        }
+        final rumSession = RumSessionDecoder.fromEvents(rumLog);
+        return logLog.length >= 2 &&
+            rumSession.visits.length == 1 &&
+            rumSession.visits[0].resourceEvents.isNotEmpty &&
+            rumSession.visits[0].errorEvents.isNotEmpty;
+      },
+    );
+
+    final firstLog = logLog[0];
+    expect(firstLog.status, 'info');
+    expect(firstLog.message, 'Message from background isolate!');
+
+    final secondLog = logLog[1];
+    expect(secondLog.status, 'warn');
+    expect(secondLog.message, 'Finished with background isolate!');
+
+    final session = RumSessionDecoder.fromEvents(rumLog);
+    final view1 = session.visits[0];
+
+    final manualResourceEvents = view1.resourceEvents
+        .where((e) => e.url == 'https://fake_url/resource/1')
+        .toList();
+    expect(manualResourceEvents.length, 1);
+    expect(manualResourceEvents[0].statusCode, 200);
+    expect(manualResourceEvents[0].resourceType, 'image');
+    final resourceDuration = manualResourceEvents[0].duration;
+    expect(resourceDuration,
+        greaterThan(const Duration(milliseconds: 90).inNanoseconds - 1));
+    expect(
+        resourceDuration, lessThan(const Duration(seconds: 10).inNanoseconds));
+
+    expect(view1.errorEvents.length, 1);
+    expect(view1.errorEvents[0].resourceUrl, 'https://fake_url/resource/2');
+    expect(view1.errorEvents[0].message, 'Status code 400');
+    expect(view1.errorEvents[0].errorType, 'ErrorLoading');
+    expect(view1.errorEvents[0].source, 'network');
+  });
+}
+
+// MARK - Utilities
+
+class _BecameInactiveMatcher extends Matcher {
+  const _BecameInactiveMatcher();
+
+  @override
+  Description describe(Description description) {
+    return description.add('was a view that eventually became inactive');
+  }
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
+    if (item is RumViewVisit) {
+      return item.viewEvents.last.view.isActive == false;
+    }
+    return false;
+  }
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/isolate_tracking_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/isolate_tracking_test.dart
@@ -80,22 +80,3 @@ void main() {
     expect(view1.errorEvents[0].source, 'network');
   });
 }
-
-// MARK - Utilities
-
-class _BecameInactiveMatcher extends Matcher {
-  const _BecameInactiveMatcher();
-
-  @override
-  Description describe(Description description) {
-    return description.add('was a view that eventually became inactive');
-  }
-
-  @override
-  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
-    if (item is RumViewVisit) {
-      return item.viewEvents.last.view.isActive == false;
-    }
-    return false;
-  }
-}

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/integration_scenarios_screen.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../auto_integration_scenarios/rum_auto_instrumentation_scenario.dart';
+import 'isolate_tracking_scenario.dart';
 import 'kiosk_integration_scenario.dart';
 import 'logging_scenario.dart';
 import 'logging_user_account_scenario.dart';
@@ -50,7 +51,10 @@ class _IntegrationScenariosScreenState
     ScenarioItem(
       label: 'Kiosk RUM Scenario',
       navItem: KioskIntegrationScenario.new,
-    )
+    ),
+    ScenarioItem(
+        label: 'Isolate Tracking Scenario',
+        navItem: IsolateTrackingScenario.new)
   ];
 
   @override

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/isolate_tracking_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/isolate_tracking_scenario.dart
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:isolate';
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:flutter/material.dart';
+
+import '../main.dart';
+
+const fakeRootUrl = 'https://fake_url';
+
+class IsolateTrackingScenario extends StatefulWidget {
+  const IsolateTrackingScenario({super.key});
+
+  @override
+  State<IsolateTrackingScenario> createState() =>
+      _IsolateTrackingScenarioState();
+}
+
+class _IsolateTrackingScenarioState extends State<IsolateTrackingScenario>
+    implements RouteAware {
+  static const String _viewKey = 'IsolateTrackingScenario';
+
+  String _statusText = 'Creating An Isolate';
+
+  final _receivePort = ReceivePort();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void didPop() {
+    DatadogSdk.instance.rum?.stopView(_viewKey);
+  }
+
+  @override
+  void didPopNext() {
+    DatadogSdk.instance.rum?.startView(_viewKey);
+  }
+
+  @override
+  void didPush() {
+    DatadogSdk.instance.rum?.startView(_viewKey);
+    _spawnIsolate();
+  }
+
+  @override
+  void didPushNext() {
+    DatadogSdk.instance.rum?.stopView(_viewKey);
+  }
+
+  Future<void> _spawnIsolate() async {
+    _receivePort.listen((message) {
+      if (message is String) {
+        setState(() {
+          _statusText = message;
+        });
+      }
+    });
+    await Isolate.spawn(_backgroundWork, _receivePort.sendPort);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Background Isolate Tracking'),
+      ),
+      body: Padding(
+        padding: const EdgeInsetsGeometry.all(12),
+        child: Column(children: [
+          Text(_statusText),
+        ]),
+      ),
+    );
+  }
+}
+
+void _backgroundWork(SendPort port) async {
+  await DatadogSdk.instance.attachToBackgroundIsolate();
+
+  port.send('Sending log messages');
+
+  final logger =
+      DatadogSdk.instance.logs?.createLogger(DatadogLoggerConfiguration());
+  logger?.info('Message from background isolate!');
+
+  port.send('Fake Downloading resources');
+  final rum = DatadogSdk.instance.rum;
+
+  rum?.addTiming('first-interaction');
+  rum?.addAction(RumActionType.tap, 'Tapped Download');
+
+  var simulatedResourceKey1 = '/resource/1';
+  var simulatedResourceKey2 = '/resource/2';
+
+  rum?.startResource(simulatedResourceKey1, RumHttpMethod.get,
+      '$fakeRootUrl$simulatedResourceKey1');
+  rum?.startResource(simulatedResourceKey2, RumHttpMethod.get,
+      '$fakeRootUrl$simulatedResourceKey2');
+
+  await Future<void>.delayed(const Duration(milliseconds: 100));
+  rum?.stopResource(simulatedResourceKey1, 200, RumResourceType.image);
+  rum?.stopResourceWithErrorInfo(
+      simulatedResourceKey2, 'Status code 400', 'ErrorLoading');
+
+  logger?.warn('Finished with background isolate!');
+
+  port.send('Done!');
+}

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogRumPlugin.swift
@@ -92,7 +92,13 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        if call.method != "enable" && rum == nil {
+        if call.method == "enable" {
+            enable(arguments: arguments, call: call)
+            result(nil)
+            return
+        }
+
+        if !ensureRumEnabled() {
             result(
                 FlutterError.invalidOperation(
                     message: "Attempting to call RUM method (\(call.method)) when RUM has not been enabled."
@@ -102,10 +108,6 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         }
 
         switch call.method {
-        case "enable":
-            enable(arguments: arguments, call: call)
-            result(nil)
-
         case "deinitialize":
             deinitialize(arguments: arguments, call: call)
             result(nil)
@@ -342,9 +344,16 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    internal func attachToExisting(rumInstance: RUMMonitorProtocol) {
-        rum = rumInstance
+    private func ensureRumEnabled() -> Bool {
+        if rum == nil {
+            if RUM._internal.isEnabled() {
+                rum = RUMMonitor.shared()
+            }
+        }
+
+        return rum != nil
     }
+
 
     private func enable(arguments: [String: Any?], call: FlutterMethodCall) {
         let configArg = arguments["configuration"] as? [String: Any?]

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/DatadogSdkPlugin.swift
@@ -386,7 +386,6 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
         }
 
         if RUM._internal.isEnabled() {
-            DatadogRumPlugin.instance.attachToExisting(rumInstance: RUMMonitor.shared())
             rumEnabled = true
         }
 

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -194,6 +194,47 @@ class DatadogSdk {
     _initialized = true;
   }
 
+  /// Attach an initialized Datadog Flutter SDK the currently active background isolate.
+  ///
+  /// Datadog must already be initialized in the root isolate for [attachToBackgroundIsolate]
+  /// to work properly.
+  Future<void> attachToBackgroundIsolate() async {
+    try {
+      final attachResponse = await platform.attachToIsolate();
+      if (attachResponse == null) {
+        internalLogger.warn(
+          'Could not attach to background isolate. Did not recieve a configuration from the main isolate.'
+          ' You are either trying to attach on a platform that does not support isolates, or trying to attach before Datadog initialization is complete.',
+        );
+      } else {
+        _setFirstPartyHosts(
+          attachResponse.capturedConfiguration.firstPartyHosts,
+        );
+        if (attachResponse.capturedConfiguration.loggingEnabled) {
+          _logs = DatadogLogging(this);
+        }
+
+        if (attachResponse.capturedConfiguration.rumEnabled) {
+          _rum = DatadogRum.forBackgroundIsolate(
+            this,
+            attachResponse.capturedConfiguration.traceSampleRate ?? 100.0,
+            attachResponse.capturedConfiguration.traceContextInjection ??
+                TraceContextInjection.sampled,
+          );
+        }
+      }
+    } catch (e, st) {
+      internalLogger.sendToDatadog(
+        'Failed to attach background isolate: $e',
+        st,
+        e.runtimeType.toString(),
+      );
+      internalLogger.warn(
+        'Encountered an error attempting to attach to a background isolate: $e',
+      );
+    }
+  }
+
   /// Attach the Datadog Flutter SDK to an already initialized Datadog Native
   /// (iOS or Android) SDK.  This is used for "app in app" embedding of Flutter.
   Future<void> attachToExisting(DatadogAttachConfiguration config) async {
@@ -205,7 +246,7 @@ class DatadogSdk {
       internalLogger,
       null,
       () async {
-        return await _platform.attachToExisting();
+        return await _platform.attachToExisting(config);
       },
     );
 

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin_web.dart
@@ -165,7 +165,9 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   }
 
   @override
-  Future<AttachResponse?> attachToExisting() async {
+  Future<AttachResponse?> attachToExisting(
+    DatadogAttachConfiguration attachConfig,
+  ) async {
     return null;
   }
 
@@ -194,5 +196,10 @@ class DatadogSdkWeb extends DatadogSdkPlatform {
   @override
   Future<void> clearAllData() async {
     // Not currently supported
+  }
+
+  @override
+  Future<IsolateAttachResponse?> attachToIsolate() async {
+    return null;
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_noop_platform.dart
@@ -15,7 +15,9 @@ class DatadogSdkNoOpPlatform extends DatadogSdkPlatform {
   }
 
   @override
-  Future<AttachResponse?> attachToExisting() async {
+  Future<AttachResponse?> attachToExisting(
+    DatadogAttachConfiguration attachConfig,
+  ) async {
     return AttachResponse(loggingEnabled: false, rumEnabled: false);
   }
 
@@ -96,5 +98,10 @@ class DatadogSdkNoOpPlatform extends DatadogSdkPlatform {
     Map<String, Object?> extraInfo,
   ) {
     return Future.value();
+  }
+
+  @override
+  Future<IsolateAttachResponse?> attachToIsolate() {
+    return Future.value(null);
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -2,7 +2,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
+import 'dart:async';
 import 'dart:io';
+import 'dart:isolate';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -13,7 +16,27 @@ import 'android/android_plugin_stub.dart'
 import 'datadog_sdk_platform_interface.dart';
 import 'internal_logger.dart';
 
+@immutable
+class _IsolateAttachRequest {
+  final SendPort sendPort;
+
+  const _IsolateAttachRequest({required this.sendPort});
+}
+
+class DatadogCommunicationError extends Error {
+  final Object unknownMessage;
+  DatadogCommunicationError(this.unknownMessage);
+
+  @override
+  String toString() {
+    return 'Uknown object sent in internal communicaiton: $unknownMessage';
+  }
+}
+
 class DatadogSdkMethodChannel extends DatadogSdkPlatform {
+  static const String globalCommunicationPortName =
+      'datadog.global.isolate.port';
+
   @visibleForTesting
   final methodChannel = const MethodChannel('datadog_sdk_flutter');
 
@@ -29,6 +52,37 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       return AndroidDatadogFlutterPlugin.getContext();
     }
     return null;
+  }
+
+  final ReceivePort _globalRecievePort = ReceivePort(
+    'Datadog Isolate Communication Port',
+  );
+
+  @override
+  Future<IsolateAttachResponse?> attachToIsolate() {
+    // Grab the main instance's send port
+    final sendPort = IsolateNameServer.lookupPortByName(
+      globalCommunicationPortName,
+    );
+    if (sendPort != null) {
+      final completer = Completer<IsolateAttachResponse>();
+      // Listen on my receive port for a response
+      _globalRecievePort.first.then((response) {
+        if (response is IsolateAttachResponse) {
+          BackgroundIsolateBinaryMessenger.ensureInitialized(
+            response.rootIsolateToken,
+          );
+          completer.complete(response);
+        } else {
+          completer.completeError(DatadogCommunicationError(response));
+        }
+      });
+      sendPort.send(
+        _IsolateAttachRequest(sendPort: _globalRecievePort.sendPort),
+      );
+      return completer.future;
+    }
+    return Future.value(null);
   }
 
   @override
@@ -130,11 +184,24 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       'setLogCallback': logCallback != null,
     });
 
+    _initIsolateCommunication(
+      CapturedConfiguration(
+        loggingEnabled: configuration.loggingConfiguration != null,
+        rumEnabled: configuration.rumConfiguration != null,
+        traceSampleRate: configuration.rumConfiguration?.traceSampleRate,
+        traceContextInjection:
+            configuration.rumConfiguration?.traceContextInjection,
+        firstPartyHosts: configuration.firstPartyHostsWithTracingHeaders,
+      ),
+    );
+
     return const PlatformInitializationResult(logs: true, rum: true);
   }
 
   @override
-  Future<AttachResponse?> attachToExisting() async {
+  Future<AttachResponse?> attachToExisting(
+    DatadogAttachConfiguration attachConfig,
+  ) async {
     final channelResponse = await methodChannel
         .invokeMapMethod<String, Object?>(
           'attachToExisting',
@@ -144,6 +211,17 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
     AttachResponse? response;
     if (channelResponse != null) {
       response = AttachResponse.decode(channelResponse);
+      if (response != null) {
+        _initIsolateCommunication(
+          CapturedConfiguration(
+            loggingEnabled: response.loggingEnabled,
+            rumEnabled: response.rumEnabled,
+            traceSampleRate: attachConfig.traceSampleRate,
+            traceContextInjection: attachConfig.traceContextInjection,
+            firstPartyHosts: attachConfig.firstPartyHostsWithTracingHeaders,
+          ),
+        );
+      }
     }
     return response;
   }
@@ -185,6 +263,27 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
 
   Future<Object?> getInternalVar(String name) {
     return methodChannel.invokeMethod('getInternalVar', {'name': name});
+  }
+
+  void _initIsolateCommunication(CapturedConfiguration capturedConfiguration) {
+    // If the RootIsolateToken is null, we were started on a background isolate... somehow
+    final rootIsolateToken = RootIsolateToken.instance;
+    if (rootIsolateToken == null) return;
+
+    IsolateNameServer.registerPortWithName(
+      _globalRecievePort.sendPort,
+      globalCommunicationPortName,
+    );
+    _globalRecievePort.listen((message) {
+      if (message is _IsolateAttachRequest) {
+        message.sendPort.send(
+          IsolateAttachResponse(
+            rootIsolateToken: rootIsolateToken,
+            capturedConfiguration: capturedConfiguration,
+          ),
+        );
+      }
+    });
   }
 
   Future<dynamic> handleMethodCall(MethodCall call) async {

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -2,20 +2,26 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-Present Datadog, Inc.
 
+import 'dart:ui';
+
 import 'package:meta/meta.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '../datadog_flutter_plugin.dart';
+import '../datadog_internal.dart';
 import 'datadog_sdk_method_channel.dart';
-import 'internal_logger.dart';
 
 typedef LogCallback = void Function(String line);
 
+@immutable
 class AttachResponse {
   final bool loggingEnabled;
   final bool rumEnabled;
 
-  AttachResponse({required this.loggingEnabled, required this.rumEnabled});
+  const AttachResponse({
+    required this.loggingEnabled,
+    required this.rumEnabled,
+  });
 
   static AttachResponse? decode(Map<String, Object?> json) {
     try {
@@ -33,6 +39,34 @@ class AttachResponse {
 
     return null;
   }
+}
+
+@immutable
+class CapturedConfiguration {
+  final bool loggingEnabled;
+  final bool rumEnabled;
+  final double? traceSampleRate;
+  final TraceContextInjection? traceContextInjection;
+  final Map<String, Set<TracingHeaderType>> firstPartyHosts;
+
+  const CapturedConfiguration({
+    required this.loggingEnabled,
+    required this.rumEnabled,
+    required this.traceSampleRate,
+    required this.traceContextInjection,
+    required this.firstPartyHosts,
+  });
+}
+
+@immutable
+class IsolateAttachResponse {
+  final RootIsolateToken rootIsolateToken;
+  final CapturedConfiguration capturedConfiguration;
+
+  const IsolateAttachResponse({
+    required this.rootIsolateToken,
+    required this.capturedConfiguration,
+  });
 }
 
 /// Result from initializing the platform. Individual members are set to `false`
@@ -69,6 +103,7 @@ abstract class DatadogSdkPlatform extends PlatformInterface {
   }
 
   DatadogContext? get cachedContext;
+  Future<IsolateAttachResponse?> attachToIsolate();
 
   Future<void> setSdkVerbosity(CoreLoggerLevel verbosity);
   Future<void> setTrackingConsent(TrackingConsent trackingConsent);
@@ -98,7 +133,9 @@ abstract class DatadogSdkPlatform extends PlatformInterface {
     LogCallback? logCallback,
     required InternalLogger internalLogger,
   });
-  Future<AttachResponse?> attachToExisting();
+  Future<AttachResponse?> attachToExisting(
+    DatadogAttachConfiguration attachConfig,
+  );
   Future<void> flushAndDeinitialize();
   Future<void> clearAllData();
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -161,6 +161,21 @@ class DatadogRum {
     );
   }
 
+  @internal
+  DatadogRum.forBackgroundIsolate(
+    DatadogSdk core,
+    this.traceSampleRate,
+    this.traceContextInjection,
+  ) : _maxSampledTraceId = _getMaxTraceId(traceSampleRate),
+      logger = core.internalLogger {
+    _init(
+      core: core,
+      detectLongTasks: false,
+      longTaskThreshold: 0.0,
+      reportFlutterPerformance: false,
+    );
+  }
+
   DatadogRum._(DatadogSdk core, DatadogRumConfiguration configuration)
     : traceSampleRate = configuration.traceSampleRate,
       _maxSampledTraceId = _getMaxTraceId(configuration.traceSampleRate),

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_method_channel_test.dart
@@ -98,7 +98,9 @@ void main() {
     () async {
       // The mock method channel is already set up to return null, so this should
       // just pass it through.
-      final response = await ddSdkPlatform.attachToExisting();
+      final response = await ddSdkPlatform.attachToExisting(
+        DatadogAttachConfiguration(),
+      );
 
       expect(response, isNull);
     },
@@ -118,7 +120,9 @@ void main() {
 
           return null;
         });
-    final response = await ddSdkPlatform.attachToExisting();
+    final response = await ddSdkPlatform.attachToExisting(
+      DatadogAttachConfiguration(),
+    );
 
     expect(response, isNotNull);
     if (response != null) {
@@ -137,7 +141,9 @@ void main() {
 
           return null;
         });
-    final response = await ddSdkPlatform.attachToExisting();
+    final response = await ddSdkPlatform.attachToExisting(
+      DatadogAttachConfiguration(),
+    );
 
     expect(response, isNull);
   });

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -40,6 +40,7 @@ void main() {
     registerFallbackValue(FakeDatadogConfiguration());
     registerFallbackValue(DatadogLoggingConfiguration());
     registerFallbackValue(DatadogLoggerConfiguration());
+    registerFallbackValue(DatadogAttachConfiguration());
     registerFallbackValue(LateConfigurationProperty.trackErrors);
     registerFallbackValue(InternalLogger());
     registerFallbackValue(CoreLoggerLevel.error);

--- a/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -61,7 +61,7 @@ void main() {
         const PlatformInitializationResult(logs: true, rum: true),
       ),
     );
-    when(() => mockPlatform.attachToExisting()).thenAnswer(
+    when(() => mockPlatform.attachToExisting(any())).thenAnswer(
       (_) => Future<AttachResponse?>.value(
         AttachResponse(loggingEnabled: false, rumEnabled: false),
       ),
@@ -282,7 +282,7 @@ void main() {
   test('attachToExisting calls out to platform', () async {
     await datadogSdk.attachToExisting(DatadogAttachConfiguration());
 
-    verify(() => mockPlatform.attachToExisting());
+    verify(() => mockPlatform.attachToExisting(any()));
     expect(datadogSdk.logs, isNull);
     expect(datadogSdk.rum, isNull);
   });
@@ -308,7 +308,7 @@ void main() {
   });
 
   test('attachToExisting with loggingEnabled creates Logging bridge', () async {
-    when(() => mockPlatform.attachToExisting()).thenAnswer(
+    when(() => mockPlatform.attachToExisting(any())).thenAnswer(
       (invocation) => Future<AttachResponse?>.value(
         AttachResponse(loggingEnabled: true, rumEnabled: false),
       ),
@@ -321,7 +321,7 @@ void main() {
   });
 
   test('attachToExisting with rumEnabled creates RUM bridge', () async {
-    when(() => mockPlatform.attachToExisting()).thenAnswer(
+    when(() => mockPlatform.attachToExisting(any())).thenAnswer(
       (invocation) => Future<AttachResponse?>.value(
         AttachResponse(loggingEnabled: false, rumEnabled: true),
       ),
@@ -334,7 +334,7 @@ void main() {
   });
 
   test('attachToExisting with rumEnabled forwards RUM parameters', () async {
-    when(() => mockPlatform.attachToExisting()).thenAnswer(
+    when(() => mockPlatform.attachToExisting(any())).thenAnswer(
       (invocation) => Future<AttachResponse?>.value(
         AttachResponse(loggingEnabled: false, rumEnabled: true),
       ),
@@ -694,7 +694,7 @@ void main() {
   test(
     'plugin added to configuration is created during attachToExisting',
     () async {
-      when(() => mockPlatform.attachToExisting()).thenAnswer(
+      when(() => mockPlatform.attachToExisting(any())).thenAnswer(
         (invocation) => Future<AttachResponse?>.value(
           AttachResponse(loggingEnabled: false, rumEnabled: false),
         ),

--- a/tools/ci/bin/web_integration_tests.dart
+++ b/tools/ci/bin/web_integration_tests.dart
@@ -26,6 +26,8 @@ const fileExclude = [
   'tracing_id_helpers.dart',
   // Web does not support dart:io clients
   'tracking_http_client_test.dart',
+  // Web does not support isolates
+  'isolate_tracking_test.dart',
 ];
 
 const testDriver = 'test_driver/integration_test.dart';


### PR DESCRIPTION
### What and why?

Added a method `attachToBackgroundIsolate` which allows the DatadogSdk to begin tracking information from background isolates. In order to support RUM tracking, certain configuration variables need to be passed to the background isolate, along with the `rootIsolateToken`.

Additionally, this PR lazily pulls any already enabled RUM instance, which should prevent, or mitigate, issues with multiple Flutter engines and potential initialization order issues between those engines.

refs: RUM-491 #869 #828 #580

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
