### PR TITLE
chore: Fix iOS mocks from develop

### DIFF
--- a/packages/datadog_session_replay/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/datadog_session_replay/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -10,23 +10,34 @@ PODS:
   - datadog_session_replay (0.0.1):
     - DatadogCore (~> 3)
     - Flutter
-  - DatadogCore (3.4.0):
-    - DatadogInternal (= 3.4.0)
-  - DatadogCrashReporting (3.4.0):
-    - DatadogInternal (= 3.4.0)
-    - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (3.4.0)
-  - DatadogLogs (3.4.0):
-    - DatadogInternal (= 3.4.0)
-  - DatadogRUM (3.4.0):
-    - DatadogInternal (= 3.4.0)
+  - DatadogCore (3.5.0):
+    - DatadogInternal (= 3.5.0)
+  - DatadogCrashReporting (3.5.0):
+    - DatadogInternal (= 3.5.0)
+    - KSCrash/Filters (= 2.5.0)
+    - KSCrash/Recording (= 2.5.0)
+  - DatadogInternal (3.5.0)
+  - DatadogLogs (3.5.0):
+    - DatadogInternal (= 3.5.0)
+  - DatadogRUM (3.5.0):
+    - DatadogInternal (= 3.5.0)
   - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
+  - KSCrash/Core (2.5.0)
+  - KSCrash/Filters (2.5.0):
+    - KSCrash/Recording
+    - KSCrash/RecordingCore
+    - KSCrash/ReportingCore
+  - KSCrash/Recording (2.5.0):
+    - KSCrash/RecordingCore
+  - KSCrash/RecordingCore (2.5.0):
+    - KSCrash/Core
+  - KSCrash/ReportingCore (2.5.0):
+    - KSCrash/Core
   - objective_c (0.0.1):
     - Flutter
-  - PLCrashReporter (1.12.0)
 
 DEPENDENCIES:
   - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
@@ -43,7 +54,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - DictionaryCoder
-    - PLCrashReporter
+    - KSCrash
 
 EXTERNAL SOURCES:
   datadog_flutter_plugin:
@@ -74,34 +85,34 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogCore:
-    :commit: 2f28ab96da8fdba15bc3605d6ac3aed5ae9bc8c4
+    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogCrashReporting:
-    :commit: 2f28ab96da8fdba15bc3605d6ac3aed5ae9bc8c4
+    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogInternal:
-    :commit: 2f28ab96da8fdba15bc3605d6ac3aed5ae9bc8c4
+    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogLogs:
-    :commit: 2f28ab96da8fdba15bc3605d6ac3aed5ae9bc8c4
+    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogRUM:
-    :commit: 2f28ab96da8fdba15bc3605d6ac3aed5ae9bc8c4
+    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: 64adc7ef089a1328c78fd4fab24e49afa09d95a5
   datadog_session_replay: 8e4f4a520f20feb2916c623c011a53ba63f8d77f
-  DatadogCore: 8c384b6338c49534e43fdf7f9a0508b62bf1d426
-  DatadogCrashReporting: 103bfb4077db2ccee1846f71e53712972732d3b7
-  DatadogInternal: b0372935ad8dde5ad06960fe8d88c39b2cc92bcc
-  DatadogLogs: 484bb1bfe0c9a7cb2a7d9733f61614e8ea7b2f3a
-  DatadogRUM: 00069b27918e0ce4a9223b87b4bfa7929d6a0a1f
+  DatadogCore: 4cbe2646591d2f96fb3188400863ec93ac411235
+  DatadogCrashReporting: e48da3f880a59d2aa2d04e5034e56507177e9d64
+  DatadogInternal: 63308b529cd87fb2f99c5961d9ff13afb300a3aa
+  DatadogLogs: be538def1d5204e011f7952915ad0261014a0dd5
+  DatadogRUM: cffc65659ce29546fcc2639a74003135259548fc
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  KSCrash: 80e1e24eaefbe5134934ae11ca8d7746586bc2ed
   objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
-  PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
 
 PODFILE CHECKSUM: 357bc2de26f249c9e5dd52e99a556d5704fbd68b
 

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
@@ -191,7 +191,9 @@ extension DeviceInfo: AnyMockable, RandomMockable {
         isSimulator: Bool = true,
         vendorId: String? = "xyz",
         isDebugging: Bool = false,
-        systemBootTime: TimeInterval = Date.timeIntervalSinceReferenceDate
+        systemBootTime: TimeInterval = Date.timeIntervalSinceReferenceDate,
+        logicalCpuCount: Double? = nil,
+        totalRam: Double? = nil
     ) -> DeviceInfo {
         return .init(
             name: name,
@@ -201,7 +203,9 @@ extension DeviceInfo: AnyMockable, RandomMockable {
             isSimulator: isSimulator,
             vendorId: vendorId,
             isDebugging: isDebugging,
-            systemBootTime: systemBootTime
+            systemBootTime: systemBootTime,
+            logicalCpuCount: logicalCpuCount,
+            totalRam: totalRam
         )
     }
 
@@ -214,7 +218,9 @@ extension DeviceInfo: AnyMockable, RandomMockable {
             isSimulator: .mockRandom(),
             vendorId: .mockRandom(),
             isDebugging: .mockRandom(),
-            systemBootTime: .mockRandom()
+            systemBootTime: .mockRandom(),
+            logicalCpuCount: .mockRandom(),
+            totalRam: .mockRandom()
         )
     }
 }


### PR DESCRIPTION
### What and why?

Some internal data structure changes broke Session Replay builds. This should fix them by updating mocks with correct parameters.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
