### PR TITLE
RUM Add "manual" resource size tracking when content-length is not available (Issue #940)

### DIFF
--- a/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
+++ b/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: invalid_use_of_internal_member
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
@@ -92,6 +93,20 @@ class DatadogDioInterceptor extends Interceptor {
     super.onError(err, handler);
   }
 
+  /// Returns byte length of response body when already in memory (e.g. chunked response).
+  static int? _responseDataByteLength(dynamic data) {
+    if (data is List<int>) {
+      return data.length;
+    }
+    if (data is Uint8List) {
+      return data.length;
+    }
+    if (data is String) {
+      return utf8.encode(data).length;
+    }
+    return null;
+  }
+
   void _stopWithResponse(
       DatadogRum rum, String rumKey, Response<dynamic> response) {
     final contentTypeHeader =
@@ -105,6 +120,10 @@ class DatadogDioInterceptor extends Interceptor {
         response.headers[Headers.contentLengthHeader]?.firstOrNull;
     if (contentLengthHeader != null) {
       contentLength = int.tryParse(contentLengthHeader);
+    }
+    // Chunked/streamed responses may omit Content-Length; use response body size when available
+    if (contentLength == null && response.data != null) {
+      contentLength = _responseDataByteLength(response.data);
     }
     final attributes = attributesProvider?.onResponse(response) ?? {};
     rum.stopResource(

--- a/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
+++ b/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
@@ -375,6 +375,29 @@ void main() {
           .stopResource(rumKey, 202, any(), any(), {'my_attribute': 100}));
     });
 
+    test('reports resource size from response body when Content-Length is missing (chunked)',
+        () {
+      // Given: chunked response with no content-length header but body in memory
+      final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);
+      final requestOptions =
+          RequestOptions(path: 'https://test_uri', method: 'GET', headers: {});
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+      final response = Response(
+        requestOptions: requestOptions,
+        statusCode: 200,
+        data: [1, 2, 3, 4, 5],
+        headers: Headers(),
+      );
+
+      // When
+      final handler = ResponseInterceptionHandlerMock();
+      interceptor.onResponse(response, handler);
+
+      // Then
+      verify(() => mockRum.stopResource(rumKey, 200, any(), 5, any()));
+    });
+
     test('the interceptor stops resource with error on error', () {
       // Given
       final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -146,11 +146,15 @@ class DatadogClient extends http.BaseClient {
       try {
         // Copy the response so we can spy on the stream.
         final spyStream = StreamController<List<int>>();
-
         Object? firstError;
+        int? bytesReceived;
 
         response.stream.listen(
-          spyStream.sink.add,
+          (List<int> data) {
+            bytesReceived ??= 0;
+            bytesReceived = bytesReceived! + data.length;
+            spyStream.sink.add(data);
+          },
           onError: (Object e, StackTrace? st) {
             if (firstError == null) {
               firstError = e;
@@ -169,7 +173,8 @@ class DatadogClient extends http.BaseClient {
             if (rumKey != null) {
               final attributes =
                   attributesProvider?.call(request, response, null) ?? {};
-              _onFinish(rum, rumKey, response, attributes, firstError);
+              final size = response.contentLength ?? bytesReceived;
+              _onFinish(rum, rumKey, response, attributes, firstError, size);
             }
             spyStream.close();
           },
@@ -208,7 +213,7 @@ class DatadogClient extends http.BaseClient {
   }
 
   void _onFinish(DatadogRum rum, String rumKey, http.StreamedResponse response,
-      Map<String, Object?> attributes, Object? error) {
+      Map<String, Object?> attributes, Object? error, int? size) {
     try {
       // If we saw an error, this resource has already been stopped
       if (error == null) {
@@ -222,7 +227,7 @@ class DatadogClient extends http.BaseClient {
           rumKey,
           response.statusCode,
           resourceType,
-          response.contentLength,
+          size,
           attributes,
         );
       }

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -509,6 +509,7 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
   final TracingContext? tracingContext;
   final Map<String, Object?> userAttributes;
   Object? lastError;
+  int? bytesReceived;
 
   _DatadogTrackingHttpResponse(
     this.client,
@@ -522,7 +523,14 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
   StreamSubscription<List<int>> listen(void Function(List<int> event)? onData,
       {Function? onError, void Function()? onDone, bool? cancelOnError}) {
     return innerResponse.listen(
-      onData,
+      (List<int> data) {
+        bytesReceived ??= 0;
+        bytesReceived = bytesReceived! + data.length;
+        if (onData == null) {
+          return;
+        }
+        onData.call(data);
+      },
       cancelOnError: cancelOnError,
       onError: (Object e, StackTrace st) {
         _onError(e, st);
@@ -580,7 +588,7 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
           var resourceType = resourceTypeFromContentType(headers.contentType);
           var size = innerResponse.contentLength > 0
               ? innerResponse.contentLength
-              : null;
+              : bytesReceived;
           var attributes =
               generateDatadogAttributes(tracingContext, rum.traceSampleRate);
           client.configuration.clientListener?.responseFinished(

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -164,6 +164,30 @@ void main() {
           mockRum.stopResource(key, 200, RumResourceType.image, 88888, any()));
     });
 
+    test('reports streamed response size when contentLength is null (chunked)',
+        () async {
+      final client =
+          DatadogClient(datadogSdk: mockDatadog, innerClient: mockClient);
+      final testUri = Uri.parse('https://test_url/test');
+
+      when(() => mockResponse.contentLength).thenReturn(null);
+      when(() => mockResponse.headers).thenReturn({
+        HttpHeaders.contentTypeHeader: ContentType('image', 'png').toString()
+      });
+      final chunkedStream =
+          http.ByteStream(Stream.fromIterable([[1, 2, 3], [4, 5]]));
+      when(() => mockResponse.stream).thenAnswer((_) => chunkedStream);
+
+      await client.get(testUri, headers: {'x-datadog-header': 'header'});
+
+      final key = verify(() => mockRum.startResource(
+              captureAny(), RumHttpMethod.get, testUri.toString(), any()))
+          .captured[0] as String;
+
+      verify(() =>
+          mockRum.stopResource(key, 200, RumResourceType.image, 5, any()));
+    });
+
     test('calls stopResource with provided attributes', () async {
       http.BaseRequest? providedRequest;
       http.StreamedResponse? providedResponse;

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -310,6 +310,34 @@ void main() {
           capturedKey, 200, RumResourceType.media, 88888, any()));
     });
 
+    test('reports streamed response size when contentLength is unknown (chunked)',
+        () async {
+      var url = Uri.parse('https://test_url/path');
+      final completer = setupMockRequest(url);
+
+      var request = await client.openUrl('get', url);
+
+      verify(() => mockClient.openUrl('get', url));
+      var capturedKey = verify(
+        () => mockRum.startResource(
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
+      ).captured[0] as String;
+
+      // contentLength -1 = unknown (e.g. chunked transfer encoding)
+      final mockResponse = setupMockClientResponse(200, size: -1,
+          mimeType: 'application/octet-stream');
+      completer.complete(mockResponse);
+      var response = await request.done;
+
+      response.listen((event) {});
+      mockResponse.streamController.sink.add([1, 2, 3]);
+      mockResponse.streamController.sink.add([4, 5]);
+      await mockResponse.streamController.close();
+
+      verify(() => mockRum.stopResource(
+          capturedKey, 200, RumResourceType.native, 5, any()));
+    });
+
     test('calls stop resource with error connection error', () async {
       var url = Uri.parse('https://test_url/path');
       final completer = setupMockRequest(url);


### PR DESCRIPTION
### What and why?

Track resource size "manually" (tracking incoming stream total byte size) when content-length is not available.

Updates `datadog_dio` and `datadog_tracking_http_client`.

### How?

When the content length is not available, track the size of the response manually.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue #940 
