### PR TITLE
Handle reporting resource size for chunked responses

### DIFF
--- a/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
+++ b/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
@@ -106,6 +106,12 @@ class DatadogDioInterceptor extends Interceptor {
     if (contentLengthHeader != null) {
       contentLength = int.tryParse(contentLengthHeader);
     }
+    if (contentLength == null) {
+      final data = response.data;
+      if (data is List<int>) { // Only treat ResponseType.bytes. JSON will already have been parse to Dart Objects.
+        contentLength = data.length;
+      }
+    }
     final attributes = attributesProvider?.onResponse(response) ?? {};
     rum.stopResource(
       rumKey,

--- a/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
+++ b/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
@@ -466,6 +466,33 @@ void main() {
       verify(() => handler.next(dioException));
     });
 
+    test(
+        'the interceptor reports data length when content-length header is absent and data is bytes',
+        () {
+      // Given
+      final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);
+      final requestOptions = RequestOptions(
+          path: 'https://test_uri',
+          method: 'GET',
+          headers: {},
+          responseType: ResponseType.bytes);
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+      final response = Response(
+        requestOptions: requestOptions,
+        statusCode: 200,
+        data: [1, 2, 3, 4, 5],
+      );
+
+      // When
+      final handler = ResponseInterceptionHandlerMock();
+      interceptor.onResponse(response, handler);
+
+      // Then
+      verify(() =>
+          mockRum.stopResource(rumKey, 200, RumResourceType.native, 5, any()));
+    });
+ 
     test('the interceptor ignores requests that match a regex', () {
       // Given
       final interceptor = DatadogDioInterceptor(

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -148,9 +148,13 @@ class DatadogClient extends http.BaseClient {
         final spyStream = StreamController<List<int>>();
 
         Object? firstError;
+        int byteCount = 0;
 
         response.stream.listen(
-          spyStream.sink.add,
+          (data) {
+            byteCount += data.length;
+            spyStream.sink.add(data);
+          },
           onError: (Object e, StackTrace? st) {
             if (firstError == null) {
               firstError = e;
@@ -169,7 +173,8 @@ class DatadogClient extends http.BaseClient {
             if (rumKey != null) {
               final attributes =
                   attributesProvider?.call(request, response, null) ?? {};
-              _onFinish(rum, rumKey, response, attributes, firstError);
+              _onFinish(
+                  rum, rumKey, response, attributes, firstError, byteCount);
             }
             spyStream.close();
           },
@@ -208,7 +213,7 @@ class DatadogClient extends http.BaseClient {
   }
 
   void _onFinish(DatadogRum rum, String rumKey, http.StreamedResponse response,
-      Map<String, Object?> attributes, Object? error) {
+      Map<String, Object?> attributes, Object? error, int byteCount) {
     try {
       // If we saw an error, this resource has already been stopped
       if (error == null) {
@@ -218,11 +223,15 @@ class DatadogClient extends http.BaseClient {
             ? ContentType.parse(contentTypeHeader)
             : ContentType.text;
         var resourceType = resourceTypeFromContentType(contentType);
+        var size = response.contentLength;
+        if (size == null || size <= 0) {
+          size = byteCount > 0 ? byteCount : null;
+        }
         datadogSdk.rum?.stopResource(
           rumKey,
           response.statusCode,
           resourceType,
-          response.contentLength,
+          size,
           attributes,
         );
       }

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -509,6 +509,7 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
   final TracingContext? tracingContext;
   final Map<String, Object?> userAttributes;
   Object? lastError;
+  int _byteCount = 0;
 
   _DatadogTrackingHttpResponse(
     this.client,
@@ -522,7 +523,12 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
   StreamSubscription<List<int>> listen(void Function(List<int> event)? onData,
       {Function? onError, void Function()? onDone, bool? cancelOnError}) {
     return innerResponse.listen(
-      onData,
+      (event) {
+        _byteCount += event.length;
+        if (onData != null) {
+          onData(event);
+        }
+      },
       cancelOnError: cancelOnError,
       onError: (Object e, StackTrace st) {
         _onError(e, st);
@@ -580,7 +586,7 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
           var resourceType = resourceTypeFromContentType(headers.contentType);
           var size = innerResponse.contentLength > 0
               ? innerResponse.contentLength
-              : null;
+              : (_byteCount > 0 ? _byteCount : null);
           var attributes =
               generateDatadogAttributes(tracingContext, rum.traceSampleRate);
           client.configuration.clientListener?.responseFinished(

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -393,6 +393,54 @@ void main() {
       verify(() => mockRum.stopResource(any(), any(), any(), any(), any()));
     });
 
+    test(
+        'reports counted byte size when contentLength is null (chunked response)',
+        () async {
+      final client =
+          DatadogClient(datadogSdk: mockDatadog, innerClient: mockClient);
+      final testUri = Uri.parse('https://test_url/test');
+
+      when(() => mockResponse.contentLength).thenReturn(null);
+      when(() => mockResponse.stream).thenAnswer(
+          (_) => http.ByteStream.fromBytes([1, 2, 3, 4, 5]));
+
+      final future =
+          client.get(testUri, headers: {'x-datadog-header': 'header'});
+
+      await future;
+
+      final key = verify(() => mockRum.startResource(
+              captureAny(), RumHttpMethod.get, testUri.toString(), any()))
+          .captured[0] as String;
+
+      verify(() =>
+          mockRum.stopResource(key, 200, RumResourceType.native, 5, any()));
+    });
+
+    test(
+        'reports contentLength when available even if bytes are also counted',
+        () async {
+      final client =
+          DatadogClient(datadogSdk: mockDatadog, innerClient: mockClient);
+      final testUri = Uri.parse('https://test_url/test');
+
+      when(() => mockResponse.contentLength).thenReturn(88888);
+      when(() => mockResponse.stream).thenAnswer(
+          (_) => http.ByteStream.fromBytes([1, 2, 3]));
+
+      final future =
+          client.get(testUri, headers: {'x-datadog-header': 'header'});
+
+      await future;
+
+      final key = verify(() => mockRum.startResource(
+              captureAny(), RumHttpMethod.get, testUri.toString(), any()))
+          .captured[0] as String;
+
+      verify(() =>
+          mockRum.stopResource(key, 200, RumResourceType.native, 88888, any()));
+    });
+
     for (final headerType in TracingHeaderType.values) {
       group('when rum is enabled with $headerType tracing headers', () {
         setUp(() {

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -594,6 +594,55 @@ void main() {
             any(),
           ));
     });
+
+    test(
+        'reports counted byte size when contentLength is unavailable (chunked response)',
+        () async {
+      var url = Uri.parse('https://test_url/path');
+      final completer = setupMockRequest(url);
+
+      var request = await client.openUrl('get', url);
+      var capturedKey = verify(
+        () => mockRum.startResource(
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
+      ).captured[0] as String;
+
+      final mockResponse = setupMockClientResponse(200, size: -1);
+      completer.complete(mockResponse);
+      var response = await request.done;
+
+      response.listen((event) {});
+      mockResponse.streamController.sink.add([1, 2, 3]);
+      mockResponse.streamController.sink.add([4, 5]);
+      await mockResponse.streamController.close();
+
+      verify(() => mockRum.stopResource(
+          capturedKey, 200, RumResourceType.image, 5, any()));
+    });
+
+    test(
+        'reports contentLength when available even if bytes are also counted',
+        () async {
+      var url = Uri.parse('https://test_url/path');
+      final completer = setupMockRequest(url);
+
+      var request = await client.openUrl('get', url);
+      var capturedKey = verify(
+        () => mockRum.startResource(
+            captureAny(), RumHttpMethod.get, url.toString(), any()),
+      ).captured[0] as String;
+
+      final mockResponse = setupMockClientResponse(200, size: 88888);
+      completer.complete(mockResponse);
+      var response = await request.done;
+
+      response.listen((event) {});
+      mockResponse.streamController.sink.add([1, 2, 3]);
+      await mockResponse.streamController.close();
+
+      verify(() => mockRum.stopResource(
+          capturedKey, 200, RumResourceType.image, 88888, any()));
+    });
   });
 
   for (final headerType in TracingHeaderType.values) {


### PR DESCRIPTION
### What and why?

Addresses the lack of reported resource size in the case of no `Content-Length` available.
See Issue #940. 

### How?

Falls back to manually tracking the number of bytes recieved.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue

