### PR TITLE
fix: Properly depend on datadog 3.0 in all packages

### DIFF
--- a/packages/datadog_inappwebview_tracking/README.md
+++ b/packages/datadog_inappwebview_tracking/README.md
@@ -14,7 +14,7 @@ Add both the `datadog_inappwebview_tracking` package and the `flutter_inappwebvi
 ```yaml
 dependencies:
   flutter_inappwebview: ^6.1.5
-  datadog_flutter_plugin: ^2.8.0
+  datadog_flutter_plugin: ^3.0.0
   datadog_inappwebview_tracking: ^1.0.0
 ```
 

--- a/packages/datadog_inappwebview_tracking/example/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   flutter_inappwebview: ^6.1.0
   go_router: ^14.5.0
-  datadog_flutter_plugin: ^2.10.0
+  datadog_flutter_plugin: ^3.0.0
   datadog_inappwebview_tracking:
     path: ../
   cupertino_icons: ^1.0.8

--- a/packages/datadog_session_replay/example/pubspec.yaml
+++ b/packages/datadog_session_replay/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  datadog_flutter_plugin: ^2.12.0
+  datadog_flutter_plugin: ^3.0.0
   datadog_session_replay:
     path: ../
   cupertino_icons: ^1.0.8

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.7.0
+  datadog_flutter_plugin: ^3.0.0
   uuid: ^4.0.0
   http: ^1.0.0
 

--- a/packages/datadog_webview_tracking/example/pubspec.yaml
+++ b/packages/datadog_webview_tracking/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  datadog_flutter_plugin: ^2.9.0
+  datadog_flutter_plugin: ^3.0.0
   datadog_webview_tracking:
     path: ../
   webview_flutter: ^4.0.4

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^2.9.0
+  datadog_flutter_plugin: ^3.0.0
   webview_flutter: ^4.0.4
   webview_flutter_android: ^3.8.2
   webview_flutter_wkwebview: ^3.18.0


### PR DESCRIPTION
### What and why?

The only packages this was definitely broken in were `datadog_webview_tracking` and `datadog_tracking_http_client`. Both have been retracted.

This will be cherry picked into the release branch.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
