### PR TITLE
fix(sr): Recognize `ExactAssetImage` as an asset when masking non-assets

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
@@ -171,14 +171,14 @@ class ImageRecorder implements ElementRecorder {
     );
   }
 
-  AssetImage? _extractAssetImage(Image widget) {
-    AssetImage? assetImage;
-    if (widget.image is AssetImage) {
-      assetImage = widget.image as AssetImage;
+  AssetBundleImageProvider? _extractAssetImage(Image widget) {
+    AssetBundleImageProvider? assetImage;
+    if (widget.image is AssetBundleImageProvider) {
+      assetImage = widget.image as AssetBundleImageProvider;
     } else if (widget.image is ResizeImage) {
       final resizeImage = widget.image as ResizeImage;
-      if (resizeImage.imageProvider is AssetImage) {
-        assetImage = resizeImage.imageProvider as AssetImage;
+      if (resizeImage.imageProvider is AssetBundleImageProvider) {
+        assetImage = resizeImage.imageProvider as AssetBundleImageProvider;
       }
     }
     return assetImage;

--- a/packages/datadog_session_replay/test/capture/image_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/image_recorder_test.dart
@@ -429,9 +429,63 @@ void main() {
       verifyZeroInteractions(platform);
     });
 
-    // Missing Test - ImagePrivacyLevel.maskNonAssetsOnly checks for Assets.
-    // This requires being able to load an asset, so it is checked as part of the
-    // golden tests, not here.
+    testWidgets('maskNonAssetsOnly processes ExactAssetImage as asset',
+        (tester) async {
+      // Given
+      recorder.defaultTreeCapturePrivacy = TreeCapturePrivacy(
+        textAndInputPrivacyLevel: TextAndInputPrivacyLevel.maskSensitiveInputs,
+        imagePrivacyLevel: ImagePrivacyLevel.maskNonAssetsOnly,
+      );
+
+      when(
+        () => platform.saveImageForProcessing(any(), any(), any(), any()),
+      ).thenAnswer((_) => Future.value());
+      when(() => platform.resourceIdForKey(any())).thenReturn(randomString());
+
+      final imageProvider = TestExactAssetImage(testImage);
+      final tree = MaterialApp(
+        home: SimpleTestCapture(
+          key: Key('key'),
+          recorder: recorder,
+          child: Stack(
+            children: [
+              Positioned(
+                top: 10,
+                left: 10,
+                width: testImage.width.toDouble(),
+                height: testImage.height.toDouble(),
+                child: Image(image: imageProvider),
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpWidget(tree);
+      imageProvider.complete();
+      await tester.pump();
+
+      // When
+      CaptureResult? capture;
+      await tester.runAsync(() async {
+        capture = await recorder.performCapture();
+      });
+
+      // Then
+      final allWireframes = capture!.viewTreeSnapshot.nodes
+          .expand((node) => node.buildWireframes())
+          .toList();
+
+      expect(
+        allWireframes.whereType<SRPlaceholderWireframe>(),
+        isEmpty,
+        reason: 'ExactAssetImage should not be masked under maskNonAssetsOnly',
+      );
+      expect(
+        allWireframes.whereType<SRImageWireframe>(),
+        isNotEmpty,
+        reason: 'ExactAssetImage should produce SRImageWireframe',
+      );
+    });
 
     testWidgets('maskNonAssetsOnly does not process non-asset', (tester) async {
       // Given

--- a/packages/datadog_session_replay/test/test_utils.dart
+++ b/packages/datadog_session_replay/test/test_utils.dart
@@ -10,6 +10,7 @@ import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 Random _random = Random();
@@ -80,4 +81,42 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
 
   @override
   String toString() => '${describeIdentity(this)}()';
+}
+
+/// A test-friendly subclass of [ExactAssetImage] that provides a pre-built
+/// [ui.Image] instead of loading from an asset bundle.
+class TestExactAssetImage extends ExactAssetImage {
+  final ui.Image _testImage;
+  final Completer<ImageInfo> _completer = Completer<ImageInfo>.sync();
+
+  TestExactAssetImage(this._testImage) : super('test_asset.png', scale: 2.0);
+
+  @override
+  Future<AssetBundleImageKey> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<AssetBundleImageKey>(
+      AssetBundleImageKey(
+        bundle: _DummyAssetBundle(),
+        name: 'test_asset.png',
+        scale: 2.0,
+      ),
+    );
+  }
+
+  @override
+  ImageStreamCompleter loadImage(
+    AssetBundleImageKey key,
+    ImageDecoderCallback decode,
+  ) {
+    return OneFrameImageStreamCompleter(_completer.future);
+  }
+
+  void complete() {
+    _completer.complete(ImageInfo(image: _testImage));
+  }
+}
+
+class _DummyAssetBundle extends CachingAssetBundle {
+  @override
+  Future<ByteData> load(String key) async =>
+      throw UnsupportedError('DummyAssetBundle.load should not be called');
 }


### PR DESCRIPTION
### What and why?

Under `ImagePrivacyLevel.maskNonAssetsOnly`, Session Replay was incorrectly masking images loaded via `Image.asset()` when an explicit `scale` parameter was provided. Flutter creates an `ExactAssetImage` internally in that case, but `_extractAssetImage` only recognized `AssetImage`, so these images were treated as non-assets and replaced with placeholders in the replay.

### How?

- `_extractAssetImage` now checks for `AssetBundleImageProvider` instead of `AssetImage`. This parent class covers both `AssetImage` and `ExactAssetImage`, as well as any future `AssetBundleImageProvider` subclasses.

- Added a regression test.

refs: PANA-7063

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue
