### PR TITLE
fix(sr): Shutdown the processing isolate on lifecycle detach.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,8 @@ stages:
     - dart pub global activate junitreport
     - melos bootstrap
     - mkdir -p $CI_PROJECT_DIR/.build/test-results/
-    - melos prepare
+    - melos full_clean
+    - melos prepare    
 
 .pre-web:
   script:
@@ -64,7 +65,7 @@ stages:
 
 .pre-android:
   script:
-    - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;34.0.0" "platform-tools" "platforms;android-35" || true
+    - yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;36.0.0" "platform-tools" "platforms;android-36" || true
     - yes | flutter doctor --android-licenses || true
     # Kill all active emulators
     - pushd tools/ci 

--- a/examples/native-hybrid-app/android/build.gradle
+++ b/examples/native-hybrid-app/android/build.gradle
@@ -20,6 +20,8 @@ plugins {
 }
 
 subprojects {
-    apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
+    if (project.projectDir.canonicalPath.startsWith(rootProject.projectDir.canonicalPath)) {
+        apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
+    }
 }
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -74,7 +74,7 @@ scripts:
       concurrency: 1
     run: |
       cd example/android
-      ./gradlew --console=plain --quiet ktlintCheck detekt
+      ./gradlew --console=plain ktlintCheck detekt
     packageFilters:
       dirExists: android
       ignore: 

--- a/packages/datadog_flutter_plugin/example/android/build.gradle
+++ b/packages/datadog_flutter_plugin/example/android/build.gradle
@@ -37,8 +37,10 @@ subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
     project.evaluationDependsOn(':app')
 
-    apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
-    apply from: "${project.rootDir}/buildscripts/detekt.gradle"
+    if (project.projectDir.canonicalPath.startsWith(rootProject.projectDir.canonicalPath)) {
+        apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
+        apply from: "${project.rootDir}/buildscripts/detekt.gradle"
+    }
 }
 
 tasks.register("clean", Delete) {

--- a/packages/datadog_inappwebview_tracking/example/android/build.gradle
+++ b/packages/datadog_inappwebview_tracking/example/android/build.gradle
@@ -27,8 +27,10 @@ subprojects {
 subprojects {
     project.evaluationDependsOn(":app")
 
-    apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
-    apply from: "${project.rootDir}/buildscripts/detekt.gradle"
+    if (project.projectDir.canonicalPath.startsWith(rootProject.projectDir.canonicalPath)) {
+        apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
+        apply from: "${project.rootDir}/buildscripts/detekt.gradle"
+    }
 }
 
 tasks.register("clean", Delete) {

--- a/packages/datadog_session_replay/example/android/build.gradle.kts
+++ b/packages/datadog_session_replay/example/android/build.gradle.kts
@@ -28,8 +28,10 @@ subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
 
-    apply(from = "${project.rootDir}/buildscripts/ktlint.gradle")
-    apply(from = "${project.rootDir}/buildscripts/detekt.gradle")
+    if (project.projectDir.canonicalPath.startsWith(rootProject.projectDir.canonicalPath)) {
+        apply(from = "${project.rootDir}/buildscripts/ktlint.gradle")
+        apply(from = "${project.rootDir}/buildscripts/detekt.gradle")
+    }
 }
 subprojects {
     project.evaluationDependsOn(":app")

--- a/packages/datadog_session_replay/example/android/build.gradle.kts
+++ b/packages/datadog_session_replay/example/android/build.gradle.kts
@@ -37,6 +37,19 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// We need to ignore tests in included projects because `flutter_test_goldens` pulls in
+// `flutter_android_lifecycle` which has a dependency on a version of mockito that requires
+// Java 24.
+subprojects {
+    if (!project.projectDir.canonicalPath.startsWith(rootProject.projectDir.canonicalPath)) {
+        afterEvaluate {
+            tasks.matching { task -> task.name.contains("test", ignoreCase = true) }.configureEach {
+                setEnabled(false)
+            }
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }

--- a/packages/datadog_session_replay/lib/src/processor/processor.dart
+++ b/packages/datadog_session_replay/lib/src/processor/processor.dart
@@ -4,8 +4,8 @@
 
 import 'dart:isolate';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
 import '../capture/recorder.dart';
 import '../datadog_session_replay_init_stub.dart'
@@ -16,12 +16,14 @@ import 'processor_worker.dart';
 /// Spawns a background isolate to process session replay snapshots before
 /// sending them to the native platform for serialization and distribution to
 /// intake
-class SessionReplayProcessor {
+class SessionReplayProcessor with WidgetsBindingObserver {
   final ReceivePort _mainReceivePort = ReceivePort('sr-replay-port');
   SendPort? _mainSendPort;
+  Isolate? _processorIsolate;
 
   Future<void> start() async {
-    await Isolate.spawn(
+    WidgetsBinding.instance.addObserver(this);
+    _processorIsolate = await Isolate.spawn(
       _captureProcessor,
       _ProcessorArgs(
         RootIsolateToken.instance!,
@@ -35,6 +37,14 @@ class SessionReplayProcessor {
 
   void process(CaptureResult captureResult) {
     _mainSendPort?.send(captureResult);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.detached) {
+      _mainSendPort?.send(null);
+      _processorIsolate?.kill(priority: Isolate.immediate);
+    }
   }
 
   static Future<void> _captureProcessor(_ProcessorArgs args) async {
@@ -54,6 +64,7 @@ class SessionReplayProcessor {
       }
     }
 
+    commandPort.close();
     Isolate.exit();
   }
 }

--- a/packages/datadog_webview_tracking/example/android/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/build.gradle
@@ -30,8 +30,10 @@ subprojects {
 subprojects {
     project.evaluationDependsOn(':app')
 
-    apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
-    apply from: "${project.rootDir}/buildscripts/detekt.gradle"
+    if (project.projectDir.canonicalPath.startsWith(rootProject.projectDir.canonicalPath)) {
+        apply from: "${project.rootDir}/buildscripts/ktlint.gradle"
+        apply from: "${project.rootDir}/buildscripts/detekt.gradle"
+    }
 }
 
 tasks.register("clean", Delete) {


### PR DESCRIPTION
### What and why?

Detaching the Flutter engine wasn't killing the spawned isolate properly. This could result in multiple processing isolates being active at the same time. This would not cause contention, though, because the communication port on which the processing isolate waits on is destroyed when the engine detaches, so the zombie isolate would be stuck in a waiting state. However, that isolate would still take up resources, so should be shut down properly on isolate detach.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
