### PR TITLE
chore: Upgrade all examples to use AGP 8.9.1 and gradle 8.11.1

### DIFF
--- a/examples/native-hybrid-app/android/build.gradle
+++ b/examples/native-hybrid-app/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.6.0' apply false
+    id 'com.android.application' version '8.9.1' apply false
     id 'com.android.library' version '8.6.0' apply false
     id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
 }

--- a/examples/simple_example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/simple_example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Mar 06 14:29:56 EST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/simple_example/android/settings.gradle
+++ b/examples/simple_example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 

--- a/packages/datadog_flutter_plugin/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Nov 04 16:56:33 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/settings.gradle
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/settings.gradle
@@ -24,7 +24,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:11.6.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"

--- a/packages/datadog_flutter_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/datadog_flutter_plugin/example/android/settings.gradle
+++ b/packages/datadog_flutter_plugin/example/android/settings.gradle
@@ -24,7 +24,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -9,4 +9,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/packages/datadog_flutter_plugin/integration_test_app/android/settings.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/settings.gradle
@@ -24,7 +24,7 @@
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 

--- a/packages/datadog_inappwebview_tracking/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_inappwebview_tracking/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/datadog_inappwebview_tracking/example/android/settings.gradle
+++ b/packages/datadog_inappwebview_tracking/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 

--- a/packages/datadog_session_replay/example/android/settings.gradle.kts
+++ b/packages/datadog_session_replay/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.7.0" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 

--- a/packages/datadog_tracking_http_client/example/android/build.gradle
+++ b/packages/datadog_tracking_http_client/example/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/datadog_tracking_http_client/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_tracking_http_client/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Apr 14 16:55:38 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/datadog_tracking_http_client/example/android/settings.gradle
+++ b/packages/datadog_tracking_http_client/example/android/settings.gradle
@@ -24,7 +24,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 

--- a/packages/datadog_webview_tracking/example/android/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:11.6.0"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"

--- a/packages/datadog_webview_tracking/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/datadog_webview_tracking/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/packages/datadog_webview_tracking/example/android/settings.gradle
+++ b/packages/datadog_webview_tracking/example/android/settings.gradle
@@ -24,7 +24,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 

--- a/test_apps/stress_test/android/build.gradle
+++ b/test_apps/stress_test/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.6.0'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/test_apps/stress_test/android/settings.gradle
+++ b/test_apps/stress_test/android/settings.gradle
@@ -24,7 +24,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
+    id "com.android.application" version "8.9.1" apply false
     id "org.jetbrains.kotlin.android" version "$kotlin_version" apply false
 }
 


### PR DESCRIPTION
### What and why?

Changes to either Flutter or Datadog Android introduced dependencies that require the Android Gradle Plugin >8.9.1, which requires Gradle >8.11.1. Upgrade gradle wrappers and properties files in examples to upgrade those dependencies.

Fixes build issue in CI.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
