### PR TITLE
feat(rum): Extend HTTP header capture to GraphQL and Flutter Web

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/resource_headers_extractor.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/resource_headers_extractor.dart
@@ -116,6 +116,18 @@ class ResourceHeadersExtractor {
     return _extractHeaders(headers, _responseHeaders);
   }
 
+  /// Lowercased, security-filtered set of header names this extractor will
+  /// capture on the **request** side. Used by the Flutter Web RUM bridge to
+  /// build direction-scoped `trackResourceHeaders` matchers for the Browser SDK
+  /// so request-only and response-only defaults stay scoped to their direction.
+  @internal
+  Set<String> get requestHeaderNames => _requestHeaders;
+
+  /// Lowercased, security-filtered set of header names this extractor will
+  /// capture on the **response** side.
+  @internal
+  Set<String> get responseHeaderNames => _responseHeaders;
+
   /// Convenience method that extracts both request and response headers and
   /// returns them as a map of internal attributes suitable for merging into
   /// `stopResource()` attributes.

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -78,6 +78,9 @@ class DdRumWeb extends DdRumPlatform {
         trackViewsManually: true,
         trackUserInteractions: false,
         trackResources: trackResources,
+        trackResourceHeaders: _convertTrackResourceHeaders(
+          rumConfiguration.trackResourceHeaders,
+        ),
         trackFrustrations: rumConfiguration.trackFrustrations,
         trackLongTasks: rumConfiguration.detectLongTasks,
         enableExperimentalFeatures: [
@@ -85,6 +88,9 @@ class DdRumWeb extends DdRumPlatform {
           'feature_operation_vital'.toJS,
           'start_stop_action'.toJS,
           'start_stop_resource'.toJS,
+          // Required to emit resource headers on Browser SDK v6.x (GA in v7.1.0+).
+          if (rumConfiguration.trackResourceHeaders != null)
+            'track_resource_headers'.toJS,
         ].toJS,
         trackingConsent: trackingConsent.webValue(),
         compressIntakeRequests: false,
@@ -542,6 +548,21 @@ JSString _headerTypeToPropagatorType(TracingHeaderType type) {
   }
 }
 
+JSAny? _convertTrackResourceHeaders(ResourceHeadersExtractor? extractor) {
+  if (extractor == null) return null;
+
+  // Explicit per-direction MatchHeaders — Browser SDK's `true` mode would
+  // apply its broad default list to both directions.
+  final matchers = <_MatchHeader>[
+    for (final name in extractor.requestHeaderNames)
+      _MatchHeader(name: name, location: 'request'),
+    for (final name in extractor.responseHeaderNames)
+      _MatchHeader(name: name, location: 'response'),
+  ];
+  if (matchers.isEmpty) return null;
+  return matchers.toJS;
+}
+
 String _contextInjectionString(TraceContextInjection contextInjection) {
   switch (contextInjection) {
     case TraceContextInjection.all:
@@ -562,6 +583,11 @@ extension on RumFeatureOperationFailureReason {
         return 'other';
     }
   }
+}
+
+@anonymous
+extension type _MatchHeader._(JSObject _) implements JSObject {
+  external factory _MatchHeader({String name, String? location});
 }
 
 @anonymous
@@ -599,6 +625,7 @@ extension type _RumInitOptions._(JSObject _) implements JSObject {
     bool? trackFrustrations,
     String? trackingConsent,
     bool? trackResources,
+    JSAny? trackResourceHeaders,
     // ignore: unused_element_parameter
     bool? trackUserInteractions,
     bool? trackViewsManually,

--- a/packages/datadog_flutter_plugin/test/rum/resource_headers_extractor_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/resource_headers_extractor_test.dart
@@ -392,5 +392,60 @@ void main() {
         });
       });
     });
