### PR TITLE
chore: Fix DatadogGqlLink documentation

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -36,14 +36,6 @@ abstract interface class DatadogGqlListener {
 ///
 /// This link can be used on its own or with `datadog_tracking_http_client`.
 ///
-/// By default, this link will temporarily add a header (`x-datadog-graphql-resource-id`)
-/// to your http request that is removed by the `datadog_tracking_http_client`.
-///
-/// If you are not using `datadog_tracking_http_client`, or if you are using
-/// a connection method that normally bypasses the `datadog_tracking_http_client`,
-/// you should set [standAlone] to true. This will prevent the link from
-/// adding the temporary header.
-///
 /// This Link is not a terminating link.
 class DatadogGqlLink extends Link {
   final DatadogSdk datadogSdk;


### PR DESCRIPTION
### What and why?

The overview documentation of DatadogGqlLink contains references to a header and parameter that ended up not being required and were removed even before release.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
