### PR TITLE
chore: Fix nightly builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -364,6 +364,7 @@ nightly-beta-test-web:
   script:
     - !reference [.pre, script]
     - !reference [.pre-web, script]
+    - git -C "$(dirname $(dirname $(which flutter)))" reset --hards
     - flutter channel beta
     - flutter upgrade --force
     - dart pub global activate melos


### PR DESCRIPTION
### What and why?

Flutter can get stuck if its git repo gets out of sync. Reset it hard before switching channels on the web nightly tests.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
