### PR TITLE
fix: Nested GestureDetector should take precedence over parent InkWell

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -39,9 +39,18 @@ class _ElementDescription {
       return true;
     }
 
-    // Literally anything is better than GestureDetector...
+    // GestureDetector and InkWell are both generic tappable containers.
+    // A GestureDetector with its own annotation (different from the parent
+    // InkWell's annotation) should take precedence, indicating the user
+    // intentionally created a separate tappable area. However, if they share
+    // the same annotation, prefer InkWell as the GestureDetector is likely
+    // internal or unintentional.
     if (element.widget is GestureDetector) {
-      // ... except another GestureDetector
+      if (other.element.widget is InkWell &&
+          elementDescription != other.elementDescription) {
+        return true;
+      }
+      // Otherwise, GestureDetector only replaces another GestureDetector
       return other.element.widget is GestureDetector;
     }
 

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -259,6 +259,125 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
+  testWidgets(
+      'nested GestureDetector inside InkWell uses inner GestureDetector',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final parentAnnotation = randomString();
+    final childAnnotation = randomString();
+    final childText = randomString();
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      RumUserActionAnnotation(
+        description: parentAnnotation,
+        child: InkWell(
+          onTap: () {},
+          child: Column(children: [
+            const Text('Parent text'),
+            RumUserActionAnnotation(
+              description: childAnnotation,
+              child: GestureDetector(
+                onTap: () {},
+                child: Text(childText),
+              ),
+            ),
+          ]),
+        ),
+      ),
+    ));
+
+    final text = find
+        .byWidgetPredicate((widget) => widget is Text && widget.data == childText);
+    await tester.tap(text);
+
+    verify(() => mockRum.addAction(
+        RumActionType.tap, 'GestureDetector($childAnnotation)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'nested GestureDetector inside InkWell without annotation uses InkWell',
+      (tester) async {
+    // When a GestureDetector is nested inside InkWell but has NO annotation,
+    // the InkWell should take precedence (the GestureDetector is likely
+    // internal or unintentional).
+    final mockRum = MockDdRum();
+
+    final parentAnnotation = randomString();
+    final childText = randomString();
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      RumUserActionAnnotation(
+        description: parentAnnotation,
+        child: InkWell(
+          onTap: () {},
+          child: Column(children: [
+            const Text('Parent text'),
+            // No RumUserActionAnnotation wrapping the GestureDetector
+            GestureDetector(
+              onTap: () {},
+              child: Text(childText),
+            ),
+          ]),
+        ),
+      ),
+    ));
+
+    final text = find
+        .byWidgetPredicate((widget) => widget is Text && widget.data == childText);
+    await tester.tap(text);
+
+    // Should report InkWell since the nested GestureDetector has no annotation
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'InkWell($parentAnnotation)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'nested GestureDetector inside InkWell reports correct attributes',
+      (tester) async {
+    // Verify that attributes from the inner annotation are correctly reported
+    final mockRum = MockDdRum();
+
+    final parentAnnotation = randomString();
+    final childAnnotation = randomString();
+    final childText = randomString();
+    final childAttributes = {'placement': 'child', 'test_id': 12345};
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      RumUserActionAnnotation(
+        description: parentAnnotation,
+        attributes: {'placement': 'parent'},
+        child: InkWell(
+          onTap: () {},
+          child: Column(children: [
+            const Text('Parent text'),
+            RumUserActionAnnotation(
+              description: childAnnotation,
+              attributes: childAttributes,
+              child: GestureDetector(
+                onTap: () {},
+                child: Text(childText),
+              ),
+            ),
+          ]),
+        ),
+      ),
+    ));
+
+    final text = find
+        .byWidgetPredicate((widget) => widget is Text && widget.data == childText);
+    await tester.tap(text);
+
+    verify(() => mockRum.addAction(
+        RumActionType.tap, 'GestureDetector($childAnnotation)', childAttributes));
+    verifyNoMoreInteractions(mockRum);
+  });
+
   testWidgets('tap button with annotation reports annotation over text',
       (tester) async {
     final mockRum = MockDdRum();


### PR DESCRIPTION
### What and why?

Fixes #740

When a `GestureDetector` with its own `RumUserActionAnnotation` is nested inside an `InkWell`, it should take precedence over the parent `InkWell` when reporting user actions to RUM. Previously, the `InkWell` would always be reported because the `betterThan()` method treated `GestureDetector` as the "worst" option that could never replace other widgets.

This is a common pattern when users want separate tappable areas within an `InkWell`, each with their own tracking annotations.

### How?

Modified the `betterThan()` method in `_ElementDescription` class to allow a `GestureDetector` to take precedence over an `InkWell` **only when they have different annotations**. This distinguishes between:

1. **User-created nested GestureDetector** (has its own annotation → different description) - should take precedence
2. **InkWell's internal GestureDetector** (inherits parent annotation → same description) - should NOT take precedence

The comparison uses the `elementDescription` field which contains the annotation text, ensuring that only intentionally annotated nested `GestureDetector`s override their parent `InkWell`.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue

### Tests Added

| Test | Scenario | Expected Result |
|------|----------|-----------------|
| `nested GestureDetector inside InkWell uses inner GestureDetector` | InkWell + child annotation + GestureDetector | Reports GestureDetector ✓ |
| `nested GestureDetector inside InkWell without annotation uses InkWell` | InkWell + unannotated GestureDetector | Reports InkWell ✓ |
| `nested GestureDetector inside InkWell reports correct attributes` | Verifies attributes pass through | Correctly reported ✓ |