### PR TITLE
chore: Add missing RUMMonitor mock

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/MockRumMonitor.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/MockRumMonitor.kt
@@ -99,6 +99,11 @@ class MockRumMonitor : RumMonitor {
         mockMonitor.removeViewAttributes(attributes)
     }
 
+    @ExperimentalRumApi
+    override fun reportAppFullyDisplayed() {
+        mockMonitor.reportAppFullyDisplayed()
+    }
+
     override fun startAction(type: RumActionType, name: String, attributes: Map<String, Any?>) {
         mockMonitor.startAction(type, name, attributes)
     }


### PR DESCRIPTION
### What and why?

Android added a method to RUMMonitor which needs to be added to our mock to support unit testing.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
