### PR TITLE
chore: Fix nightly beta test builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -336,6 +336,7 @@ nightly-beta-test:
     - fvm install beta
     - fvm use beta
     - fvm flutter upgrade
+    - fvm flutter precache --ios
     - fvm exec dart pub global activate melos
     - pod repo update    
     - flutter doctor


### PR DESCRIPTION
### What and why?

iOS isn't precached in FVM and needs to be.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
