### PR TITLE
feat(session-replay): add dart based manual start/stop

### DIFF
--- a/packages/datadog_session_replay/CHANGELOG.md
+++ b/packages/datadog_session_replay/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Add `DatadogSessionReplayConfiguration.startRecordingImmediately` (default `true`), `DatadogSessionReplay.startRecording()`, and `DatadogSessionReplay.stopRecording()` to control Dart-side tree capture.
+
 ## 1.0.0-preview.11
 
 * Fix lifecycle issue with Android calling a dead callback on activity destruction.

--- a/packages/datadog_session_replay/README.md
+++ b/packages/datadog_session_replay/README.md
@@ -43,6 +43,10 @@ final configuration = DatadogConfiguration(
 );
 ```
 
+### Manual start and stop
+
+By default, tree capture begins as soon as Session Replay initializes. To defer capture until you are ready, set `startRecordingImmediately: false` on `DatadogSessionReplayConfiguration`, then call `DatadogSessionReplay.instance!.startRecording()` and `DatadogSessionReplay.instance!.stopRecording()` to toggle the Dart-side capture timer. The background processor isolate stays running while capture is stopped.
+
 Last, add a SessionReplayCapture widget to the root of your Widget tree, above your MaterialApp or similar application widget:
 
 ```dart

--- a/packages/datadog_session_replay/lib/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/datadog_session_replay.dart
@@ -78,12 +78,18 @@ class DatadogSessionReplayConfiguration {
 
   String? customEndpoint;
 
+  /// When `true` (default), tree capture begins as soon as Session Replay is
+  /// initialized. When `false`, call [DatadogSessionReplay.startRecording] to
+  /// begin capture.
+  bool startRecordingImmediately;
+
   DatadogSessionReplayConfiguration({
     required this.replaySampleRate,
     this.textAndInputPrivacyLevel = TextAndInputPrivacyLevel.maskAll,
     this.imagePrivacyLevel = ImagePrivacyLevel.maskAll,
     this.touchPrivacyLevel = TouchPrivacyLevel.hide,
     this.customEndpoint,
+    this.startRecordingImmediately = true,
   });
 }
 

--- a/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
+++ b/packages/datadog_session_replay/lib/src/datadog_session_replay.dart
@@ -39,6 +39,14 @@ class DatadogSessionReplay {
   int _errorCounter = 0;
   bool _newFrameBuilt = true;
 
+  /// Whether [platform.enable] succeeded during [_start].
+  bool _platformEnabled = false;
+
+  /// Whether periodic tree capture is active (timer running).
+  bool _isRecording = false;
+
+  Timer? _captureTimer;
+
   @internal
   static Future<DatadogSessionReplay> init(
     DatadogSessionReplayConfiguration configuration,
@@ -72,6 +80,54 @@ class DatadogSessionReplay {
     _recorder.onContextChanged(context);
   }
 
+  /// Starts periodic tree capture. Idempotent while already recording.
+  void startRecording() {
+    if (!_platformEnabled) {
+      internalLogger.log(
+        CoreLoggerLevel.warn,
+        'DatadogSessionReplay.startRecording() ignored: Session Replay is not '
+        'enabled (initialization did not succeed).',
+      );
+      return;
+    }
+    if (_isRecording) {
+      return;
+    }
+    _isRecording = true;
+    _startPeriodicCapture();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _newFrameBuilt = true;
+    });
+  }
+
+  /// Stops periodic tree capture. The processor isolate keeps running.
+  /// Idempotent while not recording.
+  void stopRecording() {
+    if (!_isRecording) {
+      return;
+    }
+    _isRecording = false;
+    _captureTimer?.cancel();
+    _captureTimer = null;
+  }
+
+  /// Clears the singleton and stops capture. For tests only.
+  @visibleForTesting
+  static void resetForTest() {
+    final inst = _instance;
+    _instance = null;
+    inst?.stopRecording();
+  }
+
+  /// Whether periodic capture is considered active (timer created and not cancelled).
+  @visibleForTesting
+  bool get debugIsRecordingForTest => _isRecording;
+
+  /// Whether the periodic capture [Timer] exists and is still active.
+  @visibleForTesting
+  bool get debugIsCaptureTimerActiveForTest =>
+      _captureTimer != null && _captureTimer!.isActive;
+
   Future<void> _start() async {
     final platform = DatadogSessionReplayPlatform.instance;
     bool success = false;
@@ -79,25 +135,28 @@ class DatadogSessionReplay {
       success = await platform.enable(_configuration, _onContextChanged);
     });
 
