### PR TITLE
feat(rum): Capture HTTP request and response headers

### DIFF
--- a/examples/simple_example/lib/main.dart
+++ b/examples/simple_example/lib/main.dart
@@ -31,9 +31,23 @@ void main() async {
     loggingConfiguration: DatadogLoggingConfiguration(),
     firstPartyHosts: ['localhost'],
     rumConfiguration: DatadogRumConfiguration(
-      applicationId: dotenv.get('DD_APPLICATION_ID', fallback: ''),
-      traceSampleRate: 100.0,
-    ),
+        applicationId: dotenv.get('DD_APPLICATION_ID', fallback: ''),
+        traceSampleRate: 100.0,
+        trackResourceHeaders: ResourceHeadersExtractor(
+          captureHeaders: [
+            'accept-ranges',
+            'content-disposition',
+            'server',
+            'user-agent',
+            'via',
+            'x-cache-hits',
+            'x-served-by',
+            'x-datadog-trace-id',
+            'x-datadog-parent-id',
+            'x-datadog-origin',
+            'traceparent',
+          ],
+        )),
   )
     ..enableHttpTracking(
       // Using ignoreUrlPatterns is needed if you want to combine HttpClient

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -277,6 +277,22 @@ class RumResourceEventDecoder extends RumEventDecoder {
   int? get duration => rumEvent['resource']['duration'];
   String? get method => rumEvent['resource']['method'];
   int? get size => rumEvent['resource']['size'];
+
+  Map<String, String>? get requestHeaders {
+    final raw = rumEvent['resource']?['request']?['headers'];
+    if (raw is Map) {
+      return raw.map((k, v) => MapEntry(k.toString(), v.toString()));
+    }
+    return null;
+  }
+
+  Map<String, String>? get responseHeaders {
+    final raw = rumEvent['resource']?['response']?['headers'];
+    if (raw is Map) {
+      return raw.map((k, v) => MapEntry(k.toString(), v.toString()));
+    }
+    return null;
+  }
 }
 
 class RumErrorEventDecoder extends RumEventDecoder {

--- a/packages/datadog_dio/example/integration_test/dio_interceptor_headers_test.dart
+++ b/packages/datadog_dio/example/integration_test/dio_interceptor_headers_test.dart
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_common_test/widget_tester_extensions.dart';
+import 'package:datadog_dio_example/main.dart' as app;
+import 'package:datadog_dio_example/scenario_config.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+Future<void> performRumUserFlow(WidgetTester tester) async {
+  await tester.pump(const Duration(seconds: 5));
+
+  var topItem = find.text('Item 0');
+  await tester.tap(topItem);
+  await tester.pumpAndSettle();
+
+  var fetchButton = find.text('Fetch Resources');
+  await tester.tap(fetchButton);
+  await tester.pumpAndSettle();
+
+  var nextButton = find.widgetWithText(ElevatedButton, 'Next Page');
+  await tester.waitFor(nextButton, const Duration(seconds: 100),
+      (e) => (e.widget as ElevatedButton).enabled);
+  await tester.tap(nextButton);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('captures request and response headers on RUM resource events',
+      (WidgetTester tester) async {
+    final sessionRecorder = await startMockServer();
+
+    const clientToken = bool.hasEnvironment('DD_CLIENT_TOKEN')
+        ? String.fromEnvironment('DD_CLIENT_TOKEN')
+        : null;
+    const applicationId = bool.hasEnvironment('DD_APPLICATION_ID')
+        ? String.fromEnvironment('DD_APPLICATION_ID')
+        : null;
+
+    final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
+      firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
+      firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',
+      firstPartyBadUrl: 'https://foo.bar',
+      thirdPartyGetUrl: 'https://httpbingo.org/get',
+      thirdPartyPostUrl: 'https://httpbingo.org/post',
+      thirdPartyMissingUrl: 'https://httpbingo.org/status/404',
+    );
+    RumAutoInstrumentationScenarioConfig.instance = scenarioConfig;
+
+    app.testingConfiguration = TestingConfiguration(
+        customEndpoint: sessionRecorder.sessionEndpoint,
+        clientToken: clientToken,
+        applicationId: applicationId,
+        firstPartyHosts: ['localhost']);
+    await app.main();
+    await tester.pumpAndSettle();
+
+    await performRumUserFlow(tester);
+
+    final rumLog = <RumEventDecoder>[];
+    await sessionRecorder.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        for (var request in requests) {
+          if (!request.requestedUrl.contains('integration')) {
+            request.data.split('\n').forEach((e) {
+              var jsonValue = json.decode(e);
+              if (jsonValue is Map<String, dynamic>) {
+                rumLog.add(RumEventDecoder(jsonValue));
+              }
+            });
+          }
+        }
+        return RumSessionDecoder.fromEvents(rumLog).visits.length >= 3;
+      },
+    );
+
+    final session = RumSessionDecoder.fromEvents(rumLog);
+    expect(session.visits.length, greaterThanOrEqualTo(3));
+
+    final view2 = session.visits[1];
+
+    final getEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyGetUrl);
+    expect(getEvent, isNotNull);
+    expect(getEvent!.requestHeaders, isNotNull);
+    expect(getEvent.requestHeaders!['x-datadog-origin'], 'rum');
+    expect(getEvent.responseHeaders, isNotNull);
+    expect(getEvent.responseHeaders!['content-type'], isNotNull);
+
+    final postEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyPostUrl);
+    expect(postEvent, isNotNull);
+    expect(postEvent!.requestHeaders, isNotNull);
+    expect(postEvent.requestHeaders!['x-datadog-origin'], 'rum');
+    expect(postEvent.responseHeaders, isNotNull);
+    expect(postEvent.responseHeaders!['content-type'], isNotNull);
+  }, skip: kIsWeb);
+}

--- a/packages/datadog_dio/example/lib/main.dart
+++ b/packages/datadog_dio/example/lib/main.dart
@@ -66,6 +66,21 @@ Future<void> main() async {
             applicationId: applicationId,
             traceSampleRate: 100,
             customEndpoint: customEndpoint,
+            trackResourceHeaders: ResourceHeadersExtractor(
+              captureHeaders: [
+                'accept-ranges',
+                'content-disposition',
+                'server',
+                'user-agent',
+                'via',
+                'x-cache-hits',
+                'x-served-by',
+                'x-datadog-trace-id',
+                'x-datadog-parent-id',
+                'x-datadog-origin',
+                'traceparent',
+              ],
+            ),
           )
         : null,
   );

--- a/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
+++ b/packages/datadog_dio/lib/src/datadog_dio_interceptor.dart
@@ -125,7 +125,22 @@ class DatadogDioInterceptor extends Interceptor {
     if (contentLength == null && response.data != null) {
       contentLength = _responseDataByteLength(response.data);
     }
-    final attributes = attributesProvider?.onResponse(response) ?? {};
+    var attributes =
+        attributesProvider?.onResponse(response) ?? <String, Object?>{};
+    final extractor = rum.resourceHeadersExtractor;
+    if (extractor != null) {
+      final requestHeaders = response.requestOptions.headers.map((k, v) {
+        if (v is Iterable) {
+          return MapEntry(k, v.map((e) => e.toString()).toList());
+        }
+        return MapEntry(k, [v.toString()]);
+      });
+      final headerAttrs = extractor.toResourceAttributes(
+        requestHeaders,
+        response.headers.map,
+      );
+      attributes = {...attributes, ...headerAttrs};
+    }
     rum.stopResource(
       rumKey,
       response.statusCode,

--- a/packages/datadog_dio/pubspec.yaml
+++ b/packages/datadog_dio/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ^3.3.0
   dio: ^5.0.0
   uuid: ^4.0.0
   

--- a/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
+++ b/packages/datadog_dio/test/datadog_dio_interceptor_test.dart
@@ -687,4 +687,102 @@ void main() {
       });
     });
   }