+
+    group('Flutter Web mapping accessors', () {
+      test(
+          'requestHeaderNames returns the narrower request defaults; '
+          'responseHeaderNames returns the broader response defaults', () {
+        final extractor = ResourceHeadersExtractor();
+        // ignore: invalid_use_of_internal_member
+        final requestNames = extractor.requestHeaderNames;
+        // ignore: invalid_use_of_internal_member
+        final responseNames = extractor.responseHeaderNames;
+        // Request defaults are a subset: just cache-control + content-type.
+        expect(requestNames, containsAll(['cache-control', 'content-type']));
+        // etag is response-only and must not leak onto the request side.
+        expect(requestNames.contains('etag'), isFalse);
+        expect(responseNames,
+            containsAll(['cache-control', 'content-type', 'etag']));
+      });
+
+      test('custom captureHeaders apply to both directions', () {
+        final extractor = ResourceHeadersExtractor(
+          captureHeaders: ['x-custom', 'X-Other'],
+        );
+        // ignore: invalid_use_of_internal_member
+        expect(
+            extractor.requestHeaderNames, containsAll(['x-custom', 'x-other']));
+        // ignore: invalid_use_of_internal_member
+        expect(extractor.responseHeaderNames,
+            containsAll(['x-custom', 'x-other']));
+      });
+
+      test('forbidden headers are excluded from both directions', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: ['authorization', 'x-custom'],
+        );
+        // ignore: invalid_use_of_internal_member
+        expect(extractor.requestHeaderNames.contains('authorization'), isFalse);
+        // ignore: invalid_use_of_internal_member
+        expect(
+            extractor.responseHeaderNames.contains('authorization'), isFalse);
+        // ignore: invalid_use_of_internal_member
+        expect(extractor.requestHeaderNames, contains('x-custom'));
+      });
+
+      test('header name sets are empty when nothing is configured', () {
+        final extractor = ResourceHeadersExtractor(
+          includeDefaults: false,
+          captureHeaders: const [],
+        );
+        // ignore: invalid_use_of_internal_member
+        expect(extractor.requestHeaderNames, isEmpty);
+        // ignore: invalid_use_of_internal_member
+        expect(extractor.responseHeaderNames, isEmpty);
+      });
+    });
   });
 }

--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:flutter/foundation.dart';
 import 'package:gql/ast.dart';
 import 'package:gql/language.dart' show printNode;
 import 'package:gql_exec/gql_exec.dart';
