### PR TITLE
chore: Changes from releasing webview tracking 3.0.2

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.2
+
+* Fix crash with iOS Webview tracking in Flutter 3.38+.
+
 ## 3.0.1
 
 * Properly depend on Datadog 3.0.0.

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_webview_tracking
 description: A package for tracking Datadog sessions in a webview
-version: 3.1.0
+version: 3.0.2
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_webview_tracking
 description: A package for tracking Datadog sessions in a webview
-version: 3.0.2
+version: 3.1.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

Shipping 3.0.2 to fix a crash in Flutter 3.38 when using webview tracking.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
