### PR TITLE
cherrypick: Reuse TracingContext between RUM resource and wire headers

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:flutter/foundation.dart';
 import 'package:gql/ast.dart';
 import 'package:gql_exec/gql_exec.dart';
 import 'package:gql_link/gql_link.dart';
@@ -69,9 +70,8 @@ class DatadogGqlLink extends Link {
     try {
       if (tracingHeaderTypes.isNotEmpty) {
         tracingContext = generateTracingContext(datadogSdk, rum);
+        request = _injectTracingHeaders(request, tracingContext);
       }
-
-      request = _injectTracingHeaders(request);
     } catch (e, st) {
       datadogSdk.internalLogger.sendToDatadog(
         '$DatadogGqlLink encountered an error attempting to create a tracing context; $e',
@@ -207,7 +207,11 @@ class DatadogGqlLink extends Link {
     return resourceId;
   }
 
-  Request _injectTracingHeaders(Request request) {
+  Request _injectTracingHeaders(
+      Request request, TracingContext tracingContext) {
+    // On Web the Browser SDK injects tracing headers itself; skipping here
+    // avoids two independent trace contexts ending up on the wire.
+    if (kIsWeb) return request;
     try {
       final rum = datadogSdk.rum;
       final tracingHeaderTypes = datadogSdk.headerTypesForHost(uri);
@@ -215,9 +219,6 @@ class DatadogGqlLink extends Link {
       if (rum != null && tracingHeaderTypes.isNotEmpty) {
         return request.updateContextEntry<HttpLinkHeaders>((context) {
           var headers = context?.headers ?? <String, String>{};
-
-          // No tracing context, generate one ourselves
-          final tracingContext = generateTracingContext(datadogSdk, rum);
 
           for (final headerType in tracingHeaderTypes) {
             injectTracingHeaders(tracingContext, headerType, headers,

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -933,7 +933,89 @@ query UserInfo($id: ID!) {
         verifyHeaders(headersEntry!.headers, headerType, false,
             TraceContextInjection.sampled);
       });
+
+      test('RUM resource trace and span ids match injected wire headers', () {
+        when(() => mockRum.shouldSampleTrace(any(), any())).thenReturn(true);
+        when(() => mockRum.contextInjectionSetting)
+            .thenReturn(TraceContextInjection.sampled);
+        final link =
+            DatadogGqlLink(mockDatadog, Uri.parse('https://test_url/graphql'));
+        final request = Request(
+            operation: Operation(document: query, operationName: 'UserInfo'));
+
+        // When
+        Request? forwardedRequest;
+        link.request(request, (request) {
+          forwardedRequest = request;
+          return const Stream<Response>.empty();
+        });
+
+        // Then
+        final headers =
+            forwardedRequest!.context.entry<HttpLinkHeaders>()!.headers;
+        final capturedAttrs = verify(
+                () => mockRum.startResource(any(), any(), any(), captureAny()))
+            .captured[0] as Map<String, dynamic>;
+        final headerIds = extractTraceAndSpanFromHeaders(headers, headerType);
+        final rumTraceId = TracingId.fromString(
+                capturedAttrs[DatadogRumPlatformAttributeKey.traceID] as String,
+                TracingIdRepresentation.hex)
+            .value;
+        final rumSpanId = TracingId.fromString(
+                capturedAttrs[DatadogRumPlatformAttributeKey.spanID] as String,
+                TracingIdRepresentation.decimal)
+            .value;
+        expect(rumTraceId, headerIds.traceId);
+        expect(rumSpanId, headerIds.spanId);
+      });
     });
+  }
+}
+
+({BigInt traceId, BigInt spanId}) extractTraceAndSpanFromHeaders(
+  Map<String, String> headers,
+  TracingHeaderType type,
+) {
+  switch (type) {
+    case TracingHeaderType.datadog:
+      final low = TracingId.fromString(
+              headers['x-datadog-trace-id'], TracingIdRepresentation.decimal)
+          .value;
+      final high = TracingId.fromString(
+              headers['x-datadog-tags']!.split('=')[1],
+              TracingIdRepresentation.hex)
+          .value;
+      return (
+        traceId: (high << 64) | low,
+        spanId: TracingId.fromString(
+                headers['x-datadog-parent-id'], TracingIdRepresentation.decimal)
+            .value,
+      );
+    case TracingHeaderType.b3:
+      final parts = headers['b3']!.split('-');
+      return (
+        traceId:
+            TracingId.fromString(parts[0], TracingIdRepresentation.hex).value,
+        spanId:
+            TracingId.fromString(parts[1], TracingIdRepresentation.hex).value,
+      );
+    case TracingHeaderType.b3multi:
+      return (
+        traceId: TracingId.fromString(
+                headers['X-B3-TraceId'], TracingIdRepresentation.hex)
+            .value,
+        spanId: TracingId.fromString(
+                headers['X-B3-SpanId'], TracingIdRepresentation.hex)
+            .value,
+      );
+    case TracingHeaderType.tracecontext:
+      final parts = headers['traceparent']!.split('-');
+      return (
+        traceId:
+            TracingId.fromString(parts[1], TracingIdRepresentation.hex).value,
+        spanId:
+            TracingId.fromString(parts[2], TracingIdRepresentation.hex).value,
+      );
   }
 }
 


### PR DESCRIPTION
### What and why?

Cherry pick of PR #1039 onto 2.0.x so we can ship it as a patch release.

(cherry picked from commit ccba5b445799389c9db852f761e2c5ccb410790a)

# Conflicts:
#	packages/datadog_gql_link/lib/src/datadog_gql_link.dart

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
