### PR TITLE
[Flutter] [Session Replay] Widget Support - Checkbox: Add CheckboxRecorder to capture Checkbox widgets properly

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
@@ -1,0 +1,156 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'package:flutter/material.dart';
+
+import '../../../extensions.dart';
+import '../../../sr_data_models.dart';
+import '../../capture_node.dart';
+import '../../recorder.dart';
+import '../../view_tree_snapshot.dart';
+
+// Characters to represent the checkbox states
+const String checkmark = '\u2713';
+const String dash = '\u2014';
+
+// Scale for the text size within the box
+const double textScale = 0.7;
+
+// Radius for the box. (Could be custom)
+const double checkboxRadius = 2.0;
+
+/// Detects `CheckBox` widgets and places a check box
+/// in SessionReplay.
+class CheckboxRecorder implements ElementRecorder {
+  final KeyGenerator keyGenerator;
+
+  const CheckboxRecorder(this.keyGenerator);
+
+  @override
+  List<Type> get handlesTypes => [Checkbox];
+
+  @override
+  CaptureNodeSemantics? captureSemantics(
+    Element element,
+    CapturedViewAttributes attributes,
+    TreeCapturePrivacy capturePrivacy,
+  ) {
+    final widget = element.widget;
+    if (widget is! Checkbox) return null;
+
+    // Resolves for checkbox state, either checked and enabled
+    final isEnabled = widget.onChanged != null;       // checkbox mutability state
+    final value = widget.value;                       // true = checked, false = unchecked, null = tristate (undeterminate)
+
+    // Resolves for checkbox theme, typography is irrelevant
+    final theme = Theme.of(element);
+    final checkboxTheme = theme.checkboxTheme;
+
+
+    final states = <WidgetState> {
+      if (!isEnabled) WidgetState.disabled,
+      if (value == true) WidgetState.selected
+    };
+
+    Color fillColor =
+      widget.fillColor?.resolve(states) ??
+      ((value != false)
+          ? (widget.activeColor ?? theme.colorScheme.primary)
+          : Colors.transparent);
+    if (!isEnabled && value != false) fillColor = fillColor.withValues(alpha: 0.38);
+
+    // Resolve for checkmark color
+    Color symbolColor = widget.checkColor 
+        ?? checkboxTheme.checkColor?.resolve(states)
+        ?? theme.colorScheme.onPrimary;
+
+    // Resolve for checkbox border
+    BorderSide? borderSide;
+    if (value == false) {
+      borderSide = widget.side 
+             ?? checkboxTheme.side
+             ?? BorderSide(
+              color: isEnabled                                                                                            
+                ? theme.colorScheme.onSurface.withValues(alpha: 0.6)
+                : theme.colorScheme.onSurface.withValues(alpha: 0.38),                                                  
+              width: 2.0,
+             );
+    }
+
+    final wireframeKey = keyGenerator.keyForElement(element);                                                             
+
+    final node = CheckboxNode(
+          attributes,
+          wireframeId: wireframeKey,
+          value: value,
+          fillColor: fillColor,
+          symbolColor: symbolColor,
+          side: borderSide,
+        );
+
+    return SpecificElement(
+      subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,       // Checkbox Widget does not have child attribute
+      nodes: [node],
+    );
+  }
+}
+
+
+@immutable
+class CheckboxNode extends CaptureNode {
+
+  final int wireframeId;
+  final bool? value;
+  final Color fillColor;
+  final Color symbolColor;
+  final BorderSide? side;
+  
+  const CheckboxNode(
+    super.attributes, {
+      required this.value,
+      required this.wireframeId,
+      required this.symbolColor,
+      required this.fillColor,
+      required this.side,
+    }
+  );
+
+  @override
+  List<SRWireframe> buildWireframes() {
+
+    final symbol = switch (value) {
+      true => checkmark,
+      false => '',
+      null => dash
+    };
+
+    return[
+      SRTextWireframe(
+        id: wireframeId, 
+        x: attributes.x, 
+        y: attributes.y,
+        width: attributes.width, 
+        height: attributes.height, 
+        text: symbol, 
+        textStyle: SRTextStyle(
+          color: symbolColor.toHexString(),
+          family: 'sans-serif', 
+          size: (attributes.height * textScale).round(),
+        ),
+        textPosition: SRTextPosition(
+          alignment: SRAlignment(
+            horizontal: SRHorizontalAlignment.center,
+            vertical: SRVerticalAlignment.center,                                                                     
+          ),
+        ),  
+        border : 
+          side != null ? SRShapeBorder(color: side!.color.toHexString(), width: side!.width.toInt()) : null,
+        shapeStyle: SRShapeStyle(
+            backgroundColor: fillColor.toHexString(),
+            cornerRadius: checkboxRadius,
+          ),
+        )
+    ];
+  }
+}

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
@@ -17,8 +17,11 @@ const String dash = '\u2014';
 // Scale for the text size within the box
 const double textScale = 0.7;
 
-// Radius for the box. (Could be custom)
+// Corner radius for the box.
 const double checkboxRadius = 2.0;
+
+// Default checkbox size
+const double _checkboxVisualSize = 18.0;
 
 /// Detects `CheckBox` widgets and places a check box
 /// in SessionReplay.
