### PR TITLE
feat(gql): Support payload capture for GraphQL Link

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
 import 'package:gql/ast.dart';
+import 'package:gql/language.dart' show printNode;
 import 'package:gql_exec/gql_exec.dart';
 import 'package:gql_link/gql_link.dart';
 import 'package:uuid/uuid.dart';
@@ -20,6 +21,7 @@ class _GraphQLAttributes {
   static const operationType = '_dd.graphql.operation_type';
   static const operationName = '_dd.graphql.operation_name';
   static const variables = '_dd.graphql.variables';
+  static const payload = '_dd.graphql.payload';
   static const errors = '_dd.graphql.errors';
 }
 
@@ -44,10 +46,17 @@ class DatadogGqlLink extends Link {
 
   final _uuid = const Uuid();
 
+  /// When `true`, the full GraphQL document (query or mutation string) is
+  /// captured in the RUM resource event
+  ///
+  /// Defaults to `false`.
+  final bool trackPayload;
+
   DatadogGqlLink(
     this.datadogSdk,
     this.uri, {
     this.listener,
+    this.trackPayload = false,
   });
 
   @override
@@ -183,6 +192,19 @@ class DatadogGqlLink extends Link {
       );
     }
 
+    if (trackPayload) {
+      try {
+        attributes[_GraphQLAttributes.payload] =
+            printNode(request.operation.document);
+      } catch (e, st) {
+        datadogSdk.internalLogger.sendToDatadog(
+          '$DatadogGqlLink encountered an error while attempting to serialize payload: $e',
+          st,
+          e.runtimeType.toString(),
+        );
+      }
+    }
+
     return attributes;
   }
 
@@ -250,7 +272,8 @@ class DatadogGqlLink extends Link {
                   'column': l.column,
                 })
             .toList(),
-        'path': e.path
+        'path': e.path,
+        if (e.extensions?['code'] != null) 'code': e.extensions!['code'],
       };
     }).toList();
     return {

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -684,6 +684,116 @@ query UserInfo($id: ID!) {
       expect(capturedAttrs['_dd.graphql.errors'], expectedErrorString);
     });
 
+    test('link includes error code from extensions in serialized errors',
+        () async {
+      // Given
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+      final response = MockResponse();
+      when(() => response.context).thenReturn(const Context());
+      when(() => response.errors).thenReturn([
+        const GraphQLError(
+          message: 'Not Found',
+          path: ['user'],
+          extensions: {'code': 'USER_NOT_FOUND'},
+        ),
+      ]);
+
+      // When
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      // Then
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
+      final errors =
+          json.decode(capturedAttrs['_dd.graphql.errors']) as List<dynamic>;
+      expect(errors.length, 1);
+      expect(errors[0]['message'], 'Not Found');
+      expect(errors[0]['code'], 'USER_NOT_FOUND');
+    });
+
+    test('link omits error code when extensions has no code field', () async {
+      // Given
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+      final response = MockResponse();
+      when(() => response.context).thenReturn(const Context());
+      when(() => response.errors).thenReturn([
+        const GraphQLError(message: 'Server Error'),
+      ]);
+
+      // When
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      // Then
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
+      final errors =
+          json.decode(capturedAttrs['_dd.graphql.errors']) as List<dynamic>;
+      expect(errors[0].containsKey('code'), isFalse);
+    });
+
+    test('link does not add payload attribute by default', () {
+      // Given
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+
+      // When
+      link.request(request, (request) {
+        return const Stream<Response>.empty();
+      });
+
+      // Then
+      final capturedAttributes = verify(() => mockRum.startResource(
+              any(), RumHttpMethod.post, 'https://test_uri', captureAny()))
+          .captured[0] as Map<String, Object?>;
+      expect(capturedAttributes['_dd.graphql.payload'], isNull);
+    });
+
+    test('link adds payload attribute when trackPayload is true', () {
+      // Given
+      final link = DatadogGqlLink(
+        mockDatadog,
+        Uri.parse('https://test_uri'),
+        trackPayload: true,
+      );
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+
+      // When
+      link.request(request, (request) {
+        return const Stream<Response>.empty();
+      });
+
+      // Then
+      final capturedAttributes = verify(() => mockRum.startResource(
+              any(), RumHttpMethod.post, 'https://test_uri', captureAny()))
+          .captured[0] as Map<String, Object?>;
+      final payload = capturedAttributes['_dd.graphql.payload'] as String?;
+      expect(payload, isNotNull);
+      expect(payload, contains('UserInfo'));
+      expect(payload, contains('query'));
+    });
+
     test('link supports mutation operations in attributes', () async {
       // Given
       final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));


### PR DESCRIPTION
### What and why?

Add payload capture for GraphQL when `trackPayload` is true on the GQL link.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
