### PR TITLE
Dockerfile.gitlab: remove redundant dd-package install

### DIFF
--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -64,12 +64,6 @@ RUN python3 --version
 RUN set -x \
  && pip install awscli
 
-RUN set -x \
- && curl -OL https://s3.amazonaws.com/dd-package-public/dd-package.deb && dpkg -i dd-package.deb && rm dd-package.deb \
- && apt-get update \
- && apt-get -y clean \
- && rm -rf /var/lib/apt/lists/*
-
 # Gradle
 RUN \
     cd /usr/local && \


### PR DESCRIPTION
### What and why?

dd-package is already installed in the base GBI, redundant installation is unnecessary

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
