### PR TITLE
chore: Update iOS SessionReplayFeature to support `performanceOverride`

### DIFF
--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -10,17 +10,17 @@ PODS:
   - datadog_session_replay (0.0.1):
     - DatadogCore (~> 3)
     - Flutter
-  - DatadogCore (3.5.0):
-    - DatadogInternal (= 3.5.0)
-  - DatadogCrashReporting (3.5.0):
-    - DatadogInternal (= 3.5.0)
+  - DatadogCore (3.6.1):
+    - DatadogInternal (= 3.6.1)
+  - DatadogCrashReporting (3.6.1):
+    - DatadogInternal (= 3.6.1)
     - KSCrash/Filters (= 2.5.0)
     - KSCrash/Recording (= 2.5.0)
-  - DatadogInternal (3.5.0)
-  - DatadogLogs (3.5.0):
-    - DatadogInternal (= 3.5.0)
-  - DatadogRUM (3.5.0):
-    - DatadogInternal (= 3.5.0)
+  - DatadogInternal (3.6.1)
+  - DatadogLogs (3.6.1):
+    - DatadogInternal (= 3.6.1)
+  - DatadogRUM (3.6.1):
+    - DatadogInternal (= 3.6.1)
   - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -85,29 +85,29 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogCore:
-    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
+    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogCrashReporting:
-    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
+    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogInternal:
-    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
+    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogLogs:
-    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
+    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogRUM:
-    :commit: 19db3afca5bafd34971e11eb8701f18bd0f699a2
+    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: 64adc7ef089a1328c78fd4fab24e49afa09d95a5
   datadog_session_replay: 8e4f4a520f20feb2916c623c011a53ba63f8d77f
-  DatadogCore: 4cbe2646591d2f96fb3188400863ec93ac411235
-  DatadogCrashReporting: e48da3f880a59d2aa2d04e5034e56507177e9d64
-  DatadogInternal: 63308b529cd87fb2f99c5961d9ff13afb300a3aa
-  DatadogLogs: be538def1d5204e011f7952915ad0261014a0dd5
-  DatadogRUM: cffc65659ce29546fcc2639a74003135259548fc
+  DatadogCore: 6a06e0ebe2ddbb6da25b8cfdc3069e9d808aa645
+  DatadogCrashReporting: 03f23e6ad3a449f4d066531164fd8e4cec9651c2
+  DatadogInternal: 3c909dcfb157d420686e62af2eb7cb88af406248
+  DatadogLogs: 5dcb68859d43c4b5a43ef61a5ff1360e24da87d2
+  DatadogRUM: b8c1b0ea81da5a2379e874be065d41ac1d9bc4f1
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Feature/FlutterSessionReplayFeature.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Feature/FlutterSessionReplayFeature.swift
@@ -43,6 +43,8 @@ class DefaultFlutterSessionReplayFeature: FlutterSessionReplayFeature, DatadogRe
     private var core: DatadogCoreProtocol?
     private var featureScope: FeatureScope?
 
+    let performanceOverride: DatadogInternal.PerformancePresetOverride?
+
     let requestBuilder: DatadogInternal.FeatureRequestBuilder
     let messageReceiver: DatadogInternal.FeatureMessageReceiver
 
@@ -54,7 +56,8 @@ class DefaultFlutterSessionReplayFeature: FlutterSessionReplayFeature, DatadogRe
     init(
         core: DatadogCoreProtocol,
         configuration: Configuration,
-        resourceResolver: ResourceResolver?
+        resourceResolver: ResourceResolver?,
+        performanceOverride: PerformancePresetOverride? = nil
     ) throws {
         self.core = core
         self.featureScope = core.scope(for: DefaultFlutterSessionReplayFeature.self)
@@ -78,6 +81,8 @@ class DefaultFlutterSessionReplayFeature: FlutterSessionReplayFeature, DatadogRe
         self.resourceResolver = resourceResolver ?? DefaultResourceResolver(
             writer: ResourcesWriter(scope: core.scope(for: ResourcesFeature.self))
         )
+        
+        self.performanceOverride = performanceOverride
     }
 
     func setHasReplay(_ hasReplay: Bool) {


### PR DESCRIPTION
### What and why?

Latest iOS `develop` added a protocol item to `DatadogRemoteFeature` that `SessionReplayFeature` needs to implement to remain in compliance.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
