### PR TITLE
fix: Cherry pick changes to fix ios webview crash in Flutter 3.38+

### DIFF
--- a/packages/datadog_common_test/pubspec.yaml
+++ b/packages/datadog_common_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ^3.8.0
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
@@ -57,7 +57,7 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                 result(nil)
             } else {
                 consolePrint(
-                    "⚠️ Could not find WebViewFlutterPlugin to enable Datadog tracking. This may be because of a change in Flutter." +
+                    "⚠️ Could not find WebViewFlutterPlugin to enable Datadog tracking. This may be because of a change in Flutter. " +
                     "Please report this issue to Datadog along with the version of flutter_webview and Flutter you are using.",
                     .warn)
                 result(

--- a/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
@@ -4,6 +4,8 @@
 
 import Flutter
 import UIKit
+import DatadogCore
+import DatadogInternal
 import DatadogWebViewTracking
 import webview_flutter_wkwebview
 
@@ -44,9 +46,20 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                         forIdentifier: webViewIdentifier,
                         withPluginRegistry: registry) {
                     WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
+                } else {
+                    Datadog._internal.telemetry.error(
+                        id: "webview_tracking_init_failed",
+                        message: "Failed to initialie WebViewTracking because a WebViewFlutterPlugin instance was not found",
+                        kind: "DependencyFailure",
+                        stack: nil
+                    )
                 }
                 result(nil)
             } else {
+                consolePrint(
+                    "⚠️ Could not find WebViewFlutterPlugin to enable Datadog tracking. This may be because of a change in Flutter." +
+                    "Please report this issue to Datadog along with the version of flutter_webview and Flutter you are using.",
+                    .warn)
                 result(
                     FlutterError(code: "DatadogSdk:ContractViolation",
                                  message: "Missing parameter in call to \(call.method)",

--- a/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/Classes/DatadogWebviewTrackingPlugin.swift
@@ -36,13 +36,13 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                let allowedHosts = arguments["allowedHosts"] as? [String] {
                 let webViewIdentifier = number.int64Value
 
-                // swiftlint:disable:next todo
-                // TODO: Add to app scenario, search for a FlutterViewController to get the
-                // registry
-                if let pluginRegistry = UIApplication.shared.delegate as? FlutterPluginRegistry,
+                if let registry = getPluginRegistry(),
+                   // FWFWebviewFlutterWKWebViewExternalAPI does a force cast, which can crash,
+                   // so to try to avoid that, we're going to check to make sure the plugin is there first.
+                   let _ = registry.valuePublished(byPlugin: "WebViewFlutterPlugin") as? WebViewFlutterPlugin,
                    let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(
                         forIdentifier: webViewIdentifier,
-                        withPluginRegistry: pluginRegistry) {
+                        withPluginRegistry: registry) {
                     WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
                 }
                 result(nil)
@@ -56,5 +56,23 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
         } else {
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func getPluginRegistry() -> FlutterPluginRegistry? {
+        // swiftlint:disable:next todo
+        // TODO: Add to app scenario, search for a FlutterViewController to get the
+        // registry
+        // Note, in Flutter 3.38, registrars expose `viewController` which will be the
+        // correct way to get the plugin registry. To be compatibile with <= 3.37 and 3.38+,
+        // we're going to first try to se if the RootViewController is a plugin registry (3.38+),
+        // and if not, fall back to the delegate (<= 3.37).
+        let delegate = UIApplication.shared.delegate as? FlutterAppDelegate
+        if let rootViewController = delegate?.window?.rootViewController,
+           let pluginRegistry = rootViewController as? FlutterPluginRegistry {
+            return pluginRegistry
+        } else if let delegate = UIApplication.shared.delegate as? FlutterPluginRegistry {
+            return delegate
+        }
+        return nil
     }
 }

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
@@ -15,6 +15,7 @@ A Flutter plugin for use with the Datadog Flutter Plugin to track webviews as pa
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  s.dependency 'DatadogCore', '~> 2'
   s.dependency 'DatadogWebViewTracking', '~> 2'
   s.dependency 'webview_flutter_wkwebview'
   s.platform = :ios, '12.0'


### PR DESCRIPTION
### What and why?

See #926 for more details. This cherry picks the fix into the 2.2.x release branch so we can submit a patch release of `datadog_webview_tracking` that is Flutter 3.38 compatible.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
