### PR TITLE
fix(sr): Include RUM context when writing Session Replay resources on Android

### DIFF
--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriter.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriter.kt
@@ -22,7 +22,9 @@ internal class DefaultResourceWriter(
 ) : ResourceWriter {
     override fun write(identifier: String, resourceData: ByteArray) {
         sdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, writeScope ->
+            ?.withWriteContext(
+                withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)
+            ) { datadogContext, writeScope ->
                 synchronized(this) {
                     val resourceEvent = ResourceEvent(
                         identifier = identifier,


### PR DESCRIPTION
### What and why?

On Android, image resources uploaded by the Session Replay SDK were arriving at the intake with an empty `applicationId` in their multipart metadata (`{"application":{"id":""},"type":"resource"}`). The intake accepts the upload, but the Session Replay player can't match the resource to an application and returns 404, so every image appears broken in the replay.

Affects all images on Android.

### How?

`ResourceWriter.kt` was calling `withWriteContext` without the `withFeatureContexts` parameter, so the RUM context wasn't included in `DatadogContext`. Passing `setOf(Feature.RUM_FEATURE_NAME)` aligns this with the native Android SDK's `SessionReplayResourcesWriter.kt`.

refs: PANA-7062 RUMS-5633

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
