### PR TITLE
chore: Fix session replay pulling wrong native versions.

### DIFF
--- a/packages/datadog_session_replay/android/build.gradle
+++ b/packages/datadog_session_replay/android/build.gradle
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     ext.kotlin_version = "2.1.0"
-    ext.datadog_version = "2.20.0"
+    ext.datadog_version = "3.0.0"
 
     repositories {
         google()

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "datadog-session-replay", targets: ["datadog_session_replay", "datadog_session_replay_objc"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", branch: "develop"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

Sub-packages should let the main package dictate which native versions to pull as much as they are able. Fix an issue where we switched SR to develop over having it ask for any version above 3.0. Fix Android asking for 2.30, and instead have it ask for 3.0.0 (which the gradle should then silently pull minor version updates for).

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
