### PR TITLE
fix: (Cherry-Pick) Fix crash with ios webview tracking in Flutter 3.38+ 

### DIFF
--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking.podspec
@@ -15,6 +15,7 @@ A Flutter plugin for use with the Datadog Flutter Plugin to track webviews as pa
   s.source           = { :path => '.' }
   s.source_files = 'datadog_webview_tracking/Sources/**/*'
   s.dependency 'Flutter'
+  s.dependency 'DatadogCore', '~> 2'
   s.dependency 'DatadogWebViewTracking', '~> 2'
   s.dependency 'webview_flutter_wkwebview'
   s.platform = :ios, '12.0'

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .target(
             name: "datadog_webview_tracking",
             dependencies: [
+                .product(name: "DatadogCore", package: "dd-sdk-ios"),
                 .product(name: "DatadogWebViewTracking", package: "dd-sdk-ios")
             ],
             resources: []

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Sources/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Sources/DatadogWebviewTrackingPlugin.swift
@@ -4,6 +4,8 @@
 
 import Flutter
 import UIKit
+import DatadogCore
+import DatadogInternal
 import DatadogWebViewTracking
 import webview_flutter_wkwebview
 
@@ -36,17 +38,28 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                let allowedHosts = arguments["allowedHosts"] as? [String] {
                 let webViewIdentifier = number.int64Value
 
-                // swiftlint:disable:next todo
-                // TODO: Add to app scenario, search for a FlutterViewController to get the
-                // registry
-                if let pluginRegistry = UIApplication.shared.delegate as? FlutterPluginRegistry,
+                if let registry = getPluginRegistry(),
+                   // FWFWebviewFlutterWKWebViewExternalAPI does a force cast, which can crash,
+                   // so to try to avoid that, we're going to check to make sure the plugin is there first.
+                   let _ = registry.valuePublished(byPlugin: "WebViewFlutterPlugin") as? WebViewFlutterPlugin,
                    let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(
                         forIdentifier: webViewIdentifier,
-                        withPluginRegistry: pluginRegistry) {
+                        withPluginRegistry: registry) {
                     WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
+                } else {
+                    Datadog._internal.telemetry.error(
+                        id: "webview_tracking_init_failed",
+                        message: "Failed to initialie WebViewTracking because a WebViewFlutterPlugin instance was not found",
+                        kind: "DependencyFailure",
+                        stack: nil
+                    )
                 }
                 result(nil)
             } else {
+                consolePrint(
+                    "⚠️ Could not find WebViewFlutterPlugin to enable Datadog tracking. This may be because of a change in Flutter. " +
+                    "Please report this issue to Datadog along with the version of flutter_webview and Flutter you are using.",
+                    .warn)
                 result(
                     FlutterError(code: "DatadogSdk:ContractViolation",
                                  message: "Missing parameter in call to \(call.method)",
@@ -56,5 +69,23 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
         } else {
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func getPluginRegistry() -> FlutterPluginRegistry? {
+        // swiftlint:disable:next todo
+        // TODO: Add to app scenario, search for a FlutterViewController to get the
+        // registry
+        // Note, in Flutter 3.38, registrars expose `viewController` which will be the
+        // correct way to get the plugin registry. To be compatibile with <= 3.37 and 3.38+,
+        // we're going to first try to se if the RootViewController is a plugin registry (3.38+),
+        // and if not, fall back to the delegate (<= 3.37).
+        let delegate = UIApplication.shared.delegate as? FlutterAppDelegate
+        if let rootViewController = delegate?.window?.rootViewController,
+           let pluginRegistry = rootViewController as? FlutterPluginRegistry {
+            return pluginRegistry
+        } else if let delegate = UIApplication.shared.delegate as? FlutterPluginRegistry {
+            return delegate
+        }
+        return nil
     }
 }


### PR DESCRIPTION
### What and why?

This is a cherry pick from `develop` to pull this into a patch release of v2.4.x.

Flutter 3.38+ changes where plugins are registered, using the ViewController over the AppDelegate as the registrar / registry.

FWFWebViewFlutterWKWebViewExternalAPI also performs a force cast (`as!`) to get the plugin from the registry, which crashes on iOS.

Flutter 3.38 adds a `viewController` property to FlutterPluginRegistrar to more easily access the `PluginRegistry`, but this property is not available for our min versions (3.27). So, instead, we ask for the `viewController` from the `FlutterAppDelegate`, which should be valid for both 3.27+ and 3.28. As a final fallback, we use the AppDelegate as the plugin registry.

The last added check prevents the force cast `as!`. We look to see if the plugin is registered *before* we ask the external API for it.

(cherry picked from commit 35dc5c51ee6dfc934fadecf8fb839dc5c819d603)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