@@ -94,6 +95,9 @@ class DatadogGqlLink extends Link {
     final resourceId = _startRumResource(
         request, internalAttributes, tracingContext, userAttributes);
 
+    final capturedRequestHeaders =
+        request.context.entry<HttpLinkHeaders>()?.headers ?? const {};
+
     return forward!(request).transform(StreamTransformer.fromHandlers(
       handleData: (data, sink) {
         listener?.responseReceived(data, userAttributes);
@@ -120,6 +124,11 @@ class DatadogGqlLink extends Link {
           );
         }
 
+        final headerAttributes = _extractHeaderAttributes(
+          capturedRequestHeaders,
+          linkResponseContext?.headers ?? const {},
+        );
+
         datadogSdk.rum?.stopResource(
           resourceId,
           statusCode,
@@ -128,6 +137,7 @@ class DatadogGqlLink extends Link {
           {
             if (errorMap != null) ...errorMap,
             ...userAttributes,
+            ...headerAttributes,
           },
         );
 
@@ -230,6 +240,9 @@ class DatadogGqlLink extends Link {
   }
 
   Request _injectTracingHeaders(Request request) {
+    // On Web the Browser SDK injects tracing headers itself; skipping here
+    // avoids two independent trace contexts ending up on the wire.
+    if (kIsWeb) return request;
     try {
       final rum = datadogSdk.rum;
       final tracingHeaderTypes = datadogSdk.headerTypesForHost(uri);
@@ -258,6 +271,18 @@ class DatadogGqlLink extends Link {
     }
 
     return request;
+  }
+
+  Map<String, Object?> _extractHeaderAttributes(
+    Map<String, String> requestHeaders,
+    Map<String, String> responseHeaders,
+  ) {
+    final extractor = datadogSdk.rum?.resourceHeadersExtractor;
+    if (extractor == null) return const {};
+    return extractor.toResourceAttributes(
+      requestHeaders.map((k, v) => MapEntry(k, [v])),
+      responseHeaders.map((k, v) => MapEntry(k, [v])),
+    );
   }
 
   Map<String, Object>? _serializeResponseErrors(Response response) {

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -79,6 +79,8 @@ query UserInfo($id: ID!) {
     mockRum = MockDdRum();
     when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
     when(() => mockRum.traceSampleRate).thenReturn(50.0);
+    // ignore: invalid_use_of_internal_member
+    when(() => mockRum.resourceHeadersExtractor).thenReturn(null);
   });
 
   group('when rum is disabled', () {
@@ -847,6 +849,167 @@ query UserInfo($id: ID!) {
           .captured[0] as Map<String, Object?>;
       expect(capturedAttributes['_dd.graphql.operation_type'], 'subscription');
       expect(capturedAttributes['_dd.graphql.operation_name'], 'ReviewAdded');
+    });
+  });
+
+  group('when resource header capture is enabled', () {
+    setUp(() {
+      when(() => mockDatadog.rum).thenReturn(mockRum);
+      when(() => mockDatadog.headerTypesForHost(any())).thenReturn({});
+    });
+
+    test('attaches matching response headers to stopResource attributes',
+        () async {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor)
+          .thenReturn(ResourceHeadersExtractor());
+
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+      final response = MockResponse();
+      var responseContext = const Context();
+      responseContext = responseContext.updateEntry<HttpLinkResponseContext>(
+        (entry) => const HttpLinkResponseContext(
+          statusCode: 200,
+          headers: {
+            'content-type': 'application/json',
+            'cache-control': 'no-cache',
+            // Must be stripped by the security filter even on the response side.
+            'authorization': 'Bearer secret-token',
+          },
+        ),
+      );
+      when(() => response.context).thenReturn(responseContext);
+
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final attrs = captured.captured[0] as Map<String, dynamic>;
+      final responseHeaders =
+          attrs[DatadogRumPlatformAttributeKey.responseHeaders]
+              as Map<String, String>?;
+      expect(responseHeaders, isNotNull);
+      expect(responseHeaders!['content-type'], 'application/json');
+      expect(responseHeaders['cache-control'], 'no-cache');
+      expect(responseHeaders.containsKey('authorization'), isFalse);
+    });
+
+    test(
+        'attaches matching request headers from HttpLinkHeaders to stopResource attributes',
+        () async {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor)
+          .thenReturn(ResourceHeadersExtractor());
+
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      var requestContext = const Context();
+      requestContext = requestContext.updateEntry<HttpLinkHeaders>(
+        (entry) => const HttpLinkHeaders(headers: {
+          'content-type': 'application/json',
+          'cache-control': 'max-age=0',
+        }),
+      );
+      final request = Request(
+        operation: Operation(document: query, operationName: 'UserInfo'),
+        context: requestContext,
+      );
+      final response = MockResponse();
+      when(() => response.context).thenReturn(const Context());
+
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final attrs = captured.captured[0] as Map<String, dynamic>;
+      final requestHeaders =
+          attrs[DatadogRumPlatformAttributeKey.requestHeaders]
+              as Map<String, String>?;
+      expect(requestHeaders, isNotNull);
+      expect(requestHeaders!['content-type'], 'application/json');
+      expect(requestHeaders['cache-control'], 'max-age=0');
+    });
+
+    test('does not add header attributes when extractor is not configured',
+        () async {
+      // Default setUp already stubs resourceHeadersExtractor → null.
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+      final response = MockResponse();
+      var responseContext = const Context();
+      responseContext = responseContext.updateEntry<HttpLinkResponseContext>(
+        (entry) => const HttpLinkResponseContext(
+          statusCode: 200,
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      when(() => response.context).thenReturn(responseContext);
+
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final attrs = captured.captured[0] as Map<String, dynamic>;
+      expect(attrs.containsKey(DatadogRumPlatformAttributeKey.requestHeaders),
+          isFalse);
+      expect(attrs.containsKey(DatadogRumPlatformAttributeKey.responseHeaders),
+          isFalse);
+    });
+
+    test('captures request headers injected by tracing into the snapshot',
+        () async {
+      // ignore: invalid_use_of_internal_member
+      when(() => mockRum.resourceHeadersExtractor).thenReturn(
+        ResourceHeadersExtractor(captureHeaders: ['x-datadog-origin']),
+      );
+      when(() => mockRum.contextInjectionSetting)
+          .thenReturn(TraceContextInjection.all);
+      when(() => mockDatadog.headerTypesForHost(any()))
+          .thenReturn({TracingHeaderType.datadog});
+
+      final link =
+          DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+      final response = MockResponse();
+      when(() => response.context).thenReturn(const Context());
+
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final attrs = captured.captured[0] as Map<String, dynamic>;
+      final requestHeaders =
+          attrs[DatadogRumPlatformAttributeKey.requestHeaders]
+              as Map<String, String>?;
+      expect(requestHeaders, isNotNull);
+      expect(requestHeaders!['x-datadog-origin'], 'rum');
     });
   });
 

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_headers_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_headers_test.dart
@@ -103,5 +103,5 @@ void main() {
     expect(postEvent.requestHeaders!['x-datadog-origin'], 'rum');
     expect(postEvent.responseHeaders, isNotNull);
     expect(postEvent.responseHeaders!['content-type'], isNotNull);
-  }, skip: kIsWeb);
+  });
 }