+
+  group('with trackResourceHeaders', () {
+    setUp(() {
+      when(() => mockDatadog.rum).thenReturn(mockRum);
+      when(() => mockDatadog.headerTypesForHost(any())).thenReturn({});
+    });
+
+    test('passes captured headers as internal attributes to stopResource', () {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor)
+          .thenReturn(ResourceHeadersExtractor());
+
+      final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);
+      final requestOptions = RequestOptions(
+          path: 'https://test_uri',
+          method: 'GET',
+          headers: {'content-type': 'application/json'});
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+
+      final response = Response(
+        requestOptions: requestOptions,
+        statusCode: 200,
+        headers: Headers.fromMap({
+          'content-type': ['image/png'],
+          'etag': ['"abc123"'],
+          'cookie': ['session=secret'], // forbidden, must be filtered
+        }),
+      );
+
+      interceptor.onResponse(response, ResponseInterceptionHandlerMock());
+
+      final captured = verify(() =>
+              mockRum.stopResource(rumKey, 200, any(), any(), captureAny()))
+          .captured[0] as Map<String, Object?>;
+
+      final responseHeaders =
+          captured['_dd.response_headers'] as Map<String, String>;
+      expect(responseHeaders['content-type'], 'image/png');
+      expect(responseHeaders['etag'], '"abc123"');
+      expect(responseHeaders.containsKey('cookie'), isFalse);
+
+      final requestHeaders =
+          captured['_dd.request_headers'] as Map<String, String>;
+      expect(requestHeaders['content-type'], 'application/json');
+    });
+
+    test('preserves multi-value request headers passed as a List', () {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor)
+          .thenReturn(ResourceHeadersExtractor());
+
+      final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);
+      final requestOptions = RequestOptions(
+        path: 'https://test_uri',
+        method: 'GET',
+        headers: {
+          // Dio allows List values for multi-value headers — must be joined
+          // with ", ", not stringified as "[no-cache, no-store]".
+          'cache-control': ['no-cache', 'no-store'],
+        },
+      );
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+      final response =
+          Response(requestOptions: requestOptions, statusCode: 200);
+
+      interceptor.onResponse(response, ResponseInterceptionHandlerMock());
+
+      final captured = verify(() =>
+              mockRum.stopResource(rumKey, 200, any(), any(), captureAny()))
+          .captured[0] as Map<String, Object?>;
+      final requestHeaders =
+          captured['_dd.request_headers'] as Map<String, String>;
+      expect(requestHeaders['cache-control'], 'no-cache, no-store');
+    });
+
+    test('does not add header attributes when extractor is null', () {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor).thenReturn(null);
+
+      final interceptor = DatadogDioInterceptor(datadogSdk: mockDatadog);
+      final requestOptions =
+          RequestOptions(path: 'https://test_uri', method: 'GET', headers: {});
+      final rumKey = randomString();
+      requestOptions.extra[DatadogDioInterceptor.datadogRumExtraKey] = rumKey;
+      final response =
+          Response(requestOptions: requestOptions, statusCode: 200);
+
+      interceptor.onResponse(response, ResponseInterceptionHandlerMock());
+
+      final captured = verify(() =>
+              mockRum.stopResource(rumKey, 200, any(), any(), captureAny()))
+          .captured[0] as Map<String, Object?>;
+      expect(captured.containsKey('_dd.request_headers'), isFalse);
+      expect(captured.containsKey('_dd.response_headers'), isFalse);
+    });
+  });
 }

--- a/packages/datadog_flutter_plugin/ios/.gitignore
+++ b/packages/datadog_flutter_plugin/ios/.gitignore
@@ -34,6 +34,7 @@ Icon?
 .tags*
 .swiftpm/
 .build/
+Package.resolved
 
 /Flutter/Generated.xcconfig
 /Flutter/ephemeral/

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
@@ -175,7 +175,18 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
             if let key = arguments["key"] as? String,
                let kindString = arguments["kind"] as? String,
                let attributes = arguments["attributes"] as? [String: Any?] {
-                let encodedAttributes = castFlutterAttributesToSwift(attributes)
+                var encodedAttributes = castFlutterAttributesToSwift(attributes)
+
+                // Cross-platform header attributes must be passed as typed
+                // [String: String] so the native SDK's .dd.decode() can read
+                // them — it does not unwrap DdFlutterEncodable.
+                if let requestHeaders = attributes["_dd.request_headers"] as? [String: String] {
+                    encodedAttributes["_dd.request_headers"] = requestHeaders
+                }
+                if let responseHeaders = attributes["_dd.response_headers"] as? [String: String] {
+                    encodedAttributes["_dd.response_headers"] = responseHeaders
+                }
+
                 let kind = RUMResourceType.parseFromFlutter(kindString)
 
                 let statusCode = arguments["statusCode"] as? NSNumber

--- a/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/datadog_flutter_plugin.dart
@@ -220,6 +220,7 @@ class DatadogSdk {
             attachResponse.capturedConfiguration.traceSampleRate ?? 100.0,
             attachResponse.capturedConfiguration.traceContextInjection ??
                 TraceContextInjection.sampled,
+            attachResponse.capturedConfiguration.resourceHeadersExtractor,
           );
         }
 

