### PR TITLE
fix: Fix crash with ios webview tracking in Flutter 3.38+

### DIFF
--- a/packages/datadog_flutter_plugin/example/.swiftlint.yml
+++ b/packages/datadog_flutter_plugin/example/.swiftlint.yml
@@ -3,9 +3,8 @@ disabled_rules:
 
 included:
   - ios
-  - example/ios
 
 excluded:
-  - example/ios/Pods
-  - example/ios/.symlinks
-  - example/ios/Flutter
+  - ios/Pods
+  - ios/.symlinks
+  - ios/Flutter

--- a/packages/datadog_flutter_plugin/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_flutter_plugin/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -225,6 +225,7 @@
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
 				B97AC012F85D11D0375B3A9A /* [CP] Check Pods Manifest.lock */,
+				4913AA84276A6045008B9D0C /* Run SwiftLint */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -276,7 +277,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -326,6 +327,24 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		4913AA84276A6045008B9D0C /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/../..\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
 		5356FB92DB6536E3B6602231 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -334,13 +353,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -355,13 +370,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -879,7 +890,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/packages/datadog_flutter_plugin/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_flutter_plugin/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -225,7 +225,6 @@
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
 				B97AC012F85D11D0375B3A9A /* [CP] Check Pods Manifest.lock */,
-				4913AA84276A6045008B9D0C /* Run SwiftLint */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -277,7 +276,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -327,24 +326,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		4913AA84276A6045008B9D0C /* Run SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Run SwiftLint";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint >/dev/null; then\n  cd ${SOURCE_ROOT}/../..\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
-		};
 		5356FB92DB6536E3B6602231 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -353,9 +334,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -370,9 +355,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -890,7 +879,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
@@ -15,6 +15,7 @@ A Flutter plugin for use with the Datadog Flutter Plugin to track webviews as pa
   s.source           = { :path => '.' }
   s.source_files = 'datadog_webview_tracking/Sources/**/*'
   s.dependency 'Flutter'
+  s.dependency 'DatadogCore', '~> 3'
   s.dependency 'DatadogWebViewTracking', '~> 3'
   s.dependency 'webview_flutter_wkwebview'
   s.platform = :ios, '13.0'

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .target(
             name: "datadog_webview_tracking",
             dependencies: [
+                .product(name: "DatadogCore", package: "dd-sdk-ios"),
                 .product(name: "DatadogWebViewTracking", package: "dd-sdk-ios")
             ],
             resources: []

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Sources/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Sources/DatadogWebviewTrackingPlugin.swift
@@ -4,6 +4,8 @@
 
 import Flutter
 import UIKit
+import DatadogCore
+import DatadogInternal
 import DatadogWebViewTracking
 import webview_flutter_wkwebview
 
@@ -36,17 +38,28 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                let allowedHosts = arguments["allowedHosts"] as? [String] {
                 let webViewIdentifier = number.int64Value
 
-                // swiftlint:disable:next todo
-                // TODO: Add to app scenario, search for a FlutterViewController to get the
-                // registry
-                if let pluginRegistry = UIApplication.shared.delegate as? FlutterPluginRegistry,
+                if let registry = getPluginRegistry(),
+                   // FWFWebviewFlutterWKWebViewExternalAPI does a force cast, which can crash,
+                   // so to try to avoid that, we're going to check to make sure the plugin is there first.
+                   let _ = registry.valuePublished(byPlugin: "WebViewFlutterPlugin") as? WebViewFlutterPlugin,
                    let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(
                         forIdentifier: webViewIdentifier,
-                        withPluginRegistry: pluginRegistry) {
+                        withPluginRegistry: registry) {
                     WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
+                } else {
+                    Datadog._internal.telemetry.error(
+                        id: "webview_tracking_init_failed",
+                        message: "Failed to initialie WebViewTracking because a WebViewFlutterPlugin instance was not found",
+                        kind: "DependencyFailure",
+                        stack: nil
+                    )
                 }
                 result(nil)
             } else {
+                consolePrint(
+                    "⚠️ Could not find WebViewFlutterPlugin to enable Datadog tracking. This may be because of a change in Flutter. " +
+                    "Please report this issue to Datadog along with the version of flutter_webview and Flutter you are using.",
+                    .warn)
                 result(
                     FlutterError(code: "DatadogSdk:ContractViolation",
                                  message: "Missing parameter in call to \(call.method)",
@@ -56,5 +69,23 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
         } else {
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func getPluginRegistry() -> FlutterPluginRegistry? {
+        // swiftlint:disable:next todo
+        // TODO: Add to app scenario, search for a FlutterViewController to get the
+        // registry
+        // Note, in Flutter 3.38, registrars expose `viewController` which will be the
+        // correct way to get the plugin registry. To be compatibile with <= 3.37 and 3.38+,
+        // we're going to first try to se if the RootViewController is a plugin registry (3.38+),
+        // and if not, fall back to the delegate (<= 3.37).
+        let delegate = UIApplication.shared.delegate as? FlutterAppDelegate
+        if let rootViewController = delegate?.window?.rootViewController,
+           let pluginRegistry = rootViewController as? FlutterPluginRegistry {
+            return pluginRegistry
+        } else if let delegate = UIApplication.shared.delegate as? FlutterPluginRegistry {
+            return delegate
+        }
+        return nil
     }
 }


### PR DESCRIPTION
### What and why?

Flutter 3.38+ changes where plugins are registered, using the ViewController over the AppDelegate as the registrar / registry.

FWFWebViewFlutterWKWebViewExternalAPI also performs a force cast (`as!`) to get the plugin from the registry, which crashes on iOS.

While Flutter 3.38 adds a `viewController` property to FlutterPluginRegistrar to more easily access the `PluginRegistry`, this property is not available for our min versions (3.27). So to fix the crash we're taking two steps:

First, we ask for the `viewController` from the `FlutterAppDelegate`, which should be valid for both 3.27+ and 3.28. Just in case as a final fallback, we use the AppDelegate as the plugin registry.

Second, we added a check that prevents the force cast `as!`. We look to see if the plugin is registered *before* we ask the external API for it. This way, if the `PluginRegistry` we're using isn't the one that the WebView plugin used, we won't crash on the force cast. We'll just miss out on tracking the given webview.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
