### PR TITLE
Fix: Pin DictionaryCoder to 1.2.0 for iOS 12 compatibility

### DIFF
--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Datadog/dd-sdk-ios.git", branch: "develop"),
-        .package(url: "https://github.com/almazrafi/DictionaryCoder.git", from: "1.2.0")
+        .package(url: "https://github.com/almazrafi/DictionaryCoder.git", exact: "1.2.0")
     ],
     targets: [
         .systemLibrary(name: "datadog_flutter_plugin_c"),


### PR DESCRIPTION
### What and why?

Fixes #913

iOS builds are failing because DictionaryCoder 1.3.0 requires iOS 13+, but we're targeting iOS 12. The Package.swift was using \`from: "1.2.0"\` which lets SPM grab 1.3.0.

This pins it to exactly 1.2.0 to prevent the version bump.

### How?

Changed Package.swift dependency from:
```swift
.package(url: "https://github.com/almazrafi/DictionaryCoder.git", from: "1.2.0")
```

to:
```swift
.package(url: "https://github.com/almazrafi/DictionaryCoder.git", exact: "1.2.0")
```

This is the least invasive option - keeps iOS 12 support without requiring code changes. Other options would be bumping to iOS 13 (breaking) or updating to DictionaryCoder 1.3.0 (has breaking API changes).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests
- [ ] This pull request references a Github or JIRA issue