--- a/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_configuration.dart
@@ -427,6 +427,12 @@ class DatadogAttachConfiguration {
   /// Defaults to [TraceContextInjection.sampled].
   TraceContextInjection traceContextInjection = TraceContextInjection.sampled;
 
+  /// Configuration for capturing HTTP request and response headers in RUM
+  /// resource events.
+  ///
+  /// See [DatadogRumConfiguration.trackResourceHeaders].
+  ResourceHeadersExtractor? trackResourceHeaders;
+
   /// Configurations for additional plugins that will be created after Datadog
   /// is initialized.
   final List<DatadogPluginConfiguration> additionalPlugins = [];
@@ -439,6 +445,7 @@ class DatadogAttachConfiguration {
     List<String>? firstPartyHosts,
     this.firstPartyHostsWithTracingHeaders = const {},
     this.traceContextInjection = TraceContextInjection.sampled,
+    this.trackResourceHeaders,
   }) {
     // Attempt a union if both configuration options are present
     if (firstPartyHosts != null) {

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_method_channel.dart
@@ -186,6 +186,8 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
       traceSampleRate: configuration.rumConfiguration?.traceSampleRate,
       traceContextInjection:
           configuration.rumConfiguration?.traceContextInjection,
+      resourceHeadersExtractor:
+          configuration.rumConfiguration?.trackResourceHeaders,
       firstPartyHosts: configuration.firstPartyHostsWithTracingHeaders,
       configuredPlugins: backgroundPlugins,
     );
@@ -215,6 +217,7 @@ class DatadogSdkMethodChannel extends DatadogSdkPlatform {
           rumEnabled: response.rumEnabled,
           traceSampleRate: attachConfig.traceSampleRate,
           traceContextInjection: attachConfig.traceContextInjection,
+          resourceHeadersExtractor: attachConfig.trackResourceHeaders,
           firstPartyHosts: attachConfig.firstPartyHostsWithTracingHeaders,
           configuredPlugins: backgroundPlugins,
         );

--- a/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/datadog_sdk_platform_interface.dart
@@ -47,6 +47,7 @@ class CapturedConfiguration {
   final bool rumEnabled;
   final double? traceSampleRate;
   final TraceContextInjection? traceContextInjection;
+  final ResourceHeadersExtractor? resourceHeadersExtractor;
   final Map<String, Set<TracingHeaderType>> firstPartyHosts;
   final List<DatadogPluginConfiguration> configuredPlugins;
 
@@ -55,6 +56,7 @@ class CapturedConfiguration {
     required this.rumEnabled,
     required this.traceSampleRate,
     required this.traceContextInjection,
+    required this.resourceHeadersExtractor,
     required this.firstPartyHosts,
     required this.configuredPlugins,
   });

--- a/packages/datadog_flutter_plugin/lib/src/rum/attributes.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/attributes.dart
@@ -22,4 +22,12 @@ class DatadogRumPlatformAttributeKey {
 
   /// Internal view attribute that specifies the "Interaction To Next View" timing.
   static const customInvValue = '_dd.view.custom_inv_value';
+
+  /// Captured HTTP request headers. Used in RUM resources created by automatic
+  /// resource tracking. Expects `Map<String, String>` value.
+  static const requestHeaders = '_dd.request_headers';
+
+  /// Captured HTTP response headers. Used in RUM resources created by automatic
+  /// resource tracking. Expects `Map<String, String>` value.
+  static const responseHeaders = '_dd.response_headers';
 }

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -130,6 +130,11 @@ class DatadogRum {
   @internal
   final TraceContextInjection traceContextInjection;
 
+  /// The extractor for capturing HTTP request/response headers in RUM
+  /// resource events, or `null` if header capture is disabled.
+  @internal
+  final ResourceHeadersExtractor? resourceHeadersExtractor;
+
   @internal
   DatadogTimeProvider timeProvider = DefaultTimeProvider();
 
@@ -159,6 +164,7 @@ class DatadogRum {
       : traceSampleRate = config.traceSampleRate,
         _maxSampledTraceId = _getMaxTraceId(config.traceSampleRate),
         traceContextInjection = config.traceContextInjection,
+        resourceHeadersExtractor = config.trackResourceHeaders,
         logger = core.internalLogger {
     _init(
       core: core,
@@ -173,6 +179,7 @@ class DatadogRum {
     DatadogSdk core,
     this.traceSampleRate,
     this.traceContextInjection,
+    this.resourceHeadersExtractor,
   )   : _maxSampledTraceId = _getMaxTraceId(traceSampleRate),
         logger = core.internalLogger {
     _init(
@@ -187,6 +194,7 @@ class DatadogRum {
       : traceSampleRate = configuration.traceSampleRate,
         _maxSampledTraceId = _getMaxTraceId(configuration.traceSampleRate),
         traceContextInjection = configuration.traceContextInjection,
+        resourceHeadersExtractor = configuration.trackResourceHeaders,
         logger = core.internalLogger {
     _init(
       core: core,

--- a/packages/datadog_flutter_plugin/lib/src/rum/resource_headers_extractor.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/resource_headers_extractor.dart
@@ -1,0 +1,208 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:convert';
+
+// Dart 3.9 moved made it so meta is no longer needed for `@internal`, but we
+// still need it for versions below 3.9.
+// ignore: unnecessary_import
+import 'package:meta/meta.dart';
+
+import 'attributes.dart';
+
+/// Default request headers captured when [includeDefaults] is true.
+const List<String> _defaultRequestHeaders = [
+  'cache-control',
+  'content-type',
+];
+
+/// Default response headers captured when [includeDefaults] is true.
+const List<String> _defaultResponseHeaders = [
+  'cache-control',
+  'etag',
+  'age',
+  'expires',
+  'content-type',
+  'content-encoding',
+  'vary',
+  'content-length',
+  'server-timing',
+  'x-cache',
+];
+
+/// Regex pattern matching header names that must never be captured, even if
+/// explicitly configured. Aligned with Android and iOS SDKs.
+final RegExp _forbiddenHeaderPattern = RegExp(
+  r'(token|cookie|secret|authorization|password|credential|bearer|(api|secret|access|app).?key|forwarded|real.?ip|connecting.?ip|client.?ip)',
+  caseSensitive: false,
+);
+
+/// Maximum total size of collected header content per direction (request or
+/// response), in bytes.
+const int _headerSizeLimitBytes = 2048;
+
+/// Maximum byte length of a single header value. Values exceeding this are
+/// truncated.
+const int _maxHeaderValueBytes = 128;
+
+/// Maximum number of headers captured per direction.
+const int _maxHeadersCount = 100;
+
+/// Configuration for capturing HTTP request and response headers in RUM
+/// resource events.
+///
+/// When provided to [DatadogRumConfiguration.trackResourceHeaders], the SDK
+/// captures matching headers from intercepted HTTP requests and responses.
+///
+/// ```dart
+/// DatadogRumConfiguration(
+///   applicationId: 'app-id',
+///   trackResourceHeaders: ResourceHeadersExtractor(),
+/// )
+/// ```
+///
+/// By default, a set of safe headers is captured (e.g. `cache-control`,
+/// `content-type`, `etag`). Pass [captureHeaders] to capture additional
+/// headers, or set [includeDefaults] to `false` to capture only the
+/// specified custom headers.
+///
+/// Headers whose names match a security pattern (e.g. `authorization`,
+/// `cookie`, `token`) are **never** captured, even if explicitly listed.
+class ResourceHeadersExtractor {
+  /// Whether to include the default safe headers in addition to any
+  /// [captureHeaders].
+  final bool includeDefaults;
+
+  /// Additional header names to capture (case-insensitive).
+  final List<String> captureHeaders;
+
+  final List<String> _requestHeaders;
+  final List<String> _responseHeaders;
+
+  /// Creates a header extractor.
+  ///
+  /// When [includeDefaults] is `true` (the default), standard safe headers
+  /// are automatically captured. Additional headers can be specified via
+  /// [captureHeaders].
+  ResourceHeadersExtractor({
+    this.includeDefaults = true,
+    this.captureHeaders = const [],
+  })  : _requestHeaders = _buildHeaderList(
+          includeDefaults ? _defaultRequestHeaders : const [],
+          captureHeaders,
+        ),
+        _responseHeaders = _buildHeaderList(
+          includeDefaults ? _defaultResponseHeaders : const [],
+          captureHeaders,
+        );
+
+  /// Extracts matching request headers from the provided header map.
+  ///
+  /// Returns a map of lowercase header names to their (potentially truncated)
+  /// values. Security-filtered headers are excluded. Size limits are enforced.
+  @internal
+  Map<String, String> extractRequestHeaders(Map<String, List<String>> headers) {
+    return _extractHeaders(headers, _requestHeaders);
+  }
+
+  /// Extracts matching response headers from the provided header map.
+  ///
+  /// Returns a map of lowercase header names to their (potentially truncated)
+  /// values. Security-filtered headers are excluded. Size limits are enforced.
+  @internal
+  Map<String, String> extractResponseHeaders(
+      Map<String, List<String>> headers) {
+    return _extractHeaders(headers, _responseHeaders);
+  }
+
+  /// Convenience method that extracts both request and response headers and
+  /// returns them as a map of internal attributes suitable for merging into
+  /// `stopResource()` attributes.
+  @internal
+  Map<String, Object?> toResourceAttributes(
+    Map<String, List<String>> requestHeaders,
+    Map<String, List<String>> responseHeaders,
+  ) {
+    final result = <String, Object?>{};
+    final extracted = extractRequestHeaders(requestHeaders);
+    if (extracted.isNotEmpty) {
+      result[DatadogRumPlatformAttributeKey.requestHeaders] = extracted;
+    }
+    final extractedResponse = extractResponseHeaders(responseHeaders);
+    if (extractedResponse.isNotEmpty) {
+      result[DatadogRumPlatformAttributeKey.responseHeaders] =
+          extractedResponse;
+    }
+    return result;
+  }
+
+  static Map<String, String> _extractHeaders(
+    Map<String, List<String>> headers,
+    List<String> allowedHeaders,
+  ) {
+    if (allowedHeaders.isEmpty) return const {};
+
+    final allowedSet = allowedHeaders.map((h) => h.toLowerCase()).toSet();
+
+    final result = <String, String>{};
+    var totalBytes = 0;
+
+    for (final entry in headers.entries) {
+      if (result.length >= _maxHeadersCount) break;
+      if (totalBytes >= _headerSizeLimitBytes) break;
+
+      final lowerName = entry.key.toLowerCase();
+      if (!allowedSet.contains(lowerName)) continue;
+      if (_forbiddenHeaderPattern.hasMatch(lowerName)) continue;
+
+      final joinedValue = entry.value.join(', ');
+      final truncatedValue = _truncateToUtf8ByteSize(
+        joinedValue,
+        _maxHeaderValueBytes,
+      );
+
+      final nameBytes = utf8.encode(lowerName).length;
+      final valueBytes = utf8.encode(truncatedValue).length;
+      final entrySize = nameBytes + valueBytes;
+
+      if (totalBytes + entrySize > _headerSizeLimitBytes) break;
+
+      result[lowerName] = truncatedValue;
+      totalBytes += entrySize;
+    }
+
+    return result;
+  }
+
+  /// Builds a deduplicated, lowercase list of header names from defaults and
+  /// custom headers.
+  static List<String> _buildHeaderList(
+    List<String> defaults,
+    List<String> custom,
+  ) {
+    final seen = <String>{};
+    final result = <String>[];
+    for (final h in [...defaults, ...custom]) {
+      final lower = h.toLowerCase();
+      if (seen.add(lower)) {
+        result.add(lower);
+      }
+    }
+    return result;
+  }
+
+  /// Truncates [value] to at most [maxBytes] UTF-8 bytes without splitting
+  /// multi-byte characters.
+  static String _truncateToUtf8ByteSize(String value, int maxBytes) {
+    final encoded = utf8.encode(value);
+    if (encoded.length <= maxBytes) return value;
+
+    // Walk back from maxBytes to avoid splitting a multi-byte character.
+    var end = maxBytes;
+    while (end > 0 && (encoded[end] & 0xC0) == 0x80) {
+      end--;
+    }
+    return utf8.decode(encoded.sublist(0, end));
+  }
+}

--- a/packages/datadog_flutter_plugin/lib/src/rum/resource_headers_extractor.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/resource_headers_extractor.dart
@@ -77,8 +77,8 @@ class ResourceHeadersExtractor {
   /// Additional header names to capture (case-insensitive).
   final List<String> captureHeaders;
 
-  final List<String> _requestHeaders;
-  final List<String> _responseHeaders;
+  final Set<String> _requestHeaders;
+  final Set<String> _responseHeaders;
 
   /// Creates a header extractor.
   ///
@@ -88,11 +88,11 @@ class ResourceHeadersExtractor {
   ResourceHeadersExtractor({
     this.includeDefaults = true,
     this.captureHeaders = const [],
-  })  : _requestHeaders = _buildHeaderList(
+  })  : _requestHeaders = _buildHeaderSet(
           includeDefaults ? _defaultRequestHeaders : const [],
           captureHeaders,
         ),
-        _responseHeaders = _buildHeaderList(
+        _responseHeaders = _buildHeaderSet(
           includeDefaults ? _defaultResponseHeaders : const [],
           captureHeaders,
         );
@@ -139,24 +139,25 @@ class ResourceHeadersExtractor {
 
   static Map<String, String> _extractHeaders(
     Map<String, List<String>> headers,
-    List<String> allowedHeaders,
+    Set<String> allowedHeaders,
   ) {
-    if (allowedHeaders.isEmpty) return const {};
+    if (headers.isEmpty || allowedHeaders.isEmpty) return const {};
 
-    final allowedSet = allowedHeaders.map((h) => h.toLowerCase()).toSet();
+    final inputByLowerName = <String, List<String>>{};
+    for (final entry in headers.entries) {
+      inputByLowerName[entry.key.toLowerCase()] = entry.value;
+    }
 
     final result = <String, String>{};
     var totalBytes = 0;
 
-    for (final entry in headers.entries) {
+    for (final lowerName in allowedHeaders) {
       if (result.length >= _maxHeadersCount) break;
-      if (totalBytes >= _headerSizeLimitBytes) break;
 
-      final lowerName = entry.key.toLowerCase();
-      if (!allowedSet.contains(lowerName)) continue;
-      if (_forbiddenHeaderPattern.hasMatch(lowerName)) continue;
+      final values = inputByLowerName[lowerName];
+      if (values == null) continue;
 
-      final joinedValue = entry.value.join(', ');
+      final joinedValue = values.join(', ');
       final truncatedValue = _truncateToUtf8ByteSize(
         joinedValue,
         _maxHeaderValueBytes,
@@ -166,7 +167,8 @@ class ResourceHeadersExtractor {
       final valueBytes = utf8.encode(truncatedValue).length;
       final entrySize = nameBytes + valueBytes;
 
-      if (totalBytes + entrySize > _headerSizeLimitBytes) break;
+      // Skip this header but keep trying smaller ones — matches dd-sdk-android.
+      if (totalBytes + entrySize > _headerSizeLimitBytes) continue;
 
       result[lowerName] = truncatedValue;
       totalBytes += entrySize;
@@ -175,19 +177,23 @@ class ResourceHeadersExtractor {
     return result;
   }
 
-  /// Builds a deduplicated, lowercase list of header names from defaults and
-  /// custom headers.
-  static List<String> _buildHeaderList(
+  /// Builds a deduplicated, lowercase set of header names from defaults and
+  /// custom headers. Headers matching [_forbiddenHeaderPattern] are filtered
+  /// out at build time so the security filter does not run per-call.
+  static Set<String> _buildHeaderSet(
     List<String> defaults,
     List<String> custom,
   ) {
-    final seen = <String>{};
-    final result = <String>[];
-    for (final h in [...defaults, ...custom]) {
+    final result = <String>{};
+    for (final h in defaults) {
       final lower = h.toLowerCase();
-      if (seen.add(lower)) {
-        result.add(lower);
-      }
+      if (_forbiddenHeaderPattern.hasMatch(lower)) continue;
+      result.add(lower);
+    }
+    for (final h in custom) {
+      final lower = h.toLowerCase();
+      if (_forbiddenHeaderPattern.hasMatch(lower)) continue;
+      result.add(lower);
     }
     return result;
   }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
@@ -5,5 +5,6 @@
 export 'ddrum.dart';
 export 'ddrum_events.dart';
 export 'navigation_observer.dart';
+export 'resource_headers_extractor.dart';
 export 'rum_configuration.dart';
 export 'rum_user_action_detector.dart';

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -226,9 +226,6 @@ class DatadogRumConfiguration {
   /// tracking clients ([DatadogTrackingHttpClient], [DatadogClient], and
   /// [DatadogDioInterceptor]).
   ///
-  /// Requires native SDK 3.8.0+ on both Android and iOS for headers to appear
-  /// in events.
-  ///
   /// Defaults to `null` (disabled).
   ResourceHeadersExtractor? trackResourceHeaders;
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -221,6 +221,17 @@ class DatadogRumConfiguration {
   /// [RumVitalOperationEvent]s before they are sent to Datadog.
   RumVitalOperationEventMapper? vitalOperationStepEventMapper;
 
+  /// Captures HTTP request and response headers from intercepted requests and
+  /// includes them in RUM resource events. Applies across all Datadog HTTP
+  /// tracking clients ([DatadogTrackingHttpClient], [DatadogClient], and
+  /// [DatadogDioInterceptor]).
+  ///
+  /// Requires native SDK 3.8.0+ on both Android and iOS for headers to appear
+  /// in events.
+  ///
+  /// Defaults to `null` (disabled).
+  ResourceHeadersExtractor? trackResourceHeaders;
+
   Map<String, Object?> additionalConfig;
 
   DatadogRumConfiguration({
@@ -246,6 +257,7 @@ class DatadogRumConfiguration {
     this.errorEventMapper,
     this.longTaskEventMapper,
     this.vitalOperationStepEventMapper,
+    this.trackResourceHeaders,
     this.additionalConfig = const <String, Object>{},
   })  : sessionSamplingRate = max(0, min(sessionSamplingRate, 100)),
         traceSampleRate = max(0, min(traceSampleRate, 100)),

--- a/packages/datadog_flutter_plugin/test/rum/resource_headers_extractor_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/resource_headers_extractor_test.dart
@@ -1,0 +1,350 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flutter_plugin/src/rum/attributes.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ResourceHeadersExtractor', () {
+    group('default headers', () {
+      test('extracts default request headers', () {
+        final extractor = ResourceHeadersExtractor();
+        final headers = <String, List<String>>{
+          'cache-control': ['no-cache'],
+          'content-type': ['application/json'],
+          'x-custom': ['value'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {
+          'cache-control': 'no-cache',
+          'content-type': 'application/json',
+        });
+      });
+
+      test('extracts default response headers', () {
+        final extractor = ResourceHeadersExtractor();
+        final headers = <String, List<String>>{
+          'cache-control': ['max-age=3600'],
+          'etag': ['"abc123"'],
+          'age': ['100'],
+          'expires': ['Thu, 01 Dec 2025 16:00:00 GMT'],
+          'content-type': ['text/html'],
+          'content-encoding': ['gzip'],
+          'vary': ['Accept-Encoding'],
+          'content-length': ['1024'],
+          'server-timing': ['total;dur=100'],
+          'x-cache': ['HIT'],
+          'x-custom': ['ignored'],
+        };
+        final result = extractor.extractResponseHeaders(headers);
+        expect(result.length, 10);
+        expect(result['cache-control'], 'max-age=3600');
+        expect(result['etag'], '"abc123"');
+        expect(result['age'], '100');
+        expect(result['expires'], 'Thu, 01 Dec 2025 16:00:00 GMT');
+        expect(result['content-type'], 'text/html');
+        expect(result['content-encoding'], 'gzip');
+        expect(result['vary'], 'Accept-Encoding');
+        expect(result['content-length'], '1024');
+        expect(result['server-timing'], 'total;dur=100');
+        expect(result['x-cache'], 'HIT');
+        expect(result.containsKey('x-custom'), false);
+      });
+
+      test('returns empty map when no matching headers', () {
+        final extractor = ResourceHeadersExtractor();
+        final headers = <String, List<String>>{
+          'x-custom': ['value'],
+          'x-other': ['value'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, isEmpty);
+      });
+    });
+
+    group('custom headers', () {
+      test('includes defaults and custom headers', () {
+        final extractor = ResourceHeadersExtractor(
+          captureHeaders: ['x-request-id'],
+        );
+        final headers = <String, List<String>>{
+          'cache-control': ['no-cache'],
+          'content-type': ['application/json'],
+          'x-request-id': ['abc-123'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {
+          'cache-control': 'no-cache',
+          'content-type': 'application/json',
+          'x-request-id': 'abc-123',
+        });
+      });
+
+      test('captures only custom headers when includeDefaults is false', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: ['x-request-id'],
+        );
+        final headers = <String, List<String>>{
+          'cache-control': ['no-cache'],
+          'content-type': ['application/json'],
+          'x-request-id': ['abc-123'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {'x-request-id': 'abc-123'});
+      });
+
+      test('returns empty map when includeDefaults is false and no custom', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+        );
+        final headers = <String, List<String>>{
+          'cache-control': ['no-cache'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, isEmpty);
+      });
+
+      test('deduplicates custom headers that overlap with defaults', () {
+        final extractor = ResourceHeadersExtractor(
+          captureHeaders: ['Cache-Control', 'x-request-id'],
+        );
+        final headers = <String, List<String>>{
+          'cache-control': ['no-cache'],
+          'x-request-id': ['abc-123'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {
+          'cache-control': 'no-cache',
+          'x-request-id': 'abc-123',
+        });
+      });
+    });
+
+    group('case insensitivity', () {
+      test('matches headers case-insensitively', () {
+        final extractor = ResourceHeadersExtractor();
+        final headers = <String, List<String>>{
+          'Content-Type': ['application/json'],
+          'CACHE-CONTROL': ['no-cache'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {
+          'content-type': 'application/json',
+          'cache-control': 'no-cache',
+        });
+      });
+
+      test('custom headers match case-insensitively', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: ['X-Request-ID'],
+        );
+        final headers = <String, List<String>>{
+          'x-request-id': ['abc-123'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {'x-request-id': 'abc-123'});
+      });
+    });
+
+    group('multi-value headers', () {
+      test('joins multiple values with comma and space', () {
+        final extractor = ResourceHeadersExtractor();
+        final headers = <String, List<String>>{
+          'cache-control': ['no-cache', 'no-store'],
+          'vary': ['Accept-Encoding', 'Accept-Language'],
+        };
+        final response = extractor.extractResponseHeaders(headers);
+        expect(response['cache-control'], 'no-cache, no-store');
+        expect(response['vary'], 'Accept-Encoding, Accept-Language');
+      });
+    });
+
+    group('security filtering', () {
+      test('filters headers matching forbidden pattern', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: [
+            'authorization',
+            'cookie',
+            'x-auth-token',
+            'x-api-key',
+            'x-secret-key',
+            'x-access-key',
+            'x-app-key',
+            'x-csrf-token',
+            'x-forwarded-for',
+            'x-real-ip',
+            'cf-connecting-ip',
+            'true-client-ip',
+            'x-password-hash',
+            'x-credential-id',
+            'bearer-token',
+            'x-safe-header',
+          ],
+        );
+        final headers = <String, List<String>>{
+          'authorization': ['Bearer abc'],
+          'cookie': ['session=xyz'],
+          'x-auth-token': ['token123'],
+          'x-api-key': ['key123'],
+          'x-secret-key': ['secret123'],
+          'x-access-key': ['access123'],
+          'x-app-key': ['app123'],
+          'x-csrf-token': ['csrf123'],
+          'x-forwarded-for': ['1.2.3.4'],
+          'x-real-ip': ['1.2.3.4'],
+          'cf-connecting-ip': ['1.2.3.4'],
+          'true-client-ip': ['1.2.3.4'],
+          'x-password-hash': ['hash'],
+          'x-credential-id': ['cred'],
+          'bearer-token': ['bt'],
+          'x-safe-header': ['safe'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result, {'x-safe-header': 'safe'});
+      });
+
+      test('filters forbidden headers even from defaults', () {
+        // None of the defaults should match the forbidden pattern, but verify
+        // that the filtering mechanism works if one were added
+        final extractor = ResourceHeadersExtractor(
+          captureHeaders: ['set-cookie'],
+        );
+        final headers = <String, List<String>>{
+          'content-type': ['text/html'],
+          'set-cookie': ['session=abc'],
+        };
+        final result = extractor.extractResponseHeaders(headers);
+        expect(result, {'content-type': 'text/html'});
+        expect(result.containsKey('set-cookie'), false);
+      });
+    });
+
+    group('truncation', () {
+      test('truncates values exceeding 128 bytes', () {
+        final extractor = ResourceHeadersExtractor();
+        final longValue = 'a' * 200;
+        final headers = <String, List<String>>{
+          'content-type': [longValue],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(utf8.encode(result['content-type']!).length,
+            lessThanOrEqualTo(128));
+      });
+
+      test('truncates without splitting multi-byte characters', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: ['x-emoji'],
+        );
+        // Each emoji is 4 bytes in UTF-8. Fill to just over 128 bytes.
+        final emoji = '\u{1F600}'; // 4 bytes
+        final value = emoji * 33; // 132 bytes
+        final headers = <String, List<String>>{
+          'x-emoji': [value],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        final encodedResult = utf8.encode(result['x-emoji']!);
+        expect(encodedResult.length, lessThanOrEqualTo(128));
+        // Should be exactly 32 emojis = 128 bytes
+        expect(encodedResult.length, 128);
+      });
+    });
+
+    group('size limits', () {
+      test('respects max 100 headers count', () {
+        final headerNames = List.generate(
+            110, (i) => 'x-header-${i.toString().padLeft(3, '0')}');
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: headerNames,
+        );
+        final headers = <String, List<String>>{
+          for (final name in headerNames) name: ['v'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result.length, 100);
+      });
+
+      test('respects 2KB total size limit', () {
+        // Create headers that would exceed 2KB
+        final headerNames =
+            List.generate(30, (i) => 'x-h-${i.toString().padLeft(2, '0')}');
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: headerNames,
+        );
+        // Each value is 100 bytes, name is ~7 bytes, so ~107 bytes per header
+        // 30 headers * 107 bytes = 3210 bytes, exceeds 2048
+        final headers = <String, List<String>>{
+          for (final name in headerNames) name: ['x' * 100],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        // Calculate total bytes
+        var totalBytes = 0;
+        for (final entry in result.entries) {
+          totalBytes +=
+              utf8.encode(entry.key).length + utf8.encode(entry.value).length;
+        }
+        expect(totalBytes, lessThanOrEqualTo(2048));
+        expect(result.length, lessThan(30));
+      });
+    });
+
+    group('toResourceAttributes', () {
+      test('returns map with internal attribute keys', () {
+        final extractor = ResourceHeadersExtractor();
+        final requestHeaders = <String, List<String>>{
+          'content-type': ['application/json'],
+        };
+        final responseHeaders = <String, List<String>>{
+          'content-type': ['text/html'],
+          'etag': ['"abc"'],
+        };
+        final attrs = extractor.toResourceAttributes(
+          requestHeaders,
+          responseHeaders,
+        );
+        expect(attrs[DatadogRumPlatformAttributeKey.requestHeaders], {
+          'content-type': 'application/json',
+        });
+        expect(attrs[DatadogRumPlatformAttributeKey.responseHeaders], {
+          'content-type': 'text/html',
+          'etag': '"abc"',
+        });
+      });
+
+      test('omits empty header maps from attributes', () {
+        final extractor = ResourceHeadersExtractor();
+        final attrs = extractor.toResourceAttributes(
+          const {},
+          const {},
+        );
+        expect(attrs, isEmpty);
+      });
+
+      test('omits request headers when none match', () {
+        final extractor = ResourceHeadersExtractor();
+        final attrs = extractor.toResourceAttributes(
+          {
+            'x-custom': ['value']
+          },
+          {
+            'content-type': ['text/html']
+          },
+        );
+        expect(attrs.containsKey(DatadogRumPlatformAttributeKey.requestHeaders),
+            false);
+        expect(attrs[DatadogRumPlatformAttributeKey.responseHeaders], {
+          'content-type': 'text/html',
+        });
+      });
+    });
+  });
+}

--- a/packages/datadog_flutter_plugin/test/rum/resource_headers_extractor_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/resource_headers_extractor_test.dart
@@ -244,7 +244,7 @@ void main() {
           captureHeaders: ['x-emoji'],
         );
         // Each emoji is 4 bytes in UTF-8. Fill to just over 128 bytes.
-        final emoji = '\u{1F600}'; // 4 bytes
+        final emoji = '😀'; // 4 bytes
         final value = emoji * 33; // 132 bytes
         final headers = <String, List<String>>{
           'x-emoji': [value],
@@ -294,6 +294,52 @@ void main() {
         }
         expect(totalBytes, lessThanOrEqualTo(2048));
         expect(result.length, lessThan(30));
+      });
+
+      test(
+          'skips an oversized header but keeps capturing smaller subsequent ones',
+          () {
+        // Burn most of the 2048-byte budget with 16 fillers (~122 bytes each
+        // ≈ 1952 bytes), leaving ~96 bytes free. A subsequent "medium" header
+        // (~117 bytes) does not fit and must be skipped; a "tiny" header
+        // listed after it (~7 bytes) must still be captured. This exercises
+        // continue-vs-break on the byte-budget check.
+        final fillers =
+            List.generate(16, (i) => 'x-fill-${i.toString().padLeft(2, '0')}');
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: [...fillers, 'x-medium-overflow', 'x-tiny'],
+        );
+        final headers = <String, List<String>>{
+          for (final name in fillers) name: ['v' * 113],
+          'x-medium-overflow': ['m' * 100],
+          'x-tiny': ['v'],
+        };
+        final result = extractor.extractRequestHeaders(headers);
+        expect(result.containsKey('x-medium-overflow'), isFalse);
+        expect(result['x-tiny'], 'v');
+      });
+
+      test(
+          'preserves default response headers when many custom headers are listed first in the input',
+          () {
+        // When many large custom headers come before defaults in the input
+        // map order, defaults must still survive the byte budget.
+        final customNames = List.generate(
+            30, (i) => 'x-custom-${i.toString().padLeft(2, '0')}');
+        final extractor = ResourceHeadersExtractor(
+          captureHeaders: customNames,
+        );
+        // Each custom value is 100 bytes — 30 customs alone would blow the
+        // 2KB budget if iterated in input order before content-type.
+        final headers = <String, List<String>>{
+          for (final name in customNames) name: ['x' * 100],
+          'content-type': ['text/html'],
+          'etag': ['"abc"'],
+        };
+        final result = extractor.extractResponseHeaders(headers);
+        expect(result['content-type'], 'text/html');
+        expect(result['etag'], '"abc"');
       });
     });
 

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_headers_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_headers_test.dart
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-2022 Datadog, Inc.
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_tracking_http_client_example/main.dart' as app;
+import 'package:datadog_tracking_http_client_example/scenario_config.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+Future<void> performRumUserFlow(WidgetTester tester) async {
+  var scenario = find.text('HttpClient (dart:io) Override');
+  await tester.tap(scenario);
+  await tester.pumpAndSettle();
+
+  await tester.pump(const Duration(seconds: 5));
+
+  var topItem = find.text('Item 0');
+  await tester.tap(topItem);
+  await tester.pumpAndSettle();
+
+  var nextButton = find.text('Next Page');
+  await tester.tap(nextButton);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('captures request and response headers on RUM resource events',
+      (WidgetTester tester) async {
+    final sessionRecorder = await startMockServer();
+
+    const clientToken = bool.hasEnvironment('DD_CLIENT_TOKEN')
+        ? String.fromEnvironment('DD_CLIENT_TOKEN')
+        : null;
+    const applicationId = bool.hasEnvironment('DD_APPLICATION_ID')
+        ? String.fromEnvironment('DD_APPLICATION_ID')
+        : null;
+
+    final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
+      firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
+      firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',
+      firstPartyBadUrl: 'https://foo.bar/',
+      thirdPartyGetUrl: 'https://httpbingo.org/get/',
+      thirdPartyPostUrl: 'https://httpbingo.org/post/',
+      enableIoHttpTracking: true,
+    );
+    RumAutoInstrumentationScenarioConfig.instance = scenarioConfig;
+
+    app.testingConfiguration = TestingConfiguration(
+        customEndpoint: sessionRecorder.sessionEndpoint,
+        clientToken: clientToken,
+        applicationId: applicationId,
+        firstPartyHosts: ['localhost']);
+    await app.main();
+    await tester.pumpAndSettle();
+
+    await performRumUserFlow(tester);
+
+    final rumLog = <RumEventDecoder>[];
+    await sessionRecorder.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        for (var request in requests) {
+          if (!request.requestedUrl.contains('integration')) {
+            request.data.split('\n').forEach((e) {
+              var jsonValue = json.decode(e);
+              if (jsonValue is Map<String, dynamic>) {
+                rumLog.add(RumEventDecoder(jsonValue));
+              }
+            });
+          }
+        }
+        return RumSessionDecoder.fromEvents(rumLog).visits.length >= 4;
+      },
+    );
+
+    final session = RumSessionDecoder.fromEvents(rumLog);
+    expect(session.visits.length, greaterThanOrEqualTo(3));
+
+    final view2 = session.visits[2];
+
+    final getEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyGetUrl);
+    expect(getEvent, isNotNull);
+    expect(getEvent!.requestHeaders, isNotNull);
+    expect(getEvent.requestHeaders!['x-datadog-origin'], 'rum');
+    expect(getEvent.responseHeaders, isNotNull);
+    expect(getEvent.responseHeaders!['content-type'], isNotNull);
+
+    final postEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyPostUrl);
+    expect(postEvent, isNotNull);
+    expect(postEvent!.requestHeaders, isNotNull);
+    expect(postEvent.requestHeaders!['x-datadog-origin'], 'rum');
+    expect(postEvent.responseHeaders, isNotNull);
+    expect(postEvent.responseHeaders!['content-type'], isNotNull);
+  }, skip: kIsWeb);
+}

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_headers_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_headers_test.dart
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-2022 Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_tracking_http_client_example/main.dart' as app;
+import 'package:datadog_tracking_http_client_example/scenario_config.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+Future<void> performRumUserFlow(WidgetTester tester) async {
+  var scenario = find.text('http.Client Override');
+  await tester.tap(scenario);
+  await tester.pumpAndSettle();
+
+  await tester.pump(const Duration(seconds: 5));
+
+  var topItem = find.text('Item 0');
+  await tester.tap(topItem);
+  await tester.pumpAndSettle();
+
+  var nextButton = find.text('Next Page');
+  await tester.tap(nextButton);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('captures request and response headers on RUM resource events',
+      (WidgetTester tester) async {
+    final sessionRecorder = await startMockServer();
+
+    const clientToken = bool.hasEnvironment('DD_CLIENT_TOKEN')
+        ? String.fromEnvironment('DD_CLIENT_TOKEN')
+        : null;
+    const applicationId = bool.hasEnvironment('DD_APPLICATION_ID')
+        ? String.fromEnvironment('DD_APPLICATION_ID')
+        : null;
+
+    final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
+      firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
+      firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',
+      firstPartyBadUrl: 'https://foo.bar',
+      thirdPartyGetUrl: 'https://httpbingo.org/get',
+      thirdPartyPostUrl: 'https://httpbingo.org/post',
+      enableIoHttpTracking: kIsWeb ? true : false,
+    );
+    RumAutoInstrumentationScenarioConfig.instance = scenarioConfig;
+
+    app.testingConfiguration = TestingConfiguration(
+        customEndpoint: sessionRecorder.sessionEndpoint,
+        clientToken: clientToken,
+        applicationId: applicationId,
+        firstPartyHosts: ['localhost']);
+    await app.main();
+    await tester.pumpAndSettle();
+
+    await performRumUserFlow(tester);
+
+    final rumLog = <RumEventDecoder>[];
+    await sessionRecorder.pollSessionRequests(
+      const Duration(seconds: 50),
+      (requests) {
+        for (var request in requests) {
+          if (!request.requestedUrl.contains('integration')) {
+            request.data.split('\n').forEach((e) {
+              var jsonValue = json.decode(e);
+              if (jsonValue is Map<String, dynamic>) {
+                rumLog.add(RumEventDecoder(jsonValue));
+              }
+            });
+          }
+        }
+        return RumSessionDecoder.fromEvents(rumLog).visits.length >= 4;
+      },
+    );
+
+    final session = RumSessionDecoder.fromEvents(rumLog);
+    expect(session.visits.length, greaterThanOrEqualTo(3));
+
+    final view2 = session.visits[2];
+
+    final getEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyGetUrl);
+    expect(getEvent, isNotNull);
+    expect(getEvent!.requestHeaders, isNotNull);
+    expect(getEvent.requestHeaders!['x-datadog-origin'], 'rum');
+    expect(getEvent.responseHeaders, isNotNull);
+    expect(getEvent.responseHeaders!['content-type'], isNotNull);
+
+    final postEvent = view2.resourceEvents
+        .firstWhereOrNull((e) => e.url == scenarioConfig.firstPartyPostUrl);
+    expect(postEvent, isNotNull);
+    expect(postEvent!.requestHeaders, isNotNull);
+    expect(postEvent.requestHeaders!['x-datadog-origin'], 'rum');
+    expect(postEvent.responseHeaders, isNotNull);
+    expect(postEvent.responseHeaders!['content-type'], isNotNull);
+  }, skip: kIsWeb);
+}

--- a/packages/datadog_tracking_http_client/example/lib/main.dart
+++ b/packages/datadog_tracking_http_client/example/lib/main.dart
@@ -87,6 +87,21 @@ Future<void> main() async {
             applicationId: applicationId,
             traceSampleRate: 100,
             customEndpoint: customEndpoint,
+            trackResourceHeaders: ResourceHeadersExtractor(
+              captureHeaders: [
+                'accept-ranges',
+                'content-disposition',
+                'server',
+                'user-agent',
+                'via',
+                'x-cache-hits',
+                'x-served-by',
+                'x-datadog-trace-id',
+                'x-datadog-parent-id',
+                'x-datadog-origin',
+                'traceparent',
+              ],
+            ),
           )
         : null,
   );

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http.dart
@@ -174,7 +174,8 @@ class DatadogClient extends http.BaseClient {
               final attributes =
                   attributesProvider?.call(request, response, null) ?? {};
               final size = response.contentLength ?? bytesReceived;
-              _onFinish(rum, rumKey, response, attributes, firstError, size);
+              _onFinish(
+                  rum, rumKey, request, response, attributes, firstError, size);
             }
             spyStream.close();
           },
@@ -212,8 +213,14 @@ class DatadogClient extends http.BaseClient {
     return true;
   }
 
-  void _onFinish(DatadogRum rum, String rumKey, http.StreamedResponse response,
-      Map<String, Object?> attributes, Object? error, int? size) {
+  void _onFinish(
+      DatadogRum rum,
+      String rumKey,
+      http.BaseRequest request,
+      http.StreamedResponse response,
+      Map<String, Object?> attributes,
+      Object? error,
+      int? size) {
     try {
       // If we saw an error, this resource has already been stopped
       if (error == null) {
@@ -223,6 +230,14 @@ class DatadogClient extends http.BaseClient {
             ? ContentType.parse(contentTypeHeader)
             : ContentType.text;
         var resourceType = resourceTypeFromContentType(contentType);
+        final extractor = rum.resourceHeadersExtractor;
+        if (extractor != null) {
+          final headerAttrs = extractor.toResourceAttributes(
+            request.headers.map((k, v) => MapEntry(k, [v])),
+            response.headers.map((k, v) => MapEntry(k, [v])),
+          );
+          attributes = {...attributes, ...headerAttrs};
+        }
         datadogSdk.rum?.stopResource(
           rumKey,
           response.statusCode,

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client.dart
@@ -300,40 +300,48 @@ class _DatadogTrackingHttpRequest implements HttpClientRequest {
   }
 
   @override
-  Future<HttpClientResponse> get done {
-    _injectHeaders();
-
-    final innerFuture = innerContext.done;
-    return innerFuture.then((value) {
-      return _DatadogTrackingHttpResponse(
-        client,
-        value,
-        rumKey,
-        _tracingContext,
-        userAttributes,
-      );
-    }, onError: (Object e, StackTrace? st) {
-      _onStreamError(e, st);
-      throw e;
-    });
-  }
+  Future<HttpClientResponse> get done => _wrapResponse(() => innerContext.done);
 
   @override
-  Future<HttpClientResponse> close() {
-    _injectHeaders();
+  Future<HttpClientResponse> close() =>
+      _wrapResponse(() => innerContext.close());
 
-    return innerContext.close().then((value) {
-      return _DatadogTrackingHttpResponse(
+  /// Injects tracing headers and captures request headers (when configured),
+  /// then starts the inner future via [startInner]. The inner future must be
+  /// passed as a thunk so [HttpClientRequest.close] / `.done` are not invoked
+  /// before headers are injected — calling `close()` finalises the request
+  /// and sends it, so any header injection after that would be lost.
+  Future<HttpClientResponse> _wrapResponse(
+    Future<HttpClientResponse> Function() startInner,
+  ) {
+    _injectHeaders();
+    final capturedRequestHeaders =
+        rumKey != null ? _captureRequestHeaders() : null;
+
+    return startInner().then(
+      (value) => _DatadogTrackingHttpResponse(
         client,
         value,
         rumKey,
         _tracingContext,
         userAttributes,
-      );
-    }, onError: (Object e, StackTrace? st) {
-      _onStreamError(e, st);
-      throw e;
+        capturedRequestHeaders,
+      ),
+      onError: (Object e, StackTrace? st) {
+        _onStreamError(e, st);
+        throw e;
+      },
+    );
+  }
+
+  Map<String, List<String>>? _captureRequestHeaders() {
+    final extractor = client.datadogSdk.rum?.resourceHeadersExtractor;
+    if (extractor == null) return null;
+    final map = <String, List<String>>{};
+    innerContext.headers.forEach((name, values) {
+      map[name] = values;
     });
+    return map;
   }
 
   void _injectHeaders() {
@@ -508,6 +516,7 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
   final String? rumKey;
   final TracingContext? tracingContext;
   final Map<String, Object?> userAttributes;
+  final Map<String, List<String>>? capturedRequestHeaders;
   Object? lastError;
   int? bytesReceived;
 
@@ -517,6 +526,7 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
     this.rumKey,
     this.tracingContext,
     this.userAttributes,
+    this.capturedRequestHeaders,
   );
 
   @override
@@ -597,6 +607,18 @@ class _DatadogTrackingHttpResponse extends Stream<List<int>>
             userAttributes: userAttributes,
           );
           attributes = _mergeAttributes(attributes, userAttributes);
+          final extractor = rum.resourceHeadersExtractor;
+          if (extractor != null) {
+            final responseHeaderMap = <String, List<String>>{};
+            innerResponse.headers.forEach((name, values) {
+              responseHeaderMap[name] = values;
+            });
+            final headerAttrs = extractor.toResourceAttributes(
+              capturedRequestHeaders ?? const {},
+              responseHeaderMap,
+            );
+            attributes = _mergeAttributes(attributes, headerAttrs);
+          }
           rum.stopResource(rumKey!, statusCode, resourceType, size, attributes);
         }
       }

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ^3.3.0
   uuid: ^4.0.0
   http: ^1.0.0
 

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_client_test.dart
@@ -379,7 +379,7 @@ void main() {
           attributes));
     });
 
-    test('ignorUrlPatterns does not perform tracking on matching url',
+    test('ignoreUrlPatterns does not perform tracking on matching url',
         () async {
       final client = DatadogClient(
         datadogSdk: mockDatadog,
@@ -675,6 +675,54 @@ void main() {
       expect(traceInt, contextTraceInt);
       final contextSpanInt = BigInt.tryParse(tracecontextParts[2], radix: 16);
       expect(spanInt, contextSpanInt);
+    });
+
+    group('with trackResourceHeaders', () {
+      test('passes captured headers as internal attributes to stopResource',
+          () async {
+        // ignore: invalid_use_of_internal_member
+        when(() => mockRum.resourceHeadersExtractor)
+            .thenReturn(ResourceHeadersExtractor());
+        when(() => mockResponse.headers).thenReturn({
+          HttpHeaders.contentTypeHeader: 'application/json',
+          'etag': '"abc123"',
+          'set-cookie': 'session=secret', // forbidden, must be filtered
+        });
+
+        final client =
+            DatadogClient(datadogSdk: mockDatadog, innerClient: mockClient);
+        await client.get(Uri.parse('https://test_url/test'),
+            headers: {'content-type': 'application/json'});
+
+        final captured = verify(() =>
+                mockRum.stopResource(any(), any(), any(), any(), captureAny()))
+            .captured[0] as Map<String, Object?>;
+
+        final responseHeaders =
+            captured['_dd.response_headers'] as Map<String, String>;
+        expect(responseHeaders['content-type'], 'application/json');
+        expect(responseHeaders['etag'], '"abc123"');
+        expect(responseHeaders.containsKey('set-cookie'), isFalse);
+
+        final requestHeaders =
+            captured['_dd.request_headers'] as Map<String, String>;
+        expect(requestHeaders['content-type'], 'application/json');
+      });
+
+      test('does not add header attributes when extractor is null', () async {
+        // ignore: invalid_use_of_internal_member
+        when(() => mockRum.resourceHeadersExtractor).thenReturn(null);
+
+        final client =
+            DatadogClient(datadogSdk: mockDatadog, innerClient: mockClient);
+        await client.get(Uri.parse('https://test_url/test'));
+
+        final captured = verify(() =>
+                mockRum.stopResource(any(), any(), any(), any(), captureAny()))
+            .captured[0] as Map<String, Object?>;
+        expect(captured.containsKey('_dd.request_headers'), isFalse);
+        expect(captured.containsKey('_dd.response_headers'), isFalse);
+      });
     });
   });
 }

--- a/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/test/datadog_tracking_http_client_test.dart
@@ -1371,6 +1371,86 @@ void main() {
     });
   });
 
+  group('with trackResourceHeaders', () {
+    setUp(() {
+      enableRum();
+    });
+
+    test('passes captured headers as internal attributes to stopResource',
+        () async {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor)
+          .thenReturn(ResourceHeadersExtractor());
+
+      final url = Uri.parse('https://test_url/path');
+      final completer = setupMockRequest(url);
+      // Pre-populate request headers via the mock's add()
+      mockRequest.headers.add('content-type', 'application/json');
+
+      final client = DatadogTrackingHttpClient(
+        mockDatadog,
+        DdHttpTrackingPluginConfiguration(),
+        mockClient,
+      );
+      final request = await client.openUrl('get', url);
+
+      final mockResponse = setupMockClientResponse(200);
+      final responseHeadersMock = mockResponse.headers;
+      // Stub response headers iteration with forEach
+      when(() => responseHeadersMock.forEach(any())).thenAnswer((invocation) {
+        final fn = invocation.positionalArguments[0] as void Function(
+            String, List<String>);
+        fn('content-type', ['image/png']);
+        fn('etag', ['"abc123"']);
+        fn('cookie', ['session=secret']); // forbidden, must be filtered
+      });
+      completer.complete(mockResponse);
+      final response = await request.done;
+      response.listen((_) {});
+      await mockResponse.streamController.close();
+
+      final captured = verify(() =>
+              mockRum.stopResource(any(), any(), any(), any(), captureAny()))
+          .captured[0] as Map<String, Object?>;
+
+      final responseHeaders =
+          captured['_dd.response_headers'] as Map<String, String>;
+      expect(responseHeaders['content-type'], 'image/png');
+      expect(responseHeaders['etag'], '"abc123"');
+      expect(responseHeaders.containsKey('cookie'), isFalse);
+
+      final requestHeaders =
+          captured['_dd.request_headers'] as Map<String, String>;
+      expect(requestHeaders['content-type'], 'application/json');
+    });
+
+    test('does not add header attributes when extractor is null', () async {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor).thenReturn(null);
+
+      final url = Uri.parse('https://test_url/path');
+      final completer = setupMockRequest(url);
+
+      final client = DatadogTrackingHttpClient(
+        mockDatadog,
+        DdHttpTrackingPluginConfiguration(),
+        mockClient,
+      );
+      final request = await client.openUrl('get', url);
+      final mockResponse = setupMockClientResponse(200);
+      completer.complete(mockResponse);
+      final response = await request.done;
+      response.listen((_) {});
+      await mockResponse.streamController.close();
+
+      final captured = verify(() =>
+              mockRum.stopResource(any(), any(), any(), any(), captureAny()))
+          .captured[0] as Map<String, Object?>;
+      expect(captured.containsKey('_dd.request_headers'), isFalse);
+      expect(captured.containsKey('_dd.response_headers'), isFalse);
+    });
+  });
+
   group(
     'when is an attach configuration',
     () {


### PR DESCRIPTION
### What and why?

- Add support for capturing HTTP request and response headers in RUM resources. Customers can opt in and have automatic instrumentation with this new feature.
- This aligns the Flutter SDK with the same feature that came recently in Android, iOS and Browser SDKs.

### How?

- Add new `trackResourceHeaders` public API on `DatadogRumConfiguration` that accepts a `ResourceHeadersExtractor`.
- Add new `ResourceHeadersExtractor` class in `datadog_flutter_plugin` that encapsulates all the logic regarding matching, filtering and size-limiting headers. All the internal behavior is aligned with the other SDKs, including default headers, security regex, and size limits.
- Wire this extractor into all 3 tracking clients: `DatadogClient`, `DatadogTrackingHttpClient` and `DatadogDioInterceptor`. Extraction happens in Dart at the point each client calls `stopResource()`.
- Captured headers flow as `_dd.request_headers` and `_dd.response_headers` internal cross-platform attributes, which are then read in the native `RumResourceScope` side and mapped into the resource schema.
- Unit and integrations tests coverage.

Resources with headers taken from the `simple_example` app:
- [Android](https://mobile-integration.datadoghq.com/rum/sessions?query=%40type%3Aresource%20%40application.id%3A948d890c-c895-4060-a960-ac92c51db12d&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZ4HDgwNKacI5wAAABhBWjRIRGhrX0FBQmRacVhjQnlUVGFnQUcAAAAkZjE5ZTA3MGUtNDIzZC00OWE0LWEwMDktYzAwZTFkNDdkODA3AAAAOQ&fromUser=false&viz=stream&from_ts=1777630053253&to_ts=1778234853253&live=true)
- [iOS](https://mobile-integration.datadoghq.com/rum/sessions?query=%40type%3Aresource%20%40application.id%3A948d890c-c895-4060-a960-ac92c51db12d&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZ4G_rY3TUPdHQAAABhBWjRHX3NfeUFBQ01iR1Q5c04xYlZRQVMAAAAkZjE5ZTA2ZmUtYmI4MS00MzgyLTk1MGUtZTJiYmVlYTUwYmJlAAAADg&fromUser=false&viz=stream&from_ts=1777629027641&to_ts=1778233827641&live=true)

### Follow-up
- Add documentation in code if necessary and docs.datadoghq.com.
- If it makes sense, add telemetry to this feature in an upcoming pr, following what we did on Browser and Android.


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
