### PR TITLE
feat(sr): migrate all element recorders from ElementRecorder to GenericElementRecorder

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
@@ -10,7 +10,7 @@ import '../recorder.dart';
 import '../view_tree_snapshot.dart';
 import 'common_nodes.dart';
 
-class ContainerRecorder implements GenericElementRecorder {
+class ContainerRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const ContainerRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/container_recorder.dart
@@ -10,13 +10,14 @@ import '../recorder.dart';
 import '../view_tree_snapshot.dart';
 import 'common_nodes.dart';
 
-class ContainerRecorder implements ElementRecorder {
+class ContainerRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const ContainerRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [ColoredBox, Material, DecoratedBox];
+  bool accepts(Widget widget) =>
+      widget is ColoredBox || widget is Material || widget is DecoratedBox;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_checkbox_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_checkbox_recorder.dart
@@ -46,13 +46,13 @@ const Color _defaultCheckColor = CupertinoDynamicColor.withBrightness(
 
 /// Detects 'CupertinoCheckbox' widgets and places a check box
 /// in SessionReplay.
-class CupertinoCheckboxRecorder implements ElementRecorder {
+class CupertinoCheckboxRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CupertinoCheckboxRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [CupertinoCheckbox];
+  bool accepts(Widget widget) => widget is CupertinoCheckbox;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_checkbox_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_checkbox_recorder.dart
@@ -46,7 +46,7 @@ const Color _defaultCheckColor = CupertinoDynamicColor.withBrightness(
 
 /// Detects 'CupertinoCheckbox' widgets and places a check box
 /// in SessionReplay.
-class CupertinoCheckboxRecorder implements GenericElementRecorder {
+class CupertinoCheckboxRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CupertinoCheckboxRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_radio_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_radio_recorder.dart
@@ -48,9 +48,6 @@ class CupertinoRadioRecorder implements GenericElementRecorder {
   const CupertinoRadioRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [];
-
-  @override
   bool accepts(Widget widget) => widget is CupertinoRadio;
 
   @override

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_radio_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_radio_recorder.dart
@@ -42,7 +42,7 @@ const CupertinoDynamicColor _defaultOuterColor =
 
 /// Detects 'CupertinoRadio' widgets and places a Radio icon
 /// on SessionReplay.
-class CupertinoRadioRecorder implements GenericElementRecorder {
+class CupertinoRadioRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CupertinoRadioRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_switch_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_switch_recorder.dart
@@ -18,13 +18,13 @@ const double _thumbRadius = 14.0;
 
 /// Detects 'CupertinoSwitch' widgets and places a Switch icon
 /// on SessionReplay.
-class CupertinoSwitchRecorder implements ElementRecorder {
+class CupertinoSwitchRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CupertinoSwitchRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [CupertinoSwitch];
+  bool accepts(Widget widget) => widget is CupertinoSwitch;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_switch_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/cupertino_widgets/cupertino_switch_recorder.dart
@@ -18,7 +18,7 @@ const double _thumbRadius = 14.0;
 
 /// Detects 'CupertinoSwitch' widgets and places a Switch icon
 /// on SessionReplay.
-class CupertinoSwitchRecorder implements GenericElementRecorder {
+class CupertinoSwitchRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CupertinoSwitchRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
@@ -12,7 +12,7 @@ import '../view_tree_snapshot.dart';
 /// Detects `CustomPaint` widgets and places a placeholder
 /// in SessionReplay.
 @immutable
-class CustomPaintRecorder implements GenericElementRecorder {
+class CustomPaintRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CustomPaintRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/custom_paint_recorder.dart
@@ -12,13 +12,13 @@ import '../view_tree_snapshot.dart';
 /// Detects `CustomPaint` widgets and places a placeholder
 /// in SessionReplay.
 @immutable
-class CustomPaintRecorder implements ElementRecorder {
+class CustomPaintRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CustomPaintRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [CustomPaint];
+  bool accepts(Widget widget) => widget is CustomPaint;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
@@ -23,7 +23,7 @@ const _sensitiveInputTypes = [
 
 /// [EditableTextRecorder] captures the actual editable portion of the
 /// text, and handles obscuring the text that's captured.
-class EditableTextRecorder implements GenericElementRecorder {
+class EditableTextRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   EditableTextRecorder(this.keyGenerator);
@@ -101,7 +101,7 @@ class EditableTextRecorder implements GenericElementRecorder {
 
 /// [InputDecoratorRecorder] handles capturing the border around [TextField]
 /// and [CupertinoTextField] widgets.
-class InputDecoratorRecorder implements GenericElementRecorder {
+class InputDecoratorRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   InputDecoratorRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/editable_text_recorder.dart
@@ -23,13 +23,13 @@ const _sensitiveInputTypes = [
 
 /// [EditableTextRecorder] captures the actual editable portion of the
 /// text, and handles obscuring the text that's captured.
-class EditableTextRecorder implements ElementRecorder {
+class EditableTextRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   EditableTextRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [EditableText];
+  bool accepts(Widget widget) => widget is EditableText;
 
   @override
   CaptureNodeSemantics? captureSemantics(
@@ -101,13 +101,13 @@ class EditableTextRecorder implements ElementRecorder {
 
 /// [InputDecoratorRecorder] handles capturing the border around [TextField]
 /// and [CupertinoTextField] widgets.
-class InputDecoratorRecorder implements ElementRecorder {
+class InputDecoratorRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   InputDecoratorRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [InputDecorator];
+  bool accepts(Widget widget) => widget is InputDecorator;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
@@ -23,13 +23,13 @@ const int _labelMinWidth = 125;
 // This is essentially an 800x800 image, with a raw size of 2meg
 const int maxImageSize = 640000;
 
-class ImageRecorder implements ElementRecorder {
+class ImageRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const ImageRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [RawImage, Image];
+  bool accepts(Widget widget) => widget is RawImage || widget is Image;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
@@ -23,7 +23,7 @@ const int _labelMinWidth = 125;
 // This is essentially an 800x800 image, with a raw size of 2meg
 const int maxImageSize = 640000;
 
-class ImageRecorder implements GenericElementRecorder {
+class ImageRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const ImageRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
@@ -31,13 +31,13 @@ const _transparentBorder =
 
 /// Detects 'Checkbox' widgets and places a check box
 /// in SessionReplay.
-class CheckboxRecorder implements ElementRecorder {
+class CheckboxRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CheckboxRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [Checkbox];
+  bool accepts(Widget widget) => widget is Checkbox;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/checkbox_recorder.dart
@@ -31,7 +31,7 @@ const _transparentBorder =
 
 /// Detects 'Checkbox' widgets and places a check box
 /// in SessionReplay.
-class CheckboxRecorder implements GenericElementRecorder {
+class CheckboxRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const CheckboxRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/radio_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/radio_recorder.dart
@@ -18,7 +18,7 @@ const double _defaultBorderThickness = 2.0;
 
 /// Detects 'Radio' widgets and places a Radio icon
 /// on SessionReplay.
-class RadioRecorder implements GenericElementRecorder {
+class RadioRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const RadioRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/radio_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/radio_recorder.dart
@@ -24,9 +24,6 @@ class RadioRecorder implements GenericElementRecorder {
   const RadioRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [];
-
-  @override
   bool accepts(Widget widget) => widget is Radio;
 
   @override

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/switch_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/switch_recorder.dart
@@ -17,13 +17,13 @@ import '../recording_extensions.dart';
 
 /// Detects 'Switch' widgets and places a Switch icon
 /// on SessionReplay.
-class SwitchRecorder implements ElementRecorder {
+class SwitchRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const SwitchRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [Switch];
+  bool accepts(Widget widget) => widget is Switch;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/switch_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/material_widgets/switch_recorder.dart
@@ -17,7 +17,7 @@ import '../recording_extensions.dart';
 
 /// Detects 'Switch' widgets and places a Switch icon
 /// on SessionReplay.
-class SwitchRecorder implements GenericElementRecorder {
+class SwitchRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const SwitchRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/privacy_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/privacy_recorder.dart
@@ -15,7 +15,7 @@ const int _minLabelWidth = 100;
 /// [PrivacyRecorder] capture and modifies the tree privacy settings
 /// by reading the [SessionReplayPrivacy] widget. It also informs
 /// the recorder when to ignore a subtree that is hidden.
-class PrivacyRecorder implements GenericElementRecorder {
+class PrivacyRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   PrivacyRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/privacy_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/privacy_recorder.dart
@@ -15,13 +15,13 @@ const int _minLabelWidth = 100;
 /// [PrivacyRecorder] capture and modifies the tree privacy settings
 /// by reading the [SessionReplayPrivacy] widget. It also informs
 /// the recorder when to ignore a subtree that is hidden.
-class PrivacyRecorder implements ElementRecorder {
+class PrivacyRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   PrivacyRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [SessionReplayPrivacy];
+  bool accepts(Widget widget) => widget is SessionReplayPrivacy;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
@@ -13,7 +13,7 @@ import '../view_tree_snapshot.dart';
 import 'common_nodes.dart';
 import 'recording_extensions.dart';
 
-class TextElementRecorder implements GenericElementRecorder {
+class TextElementRecorder implements ElementRecorder {
   final KeyGenerator keyGenerator;
 
   const TextElementRecorder(this.keyGenerator);

--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/text_recorder.dart
@@ -13,13 +13,13 @@ import '../view_tree_snapshot.dart';
 import 'common_nodes.dart';
 import 'recording_extensions.dart';
 
-class TextElementRecorder implements ElementRecorder {
+class TextElementRecorder implements GenericElementRecorder {
   final KeyGenerator keyGenerator;
 
   const TextElementRecorder(this.keyGenerator);
 
   @override
-  List<Type> get handlesTypes => [RichText];
+  bool accepts(Widget widget) => widget is RichText;
 
   @override
   CaptureNodeSemantics? captureSemantics(

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -54,7 +54,7 @@ class TreeCapturePrivacy {
   }
 }
 
-abstract interface class GenericElementRecorder {
+abstract interface class ElementRecorder {
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
@@ -131,7 +131,7 @@ class CaptureResult {
 
 class SessionReplayRecorder {
   final DatadogTimeProvider _timeProvider;
-  final List<GenericElementRecorder> _genericElementRecorder = [];
+  final List<ElementRecorder> _elementRecorders = [];
 
   final Map<Key, Element> _elements = {};
   RUMContext? _currentContext;
@@ -164,7 +164,7 @@ class SessionReplayRecorder {
     this._defaultTreeCapturePrivacy,
     this._touchPrivacyLevel,
   ) {
-    _populateElementRecorderMap([
+    _elementRecorders.addAll([
       ContainerRecorder(keyGenerator),
       TextElementRecorder(keyGenerator),
       EditableTextRecorder(keyGenerator),
@@ -183,14 +183,14 @@ class SessionReplayRecorder {
 
   @visibleForTesting
   SessionReplayRecorder.withCustomRecorders(
-    List<GenericElementRecorder> elementRecorders, {
+    List<ElementRecorder> elementRecorders, {
     DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
     required TreeCapturePrivacy defaultCapturePrivacy,
     required TouchPrivacyLevel touchPrivacyLevel,
   })  : _timeProvider = timeProvider,
         _defaultTreeCapturePrivacy = defaultCapturePrivacy,
         _touchPrivacyLevel = touchPrivacyLevel {
-    _populateElementRecorderMap(elementRecorders);
+    _elementRecorders.addAll(elementRecorders);
   }
 
   void updateContext(RUMContext? context) {
@@ -301,10 +301,6 @@ class SessionReplayRecorder {
     }
   }
 
-  void _populateElementRecorderMap(List<GenericElementRecorder> recorders) {
-    _genericElementRecorder.addAll(recorders);
-  }
-
   // Certain elements will cause everything under the element to be invisible, such
   // as Visibility or FadeTransition. Ignore these trees.
   bool _shouldIgnoreTree(Element e) {
@@ -361,7 +357,7 @@ class SessionReplayRecorder {
 
       final widget = e.widget;
       final recorder =
-          _genericElementRecorder.firstWhereOrNull((r) => r.accepts(widget));
+          _elementRecorders.firstWhereOrNull((r) => r.accepts(widget));
       var subtreeStrategy = CaptureNodeSubtreeStrategy.record;
       if (recorder != null) {
         final transformMatrix = renderObject.getTransformTo(

--- a/packages/datadog_session_replay/lib/src/capture/recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/recorder.dart
@@ -54,14 +54,14 @@ class TreeCapturePrivacy {
   }
 }
 
-abstract interface class ElementRecorder {
-  List<Type> get handlesTypes;
-
+abstract interface class GenericElementRecorder {
   CaptureNodeSemantics? captureSemantics(
     Element element,
     CapturedViewAttributes attributes,
     TreeCapturePrivacy capturePrivacy,
   );
+
+  bool accepts(Widget widget);
 }
 
 extension<T> on List<T> {
@@ -71,10 +71,6 @@ extension<T> on List<T> {
     }
     return null;
   }
-}
-
-abstract interface class GenericElementRecorder implements ElementRecorder {
-  bool accepts(Widget widget);
 }
 
 class KeyGenerator {
@@ -135,7 +131,6 @@ class CaptureResult {
 
 class SessionReplayRecorder {
   final DatadogTimeProvider _timeProvider;
-  final Map<Type, ElementRecorder> _elementRecordersByType = {};
   final List<GenericElementRecorder> _genericElementRecorder = [];
 
   final Map<Key, Element> _elements = {};
@@ -188,7 +183,7 @@ class SessionReplayRecorder {
 
   @visibleForTesting
   SessionReplayRecorder.withCustomRecorders(
-    List<ElementRecorder> elementRecorders, {
+    List<GenericElementRecorder> elementRecorders, {
     DatadogTimeProvider timeProvider = const DefaultTimeProvider(),
     required TreeCapturePrivacy defaultCapturePrivacy,
     required TouchPrivacyLevel touchPrivacyLevel,
@@ -306,17 +301,8 @@ class SessionReplayRecorder {
     }
   }
 
-  void _populateElementRecorderMap(List<ElementRecorder> recorders) {
-    for (final recorder in recorders) {
-      if (recorder is GenericElementRecorder) {
-        // Broad match recorder for widgets with generic parameters
-        _genericElementRecorder.add(recorder);
-        continue;
-      }
-      for (final type in recorder.handlesTypes) {
-        _elementRecordersByType[type] = recorder;
-      }
-    }
+  void _populateElementRecorderMap(List<GenericElementRecorder> recorders) {
+    _genericElementRecorder.addAll(recorders);
   }
 
   // Certain elements will cause everything under the element to be invisible, such
@@ -374,7 +360,7 @@ class SessionReplayRecorder {
       }
 
       final widget = e.widget;
-      final recorder = _elementRecordersByType[widget.runtimeType] ??
+      final recorder =
           _genericElementRecorder.firstWhereOrNull((r) => r.accepts(widget));
       var subtreeStrategy = CaptureNodeSubtreeStrategy.record;
       if (recorder != null) {

--- a/packages/datadog_session_replay/test/capture/recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/recorder_test.dart
@@ -25,9 +25,10 @@ class MockElement extends Mock implements Element {
   }
 }
 
-class MockElementRecorder extends Mock implements ElementRecorder {
+class MockElementRecorder extends Mock implements GenericElementRecorder {
   @override
-  List<Type> get handlesTypes => [SimpleTestCapture, Placeholder, Center];
+  bool accepts(Widget widget) =>
+      widget is SimpleTestCapture || widget is Placeholder || widget is Center;
 }
 
 class MockCaptureNode extends Mock implements CaptureNode {}

--- a/packages/datadog_session_replay/test/capture/recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/recorder_test.dart
@@ -25,7 +25,7 @@ class MockElement extends Mock implements Element {
   }
 }
 
-class MockElementRecorder extends Mock implements GenericElementRecorder {
+class MockElementRecorder extends Mock implements ElementRecorder {
   @override
   bool accepts(Widget widget) =>
       widget is SimpleTestCapture || widget is Placeholder || widget is Center;


### PR DESCRIPTION
### What and why?

This PR migrates all element recorders in the Session Replay capture pipeline from the old ElementRecorder interface (with List<Type>  handlesTypes) to GenericElementRecorder (with bool accepts(Widget widget)).

Previously, the system used two parallel interfaces: ElementRecorder dispatched recorders via a Map<Type, ElementRecorder> keyed on widget.runtimeType, while GenericElementRecorder extended it and added an accepts method for generic/parameterized widgets (e.g., Radio<T>, CupertinoRadio<T>) that can't be matched by exact runtime type. This duality required special-casing in _populateElementRecorderMap and maintained two separate lookup structures.

By making GenericElementRecorder the single interface and replacing handlesTypes lists with accepts predicates across all recorders, the dispatch logic collapses to a single _genericElementRecorder list, removes the type-map entirely, and gives each recorder full control over its matching logic without loss of performance for common cases.

### How?

- Merged ElementRecorder and GenericElementRecorder into a single GenericElementRecorder interface with captureSemantics + accepts.
- Updated all 12 concrete recorders to implement accepts(Widget widget) using is-checks in place of List<Type> get handlesTypes.
- Removed the _elementRecordersByType map from SessionReplayRecorder and simplified _populateElementRecorderMap to a single addAll.
- Widget dispatch now goes through a single firstWhereOrNull((r) => r.accepts(widget)) call.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue — RUM-16162