+    _platformEnabled = success;
     if (success) {
       await _processor.start();
 
-      _startPeriodicCapture();
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        // Let capture know that a new element tree is available for capture.
-        _newFrameBuilt = true;
-      });
+      if (_configuration.startRecordingImmediately) {
+        startRecording();
+      }
     }
   }
 
-  void _startPeriodicCapture() async {
+  void _startPeriodicCapture() {
     /// This timer periodically checks if a tree capture is necessary, which it
     /// only is if _newFrameBuilt has been set by a call to `postFrameCallback`
     ///
     /// Using the timer (instead of as part of addPostFrameCallback) allows
     /// Flutter to schedule this outside of the build phase, which means our
     /// tree capture shouldn't affect tree build time.
-    Timer.periodic(minCaptureTiming, (timer) async {
+    _captureTimer?.cancel();
+    _captureTimer = Timer.periodic(minCaptureTiming, (timer) async {
+      if (!_isRecording) {
+        return;
+      }
       bool shouldWatchForNextFrame = true;
       if (_newFrameBuilt) {
         try {
@@ -126,6 +185,8 @@ class DatadogSessionReplay {
             // Too many errors, cancel this periodic timer and don't schedule
             // another post frame callback
             timer.cancel();
+            _captureTimer = null;
+            _isRecording = false;
             shouldWatchForNextFrame = false;
           }
         }
@@ -133,7 +194,7 @@ class DatadogSessionReplay {
       }
 
       // If we've received too many errors, don't request any more post frame callbacks
-      if (shouldWatchForNextFrame) {
+      if (shouldWatchForNextFrame && _isRecording) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           _newFrameBuilt = true;
         });

--- a/packages/datadog_session_replay/test/datadog_session_replay_test.dart
+++ b/packages/datadog_session_replay/test/datadog_session_replay_test.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_session_replay/src/datadog_session_replay_platform_interface.dart';
@@ -17,11 +18,13 @@ class MockDatadogSessionReplayPlatform extends Mock
     implements DatadogSessionReplayPlatform {}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final DatadogSessionReplayPlatform initialPlatform =
       DatadogSessionReplayPlatform.instance;
 
   test('$DatadogSessionReplayPlatformNoop is the default instance', () {
-    expect(initialPlatform, isInstanceOf<DatadogSessionReplayPlatformNoop>());
+    expect(initialPlatform, isA<DatadogSessionReplayPlatformNoop>());
   });
 
   group('DatadogSessionReplay', () {
@@ -37,7 +40,12 @@ void main() {
       );
     });
 
-    test('.init() calls enable on platform', () {
+    tearDown(() {
+      DatadogSessionReplay.resetForTest();
+      DatadogSessionReplayPlatform.instance = initialPlatform;
+    });
+
+    test('.init() calls enable on platform', () async {
       // Given
       when(
         () => mockPlatform.enable(any(), any()),
@@ -45,10 +53,178 @@ void main() {
 
       // When
       final config = DatadogSessionReplayConfiguration(replaySampleRate: 100.0);
-      DatadogSessionReplay.init(config, mockInternalLogger);
+      await DatadogSessionReplay.init(config, mockInternalLogger);
 
       // Then
       verify(() => mockPlatform.enable(config, any()));
+    });
+
+    test('startRecording logs when Session Replay did not initialize', () async {
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(false));
+
+      final config = DatadogSessionReplayConfiguration(
+        replaySampleRate: 100.0,
+        startRecordingImmediately: false,
+      );
+      await DatadogSessionReplay.init(config, mockInternalLogger);
+
+      DatadogSessionReplay.instance!.startRecording();
+
+      verify(
+        () => mockInternalLogger.log(
+          CoreLoggerLevel.warn,
+          any(
+            that: predicate<String>(
+              (m) => m.contains('ignored'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'startRecording after deferred init starts capture without second enable',
+      () async {
+        when(
+          () => mockPlatform.enable(any(), any()),
+        ).thenAnswer((_) => Future.value(true));
+
+        final config = DatadogSessionReplayConfiguration(
+          replaySampleRate: 100.0,
+          startRecordingImmediately: false,
+        );
+        await DatadogSessionReplay.init(config, mockInternalLogger);
+
+        final sr = DatadogSessionReplay.instance!;
+        expect(sr.debugIsRecordingForTest, isFalse);
+        expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+
+        sr.startRecording();
+        expect(sr.debugIsRecordingForTest, isTrue);
+        expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+
+        sr.stopRecording();
+        expect(sr.debugIsRecordingForTest, isFalse);
+        expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+
+        verify(() => mockPlatform.enable(config, any())).called(1);
+      },
+    );
+
+    test('stopRecording is idempotent when never started', () async {
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(true));
+
+      final config = DatadogSessionReplayConfiguration(
+        replaySampleRate: 100.0,
+        startRecordingImmediately: false,
+      );
+      await DatadogSessionReplay.init(config, mockInternalLogger);
+
+      final sr = DatadogSessionReplay.instance!;
+      expect(sr.debugIsRecordingForTest, isFalse);
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+
+      sr.stopRecording();
+      sr.stopRecording();
+      sr.stopRecording();
+
+      expect(sr.debugIsRecordingForTest, isFalse);
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+      verify(() => mockPlatform.enable(config, any())).called(1);
+    });
+
+    test('startRecording is idempotent when called twice', () async {
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(true));
+
+      final config = DatadogSessionReplayConfiguration(
+        replaySampleRate: 100.0,
+        startRecordingImmediately: false,
+      );
+      await DatadogSessionReplay.init(config, mockInternalLogger);
+
+      final sr = DatadogSessionReplay.instance!;
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+
+      verify(() => mockPlatform.enable(config, any())).called(1);
+    });
+
+    test('startRecording is idempotent when already auto-started', () async {
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(true));
+
+      final config = DatadogSessionReplayConfiguration(
+        replaySampleRate: 100.0,
+        startRecordingImmediately: true,
+      );
+      await DatadogSessionReplay.init(config, mockInternalLogger);
+
+      final sr = DatadogSessionReplay.instance!;
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+
+      verify(() => mockPlatform.enable(config, any())).called(1);
+    });
+
+    test('stopRecording is idempotent after stop', () async {
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(true));
+
+      final config = DatadogSessionReplayConfiguration(
+        replaySampleRate: 100.0,
+        startRecordingImmediately: false,
+      );
+      await DatadogSessionReplay.init(config, mockInternalLogger);
+
+      final sr = DatadogSessionReplay.instance!;
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+      sr.stopRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+      sr.stopRecording();
+      sr.stopRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+
+      verify(() => mockPlatform.enable(config, any())).called(1);
+    });
+
+    test('repeated start and stop cycles do not call enable again', () async {
+      when(
+        () => mockPlatform.enable(any(), any()),
+      ).thenAnswer((_) => Future.value(true));
+
+      final config = DatadogSessionReplayConfiguration(
+        replaySampleRate: 100.0,
+        startRecordingImmediately: false,
+      );
+      await DatadogSessionReplay.init(config, mockInternalLogger);
+
+      final sr = DatadogSessionReplay.instance!;
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+      sr.stopRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+      sr.stopRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+      sr.startRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isTrue);
+      sr.stopRecording();
+      expect(sr.debugIsCaptureTimerActiveForTest, isFalse);
+
+      verify(() => mockPlatform.enable(config, any())).called(1);
     });
 
     // TODO: Test setup of Recorder / Processor?


### PR DESCRIPTION
### What and why?

Add startRecordingImmediately (default true), startRecording(), and stopRecording() to control the periodic tree capture timer while keeping the processor isolate running. (Inspired by how iOS and Android SDK do this.)

Document usage in README, note in CHANGELOG, and extend tests for idempotency, start/stop cycles, and timer active state via test-only getters.

### How?



### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
