### PR TITLE
feat(graphql): Add GraphQL errors to resource events

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -20,7 +20,7 @@ class _GraphQLAttributes {
   static const operationType = '_dd.graphql.operation_type';
   static const operationName = '_dd.graphql.operation_name';
   static const variables = '_dd.graphql.variables';
-  static const errors = 'errors';
+  static const errors = '_dd.graphql.errors';
 }
 
 abstract interface class DatadogGqlListener {
@@ -100,7 +100,16 @@ class DatadogGqlLink extends Link {
           }
         }
 
-        final errorMap = _serializeResponseErrors(data);
+        Map<String, Object?>? errorMap;
+        try {
+          errorMap = _serializeResponseErrors(data);
+        } catch (e, st) {
+          datadogSdk.internalLogger.sendToDatadog(
+            '$DatadogGqlLink encountered an error serializing errors; $e',
+            st,
+            e.runtimeType.toString(),
+          );
+        }
 
         datadogSdk.rum?.stopResource(
           resourceId,
@@ -245,11 +254,7 @@ class DatadogGqlLink extends Link {
       };
     }).toList();
     return {
-      '_dd': {
-        'graphql': {
-          _GraphQLAttributes.errors: serializedErrors,
-        }
-      }
+      _GraphQLAttributes.errors: serializedErrors,
     };
   }
 }

--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -238,7 +238,7 @@ class DatadogGqlLink extends Link {
     return request;
   }
 
-  Map<String, Object?>? _serializeResponseErrors(Response response) {
+  Map<String, Object>? _serializeResponseErrors(Response response) {
     if (response.errors?.isEmpty ?? true) return null;
 
     final serializedErrors = response.errors!.map((e) {
@@ -254,7 +254,7 @@ class DatadogGqlLink extends Link {
       };
     }).toList();
     return {
-      _GraphQLAttributes.errors: serializedErrors,
+      _GraphQLAttributes.errors: json.encode(serializedErrors),
     };
   }
 }

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -668,7 +668,7 @@ query UserInfo($id: ID!) {
           any(), any(), RumResourceType.native, any(), captureAny()));
       final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
       expect(findInvalidAttribute(capturedAttrs), null);
-      expect(capturedAttrs['_dd']['graphql']['errors'], [
+      expect(capturedAttrs['_dd.graphql.errors'], [
         {
           'message': 'GraphQL Error Message',
           'locations': [

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -3,6 +3,7 @@
 // Copyright 2023-Present Datadog, Inc.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_common_test/uri_matchers.dart';
@@ -668,7 +669,7 @@ query UserInfo($id: ID!) {
           any(), any(), RumResourceType.native, any(), captureAny()));
       final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
       expect(findInvalidAttribute(capturedAttrs), null);
-      expect(capturedAttrs['_dd.graphql.errors'], [
+      final expectedErrorString = json.encode([
         {
           'message': 'GraphQL Error Message',
           'locations': [
@@ -680,6 +681,7 @@ query UserInfo($id: ID!) {
           'path': ['heroes', 2, 'name'],
         }
       ]);
+      expect(capturedAttrs['_dd.graphql.errors'], expectedErrorString);
     });
 
     test('link supports mutation operations in attributes', () async {


### PR DESCRIPTION
### What and why?

Errors were being sent before but the reserved attribute has changed in native libraries.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
