### PR TITLE
feat: Set trace sampling rate to default to 100%

### DIFF
--- a/packages/datadog_flutter_plugin/MIGRATING.md
+++ b/packages/datadog_flutter_plugin/MIGRATING.md
@@ -23,6 +23,8 @@ Clients using Flutter Web should update to using the Datadog Browser SDK v6.  Ch
 
 An ID is no longer optional in `setUserInfo`. If you need to clear user info, use `clearUserInfo` instead.
 
+The default trace sampling rate (`DatadogRumConfiguration.traceSampleRate` and `DatadogAttachConfiguration.traceSampleRate`) has changed from 20% to 100%.
+
 # Migration from 1.x to 2.0
 
 This document describes the main changes introduced in SDK `2.0` compared to `1.x`.

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -290,8 +290,8 @@ class DatadogConfiguration {
       // make map mutable in case it's the default
       firstPartyHostsWithTracingHeaders =
           Map<String, Set<TracingHeaderType>>.from(
-            firstPartyHostsWithTracingHeaders,
-          );
+        firstPartyHostsWithTracingHeaders,
+      );
 
       for (var entry in firstPartyHosts) {
         final headerTypes = firstPartyHostsWithTracingHeaders[entry];
@@ -419,7 +419,7 @@ class DatadogAttachConfiguration {
   /// This property only affects network requests made from Flutter, and it is
   /// not shared or populated from the existing SDK.
   ///
-  /// Defaults to `20.0`.
+  /// Defaults to `100.0`.
   double traceSampleRate;
 
   /// The strategy for injecting trace context into requests. See [TraceContextInjection].
@@ -434,7 +434,7 @@ class DatadogAttachConfiguration {
   DatadogAttachConfiguration({
     this.detectLongTasks = true,
     this.longTaskThreshold = 0.1,
-    this.traceSampleRate = 20.0,
+    this.traceSampleRate = 100.0,
     this.reportFlutterPerformance = false,
     List<String>? firstPartyHosts,
     this.firstPartyHostsWithTracingHeaders = const {},
@@ -445,8 +445,8 @@ class DatadogAttachConfiguration {
       // make map mutable
       firstPartyHostsWithTracingHeaders =
           Map<String, Set<TracingHeaderType>>.from(
-            firstPartyHostsWithTracingHeaders,
-          );
+        firstPartyHostsWithTracingHeaders,
+      );
 
       for (var entry in firstPartyHosts) {
         final headerTypes = firstPartyHostsWithTracingHeaders[entry];

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -38,8 +38,8 @@ typedef RumActionEventMapper = RumActionEvent? Function(RumActionEvent event);
 ///
 /// The [RumResourceEventMapper] can modify any mutable (non-final) properties in the
 /// [RumResourceEvent]
-typedef RumResourceEventMapper =
-    RumResourceEvent? Function(RumResourceEvent event);
+typedef RumResourceEventMapper = RumResourceEvent? Function(
+    RumResourceEvent event);
 
 /// A function that allows you to modify or drop specific [RumErrorEvent]s before
 /// they are sent to Datadog.
@@ -53,8 +53,8 @@ typedef RumErrorEventMapper = RumErrorEvent? Function(RumErrorEvent event);
 ///
 /// The [RumLongTaskEvent] can modify any mutable (non-final) properties in the
 /// [RumLongTaskEvent]
-typedef RumLongTaskEventMapper =
-    RumLongTaskEvent? Function(RumLongTaskEvent event);
+typedef RumLongTaskEventMapper = RumLongTaskEvent? Function(
+    RumLongTaskEvent event);
 
 /// A function that allows you to modify or drop specific [RumVitalOperationEvent]s before
 /// they are sent to Datadog.
@@ -84,7 +84,7 @@ class DatadogRumConfiguration {
   /// `0.0` means no resources will include APM tracing, `100.0` resource will
   /// include APM tracing
   ///
-  /// Defaults to `20.0`.
+  /// Defaults to `100.0`.
   double traceSampleRate;
 
   /// The strategy for injecting trace context into requests. See [TraceContextInjection].
@@ -226,7 +226,7 @@ class DatadogRumConfiguration {
   DatadogRumConfiguration({
     required this.applicationId,
     double sessionSamplingRate = 100.0,
-    double traceSampleRate = 20.0,
+    double traceSampleRate = 100.0,
     this.traceContextInjection = TraceContextInjection.sampled,
     this.detectLongTasks = true,
     double longTaskThreshold = 0.1,
@@ -247,9 +247,9 @@ class DatadogRumConfiguration {
     this.longTaskEventMapper,
     this.vitalOperationStepEventMapper,
     this.additionalConfig = const <String, Object>{},
-  }) : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
-       traceSampleRate = max(0, min(traceSampleRate, 100)),
-       longTaskThreshold = max(0.02, longTaskThreshold);
+  })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
+        traceSampleRate = max(0, min(traceSampleRate, 100)),
+        longTaskThreshold = max(0.02, longTaskThreshold);
 
   Map<String, Object?> encode() {
     return {

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -88,7 +88,7 @@ void main() {
     final configuration = DatadogRumConfiguration(applicationId: 'fake-app-id');
 
     expect(configuration.sessionSamplingRate, 100.0);
-    expect(configuration.traceSampleRate, 20.0);
+    expect(configuration.traceSampleRate, 100.0);
     expect(configuration.traceContextInjection, TraceContextInjection.sampled);
     expect(configuration.detectLongTasks, true);
     expect(configuration.longTaskThreshold, 0.1);
@@ -421,7 +421,8 @@ void main() {
     verifyNever(() => mockRumPlatform.addAttribute(any(), any()));
   });
 
-  test('addViewAttribute with null calls removeViewAttribute instead', () async {
+  test('addViewAttribute with null calls removeViewAttribute instead',
+      () async {
     // Given
     DdRumPlatform.instance = mockRumPlatform;
     when(
@@ -467,7 +468,8 @@ void main() {
     rum!.addViewAttribute('view-attribute-key', 'view-attribute-value');
 
     // Then
-    verify(() => mockRumPlatform.addViewAttribute('view-attribute-key', 'view-attribute-value'));
+    verify(() => mockRumPlatform.addViewAttribute(
+        'view-attribute-key', 'view-attribute-value'));
   });
 
   test('removeViewAttribute calls platform', () async {


### PR DESCRIPTION
### What and why?

This should have been done when we set the default context injection to `TraceContextInjection.sampled`, but was missed.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
