### PR TITLE
feat(web): Support additional web only configuration options

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -16,7 +16,7 @@ enum BatchSize {
   medium,
 
   /// Prefer large sized data batches.
-  large
+  large,
 }
 
 /// Defines the frequency at which Datadog SDK will try to upload data batches.
@@ -28,7 +28,7 @@ enum UploadFrequency {
   average,
 
   /// Try to upload batched data rarely.
-  rare
+  rare,
 }
 
 /// Defines the maximum amount of batches processed sequentially without a delay
@@ -66,7 +66,7 @@ enum TrackingConsent {
   /// and will be pending there until [TrackingConsent.granted] or
   /// [TrackingConsent.notGranted] consent value is set. Based on the next
   /// consent value, intermediate data will be sent to Datadog or deleted.
-  pending
+  pending,
 }
 
 /// Determines the server for uploading RUM events.
@@ -110,6 +110,15 @@ enum TraceContextInjection {
   sampled,
 }
 
+/// Which storage strategy to use when persisting sessions on Web.
+enum WebSessionPersistence {
+  /// Use cookies to persist sessions.
+  cookie,
+
+  /// Use local storge to persist sessions.
+  localStorage,
+}
+
 class DatadogConfiguration {
   // Either a RUM client token (generated for the RUM Application) or a regular
   // client token for Logging and APM. Obtained on the Datadog website.
@@ -139,6 +148,35 @@ class DatadogConfiguration {
 
   /// Sets the level of batch processing
   BatchProcessingLevel? batchProcessingLevel;
+
+  /// [Web Only] Which storage strategy to use for persisting sessions.
+  ///
+  /// Defaults to [WebSessionPersistence.cookie].
+  WebSessionPersistence? sessionPersistence;
+
+  /// [Web Only] Store global context and user context in local storage to
+  /// preserve them along the user navigation.
+  ///
+  /// Defaults to false.
+  bool? storeContextAcrossPages;
+
+  /// [Web Only] Whether to preserve sessions across subdomains of the same site.
+  ///
+  /// Defaults to false.
+  bool? trackSessionsAcrossSubdomains;
+
+  /// [Web Only] Whether to use a secure session cookie. This disables RUM
+  /// events sent on insecure (non-HTTPS) connections.
+  ///
+  /// Defaults to false.
+  bool? useSecureSessionCookie;
+
+  /// [Web Only] Use a partitioned secure cross-site session cookie. This allows
+  /// the RUM Browser SDK to run when the site is loaded from another one
+  /// (iframe). Implies useSecureSessionCookie.
+  ///
+  /// Defaults to false.
+  bool? usePartitionedCrossSiteSessionCookie;
 
   /// Sets the current version number of the application.
   ///
@@ -192,7 +230,7 @@ class DatadogConfiguration {
     for (var entry in hosts) {
       firstPartyHostsWithTracingHeaders[entry] = {
         TracingHeaderType.datadog,
-        TracingHeaderType.tracecontext
+        TracingHeaderType.tracecontext,
       };
     }
   }
@@ -238,6 +276,10 @@ class DatadogConfiguration {
     this.batchProcessingLevel,
     this.version,
     this.flavor,
+    this.sessionPersistence,
+    this.trackSessionsAcrossSubdomains,
+    this.useSecureSessionCookie,
+    this.usePartitionedCrossSiteSessionCookie,
     List<String>? firstPartyHosts,
     this.firstPartyHostsWithTracingHeaders = const {},
     this.loggingConfiguration,
@@ -248,7 +290,8 @@ class DatadogConfiguration {
       // make map mutable in case it's the default
       firstPartyHostsWithTracingHeaders =
           Map<String, Set<TracingHeaderType>>.from(
-              firstPartyHostsWithTracingHeaders);
+            firstPartyHostsWithTracingHeaders,
+          );
 
       for (var entry in firstPartyHosts) {
         final headerTypes = firstPartyHostsWithTracingHeaders[entry];
@@ -352,7 +395,7 @@ class DatadogAttachConfiguration {
     for (var entry in hosts) {
       firstPartyHostsWithTracingHeaders[entry] = {
         TracingHeaderType.datadog,
-        TracingHeaderType.tracecontext
+        TracingHeaderType.tracecontext,
       };
     }
   }
@@ -402,14 +445,15 @@ class DatadogAttachConfiguration {
       // make map mutable
       firstPartyHostsWithTracingHeaders =
           Map<String, Set<TracingHeaderType>>.from(
-              firstPartyHostsWithTracingHeaders);
+            firstPartyHostsWithTracingHeaders,
+          );
 
       for (var entry in firstPartyHosts) {
         final headerTypes = firstPartyHostsWithTracingHeaders[entry];
         if (headerTypes == null) {
           firstPartyHostsWithTracingHeaders[entry] = {
             TracingHeaderType.datadog,
-            TracingHeaderType.tracecontext
+            TracingHeaderType.tracecontext,
           };
         } else {
           headerTypes.add(TracingHeaderType.datadog);

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -26,12 +26,19 @@ class DdLogsWeb extends DdLogsPlatform {
         clientToken: configuration.clientToken,
         env: configuration.env,
         proxy: configuration.loggingConfiguration?.customEndpoint,
-        site: siteStringForSite(configuration.site),
+        sdkVersion: DatadogSdk.sdkVersion,
         service: configuration.service,
+        sessionPersistence: configuration.sessionPersistence?.webValue(),
+        site: siteStringForSite(configuration.site),
+        source: 'flutter',
+        storeContextsAcrossPages: configuration.storeContextAcrossPages,
+        trackSessionAcrossSubdomains:
+            configuration.trackSessionsAcrossSubdomains,
+        usePartitionedCrossSiteSessionCookie:
+            configuration.usePartitionedCrossSiteSessionCookie,
+        useSecureSessionCookie: configuration.useSecureSessionCookie,
         version: configuration.versionTag,
         variant: configuration.flavor,
-        sdkVersion: DatadogSdk.sdkVersion,
-        source: 'flutter',
         trackingConsent: trackingConsent.webValue(),
       ),
     );
@@ -174,28 +181,22 @@ String _toWebLogLevel(LogLevel level) {
 
 @anonymous
 extension type _LogInitOptions._(JSObject _) implements JSObject {
-  external String get clientToken;
-  external String get site;
-  external String get env;
-  external String? get proxy;
-  external String? get service;
-  external String? get version;
-  external String? get source;
-  external String? get sdkVersion;
-  external String? get variant;
-  external String? get trackingConsent;
-
   external factory _LogInitOptions({
     String clientToken,
-    String site,
     String env,
-    String? service,
     String? proxy,
-    String? version,
-    String? source,
     String? sdkVersion,
-    String? variant,
+    String? service,
+    String? sessionPersistence,
+    String site,
+    String? source,
+    bool? storeContextsAcrossPages,
     String? trackingConsent,
+    bool? trackSessionAcrossSubdomains,
+    bool? usePartitionedCrossSiteSessionCookie,
+    bool? useSecureSessionCookie,
+    String? variant,
+    String? version,
   });
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/logs/ddlogs_web.dart
@@ -28,10 +28,13 @@ class DdLogsWeb extends DdLogsPlatform {
         proxy: configuration.loggingConfiguration?.customEndpoint,
         sdkVersion: DatadogSdk.sdkVersion,
         service: configuration.service,
-        sessionPersistence: configuration.sessionPersistence?.webValue(),
+        sessionPersistence:
+            configuration.sessionPersistence?.webValue() ?? 'cookie',
         site: siteStringForSite(configuration.site),
         source: 'flutter',
         storeContextsAcrossPages: configuration.storeContextAcrossPages,
+        trackAnonymousUser:
+            configuration.rumConfiguration?.trackAnonymousUser ?? true,
         trackSessionAcrossSubdomains:
             configuration.trackSessionsAcrossSubdomains,
         usePartitionedCrossSiteSessionCookie:
@@ -191,6 +194,7 @@ extension type _LogInitOptions._(JSObject _) implements JSObject {
     String site,
     String? source,
     bool? storeContextsAcrossPages,
+    bool? trackAnonymousUser,
     String? trackingConsent,
     bool? trackSessionAcrossSubdomains,
     bool? usePartitionedCrossSiteSessionCookie,

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -16,7 +16,7 @@ enum VitalsFrequency {
   average,
 
   /// Collect mobile vitals every 1000ms.
-  rare
+  rare,
 }
 
 /// A function that allows you to modify specific [RumViewEvent]s before they
@@ -38,8 +38,8 @@ typedef RumActionEventMapper = RumActionEvent? Function(RumActionEvent event);
 ///
 /// The [RumResourceEventMapper] can modify any mutable (non-final) properties in the
 /// [RumResourceEvent]
-typedef RumResourceEventMapper = RumResourceEvent? Function(
-    RumResourceEvent event);
+typedef RumResourceEventMapper =
+    RumResourceEvent? Function(RumResourceEvent event);
 
 /// A function that allows you to modify or drop specific [RumErrorEvent]s before
 /// they are sent to Datadog.
@@ -53,8 +53,8 @@ typedef RumErrorEventMapper = RumErrorEvent? Function(RumErrorEvent event);
 ///
 /// The [RumLongTaskEvent] can modify any mutable (non-final) properties in the
 /// [RumLongTaskEvent]
-typedef RumLongTaskEventMapper = RumLongTaskEvent? Function(
-    RumLongTaskEvent event);
+typedef RumLongTaskEventMapper =
+    RumLongTaskEvent? Function(RumLongTaskEvent event);
 
 /// Configuration options for the Datadog Real User Monitoring (RUM) feature.
 class DatadogRumConfiguration {
@@ -234,9 +234,9 @@ class DatadogRumConfiguration {
     this.errorEventMapper,
     this.longTaskEventMapper,
     this.additionalConfig = const <String, Object>{},
-  })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
-        traceSampleRate = max(0, min(traceSampleRate, 100)),
-        longTaskThreshold = max(0.02, longTaskThreshold);
+  }) : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
+       traceSampleRate = max(0, min(traceSampleRate, 100)),
+       longTaskThreshold = max(0.02, longTaskThreshold);
 
   Map<String, Object?> encode() {
     return {

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -73,6 +73,8 @@ class DdRumWeb extends DdRumPlatform {
             ),
         ].toJS,
         traceSampleRate: rumConfiguration.traceSampleRate,
+        trackSessionAcrossSubdomains:
+            configuration.trackSessionsAcrossSubdomains,
         traceContextInjection: _contextInjectionString(
           rumConfiguration.traceContextInjection,
         ),
@@ -83,12 +85,15 @@ class DdRumWeb extends DdRumPlatform {
         trackLongTasks: rumConfiguration.detectLongTasks,
         enableExperimentalFeatures: ['feature_flags'.toJS].toJS,
         trackingConsent: trackingConsent.webValue(),
-        // TODO(RUM-11211): Support and document web configuration options.
         compressIntakeRequests: false,
         plugins: plugins,
         variant: configuration.flavor,
         source: 'flutter',
+        sessionPersistence: configuration.sessionPersistence?.webValue(),
         sdkVersion: DatadogSdk.sdkVersion,
+        usePartitionedCrossSiteSessionCookie:
+            configuration.usePartitionedCrossSiteSessionCookie,
+        useSecureSessionCookie: configuration.useSecureSessionCookie,
       ),
     );
   }
@@ -393,62 +398,39 @@ extension type _TracingUrl._(JSObject _) implements JSObject {
 
 @anonymous
 extension type _RumInitOptions._(JSObject _) implements JSObject {
-  external String get applicationId;
-  external bool? get propagateTraceBaggage;
-  external String get clientToken;
-  external String get site;
-  external String? get service;
-  external String? get env;
-  external String? get version;
-  external bool? get trackViewsManually;
-  external bool? get trackUserInteractions;
-  external bool? get trackFrustrations;
-  external bool? get trackLongTasks;
-  external String? get defaultPrivacyLevel;
-  external num? get sessionSampleRate;
-  external num? get sessionReplaySampleRate;
-  external bool? get silentMultipleInit;
-  external String? get proxy;
-  external JSArray get allowedTracingUrls;
-  external JSArray get enableExperimentalFeatures;
-  external bool get compressIntakeRequests;
-  external JSArray? get plugins;
-  external String? get source;
-  external String? get sdkVersion;
-  external String? get variant;
-  external String? get trackingConsent;
-
   external factory _RumInitOptions({
+    JSArray allowedTracingUrls,
     String applicationId,
-    bool? propagateTraceBaggage,
     String clientToken,
-    String site,
-    String? service,
-    String? env,
-    String? version,
-    bool? trackResources,
-    bool? trackViewsManually,
-    // ignore: unused_element_parameter
-    bool? trackUserInteractions,
-    bool? trackFrustrations,
-    bool? trackLongTasks,
+    bool compressIntakeRequests,
     // ignore: unused_element_parameter
     String? defaultPrivacyLevel,
+    JSArray enableExperimentalFeatures,
+    String? env,
+    JSArray? plugins,
+    bool? propagateTraceBaggage,
+    String? proxy,
+    String? sdkVersion,
+    String? service,
+    String? sessionPersistence,
     num? sessionSampleRate,
     num? sessionReplaySampleRate,
-    // ignore: unused_element_parameter
-    bool? silentMultipleInit,
-    String? proxy,
-    JSArray allowedTracingUrls,
-    num? traceSampleRate,
-    String? traceContextInjection,
-    JSArray enableExperimentalFeatures,
-    bool compressIntakeRequests,
-    JSArray? plugins,
+    String site,
     String? source,
-    String? sdkVersion,
-    String? variant,
+    String? traceContextInjection,
+    num? traceSampleRate,
+    bool? trackSessionAcrossSubdomains,
+    bool? trackFrustrations,
     String? trackingConsent,
+    bool? trackResources,
+    // ignore: unused_element_parameter
+    bool? trackUserInteractions,
+    bool? trackViewsManually,
+    bool? trackLongTasks,
+    bool? usePartitionedCrossSiteSessionCookie,
+    bool? useSecureSessionCookie,
+    String? version,
+    String? variant,
   });
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -89,7 +89,8 @@ class DdRumWeb extends DdRumPlatform {
         plugins: plugins,
         variant: configuration.flavor,
         source: 'flutter',
-        sessionPersistence: configuration.sessionPersistence?.webValue(),
+        sessionPersistence:
+            configuration.sessionPersistence?.webValue() ?? 'cookie',
         sdkVersion: DatadogSdk.sdkVersion,
         usePartitionedCrossSiteSessionCookie:
             configuration.usePartitionedCrossSiteSessionCookie,

--- a/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/web_helpers.dart
@@ -56,7 +56,9 @@ JSAny? valueToJs(Object? value, String parameterName) {
     for (final item in value.entries) {
       String key = item.key is String ? item.key : item.key.toString();
       jsMap.setProperty(
-          key.toJS, valueToJs(item.value, '$parameterName.${item.key}'));
+        key.toJS,
+        valueToJs(item.value, '$parameterName.${item.key}'),
+      );
     }
     return jsMap;
   }
@@ -68,18 +70,23 @@ JSAny? valueToJs(Object? value, String parameterName) {
       // and a properly supported `add` method wasn't added until Dart 3.10, so
       // call `push` directly to create the array.
       jsArray.callMethod(
-          'push'.toJS, valueToJs(value[i], '$parameterName[$i]'));
+        'push'.toJS,
+        valueToJs(value[i], '$parameterName[$i]'),
+      );
     }
     return jsArray;
   }
 
   throw ArgumentError(
-      'Could not convert ${value.runtimeType} to javascript.', parameterName);
+    'Could not convert ${value.runtimeType} to javascript.',
+    parameterName,
+  );
 }
 
 // Regex specifying the format of a frame in a Dart stack trace.
-final _dartLineRegex =
-    RegExp(r'(?<file>.+) (?<location>\d+:\d+)\s*(?<function>.+)');
+final _dartLineRegex = RegExp(
+  r'(?<file>.+) (?<location>\d+:\d+)\s*(?<function>.+)',
+);
 
 @JS('RegExp')
 extension type JSRegExp._(JSObject _) implements JSObject {
@@ -119,6 +126,17 @@ extension TrackingConsentWebValue on TrackingConsent {
       case TrackingConsent.notGranted:
       case TrackingConsent.pending:
         return 'not-granted';
+    }
+  }
+}
+
+extension SessionPersistenceWebValue on WebSessionPersistence {
+  String webValue() {
+    switch (this) {
+      case WebSessionPersistence.cookie:
+        return 'cookie';
+      case WebSessionPersistence.localStorage:
+        return 'local-storage';
     }
   }
 }


### PR DESCRIPTION
### What and why?

There are a few configuration options that are specific to Web that need to be passed through to the Browser SDK. This adds the following configuration options to core initialization, which is then forwarded to both Logs and RUM on the browser:

 - sessionPersistence
 - storeContextsAcrossPages
 - trackSessionAcrossSubdomains
 - usePartitionedCrossSiteSessionCookie
 - useSecureSessionCookie

Configuration options in the `_web` files were reordered to be in alphabetical order.

refs: RUM-11211 #866

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
