### PR TITLE
fix(gql_link): Catch errors on tracing header creation

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -63,16 +63,25 @@ class DatadogGqlLink extends Link {
     }
 
     final tracingHeaderTypes = datadogSdk.headerTypesForHost(uri);
+    final internalAttributes = _getInternalAttributes(request);
+
     TracingContext? tracingContext;
-    if (tracingHeaderTypes.isNotEmpty) {
-      tracingContext = generateTracingContext(datadogSdk, rum);
+    try {
+      if (tracingHeaderTypes.isNotEmpty) {
+        tracingContext = generateTracingContext(datadogSdk, rum);
+      }
+
+      request = _injectTracingHeaders(request);
+    } catch (e, st) {
+      datadogSdk.internalLogger.sendToDatadog(
+        '$DatadogGqlLink encountered an error attempting to create a tracing context; $e',
+        st,
+        e.runtimeType.toString(),
+      );
     }
 
-    final internalAttributes = _getInternalAttributes(request);
     Map<String, Object?> userAttributes = {};
     listener?.requestStarted(request, userAttributes);
-    request = _injectTracingHeaders(request);
-
     final resourceId = _startRumResource(
         request, internalAttributes, tracingContext, userAttributes);
 


### PR DESCRIPTION
### What and why?

Errors in creating tracing headers shouldn't tank the whole network request. Make sure that we catch any errors in creating the tracing headers but still track the resource and perform the network request if an error occurs.

While this doesn't fix this missing symbol error that's causing issues, it will prevent it from affecting end users.

refs: #979

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
