### PR TITLE
chore(ci): Remove concurrency from prepare melos steps

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -255,7 +255,9 @@ scripts:
       scope: 'datadog_flutter_plugin'
 
   remove_cocoapods:
-    exec: |
+    exec: 
+      concurrency: 1
+    run: |
       cd example/ios
       pod deintegrate
       rm Podfile || true
@@ -273,7 +275,9 @@ scripts:
       generate `.env` files for all package examples
 
   pub:get:
-    exec: flutter pub get
+    exec:
+      concurrency: 1
+    run: flutter pub get
 
   pod_update:
     run: cd example/ios && pod update --repo-update


### PR DESCRIPTION
### What and why?

We have flakiness on CI I think because our Flutter prepare / pub steps are executing in parallel from Melos. Remove the concurrency from `prepare` and `remove_cocoapods` to try to fix the flakiness on those build steps.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
