### PR TITLE
chore(ci): Fix golden tests to use new logo location.

### DIFF
--- a/examples/simple_example/lib/screens/network_screen.dart
+++ b/examples/simple_example/lib/screens/network_screen.dart
@@ -9,7 +9,7 @@ import '../custom_card.dart';
 class NetworkScreen extends StatelessWidget {
   static const images = [
     'https://picsum.photos/200',
-    'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
+    'https://placehold.co/200x200.png'
   ];
 
   const NetworkScreen({super.key});

--- a/packages/datadog_dio/example/lib/screens/instrumentation_scenario.dart
+++ b/packages/datadog_dio/example/lib/screens/instrumentation_scenario.dart
@@ -23,7 +23,7 @@ class InstrumentationScenario extends StatefulWidget {
 class _InstrumentationScenarioState extends State<InstrumentationScenario> {
   final images = [
     'https://picsum.photos/200',
-    'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
+    'https://placehold.co/200x200.png'
   ];
 
   bool _doneWait = false;

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/rum_auto_instrumentation_scenario.dart
@@ -18,8 +18,8 @@ class RumAutoInstrumentationScenario extends StatefulWidget {
 class _RumAutoInstrumentationScenarioState
     extends State<RumAutoInstrumentationScenario> {
   final images = [
-    'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png',
-    'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
+    'https://placehold.co/75x75.png',
+    'https://placehold.co/75x75.png'
   ];
 
   @override

--- a/packages/datadog_session_replay/example/golden_test/image_masking_golden_test.dart
+++ b/packages/datadog_session_replay/example/golden_test/image_masking_golden_test.dart
@@ -21,7 +21,7 @@ import 'mock_platform.dart';
 
 const String assetImage = 'assets/dd_logo_v_rgb.png';
 const String networkImageUrl =
-    'https://datadog-docs.imgix.net/img/dd_logo_n_70x75.png';
+    'https://docs.dd-static.net/img/dd_logo_n_70x75.png';
 
 void main() {
   late SessionReplayRecorder recorder;

--- a/packages/datadog_session_replay/example/lib/screens/images_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/images_screen.dart
@@ -21,7 +21,7 @@ class _ImagesScreenState extends State<ImagesScreen> {
           children: [
             Image.asset('assets/dd_logo_v_rgb.png'),
             Image.network(
-              'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png',
+              'https://placehold.co/200x200.png',
             ),
           ],
         ),

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_dio_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_dio_test.dart
@@ -109,13 +109,12 @@ void main() {
         .firstWhereOrNull((e) => e.url.contains('picsum.photos'));
     expect(picsumResource, isNotNull);
 
-    final datadogResource = view1.resourceEvents
-        .firstWhereOrNull((e) => e.url.contains('imgix.datadoghq.com'));
-    expect(datadogResource, isNotNull);
-    expect(datadogResource!.url,
-        'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png');
+    final placeholdResource = view1.resourceEvents
+        .firstWhereOrNull((e) => e.url.contains('placehold.co'));
+    expect(placeholdResource, isNotNull);
+    expect(placeholdResource!.url, 'https://placehold.co/200x200.png');
     // Allow this to fail since we don't have as much control over them
-    if (datadogResource.statusCode == 200) {
+    if (placeholdResource.statusCode == 200) {
       expect(view1.resourceEvents[1].resourceType, kIsWeb ? 'xhr' : 'image');
     }
 

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
@@ -98,8 +98,7 @@ void main() {
     expect(view1.viewEvents.last.view.resourceCount, 2);
     // After redirects, we don't end up with a picsum.photos url.
     expect(view1.resourceEvents[0].url.contains('picsum.photos'), isTrue);
-    expect(view1.resourceEvents[1].url,
-        'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png');
+    expect(view1.resourceEvents[1].url, 'https://placehold.co/200x200.png');
     // Allow this to fail since we don't have as much control over them
     if (view1.resourceEvents[1].statusCode == 200) {
       expect(view1.resourceEvents[1].resourceType, 'image');

--- a/packages/datadog_tracking_http_client/example/lib/screens/instrumentation_scenario.dart
+++ b/packages/datadog_tracking_http_client/example/lib/screens/instrumentation_scenario.dart
@@ -25,7 +25,7 @@ class InstrumentationScenario extends StatefulWidget {
 class _InstrumentationScenarioState extends State<InstrumentationScenario> {
   final images = [
     'https://picsum.photos/200',
-    'https://imgix.datadoghq.com/img/about/presskit/kit/press_kit.png'
+    'https://placehold.co/200x200.png'
   ];
 
   bool _doneWait = false;


### PR DESCRIPTION
### What and why?

Datadog logo moved to docs.dd-static.net

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
