### PR TITLE
fix(sr): Fix a lifecycle issue with Android calling a dead callback on activity destruction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ examples/native-hybrid-app/ios/Podfile.lock
 packages/datadog_flutter_plugin/example/ios/Podfile.lock
 .build
 tools/ci/.tmp
+.fvmrc
+.plans

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
@@ -7,16 +7,37 @@
 package com.datadoghq.flutter.sessionreplay
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodChannel
 
 class DatadogSessionReplayPlugin : FlutterPlugin {
+    private var channel: MethodChannel? = null
+
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        // No-op: the context listener is set up when Dart calls enable() on the new engine.
+        // FFI plugins do not receive engine lifecycle events, so we cannot determine
+        // which engine called enable() from within the FFI call itself. Instead, after
+        // calling enable() via FFI, Dart fires a non-awaited 'claimOwnership' message
+        // through this method channel. Because method channels route to the plugin
+        // instance for their specific engine, we can reliably associate the enable()
+        // call with this engine's messenger and set listenerOwner correctly.
+        // See: https://github.com/flutter/flutter/issues/184124
+        channel = MethodChannel(binding.binaryMessenger, "datadog_session_replay/engine")
+        channel?.setMethodCallHandler { call, result ->
+            if (call.method == "claimOwnership") {
+                FlutterSessionReplayBridge.claimOwnership(binding.binaryMessenger)
+                result.success(null)
+            } else {
+                result.notImplemented()
+            }
+        }
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel?.setMethodCallHandler(null)
+        channel = null
         // Null out the context listener so context updates don't attempt to invoke a
         // callback into the now-destroyed Dart isolate, which would cause a SIGABRT.
-        // The listener will be restored when the new engine calls enable().
-        FlutterSessionReplayBridge.detachFromEngine()
+        // The ownership check ensures a secondary engine detaching doesn't clear the
+        // listener registered by a still-live engine.
+        FlutterSessionReplayBridge.detachFromEngine(binding.binaryMessenger)
     }
 }

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPlugin.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+
+class DatadogSessionReplayPlugin : FlutterPlugin {
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        // No-op: the context listener is set up when Dart calls enable() on the new engine.
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        // Null out the context listener so context updates don't attempt to invoke a
+        // callback into the now-destroyed Dart isolate, which would cause a SIGABRT.
+        // The listener will be restored when the new engine calls enable().
+        FlutterSessionReplayBridge.detachFromEngine()
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
@@ -37,7 +37,9 @@ internal object FlutterSessionReplayBridge {
         val onContextChanged: ContextListener
     )
 
+    @Volatile
     var contextListener: ContextListener? = null
+
     var feature: DefaultFlutterSessionReplayFeature? = null
     internal var listenerOwner: BinaryMessenger? = null
 

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
@@ -9,6 +9,7 @@ package com.datadoghq.flutter.sessionreplay
 import com.datadog.android.Datadog
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadoghq.flutter.sessionreplay.feature.DefaultFlutterSessionReplayFeature
+import io.flutter.plugin.common.BinaryMessenger
 import java.nio.ByteBuffer
 
 internal object FlutterSessionReplayBridge {
@@ -37,6 +38,11 @@ internal object FlutterSessionReplayBridge {
 
     var contextListener: ContextListener? = null
     var feature: DefaultFlutterSessionReplayFeature? = null
+    internal var listenerOwner: BinaryMessenger? = null
+
+    fun claimOwnership(messenger: BinaryMessenger) {
+        listenerOwner = messenger
+    }
 
     fun enable(
         configuration: Configuration,
@@ -45,6 +51,12 @@ internal object FlutterSessionReplayBridge {
         // Always replace the context listener. This is to prevent a crash in the case of a
         // Hot Restart, where the previously created context listener has been destroyed.
         contextListener = configuration.onContextChanged
+        // Clear any stale ownership. claimOwnership() will re-establish it for the correct
+        // engine once the Dart-side 'claimOwnership' method channel message is delivered.
+        // There is a brief gap between enable() and claimOwnership() during which
+        // listenerOwner is null; this is intentional and acceptable — see the comment in
+        // DatadogSessionReplayPlugin.onAttachedToEngine for the full explanation.
+        listenerOwner = null
         // If this is already initialized, just return the existing feature (don't recreate and
         // and replace it on the core).
         feature?.let {
@@ -62,14 +74,20 @@ internal object FlutterSessionReplayBridge {
         return newFeature
     }
 
-    fun detachFromEngine() {
-        contextListener = null
+    fun detachFromEngine(messenger: BinaryMessenger) {
+        // Only null the listener if the detaching engine is the one that registered it.
+        // This prevents a detaching secondary engine from clearing a live engine's callback.
+        if (listenerOwner === messenger) {
+            contextListener = null
+            listenerOwner = null
+        }
     }
 
     // Only used in testing
     internal fun shutdown() {
         feature = null
         contextListener = null
+        listenerOwner = null
     }
 
     fun setHasReplay(viewId: String, hasReplay: Boolean) {

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
@@ -12,6 +12,7 @@ import com.datadoghq.flutter.sessionreplay.feature.DefaultFlutterSessionReplayFe
 import io.flutter.plugin.common.BinaryMessenger
 import java.nio.ByteBuffer
 
+@Suppress("TooManyFunctions")
 internal object FlutterSessionReplayBridge {
     data class RumContext(
         val applicationId: String?,

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridge.kt
@@ -62,6 +62,10 @@ internal object FlutterSessionReplayBridge {
         return newFeature
     }
 
+    fun detachFromEngine() {
+        contextListener = null
+    }
+
     // Only used in testing
     internal fun shutdown() {
         feature = null

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
@@ -13,7 +13,6 @@ import assertk.assertions.isNull
 import com.datadog.android.api.feature.FeatureSdkCore
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
-import io.flutter.plugin.common.MethodChannel
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay
+
+import android.os.Looper
+import assertk.assertThat
+import assertk.assertions.isNull
+
+import com.datadog.android.api.feature.FeatureSdkCore
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DatadogSessionReplayPluginTest {
+    @BeforeAll
+    fun beforeAll() {
+        val mockLooper = mockk<Looper>()
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() }.returns(mockLooper)
+    }
+
+    @AfterAll
+    fun afterAll() {
+        unmockkStatic(Looper::class)
+    }
+
+    @AfterTest
+    fun afterEach() {
+        FlutterSessionReplayBridge.shutdown()
+    }
+
+    @Test
+    fun `M null contextListener W onDetachedFromEngine`() {
+        // Given
+        val mockCore: FeatureSdkCore = mockk(relaxed = true)
+        val configuration = FlutterSessionReplayBridge.Configuration(
+            customEndpointUrl = null,
+            onContextChanged = mockk(relaxed = true)
+        )
+        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+
+        val plugin = DatadogSessionReplayPlugin()
+        val mockBinding = mockk<FlutterPlugin.FlutterPluginBinding>(relaxed = true)
+
+        // When
+        plugin.onDetachedFromEngine(mockBinding)
+
+        // Then
+        assertThat(FlutterSessionReplayBridge.contextListener).isNull()
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/DatadogSessionReplayPluginTest.kt
@@ -8,10 +8,12 @@ package com.datadoghq.flutter.sessionreplay
 
 import android.os.Looper
 import assertk.assertThat
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
-
 import com.datadog.android.api.feature.FeatureSdkCore
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -41,23 +43,56 @@ class DatadogSessionReplayPluginTest {
         FlutterSessionReplayBridge.shutdown()
     }
 
+    private fun makeBinding(messenger: BinaryMessenger): FlutterPlugin.FlutterPluginBinding {
+        val binding = mockk<FlutterPlugin.FlutterPluginBinding>(relaxed = true)
+        every { binding.binaryMessenger } returns messenger
+        return binding
+    }
+
     @Test
-    fun `M null contextListener W onDetachedFromEngine`() {
+    fun `M null contextListener W onDetachedFromEngine with owning engine`() {
         // Given
+        val mockMessenger = mockk<BinaryMessenger>(relaxed = true)
         val mockCore: FeatureSdkCore = mockk(relaxed = true)
         val configuration = FlutterSessionReplayBridge.Configuration(
             customEndpointUrl = null,
             onContextChanged = mockk(relaxed = true)
         )
-        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
-
         val plugin = DatadogSessionReplayPlugin()
-        val mockBinding = mockk<FlutterPlugin.FlutterPluginBinding>(relaxed = true)
+        plugin.onAttachedToEngine(makeBinding(mockMessenger))
+        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+        // Simulate claimOwnership arriving from the Dart method channel
+        FlutterSessionReplayBridge.claimOwnership(mockMessenger)
 
         // When
-        plugin.onDetachedFromEngine(mockBinding)
+        plugin.onDetachedFromEngine(makeBinding(mockMessenger))
 
         // Then
         assertThat(FlutterSessionReplayBridge.contextListener).isNull()
+    }
+
+    @Test
+    fun `M not null contextListener W onDetachedFromEngine with non-owning engine`() {
+        // Given
+        val owningMessenger = mockk<BinaryMessenger>(relaxed = true)
+        val otherMessenger = mockk<BinaryMessenger>(relaxed = true)
+        val mockCore: FeatureSdkCore = mockk(relaxed = true)
+        val configuration = FlutterSessionReplayBridge.Configuration(
+            customEndpointUrl = null,
+            onContextChanged = mockk(relaxed = true)
+        )
+        val owningPlugin = DatadogSessionReplayPlugin()
+        owningPlugin.onAttachedToEngine(makeBinding(owningMessenger))
+        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+        FlutterSessionReplayBridge.claimOwnership(owningMessenger)
+
+        val otherPlugin = DatadogSessionReplayPlugin()
+        otherPlugin.onAttachedToEngine(makeBinding(otherMessenger))
+
+        // When — other engine detaches before the owning engine
+        otherPlugin.onDetachedFromEngine(makeBinding(otherMessenger))
+
+        // Then — owning engine's listener is preserved
+        assertThat(FlutterSessionReplayBridge.contextListener).isNotNull()
     }
 }

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridgeTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridgeTest.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadoghq.flutter.sessionreplay.feature.DefaultFlutterSessionReplayFeature
 import com.datadoghq.flutter.sessionreplay.resource.ResourceResolver
@@ -162,5 +163,23 @@ class FlutterSessionReplayBridgeTest {
         // Then
         verify { mockResourceResolver.resolveResource(key) }
         assertThat(result).isEqualTo(resolvedKey)
+    }
+
+    @Test
+    fun `M null contextListener only W detachFromEngine`() {
+        // Given
+        val mockCore: FeatureSdkCore = mockk(relaxed = true)
+        val configuration = FlutterSessionReplayBridge.Configuration(
+            customEndpointUrl = null,
+            onContextChanged = mockk(relaxed = true)
+        )
+        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+
+        // When
+        FlutterSessionReplayBridge.detachFromEngine()
+
+        // Then
+        assertThat(FlutterSessionReplayBridge.contextListener).isNull()
+        assertThat(FlutterSessionReplayBridge.feature).isNotNull()
     }
 }

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridgeTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/FlutterSessionReplayBridgeTest.kt
@@ -19,6 +19,7 @@ import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.flutter.plugin.common.BinaryMessenger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -73,6 +74,36 @@ class FlutterSessionReplayBridgeTest {
         // Then
         assertThat(FlutterSessionReplayBridge.feature).isNotNull()
         verify { mockCore.registerFeature(FlutterSessionReplayBridge.feature!!) }
+    }
+
+    @Test
+    fun `M clear listenerOwner W enable`() {
+        // Given — pre-seed a stale owner
+        val staleMessenger = mockk<BinaryMessenger>()
+        FlutterSessionReplayBridge.claimOwnership(staleMessenger)
+        val mockCore: FeatureSdkCore = mockk(relaxed = true)
+        val configuration = FlutterSessionReplayBridge.Configuration(
+            customEndpointUrl = null,
+            onContextChanged = mockk(relaxed = true)
+        )
+
+        // When
+        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+
+        // Then — listenerOwner is cleared; claimOwnership() will re-establish it
+        assertThat(FlutterSessionReplayBridge.listenerOwner).isNull()
+    }
+
+    @Test
+    fun `M set listenerOwner W claimOwnership`() {
+        // Given
+        val mockMessenger = mockk<BinaryMessenger>()
+
+        // When
+        FlutterSessionReplayBridge.claimOwnership(mockMessenger)
+
+        // Then
+        assertThat(FlutterSessionReplayBridge.listenerOwner).isEqualTo(mockMessenger)
     }
 
     @Test
@@ -166,20 +197,43 @@ class FlutterSessionReplayBridgeTest {
     }
 
     @Test
-    fun `M null contextListener only W detachFromEngine`() {
+    fun `M null contextListener only W detachFromEngine with owning messenger`() {
         // Given
+        val mockMessenger = mockk<BinaryMessenger>()
         val mockCore: FeatureSdkCore = mockk(relaxed = true)
         val configuration = FlutterSessionReplayBridge.Configuration(
             customEndpointUrl = null,
             onContextChanged = mockk(relaxed = true)
         )
         FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+        FlutterSessionReplayBridge.claimOwnership(mockMessenger)
 
         // When
-        FlutterSessionReplayBridge.detachFromEngine()
+        FlutterSessionReplayBridge.detachFromEngine(mockMessenger)
 
         // Then
         assertThat(FlutterSessionReplayBridge.contextListener).isNull()
+        assertThat(FlutterSessionReplayBridge.feature).isNotNull()
+    }
+
+    @Test
+    fun `M not null contextListener W detachFromEngine with non-owning messenger`() {
+        // Given
+        val owningMessenger = mockk<BinaryMessenger>()
+        val otherMessenger = mockk<BinaryMessenger>()
+        val mockCore: FeatureSdkCore = mockk(relaxed = true)
+        val configuration = FlutterSessionReplayBridge.Configuration(
+            customEndpointUrl = null,
+            onContextChanged = mockk(relaxed = true)
+        )
+        FlutterSessionReplayBridge.enable(configuration, core = mockCore)
+        FlutterSessionReplayBridge.claimOwnership(owningMessenger)
+
+        // When — a different engine detaches
+        FlutterSessionReplayBridge.detachFromEngine(otherMessenger)
+
+        // Then — listener is preserved
+        assertThat(FlutterSessionReplayBridge.contextListener).isNotNull()
         assertThat(FlutterSessionReplayBridge.feature).isNotNull()
     }
 }

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -85,19 +85,19 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogCore:
-    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
+    :commit: 471e6eb74e9f687e4d5fcfe44150a3aac3c43eb0
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogCrashReporting:
-    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
+    :commit: 471e6eb74e9f687e4d5fcfe44150a3aac3c43eb0
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogInternal:
-    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
+    :commit: 471e6eb74e9f687e4d5fcfe44150a3aac3c43eb0
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogLogs:
-    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
+    :commit: 471e6eb74e9f687e4d5fcfe44150a3aac3c43eb0
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogRUM:
-    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
+    :commit: 471e6eb74e9f687e4d5fcfe44150a3aac3c43eb0
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -10,17 +10,17 @@ PODS:
   - datadog_session_replay (0.0.1):
     - DatadogCore (~> 3)
     - Flutter
-  - DatadogCore (3.6.1):
-    - DatadogInternal (= 3.6.1)
-  - DatadogCrashReporting (3.6.1):
-    - DatadogInternal (= 3.6.1)
+  - DatadogCore (3.8.2):
+    - DatadogInternal (= 3.8.2)
+  - DatadogCrashReporting (3.8.2):
+    - DatadogInternal (= 3.8.2)
     - KSCrash/Filters (= 2.5.0)
     - KSCrash/Recording (= 2.5.0)
-  - DatadogInternal (3.6.1)
-  - DatadogLogs (3.6.1):
-    - DatadogInternal (= 3.6.1)
-  - DatadogRUM (3.6.1):
-    - DatadogInternal (= 3.6.1)
+  - DatadogInternal (3.8.2)
+  - DatadogLogs (3.8.2):
+    - DatadogInternal (= 3.8.2)
+  - DatadogRUM (3.8.2):
+    - DatadogInternal (= 3.8.2)
   - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
@@ -85,29 +85,29 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogCore:
-    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
+    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogCrashReporting:
-    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
+    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogInternal:
-    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
+    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogLogs:
-    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
+    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogRUM:
-    :commit: 826576bbfdf91f40e57fa1eddbfb615cc4cb44bc
+    :commit: e038a4a6a9dd2cc0c9423fdb77c429d6da02475a
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: 64adc7ef089a1328c78fd4fab24e49afa09d95a5
   datadog_session_replay: 8e4f4a520f20feb2916c623c011a53ba63f8d77f
-  DatadogCore: 6a06e0ebe2ddbb6da25b8cfdc3069e9d808aa645
-  DatadogCrashReporting: 03f23e6ad3a449f4d066531164fd8e4cec9651c2
-  DatadogInternal: 3c909dcfb157d420686e62af2eb7cb88af406248
-  DatadogLogs: 5dcb68859d43c4b5a43ef61a5ff1360e24da87d2
-  DatadogRUM: b8c1b0ea81da5a2379e874be065d41ac1d9bc4f1
+  DatadogCore: 4375353a93311e99153ab3bc2fba10fefb295749
+  DatadogCrashReporting: 4eedb27058432691a7e5f1bdcf3f72d8cc7c1a67
+  DatadogInternal: a4640f67e249c9b4608e806cf1c8c10b17f66626
+  DatadogLogs: 55e2c1c403e92f952f8ce451854c81f476b04d89
+  DatadogRUM: 738b6b448df9af58ba0455451e628ac81040be04
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1BF9F7287A523E34D5710707 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A0117D673D82B937FDFE484 /* Pods_RunnerTests.framework */; };
+		3698E2CC21FBD5E1AEAE147E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F083243CD88418C21034C30 /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		494123582DC129660071423F /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494123572DC129630071423F /* RequestBuilderTests.swift */; };
 		494400772E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */; };
@@ -25,13 +27,12 @@
 		495A02872DCE433B00869BEA /* MultipartBuilderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */; };
 		49B919692E5E36B60024D733 /* ResourceRequestBuilderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B919682E5E36B60024D733 /* ResourceRequestBuilderTest.swift */; };
 		49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */; };
-		7316053E503C0F41FB708DC2 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBE31217C34C0F4AF51AB0D1 /* Pods_RunnerTests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		F0E266978241F168913971FB /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 652D5F7E109B29EC17923DCD /* Pods_Runner.framework */; };
+		E1E091C69AD74808BE3733231FC76E98 /* DatadogSessionReplayPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35542C60C09A47729F76E13B6A659C63 /* DatadogSessionReplayPluginTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,9 +59,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0F083243CD88418C21034C30 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		13E1A25E04A4923630ACE64D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		35542C60C09A47729F76E13B6A659C63 /* DatadogSessionReplayPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogSessionReplayPluginTests.swift; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		494123572DC129630071423F /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
 		494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayBridgeTests.swift; sourceTree = "<group>"; };
@@ -78,12 +82,12 @@
 		495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartBuilderSpy.swift; sourceTree = "<group>"; };
 		49B919682E5E36B60024D733 /* ResourceRequestBuilderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceRequestBuilderTest.swift; sourceTree = "<group>"; };
 		49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayFeatureTests.swift; sourceTree = "<group>"; };
-		6389A5208659C800B0626AEB /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		652D5F7E109B29EC17923DCD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A0117D673D82B937FDFE484 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		79BD53055738C1114E4457B5 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		86169FEDBAA881650B5C877B /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -91,11 +95,10 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C26D39C77C8E5F3BC5175B44 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
-		C966B54817517D7E84B62D9A /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		EA66825668C023A098995432 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		F3E015530CD78AEC3A155FC2 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		FBE31217C34C0F4AF51AB0D1 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9840D6870413420E38040A85 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		CB6E419C80EE782C5F5B2C8E /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CDF9F7F84B03E7F780D7C869 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E3A52EA2C191523119AFBBD1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,7 +107,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
-				F0E266978241F168913971FB /* Pods_Runner.framework in Frameworks */,
+				3698E2CC21FBD5E1AEAE147E /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +115,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7316053E503C0F41FB708DC2 /* Pods_RunnerTests.framework in Frameworks */,
+				1BF9F7287A523E34D5710707 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,12 +125,12 @@
 		0BB2D78FFBA055BE1B719106 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				C966B54817517D7E84B62D9A /* Pods-Runner.debug.xcconfig */,
-				F3E015530CD78AEC3A155FC2 /* Pods-Runner.release.xcconfig */,
-				6389A5208659C800B0626AEB /* Pods-Runner.profile.xcconfig */,
-				EA66825668C023A098995432 /* Pods-RunnerTests.debug.xcconfig */,
-				C26D39C77C8E5F3BC5175B44 /* Pods-RunnerTests.release.xcconfig */,
-				86169FEDBAA881650B5C877B /* Pods-RunnerTests.profile.xcconfig */,
+				9840D6870413420E38040A85 /* Pods-Runner.debug.xcconfig */,
+				13E1A25E04A4923630ACE64D /* Pods-Runner.release.xcconfig */,
+				E3A52EA2C191523119AFBBD1 /* Pods-Runner.profile.xcconfig */,
+				CDF9F7F84B03E7F780D7C869 /* Pods-RunnerTests.debug.xcconfig */,
+				79BD53055738C1114E4457B5 /* Pods-RunnerTests.release.xcconfig */,
+				CB6E419C80EE782C5F5B2C8E /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -141,17 +144,9 @@
 				494123572DC129630071423F /* RequestBuilderTests.swift */,
 				49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */,
 				494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */,
+				35542C60C09A47729F76E13B6A659C63 /* DatadogSessionReplayPluginTests.swift */,
 			);
 			path = RunnerTests;
-			sourceTree = "<group>";
-		};
-		3D463E583C2891815993FE4F /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				652D5F7E109B29EC17923DCD /* Pods_Runner.framework */,
-				FBE31217C34C0F4AF51AB0D1 /* Pods_RunnerTests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		494400752E58AB3500AC46CC /* Resource */ = {
@@ -199,6 +194,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -215,7 +211,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				0BB2D78FFBA055BE1B719106 /* Pods */,
-				3D463E583C2891815993FE4F /* Frameworks */,
+				B9B66C0FC95E83708F8818C4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -243,6 +239,15 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		B9B66C0FC95E83708F8818C4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0F083243CD88418C21034C30 /* Pods_Runner.framework */,
+				6A0117D673D82B937FDFE484 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -250,7 +255,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				AAC92CDB7210512AE34869A9 /* [CP] Check Pods Manifest.lock */,
+				25D949DF85D42F4ACC32F635 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				A7D59CBE4A3F7A47600FDEF9 /* Frameworks */,
@@ -269,15 +274,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				9673E9DAA40D20400C8F3AAE /* [CP] Check Pods Manifest.lock */,
+				058B23031938E4FE3EEEEDCD /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				06D484AE81885132DA584709 /* [CP] Embed Pods Frameworks */,
-				B555DD4C0CD130FDAAEC255A /* [CP] Copy Pods Resources */,
+				856D27D165E93DCA04A44742 /* [CP] Embed Pods Frameworks */,
+				F6722193A3C2B1911D5FE9DF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -321,7 +326,7 @@
 			mainGroup = 97C146E51CF9000F007C117D;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
@@ -356,40 +361,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		06D484AE81885132DA584709 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
-			);
-			name = "Thin Binary";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		9673E9DAA40D20400C8F3AAE /* [CP] Check Pods Manifest.lock */ = {
+		058B23031938E4FE3EEEEDCD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -411,22 +383,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		AAC92CDB7210512AE34869A9 /* [CP] Check Pods Manifest.lock */ = {
+		25D949DF85D42F4ACC32F635 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -448,7 +405,55 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B555DD4C0CD130FDAAEC255A /* [CP] Copy Pods Resources */ = {
+		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
+			);
+			name = "Thin Binary";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		856D27D165E93DCA04A44742 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		F6722193A3C2B1911D5FE9DF /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -486,6 +491,7 @@
 				494123582DC129660071423F /* RequestBuilderTests.swift in Sources */,
 				49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */,
 				494400772E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift in Sources */,
+				E1E091C69AD74808BE3733231FC76E98 /* DatadogSessionReplayPluginTests.swift in Sources */,
 				4944008D2E58F71300AC46CC /* ResourcesWriterTest.swift in Sources */,
 				495642A52E5E2512000FF536 /* ResourceResolverTest.swift in Sources */,
 			);
@@ -606,7 +612,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EA66825668C023A098995432 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = CDF9F7F84B03E7F780D7C869 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -625,7 +631,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C26D39C77C8E5F3BC5175B44 /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = 79BD53055738C1114E4457B5 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -642,7 +648,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 86169FEDBAA881650B5C877B /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = CB6E419C80EE782C5F5B2C8E /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -849,7 +855,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+import Testing
+import Flutter
+@testable import datadog_session_replay
+
+/// Tests the `DatadogSessionReplayPlugin` engine-lifecycle methods.
+///
+/// The plugin uses a method channel to establish ownership after `enable()` is called via FFI,
+/// because FFI plugins do not receive engine lifecycle events (Flutter issue #184124).
+/// We exercise the ownership flow via the underlying static API since creating a real
+/// `FlutterPluginRegistrar` requires a running engine.
+@Suite(.serialized)
+class DatadogSessionReplayPluginTests {
+    init() { FlutterSessionReplay.shutdown() }
+    deinit { FlutterSessionReplay.shutdown() }
+
+    @Test
+    func detach_withOwningEngine_nullsCallback() {
+        // Given — simulate enable() + claimOwnership arriving for engine A
+        let messengerA = NSObject()
+        FlutterSessionReplay.contextCallback = { _ in }
+        FlutterSessionReplay.claimOwnership(messenger: messengerA)
+
+        // When — simulate detachFromEngine(for:) for engine A
+        FlutterSessionReplay.detachFromEngine(messenger: messengerA)
+
+        // Then
+        #expect(FlutterSessionReplay.contextCallback == nil)
+        #expect(FlutterSessionReplay.listenerOwner == nil)
+    }
+
+    @Test
+    func detach_withNonOwningEngine_preservesCallback() {
+        // Given — engine A owns the callback; engine B attaches but never enables
+        let messengerA = NSObject()
+        let messengerB = NSObject()
+        FlutterSessionReplay.contextCallback = { _ in }
+        FlutterSessionReplay.claimOwnership(messenger: messengerA)
+
+        // When — engine B detaches (non-owner)
+        FlutterSessionReplay.detachFromEngine(messenger: messengerB)
+
+        // Then — engine A's callback is preserved
+        #expect(FlutterSessionReplay.contextCallback != nil)
+        #expect(FlutterSessionReplay.listenerOwner === messengerA)
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayBridgeTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayBridgeTests.swift
@@ -9,12 +9,15 @@ import DatadogInternal
 
 extension FlutterSessionReplay {
     func enable(withMock mock: FlutterSessionReplayFeatureMock) {
-        feature = mock
+        FlutterSessionReplay.feature = mock
     }
 }
 
 @Suite(.serialized)
 class FlutterSessionReplayBridgeTests {
+    init() { FlutterSessionReplay.shutdown() }
+    deinit { FlutterSessionReplay.shutdown() }
+
     @Test
     func enableRegistersToCore() throws {
         // Given
@@ -31,6 +34,35 @@ class FlutterSessionReplayBridgeTests {
         // Then
         let feature = mockCore.get(feature: DefaultFlutterSessionReplayFeature.self)
         #expect(feature != nil)
+    }
+
+    @Test
+    func enable_clearsListenerOwner() {
+        // Given — pre-seed a stale owner
+        let staleMessenger = NSObject()
+        FlutterSessionReplay.claimOwnership(messenger: staleMessenger)
+
+        let mockCore = PassthroughCoreMock()
+        CoreRegistry.unregisterDefault()
+        CoreRegistry.register(default: mockCore)
+
+        // When
+        FlutterSessionReplay().enable(with: .init())
+
+        // Then — listenerOwner cleared; claimOwnership(messenger:) will re-establish it
+        #expect(FlutterSessionReplay.listenerOwner == nil)
+    }
+
+    @Test
+    func claimOwnership_setsListenerOwner() {
+        // Given
+        let messenger = NSObject()
+
+        // When
+        FlutterSessionReplay.claimOwnership(messenger: messenger)
+
+        // Then
+        #expect(FlutterSessionReplay.listenerOwner === messenger)
     }
 
     @Test
@@ -157,5 +189,56 @@ class FlutterSessionReplayBridgeTests {
 
         // Then
         #expect(id == resourceId)
+    }
+
+    // MARK: - Multi-engine / detach ownership tests
+
+    @Test
+    func detachFromEngine_withOwningMessenger_nullsCallback() {
+        // Given
+        let messenger = NSObject()
+        FlutterSessionReplay.contextCallback = { _ in }
+        FlutterSessionReplay.claimOwnership(messenger: messenger)
+
+        // When
+        FlutterSessionReplay.detachFromEngine(messenger: messenger)
+
+        // Then
+        #expect(FlutterSessionReplay.contextCallback == nil)
+        #expect(FlutterSessionReplay.listenerOwner == nil)
+    }
+
+    @Test
+    func detachFromEngine_withNonOwningMessenger_preservesCallback() {
+        // Given
+        let owningMessenger = NSObject()
+        let otherMessenger = NSObject()
+        FlutterSessionReplay.contextCallback = { _ in }
+        FlutterSessionReplay.claimOwnership(messenger: owningMessenger)
+
+        // When
+        FlutterSessionReplay.detachFromEngine(messenger: otherMessenger)
+
+        // Then
+        #expect(FlutterSessionReplay.contextCallback != nil)
+        #expect(FlutterSessionReplay.listenerOwner === owningMessenger)
+    }
+
+    @Test
+    func enable_whenFeatureExists_reusesFeatureWithoutReregistering() throws {
+        // Given — seed an existing feature
+        let existingFeature = FlutterSessionReplayFeatureMock()
+        FlutterSessionReplay.feature = existingFeature
+
+        let mockCore = PassthroughCoreMock()
+        CoreRegistry.unregisterDefault()
+        CoreRegistry.register(default: mockCore)
+
+        // When
+        FlutterSessionReplay().enable(with: .init())
+
+        // Then — feature is reused, not re-registered
+        #expect(FlutterSessionReplay.feature as AnyObject === existingFeature)
+        #expect(mockCore.get(feature: DefaultFlutterSessionReplayFeature.self) == nil)
     }
 }

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DatadogContextMock.swift
@@ -105,11 +105,24 @@ extension DatadogContext: AnyMockable, RandomMockable {
     }
 }
 
+extension DeterministicSampler {
+    /// Returns a sampler that always samples (100% rate, seed=0).
+    public static func mockKeepAll() -> DeterministicSampler {
+        return .init(seed: 0, samplingRate: 100)
+    }
+
+    /// Returns a sampler that never samples (0% rate, seed=0).
+    public static func mockRejectAll() -> DeterministicSampler {
+        return .init(seed: 0, samplingRate: 0)
+    }
+}
+
 extension RUMCoreContext: RandomMockable {
     public static func mockRandom() -> Self {
         return RUMCoreContext.init(
             applicationID: .mockRandom(),
             sessionID: .mockRandom(),
+            sessionSampler: .mockKeepAll(),
             viewID: .mockRandom(),
             viewServerTimeOffset: nil
         )
@@ -118,12 +131,14 @@ extension RUMCoreContext: RandomMockable {
     public static func mockWith(
         applicationID: String = .mockAny(),
         sessionID: String = .mockAny(),
+        sessionSampler: DeterministicSampler = .mockKeepAll(),
         viewID: String? = .mockAny(),
         viewServerTimeOffset: TimeInterval? = nil
     ) -> Self {
         return RUMCoreContext(
             applicationID: applicationID,
             sessionID: sessionID,
+            sessionSampler: sessionSampler,
             viewID: viewID,
             viewServerTimeOffset: viewServerTimeOffset
         )

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Package.resolved
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Package.resolved
@@ -5,26 +5,35 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Datadog/dd-sdk-ios.git",
       "state" : {
-        "revision" : "ba59a958b9a4894b0d281d9220ed1bb28fc1fae1",
-        "version" : "2.30.0"
+        "revision" : "80fe7e5fe83d2184b50e1e0ccbb3fa6b0051c33d",
+        "version" : "3.8.2"
       }
     },
     {
-      "identity" : "opentelemetry-swift-packages",
+      "identity" : "kscrash",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/DataDog/opentelemetry-swift-packages.git",
+      "location" : "https://github.com/kstenerud/KSCrash.git",
       "state" : {
-        "revision" : "4a7295600d4ebb9525a23c11586c5fdb74ae8b7e",
-        "version" : "1.13.1"
+        "revision" : "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
+        "version" : "2.5.1"
       }
     },
     {
-      "identity" : "plcrashreporter",
+      "identity" : "opentelemetry-swift-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift-core",
       "state" : {
-        "revision" : "8c61e5e38e9f737dd68512ed1ea5ab081244ad65",
-        "version" : "1.12.0"
+        "revision" : "240c8d5e36c3c7b774ed961325369f0b1f2c965f",
+        "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "datadog-session-replay", targets: ["datadog_session_replay", "datadog_session_replay_objc"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0"),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0")
     ],
     targets: [
         .target(

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/ObjC/include/datadog_session_replay_bridge.h
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/ObjC/include/datadog_session_replay_bridge.h
@@ -337,6 +337,15 @@ SWIFT_CLASS_NAMED("FlutterSessionReplayConfiguration")
 + (nonnull instancetype)new SWIFT_UNAVAILABLE_MSG("-init is unavailable");
 @end
 
+@protocol FlutterPlugin, FlutterPluginRegistrar;
+
+SWIFT_CLASS("_TtC22datadog_session_replay26DatadogSessionReplayPlugin")
+@interface DatadogSessionReplayPlugin : NSObject <FlutterPlugin>
++ (void)registerWithRegistrar:(id <FlutterPluginRegistrar> _Nonnull)registrar;
+- (nonnull instancetype)init SWIFT_UNAVAILABLE;
++ (nonnull instancetype)new SWIFT_UNAVAILABLE_MSG("-init is unavailable");
+@end
+
 #endif
 #if __has_attribute(external_source_symbol)
 # pragma clang attribute pop

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/DatadogSessionReplayPlugin.swift
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+import Foundation
+import Flutter
+
+public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
+    private let messenger: AnyObject
+
+    private init(messenger: AnyObject) {
+        self.messenger = messenger
+    }
+
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let messenger = registrar.messenger() as AnyObject
+        let instance = DatadogSessionReplayPlugin(messenger: messenger)
+        // FFI plugins do not receive engine lifecycle events, so we cannot determine
+        // which engine called enable() from within the FFI call itself. Instead, after
+        // calling enable() via FFI, Dart fires a non-awaited 'claimOwnership' message
+        // through this method channel. Because method channels route to the plugin
+        // instance for their specific engine, we can reliably associate the enable()
+        // call with this engine's messenger and set listenerOwner correctly.
+        // See: https://github.com/flutter/flutter/issues/184124
+        let channel = FlutterMethodChannel(
+            name: "datadog_session_replay/engine",
+            binaryMessenger: registrar.messenger()
+        )
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if call.method == "claimOwnership" {
+            FlutterSessionReplay.claimOwnership(messenger: messenger)
+            result(nil)
+        } else {
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        // Null out the context callback only if this engine is the registered owner.
+        // Prevents a detaching secondary engine from clearing a live engine's callback,
+        // which would cause DLRT_GetFfiCallbackMetadata crashes on the next context update.
+        FlutterSessionReplay.detachFromEngine(messenger: registrar.messenger() as AnyObject)
+    }
+}

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Feature/FlutterSessionReplayFeature.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Feature/FlutterSessionReplayFeature.swift
@@ -81,7 +81,7 @@ class DefaultFlutterSessionReplayFeature: FlutterSessionReplayFeature, DatadogRe
         self.resourceResolver = resourceResolver ?? DefaultResourceResolver(
             writer: ResourcesWriter(scope: core.scope(for: ResourcesFeature.self))
         )
-        
+
         self.performanceOverride = performanceOverride
     }
 

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/FlutterSessionReplayBridge.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/FlutterSessionReplayBridge.swift
@@ -44,11 +44,23 @@ public func __datadog_session_replay_keep_symbols() {
 }
 
 @objc(FlutterSessionReplay) public class FlutterSessionReplay: NSObject {
-    internal var feature: FlutterSessionReplayFeature?
+    // Static properties so the callback and feature survive engine detach/re-attach cycles,
+    // mirroring the Android FlutterSessionReplayBridge singleton pattern.
+    internal static var contextCallback: ((FlutterRUMCoreContext?) -> Void)?
+    internal static var feature: FlutterSessionReplayFeature?
+
+    // Ownership token for multi-engine support: only the engine that called enable()
+    // is allowed to null out the callback on detach. Set by claimOwnership(messenger:)
+    // after the Dart-side method channel message is delivered.
+    internal static var listenerOwner: AnyObject?
+
+    static func claimOwnership(messenger: AnyObject) {
+        listenerOwner = messenger
+    }
 
     @objc public func enable(with configuration: FlutterSessionReplayConfiguration) {
         do {
-            feature = try enableOrThrow(with: configuration, in: CoreRegistry.default)
+            try enableOrThrow(with: configuration, in: CoreRegistry.default)
         } catch let error {
             consolePrint("\(error)", .error)
         }
@@ -57,24 +69,41 @@ public func __datadog_session_replay_keep_symbols() {
     internal func enableOrThrow(
         with configuration: FlutterSessionReplayConfiguration,
         in core: DatadogCoreProtocol
-    ) throws -> FlutterSessionReplayFeature {
+    ) throws {
         guard !(core is NOPDatadogCore) else {
             throw ProgrammerError(
                 description: "Datadog SDK must be initialized before calling `SessionReplay.enable(with:)`."
             )
         }
 
+        // Always replace the context callback to prevent a crash on Hot Restart / engine
+        // re-attach, where the previously created FFI callback has been destroyed.
+        FlutterSessionReplay.contextCallback = configuration.onContextChanged
+        // Clear any stale ownership. claimOwnership(messenger:) will re-establish it for
+        // the correct engine once the Dart-side 'claimOwnership' method channel message
+        // is delivered. There is a brief gap between enable() and claimOwnership() during
+        // which listenerOwner is nil; this is intentional and acceptable — see the comment
+        // in DatadogSessionReplayPlugin.register(with:) for the full explanation.
+        FlutterSessionReplay.listenerOwner = nil
+
+        // If already initialized, reuse the existing feature (don't re-register with core).
+        if FlutterSessionReplay.feature != nil {
+            return
+        }
+
         let mappedConfiguration = DefaultFlutterSessionReplayFeature.Configuration(
             customEndpoint: configuration.customEndpoint,
             onContextChanged: { context in
+                // Read contextCallback at call time so that nullifying it on engine detach
+                // makes this a no-op, preventing calls into a destroyed Dart isolate.
                 if let context = context {
-                    configuration.onContextChanged?(FlutterRUMCoreContext(
+                    FlutterSessionReplay.contextCallback?(FlutterRUMCoreContext(
                         sessionID: context.sessionID,
                         viewID: context.viewID,
                         applicationID: context.applicationID
                     ))
                 } else {
-                    configuration.onContextChanged?(nil)
+                    FlutterSessionReplay.contextCallback?(nil)
                 }
             }
         )
@@ -85,20 +114,35 @@ public func __datadog_session_replay_keep_symbols() {
             resourceResolver: nil   // Use the default resource resolver
         )
         try core.register(feature: sessionReplay)
+        FlutterSessionReplay.feature = sessionReplay
+    }
 
-        return sessionReplay
+    /// Nullifies the context callback if the detaching engine is the one that registered it.
+    /// This prevents a secondary engine's detach from clearing a live engine's callback.
+    static func detachFromEngine(messenger: AnyObject) {
+        if listenerOwner === messenger {
+            contextCallback = nil
+            listenerOwner = nil
+        }
+    }
+
+    // Only used in testing
+    internal static func shutdown() {
+        feature = nil
+        contextCallback = nil
+        listenerOwner = nil
     }
 
     @objc public func setHasReplay(hasReplay: Bool) {
-        feature?.setHasReplay(hasReplay)
+        FlutterSessionReplay.feature?.setHasReplay(hasReplay)
     }
 
     @objc public func setRecordCount(for viewId: String, count: Int) {
-        feature?.setRecordCount(for: viewId, count: Int64(count))
+        FlutterSessionReplay.feature?.setRecordCount(for: viewId, count: Int64(count))
     }
 
     @objc public func writeSegment(segment segmentJson: String) {
-        feature?.writeSegment(segment: segmentJson)
+        FlutterSessionReplay.feature?.writeSegment(segment: segmentJson)
     }
 
     @objc public func postTelemetryDebug(id: String, message: String) {
@@ -111,10 +155,10 @@ public func __datadog_session_replay_keep_symbols() {
     }
 
     @objc public func saveImageForProcessing(resourceKey: Int, width: Int, height: Int, data: Data) {
-        feature?.resourceResolver.addResource(withKey: resourceKey, width: width, height: height, data: data)
+        FlutterSessionReplay.feature?.resourceResolver.addResource(withKey: resourceKey, width: width, height: height, data: data)
     }
 
     @objc public func resourceId(forKey key: Int) -> String? {
-        return feature?.resourceResolver.resolveResource(withKey: key)
+        return FlutterSessionReplay.feature?.resourceResolver.resolveResource(withKey: key)
     }
 }

--- a/packages/datadog_session_replay/lib/src/android/datadog_session_replay_platform_android.dart
+++ b/packages/datadog_session_replay/lib/src/android/datadog_session_replay_platform_android.dart
@@ -5,12 +5,18 @@
 import 'dart:async';
 import 'dart:typed_data';
 
+import 'package:flutter/services.dart';
 import 'package:jni/jni.dart';
 
 import '../../datadog_session_replay.dart';
 import '../datadog_session_replay_platform_interface.dart';
 import '../rum_context.dart';
 import 'datadog_session_replay_bridge_android.dart';
+
+// See comment in DatadogSessionReplayPlugin.onAttachedToEngine for why we use a
+// method channel to claim engine ownership after the FFI enable() call.
+// Flutter issue: https://github.com/flutter/flutter/issues/184124
+const _engineChannel = MethodChannel('datadog_session_replay/engine');
 
 class DatadogSessionReplayPlatformAndroid extends DatadogSessionReplayPlatform {
   late FlutterSessionReplayBridge _bridge;
@@ -52,6 +58,10 @@ class DatadogSessionReplayPlatformAndroid extends DatadogSessionReplayPlatform {
     );
 
     _bridge.enable(mappedConfig, null);
+    // Non-awaited: routes through the method channel to the correct engine's plugin
+    // instance, which calls claimOwnership() with that engine's BinaryMessenger.
+    // ignore: unawaited_futures
+    _engineChannel.invokeMethod<void>('claimOwnership');
 
     return true;
   }

--- a/packages/datadog_session_replay/lib/src/ios/datadog_session_replay_platform_ios.dart
+++ b/packages/datadog_session_replay/lib/src/ios/datadog_session_replay_platform_ios.dart
@@ -6,12 +6,18 @@ import 'dart:async';
 import 'dart:ffi' as ffi;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:objective_c/objective_c.dart';
 
 import '../../datadog_session_replay.dart';
 import '../datadog_session_replay_platform_interface.dart';
 import '../rum_context.dart';
 import 'datadog_session_replay_bridge_ios.dart';
+
+// See comment in DatadogSessionReplayPlugin.register(with:) for why we use a
+// method channel to claim engine ownership after the FFI enable() call.
+// Flutter issue: https://github.com/flutter/flutter/issues/184124
+const _engineChannel = MethodChannel('datadog_session_replay/engine');
 
 class DatadogSessionReplayPlatformIos extends DatadogSessionReplayPlatform {
   late FlutterSessionReplay _iosBridge;
@@ -67,6 +73,10 @@ class DatadogSessionReplayPlatformIos extends DatadogSessionReplayPlatform {
         onContextChanged: contextChangedListener,
       );
     _iosBridge.enableWith(iOsConfiguration);
+    // Non-awaited: routes through the method channel to the correct engine's plugin
+    // instance, which calls claimOwnership(messenger:) with that engine's messenger.
+    // ignore: unawaited_futures
+    _engineChannel.invokeMethod<void>('claimOwnership');
 
     return true;
   }

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -43,6 +43,7 @@ flutter:
         ffiPlugin: true
       ios:
         ffiPlugin: true
+        pluginClass: DatadogSessionReplayPlugin
       web:
         pluginClass: DatadogSessionReplayWeb
         fileName: src/datadog_session_replay_web.dart

--- a/packages/datadog_session_replay/pubspec.yaml
+++ b/packages/datadog_session_replay/pubspec.yaml
@@ -38,6 +38,8 @@ flutter:
   plugin:
     platforms:
       android:
+        package: com.datadoghq.flutter.sessionreplay
+        pluginClass: DatadogSessionReplayPlugin
         ffiPlugin: true
       ios:
         ffiPlugin: true


### PR DESCRIPTION
### What and why?

Fixing a crash in Session Replay caused when a context changed callback is received after the main Flutter Engine has detached. This happens when a user backs out of the first screen of an application, which closes the MainActivity, killing the Flutter Engine, but keeping the Application (and all FFI / JNI singletons) alive.

Because we've seen that multiple Flutter engines are pretty wide spread, we've gone through lengths to make sure we don't accidentally attach to the lifecycle of the wrong engine.

Flutter doesn't give FFI plugins a way to access the lifecycle of the current engine, or a way to figure out the currently executing context or isolate, so in order to make sure we connect the correct "main" engine with Session Replay, and only dereference the context callback when that engine is detached / removed, we utilize a method channel call to make the connection.

The method channel call is creates a very slight chance of a race condition if the engine were to quickly detach after the `enable` call but before the method channel can process the `claimOwnership` method channel call, but this is incredibly unlikely.

We perform this attachment for both iOS and Android, although the likelyhood of iOS performing the detach is much lower than Android (which will detach if the MainActivity is closed, but not the application). The hope is that this potentially solves a "crash on application termination" that might occur if an app is force killed while a context update is being broadcast.

refs: RUMS-5684 RUMS-5712 RUMS-5705

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
