### PR TITLE
feat: Expose `DatadogDioInterceptor`

### DIFF
--- a/packages/datadog_dio/lib/datadog_dio.dart
+++ b/packages/datadog_dio/lib/datadog_dio.dart
@@ -6,6 +6,8 @@ import 'package:datadog_dio/src/datadog_dio_interceptor.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:dio/dio.dart';
 
+export 'src/datadog_dio_interceptor.dart' show DatadogDioInterceptor;
+
 /// A set of callbacks that allow you to provide attributes that should be
 /// attached to a Datadog RUM resource created from a [DatadogDioInterceptor]. This
 /// callback is called as part of the [Interceptor.onResponse] and [Interceptor.onError]


### PR DESCRIPTION
### What and why?

There's no reason for `DatadogDioInterceptor` to not be publicly available. While the setup extension methods make it easier and less error prone, there are use cases where having direct access to the interceptor is required.

refs: #906

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
