### PR TITLE
fix: Losen constraints on `webview_flutter_android`.

### DIFF
--- a/packages/datadog_webview_tracking/example/android/gradle.properties
+++ b/packages/datadog_webview_tracking/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx2536M
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin_version=2.1.0

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   datadog_flutter_plugin: ^3.0.0
   webview_flutter: ^4.0.4
-  webview_flutter_android: ^3.8.2
+  webview_flutter_android: '>=3.8.2 <5.0.0'
   webview_flutter_wkwebview: ^3.18.0
 
 dev_dependencies:


### PR DESCRIPTION
### What and why?

`webview_flutter_android` updated from 3.x to 4.x because of an upgrade for minSdkVersion from 19 to 21. Our libraries already require a minSdkVersion of 23, so this is not a breaking change on our end.

We've loosened the constraint on `webview_flutter_android` to be `>=3.8.2 <5.0.0` to allow updating to more recent versions of `webview_flutter` without a breaking change on our side.

refs: #999

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
