### PR TITLE
fix: Add missing proguard rules for Android

### DIFF
--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -43,6 +43,10 @@ apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
+     defaultConfig {
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+    
     namespace "com.datadoghq.flutter"
     compileSdk 36
 

--- a/packages/datadog_flutter_plugin/android/consumer-rules.pro
+++ b/packages/datadog_flutter_plugin/android/consumer-rules.pro
@@ -1,2 +1,11 @@
--keep class com.datadoghq.flutter.DatadogLogEventMapper.** { *; }
--keep class com.datadoghq.flutter.DatadogRumEventMapper** { *; }
+-keep class com.datadog.android.api.context.* { *; }
+-keep class com.datadoghq.flutter.DatadogSdkPlugin { *; }
+-keep class com.datadoghq.flutter.DatadogSdkPlugin$Companion { *; }
+-keep class com.datadoghq.flutter.DatadogLogsPlugin { *; }
+-keep class com.datadoghq.flutter.DatadogLogsPlugin$Companion { *; }
+-keep class com.datadoghq.flutter.DatadogLogEventMapper { *; }
+-keep class com.datadoghq.flutter.DatadogLogEventMapper$EventMapper { *; }
+-keep class com.datadoghq.flutter.DatadogRumPlugin { *; }
+-keep class com.datadoghq.flutter.DatadogRumPlugin$Companion { *; }
+-keep class com.datadoghq.flutter.DatadogRumEventMapper { *; }
+-keep class com.datadoghq.flutter.DatadogRumEventMapper$EventMapper { *; }


### PR DESCRIPTION
### What and why?

Proguard rules were not properly referenced in the Android build.gradle, and several were missing, especially for the new method of getting context through JNI.

Add all proguard rules.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