@@ -43,16 +46,19 @@ class CheckboxRecorder implements ElementRecorder {
     final isEnabled = widget.onChanged != null;       // checkbox mutability state
     final value = widget.value;                       // true = checked, false = unchecked, null = tristate (undeterminate)
 
-    // Resolves for checkbox theme, typography is irrelevant
+    // Resolve checkbox theme for colors and border
     final theme = Theme.of(element);
     final checkboxTheme = theme.checkboxTheme;
 
-
+    // Build the widget state set to drive theme resolution.                                                              
+    // TODO: include WidgetState.focused and WidgetState.hovered for richer theme resolution.
     final states = <WidgetState> {
       if (!isEnabled) WidgetState.disabled,
       if (value == true) WidgetState.selected
     };
 
+    // Resolve fill color: checked and tristate (value != false) use the active color,
+    // unchecked uses transparent since the border conveys the unchecked state instead.
     Color fillColor =
       widget.fillColor?.resolve(states) ??
       ((value != false)
@@ -78,6 +84,22 @@ class CheckboxRecorder implements ElementRecorder {
              );
     }
 
+    final density = widget.visualDensity ?? theme.visualDensity;                                                                
+    final visualSizeWidth = _checkboxVisualSize + density.baseSizeAdjustment.dx;
+    final visualSizeHeight = _checkboxVisualSize + density.baseSizeAdjustment.dy;
+
+    final center = attributes.paintBounds.center;                                                                               
+    final adjustedBounds = Rect.fromCenter(                                                                                     
+      center: center,                                                                                                           
+      width: visualSizeWidth * attributes.scaleX,                                                                           
+      height: visualSizeHeight * attributes.scaleY,                                                                          
+    );                                                                                                                          
+    attributes = CapturedViewAttributes(                                                                                        
+      paintBounds: adjustedBounds,                                                                                              
+      scaleX: attributes.scaleX,                                                                                                
+      scaleY: attributes.scaleY,                                                                                                
+    );
+
     final wireframeKey = keyGenerator.keyForElement(element);                                                             
 
     final node = CheckboxNode(
@@ -90,13 +112,15 @@ class CheckboxRecorder implements ElementRecorder {
         );
 
     return SpecificElement(
-      subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,       // Checkbox Widget does not have child attribute
+      subtreeStrategy: CaptureNodeSubtreeStrategy.ignore,       // Ignore subtree to prevent CustomPaintRecorder from capturing the inner CustomPaint
       nodes: [node],
     );
   }
 }
 
-
+/// Holds the resolved visual properties of a [Checkbox] widget and builds                                            
+/// the corresponding [SRTextWireframe], using the text field to render the                                           
+/// checkmark symbol and the shape style for the box background and border.
 @immutable
 class CheckboxNode extends CaptureNode {
 
@@ -116,6 +140,8 @@ class CheckboxNode extends CaptureNode {
     }
   );
 
+  // Renders the checkbox as a single SRTextWireframe: the box shape is drawn                                           
+  // via shapeStyle/border, and the checkmark symbol is centered as text.
   @override
   List<SRWireframe> buildWireframes() {
 
@@ -145,7 +171,7 @@ class CheckboxNode extends CaptureNode {
           ),
         ),  
         border : 
-          side != null ? SRShapeBorder(color: side!.color.toHexString(), width: side!.width.toInt()) : null,
+          side != null ? SRShapeBorder(color: side!.color.toHexString(), width: side!.width.round()) : null,
         shapeStyle: SRShapeStyle(
             backgroundColor: fillColor.toHexString(),
             cornerRadius: checkboxRadius,

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -19,6 +19,7 @@ import 'element_recorders/editable_text_recorder.dart';
 import 'element_recorders/image_recorder.dart';
 import 'element_recorders/privacy_recorder.dart';
 import 'element_recorders/text_recorder.dart';
+import 'element_recorders/material_widgets/checkbox_recorder.dart';
 import 'pointer_capture.dart';
 import 'view_tree_snapshot.dart';
 
@@ -149,6 +150,7 @@ class SessionReplayRecorder {
       ImageRecorder(keyGenerator),
       CustomPaintRecorder(keyGenerator),
       PrivacyRecorder(keyGenerator),
+      CheckboxRecorder(keyGenerator),
     ]);
   }
 

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -150,7 +150,7 @@ class SessionReplayRecorder {
       ImageRecorder(keyGenerator),
       CustomPaintRecorder(keyGenerator),
       PrivacyRecorder(keyGenerator),
-      CheckboxRecorder(keyGenerator),
+      CheckboxRecorder(keyGenerator),                     // Support for rendering properly checkbox widget on SR
     ]);
   }
 


### PR DESCRIPTION
### What and why?

Adds CheckboxRecorder, a new ElementRecorder implementation that captures Flutter Checkbox widgets in Session Replay. Without this recorder, checkboxes were matched by CustomPaintRecorder and rendered as a SRPlaceholderWireframe, showing a generic box with an × inside regardless of their actual state. This ensures checked, unchecked, and tristate states are faithfully represented in replays.

### How?

CheckboxRecorder resolves the widget's visual properties (fill color, checkmark color, border, visual density) by walking the widget properties and theme fallback chain, matching Flutter's own rendering logic. It produces a single SRTextWireframe per checkbox: the box shape is rendered via shapeStyle/border, and the checkmark symbol (✓, —, or empty) is centered as its text. The subtree is ignored to prevent CustomPaintRecorder from double-capturing the inner CustomPaint.


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue — RUM-10251
