### PR TITLE
fix(sr): Prevent a deadlock when fetching context.

### DIFF
--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
@@ -7,6 +7,8 @@
 package com.datadoghq.flutter.sessionreplay.feature
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureContextUpdateReceiver
 import com.datadog.android.api.feature.FeatureEventReceiver
@@ -88,10 +90,12 @@ internal class DefaultFlutterSessionReplayFeature(
     override fun onReceive(event: Any) {
     }
 
-    override fun onContextUpdate(featureName: String, event: Map<String, Any?>) {
+    override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
         if (featureName == Feature.RUM_FEATURE_NAME) {
-            val context = RumContext(event)
-            onContextChanged(context)
+            val rumContext = RumContext(context)
+            Handler(Looper.getMainLooper()).post {
+                onContextChanged(rumContext)
+            }
         }
     }
 

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
@@ -34,7 +34,8 @@ internal interface FlutterSessionReplayFeature : StorageBackedFeature {
 internal class DefaultFlutterSessionReplayFeature(
     private val sdkCore: FeatureSdkCore,
     private val onContextChanged: (RumContext) -> Unit,
-    private val customEndpointUrl: String?
+    private val customEndpointUrl: String?,
+    private val mainThreadHandler: Handler = Handler(Looper.getMainLooper())
 ) : FlutterSessionReplayFeature,
     StorageBackedFeature,
     FeatureEventReceiver,
@@ -93,7 +94,7 @@ internal class DefaultFlutterSessionReplayFeature(
     override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
         if (featureName == Feature.RUM_FEATURE_NAME) {
             val rumContext = RumContext(context)
-            Handler(Looper.getMainLooper()).post {
+            mainThreadHandler.post {
                 onContextChanged(rumContext)
             }
         }

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridgeTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridgeTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadoghq.flutter.sessionreplay
 
+import android.os.Looper
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
@@ -19,9 +20,14 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import java.nio.ByteBuffer
 import kotlin.test.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 
 internal fun FlutterSessionReplayBridge.enableWithMock(
@@ -31,7 +37,20 @@ internal fun FlutterSessionReplayBridge.enableWithMock(
 }
 
 @ExtendWith(ForgeExtension::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FlutterSessionReplayBridgeTest {
+    @BeforeAll
+    fun beforeAll() {
+        val mockLooper = mockk<Looper>()
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() }.returns(mockLooper)
+    }
+
+    @AfterAll
+    fun afterAll() {
+        unmockkStatic(Looper::class)
+    }
+
     @Test
     fun `M register the feature W enable`() {
         // Given

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/feature/DefaultFlutterSessionReplayFeatureTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/feature/DefaultFlutterSessionReplayFeatureTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadoghq.flutter.sessionreplay.feature
 
+import android.os.Handler
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
@@ -20,12 +21,25 @@ import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ForgeExtension::class)
 internal class DefaultFlutterSessionReplayFeatureTest {
     var mockCore: FeatureSdkCore = mockk(relaxed = true)
+    val mockHandler: Handler = mockk()
+
+    @BeforeEach
+    fun beforeAll() {
+        every {
+            mockHandler.post(any())
+        }.answers {
+            val runnable = arg<Runnable>(0)
+            runnable.run()
+            true
+        }
+    }
 
     @Test
     fun `M call context changed callback W onContextUpdate`(
@@ -42,7 +56,8 @@ internal class DefaultFlutterSessionReplayFeatureTest {
         val feature = DefaultFlutterSessionReplayFeature(
             mockCore,
             onContextChanged,
-            customEndpoint
+            customEndpoint,
+            mockHandler
         )
         val contextValue = mapOf(
             "application_id" to applicationId,
@@ -54,7 +69,7 @@ internal class DefaultFlutterSessionReplayFeatureTest {
         // When
         feature.onContextUpdate(Feature.RUM_FEATURE_NAME, contextValue)
 
-        // Then - note the transform of property names
+        // Then - verify on the back of the Looper. Note the transform of property names
         val expectedContextValue = DefaultFlutterSessionReplayFeature.RumContext(
             applicationId,
             sessionId,
@@ -77,7 +92,8 @@ internal class DefaultFlutterSessionReplayFeatureTest {
         val feature = DefaultFlutterSessionReplayFeature(
             mockCore,
             onContextChanged,
-            customEndpoint
+            customEndpoint,
+            mockHandler
         )
         var context = mutableMapOf<String, Any?>()
         every { mockCore.updateFeatureContext(any(), any(), captureLambda()) } answers {
@@ -113,7 +129,8 @@ internal class DefaultFlutterSessionReplayFeatureTest {
         val feature = DefaultFlutterSessionReplayFeature(
             mockCore,
             onContextChanged,
-            customEndpoint
+            customEndpoint,
+            mockHandler
         )
         var context = mutableMapOf<String, Any?>()
         every { mockCore.updateFeatureContext(any(), any(), captureLambda()) } answers {

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/forge/DatadogContextForgeryFactory.kt
@@ -29,6 +29,7 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),
+            versionCode = forge.anInt(),
             variant = forge.anAlphabeticalString(),
             env = forge.anAlphabeticalString().lowercase(Locale.US),
             source = forge.anAlphabeticalString(),


### PR DESCRIPTION
### What and why?

Session replay could cause a deadlock when RUM posted its context changes if Flutter was attempting to read context at the same time, as they would create contention on the main isolate.

Fix this by requiring RUM context changes to be pushed to the main isolate.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