### PR DESCRIPTION
### What and why?

- Extends the resource header capture feature from #1025 to GraphQL requests (`datadog_gql_link`) and Flutter Web.
- On Web, the captured headers flow end-to-end through Browser SDK's `trackResourceHeaders` configuration, which has the same behavior.
- Fixes an adjacent double tracing-header injection on Flutter Web, where `datadog_gql_link` and Browser SDK were both injecting their own trace contexts.

### How?
- `datadog_gql_link`: Snapshot `HttpLinkHeaders` after tracing injection, capture `HttpLinkResponseContext.headers` in `handleData`, run both through `rum.resourceHeadersExtractor.toResourceAttributes()` and merge into the existing `stopResource()` call.
- `datadog_flutter_plugin` Web: Add `trackResourceHeaders` to the `_RumInitOptions` JS-interop type and convert the configured `ResourceHeadersExtractor` to Browser SDK's `boolean | MatchHeader[]` shape in `DdRumWeb.initialize()`. Conditionally append the `track_resource_headers` experimental flag (gated in Browser SDK v6.x; no-op once v7.1.0 makes it GA).
- `datadog_gql_link`: Skip `_injectTracingHeaders` on Web — Browser SDK handles tracing injection automatically via `allowedTracingUrls`. Consistent with the existing `// Never track on web` guards in `DatadogClient.send()` and `DatadogDioInterceptor`.
- Drop `skip: kIsWeb` on `tracking_http_headers_test` — `DatadogClient` delegates to fetch on Web, Browser SDK observes, headers attach.
- Unit tests for both new code paths.

### Additional notes
- dart:io-backed header tests (`tracking_http_client_headers_test`, `dio_interceptor_headers_test`) remain skipped on Web because their wrappers test code paths that don't exist on Web.
- Example app session with resources that contain headers [here](https://mobile-integration.datadoghq.com/rum/sessions?query=%40type%3Asession%20%40application.id%3A948d890c-c895-4060-a960-ac92c51db12d&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZ5ffSaIuQ2PJwAAABhBWjVmZlNhSUFBQlB3dWd6YWhiVkEtNUIAAAAkMTE5ZTVmODYtYjFhMi00MDNjLTk0MmItZTFkMTNkMGM0OGI2AAAAag&fromUser=false&from_ts=1779113767717&to_ts=1779718567717&live=true).

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
