### PR TITLE
fix(tracing): correct 'occured' -> 'occurred' in _constructBaggageHeader doc

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/tracing/baggage_helpers.dart
+++ b/packages/datadog_flutter_plugin/lib/src/tracing/baggage_helpers.dart
@@ -120,7 +120,7 @@ Map<String, String> _deconstructBaggageHeader(
 }
 
 /// This assumes validation of the baggage properties and values has already
-/// occured through [_deconstructBaggageHeader] and new members have been
+/// occurred through [_deconstructBaggageHeader] and new members have been
 /// properly encoded with [_encodeBaggageValue].
 String _constructBaggageHeader(
   Map<String, String> entries,


### PR DESCRIPTION
Doc comment on `_constructBaggageHeader` in `packages/datadog_flutter_plugin/lib/src/tracing/baggage_helpers.dart:123` read `has already occured through ...`. Doc-only Dart change inside a `///` comment.