### PR TITLE
chore: Fix beta nightlies by updating dev dependencies

### DIFF
--- a/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
+++ b/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
@@ -5,7 +5,6 @@
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_common_test/uri_matchers.dart';
 import 'package:datadog_dio/datadog_dio.dart';
-import 'package:datadog_dio/src/datadog_dio_interceptor.dart';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:dio/dio.dart';

--- a/packages/datadog_flutter_plugin/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ">=1.0.0"
-  mocktail: ^0.3.0
+  mocktail: ^1.0.4
   json_serializable: '>=6.7.0 <6.10.0'
   build_runner: ^2.1.11
   jnigen: ^0.14.2

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-  mocktail: ^0.3.0
+  mocktail: ^1.0.4
   plugin_platform_interface: ^2.0.2
   
 flutter:


### PR DESCRIPTION
### What and why?

An old version of mocktail (0.3.0) was incompatible with the newer versions of the analyzer packages in Flutter beta.

Update to the newest version of mocktail to fix.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
