### PR TITLE
feat: Support automatic dart:io network tracking from background isolates

### DIFF
--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -222,6 +222,19 @@ class DatadogSdk {
                 TraceContextInjection.sampled,
           );
         }
+
+        for (final pluginConfig
+            in attachResponse.capturedConfiguration.configuredPlugins) {
+          var plugin = pluginConfig.create(this);
+          if (_plugins.containsKey(plugin.runtimeType)) {
+            internalLogger.error(
+              'Attempting to setup two plugins of the same type: ${plugin.runtimeType}. The second plugin will be ignored.',
+            );
+          } else {
+            plugin.initializeFromBackgroundIsolate();
+            _plugins[plugin.runtimeType] = plugin;
+          }
+        }
       }
     } catch (e, st) {
       internalLogger.sendToDatadog(

--- a/packages/datadog_flutter_plugin/lib/src/datadog_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_plugin.dart
@@ -8,6 +8,20 @@ import '../datadog_flutter_plugin.dart';
 
 abstract class DatadogPluginConfiguration {
   DatadogPlugin create(DatadogSdk datadogInstance);
+
+  /// Indicate that this plugin can be used from and initialized from background
+  /// isolates when [DatadogSdk.attachToBackgroundIsolate] is called. Plugins
+  /// that have this set to `true` will have
+  /// [DatadogPlugin.initializeFromBackgroundIsolate] called when background
+  /// isolate is attached, which by default calls [DatadogPlugin.initialize]
+  ///
+  /// Any subclass that has this flag set to `true` must also be marked as
+  /// [immutable] so that the configuration can be sent to the background isolate.
+  ///
+  /// If this flag is set to `false` (the default), no initialization of the
+  /// plugin will occur when Datadog is attached to a background isolate, which
+  /// may mean the features of this plugin will not be available.
+  bool get supportsBackgroundIsolates => false;
 }
 
 abstract class DatadogPlugin {
@@ -17,5 +31,9 @@ abstract class DatadogPlugin {
   DatadogPlugin(this.instance);
 
   void initialize();
+  void initializeFromBackgroundIsolate() {
+    initialize();
+  }
+
   void shutdown() {}
 }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_plugin.dart
@@ -13,7 +13,7 @@ abstract class DatadogPluginConfiguration {
   /// isolates when [DatadogSdk.attachToBackgroundIsolate] is called. Plugins
   /// that have this set to `true` will have
   /// [DatadogPlugin.initializeFromBackgroundIsolate] called when background
-  /// isolate is attached, which by default calls [DatadogPlugin.initialize]
+  /// isolate is attached, which by default calls [DatadogPlugin.initialize].
   ///
   /// Any subclass that has this flag set to `true` must also be marked as
   /// [immutable] so that the configuration can be sent to the background isolate.

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -176,6 +176,10 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       'setLogCallback': logCallback != null,
     });
 
+    final backgroundPlugins = configuration.additionalPlugins
+        .where((e) => e.supportsBackgroundIsolates)
+        .toList();
+
     _capturedConfiguration = CapturedConfiguration(
       loggingEnabled: configuration.loggingConfiguration != null,
       rumEnabled: configuration.rumConfiguration != null,
@@ -183,6 +187,7 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       traceContextInjection:
           configuration.rumConfiguration?.traceContextInjection,
       firstPartyHosts: configuration.firstPartyHostsWithTracingHeaders,
+      configuredPlugins: backgroundPlugins,
     );
 
     return const PlatformInitializationResult(logs: true, rum: true);
@@ -202,12 +207,16 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
     if (channelResponse != null) {
       response = AttachResponse.decode(channelResponse);
       if (response != null) {
+        final backgroundPlugins = attachConfig.additionalPlugins
+            .where((e) => e.supportsBackgroundIsolates)
+            .toList();
         _capturedConfiguration = CapturedConfiguration(
           loggingEnabled: response.loggingEnabled,
           rumEnabled: response.rumEnabled,
           traceSampleRate: attachConfig.traceSampleRate,
           traceContextInjection: attachConfig.traceContextInjection,
           firstPartyHosts: attachConfig.firstPartyHostsWithTracingHeaders,
+          configuredPlugins: backgroundPlugins,
         );
       }
     }

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -48,6 +48,7 @@ class CapturedConfiguration {
   final double? traceSampleRate;
   final TraceContextInjection? traceContextInjection;
   final Map<String, Set<TracingHeaderType>> firstPartyHosts;
+  final List<DatadogPluginConfiguration> configuredPlugins;
 
   const CapturedConfiguration({
     required this.loggingEnabled,
@@ -55,6 +56,7 @@ class CapturedConfiguration {
     required this.traceSampleRate,
     required this.traceContextInjection,
     required this.firstPartyHosts,
+    required this.configuredPlugins,
   });
 }
 

--- a/packages/datadog_tracking_http_client/example/lib/main.dart
+++ b/packages/datadog_tracking_http_client/example/lib/main.dart
@@ -20,6 +20,29 @@ import 'scenario_select_screen.dart';
 // auto-instrumentation added to an existing app gives us the expected results.
 TestingConfiguration? testingConfiguration;
 
+class ClientListener extends DatadogTrackingHttpClientListener {
+  @override
+  void requestStarted(
+      {required Object resourceKey,
+      required HttpClientRequest request,
+      required Map<String, Object?> userAttributes}) {
+    if (kDebugMode) {
+      print('($resourceKey) Request started');
+    }
+  }
+
+  @override
+  void responseFinished(
+      {required Object resourceKey,
+      required HttpClientResponse response,
+      required Map<String, Object?> userAttributes,
+      Object? error}) {
+    if (kDebugMode) {
+      print('($resourceKey) Request finished');
+    }
+  }
+}
+
 Future<void> main() async {
   final merge = kIsWeb ? <String, String>{} : Platform.environment;
   await dotenv.load(mergeWith: merge);
@@ -73,7 +96,9 @@ Future<void> main() async {
   }
 
   if (RumAutoInstrumentationScenarioConfig.instance.enableIoHttpTracking) {
-    configuration.enableHttpTracking();
+    configuration.enableHttpTracking(
+      clientListener: ClientListener(),
+    );
   }
 
   await DatadogSdk.runApp(configuration, TrackingConsent.granted, () async {

--- a/packages/datadog_tracking_http_client/example/lib/screens/background_isolate_screen.dart
+++ b/packages/datadog_tracking_http_client/example/lib/screens/background_isolate_screen.dart
@@ -5,9 +5,8 @@
 import 'dart:isolate';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
-import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 
 import '../scenario_config.dart';
 
@@ -86,14 +85,12 @@ void _backgroundWork(SendPort port) async {
 
 Future<void> _performBackgroundFetch(
     RumAutoInstrumentationScenarioConfig config, SendPort port) async {
-  final client =
-      DatadogClient(datadogSdk: DatadogSdk.instance, innerClient: Client());
   port.send('Get First Party');
-  await client.get(Uri.parse(config.firstPartyGetUrl));
+  await http.get(Uri.parse(config.firstPartyGetUrl));
 
   if (config.firstPartyPostUrl != null) {
     port.send('Post First Party');
-    await client.post(Uri.parse(config.firstPartyPostUrl!));
+    await http.post(Uri.parse(config.firstPartyPostUrl!));
   }
 
   port.send('Done');

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:flutter/foundation.dart';
 
 import '../datadog_tracking_http_client.dart';
 
@@ -21,6 +22,14 @@ import '../datadog_tracking_http_client.dart';
 /// [responseFinished] are the same map, and it is possible to inspect and
 /// modify attributes between the two calls. Only the attributes remaining after
 /// [responseFinished] is called will be sent to Datadog.
+///
+/// If you are performing network calls from background isolates, Flutter will
+/// attempts to serialize and recreate this class on the background isolate
+/// during your call to [DatadogSdk.attachToBackgroundIsolate], and any state
+/// changed in the listener from the main isolate from that point forward will
+/// not be reflected in the background isolate. It is generally best practice to
+/// set any state variables in this listener to `final` (or not use any at all)
+/// to avoid unexpected value discrepancies between isolates.
 abstract class DatadogTrackingHttpClientListener {
   /// Called when an HttpClientRequest is started.
   ///
@@ -28,8 +37,8 @@ abstract class DatadogTrackingHttpClientListener {
   /// connect to other user operations.
   void requestStarted({
     required Object resourceKey,
-    HttpClientRequest request,
-    Map<String, Object?> userAttributes,
+    required HttpClientRequest request,
+    required Map<String, Object?> userAttributes,
   });
 
   /// Called when an HttpClientResponse is finished.
@@ -38,15 +47,19 @@ abstract class DatadogTrackingHttpClientListener {
   /// connect to other user operations.
   void responseFinished({
     required Object resourceKey,
-    HttpClientResponse response,
-    Map<String, Object?> userAttributes,
+    required HttpClientResponse response,
+    required Map<String, Object?> userAttributes,
     Object? error,
   });
 }
 
+@immutable
 class DdHttpTrackingPluginConfiguration extends DatadogPluginConfiguration {
-  DatadogTrackingHttpClientListener? clientListener;
-  List<RegExp> ignoreUrlPatterns;
+  final DatadogTrackingHttpClientListener? clientListener;
+  final List<RegExp> ignoreUrlPatterns;
+
+  @override
+  bool get supportsBackgroundIsolates => true;
 
   DdHttpTrackingPluginConfiguration({
     this.clientListener,
@@ -69,13 +82,22 @@ class _DdHttpTrackingPlugin extends DatadogPlugin {
 
   @override
   void initialize() {
+    _setHttpOverrides();
+    instance.updateConfigurationInfo(
+        LateConfigurationProperty.trackNetworkRequests, true);
+  }
+
+  @override
+  void initializeFromBackgroundIsolate() {
+    _setHttpOverrides();
+  }
+
+  void _setHttpOverrides() {
     final existingOverrides = HttpOverrides.current;
     HttpOverrides.global = DatadogTrackingHttpOverrides(
       instance,
       configuration,
       existingOverrides,
     );
-    instance.updateConfigurationInfo(
-        LateConfigurationProperty.trackNetworkRequests, true);
   }
 }


### PR DESCRIPTION
### What and why?

Add support to `DatadogPlugin` for transmitting configuration information and initializing from background isolates. The only plugin that actually needs to support this is the DdHttpTrackingPlugin, because it needs to set HttpOverrides in the background isolate to be effective.

Also fix missing `required` annotations in `DatadogTrackingHttpClientListener`.

refs: RUM-13278


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
