### PR TITLE
chore: Update SR to require core package 3.1.0+

### DIFF
--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   web: ^1.0.0
   meta: ^1.15.0  
   plugin_platform_interface: ^2.0.2
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ^3.1.0
   json_annotation: ^4.9.0
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

Changes to the DatadogFeature interface in iOS require that Session Replay be paired with a higher version of the Datadog SDK.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
