### PR TITLE
ci: Remove fvm install from build steps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -307,8 +307,6 @@ nightly-min-version-test:
   script:
     - !reference [.pre, script]
     - !reference [.pre-ios, script]
-    - brew tap leoafarias/fvm
-    - brew install fvm
     - fvm install $FLUTTER_MIN_VERSION
     - fvm use $FLUTTER_MIN_VERSION
     - fvm exec dart pub global activate melos
@@ -333,8 +331,6 @@ nightly-beta-test:
   script:
     - !reference [.pre, script]
     - !reference [.pre-ios, script]
-    - brew tap leoafarias/fvm
-    - brew install fvm
     - fvm destroy
     - fvm install beta
     - fvm use beta


### PR DESCRIPTION
### What and why?

Removing Flutter Version Manager (`fvm`) installs from the nightly beta and min version tests, as `fvm` is now installed on the AMIs.

This should fix some issues where a conflict with the Dart AOT runtime was causing `brew install fvm` to fail.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
