### PR TITLE
chore(ci): Force flutter upgrades in the case of a dirty working tree.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ stages:
   script:
     - ulimit -S -n 2048
     - export PATH=$PATH:$HOME/.pub-cache/bin
-    - flutter upgrade
+    - flutter upgrade --force
     - flutter --version
     - flutter doctor
     # SPM is the exception, make sure its disabled before starting the build
@@ -335,7 +335,7 @@ nightly-beta-test:
     - fvm destroy
     - fvm install beta
     - fvm use beta
-    - fvm flutter upgrade
+    - fvm flutter upgrade --force
     - fvm flutter precache --ios
     - fvm exec dart pub global activate melos
     - pod repo update    
@@ -365,7 +365,7 @@ nightly-beta-test-web:
     - !reference [.pre, script]
     - !reference [.pre-web, script]
     - flutter channel beta
-    - flutter upgrade
+    - flutter upgrade --force
     - dart pub global activate melos
     - flutter doctor
     - melos pub:get


### PR DESCRIPTION
### What and why?

Our internal CI can get stuck if for some reason the Flutter checkout has modified files.

It is okay for Flutter to force an upgrade on CI, and is preferred over failing builds.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
