### PR TITLE
chore(sr): Update CONTRIBUTING to mention golden_tests

### DIFF
--- a/packages/datadog_session_replay/CONTRIBUTING.md
+++ b/packages/datadog_session_replay/CONTRIBUTING.md
@@ -45,3 +45,23 @@ Then, run jnigen:
 # From the root
 dart run jnigen --config jnigen.ysml
 ```
+
+## Golden Tests
+
+Flutter Sesssion Replay uses "golden testing" to try to ensure that the SR wireframes remain consistent and are a reasonable representation of the widgets we capture. Each golden test captures a widget tree as SR wireframes, then renders the resulting wireframes using a Flutter `CustomPainter` called `WireframeCustomPainter`. The resulting render is captured and compared known good, "golden" image held in `example/golden_test/goldens`.  This also allows us to look at the results of simple widget captures without needing to send them to Datadog intake for verification.
+
+To write a new Golden test, follow the examples in `example/golden_test/simple_widget_golden_test.dart`.
+
+If you are making changes and need to test that you have not broken anything in the golden tests, you can run:
+
+```bash
+# from ./example
+flutter test golden_test
+```
+
+If you have made changes that require updated the golden images, run:
+
+```bash
+# from ./example
+flutter test golden_test --update-goldens
+```

--- a/packages/datadog_session_replay/CONTRIBUTING.md
+++ b/packages/datadog_session_replay/CONTRIBUTING.md
@@ -48,7 +48,7 @@ dart run jnigen --config jnigen.ysml
 
 ## Golden Tests
 
-Flutter Sesssion Replay uses "golden testing" to try to ensure that the SR wireframes remain consistent and are a reasonable representation of the widgets we capture. Each golden test captures a widget tree as SR wireframes, then renders the resulting wireframes using a Flutter `CustomPainter` called `WireframeCustomPainter`. The resulting render is captured and compared known good, "golden" image held in `example/golden_test/goldens`.  This also allows us to look at the results of simple widget captures without needing to send them to Datadog intake for verification.
+Flutter Session Replay uses "golden testing" to try to ensure that the SR wireframes remain consistent and are a reasonable representation of the widgets we capture. Each golden test captures a widget tree as SR wireframes, then renders the resulting wireframes using a Flutter `CustomPainter` called `WireframeCustomPainter`. The resulting render is captured and compared known good, "golden" image held in `example/golden_test/goldens`. This also allows us to look at the results of simple widget captures without needing to send them to Datadog intake for verification.
 
 To write a new Golden test, follow the examples in `example/golden_test/simple_widget_golden_test.dart`.
 
@@ -59,7 +59,7 @@ If you are making changes and need to test that you have not broken anything in 
 flutter test golden_test
 ```
 
-If you have made changes that require updated the golden images, run:
+If you have made changes that require updating the golden images, run:
 
 ```bash
 # from ./example


### PR DESCRIPTION
### What and why?

We use golden tests to make sure we're sending consistent wireframes to intake, and they allow quick visual inspection of changes without needing to use the SR player.  Update the documentation to include how to run, create, and update the golden tests.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
