### PR TITLE
fix: Switch to merged vital event mapper in Android

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
@@ -57,10 +57,12 @@ class DatadogRumEventMapper {
             configBuilder.setLongTaskEventMapper { event -> mapLongTaskEvent(event) }
         }
         if (optionIsSet("attachVitalOperationStepEventMapper")) {
-            configBuilder.setVitalOperationStepEventMapper {
-                    event ->
-                mapVitalOperationStepEvent(event)
-            }
+            configBuilder.setVitalEventMapper(
+                vitalOperationStepEventMapper = {
+                        event ->
+                    mapVitalOperationStepEvent(event)
+                }
+            )
         }
 
         return configBuilder


### PR DESCRIPTION
### What and why?

The vital event mapper in Android has been merged with the app launch event mapper and renamed. Fix so the proper mapper method is being used.

We're ignoring app launch event mapping for now.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
