### PR TITLE
chore: Release datadog_session_replay preview 10.

### DIFF
--- a/packages/datadog_session_replay/CHANGELOG.md
+++ b/packages/datadog_session_replay/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-preview.10
+
+* Update required minimum version of `datadog_flutter_plugin` to 3.1.0 to support changes in iOS core libraries.
+
 ## 1.0.0-preview.9
 
 * Switch to using a Singleton bridge for SessionReplay on Android to prevent crashes on Hot Restart. See [#932](https://github.com/DataDog/dd-sdk-flutter/issues/932)

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_session_replay
 description: "Support for Flutter Session Replay in Datadog"
-version: 1.0.0-preview.10
+version: 1.1.0
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_session_replay
 description: "Support for Flutter Session Replay in Datadog"
-version: 1.1.0
+version: 1.0.0-preview.10
 homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

Changes related to releasing Session Replay preview 10.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
