### PR TITLE
cherrypick: Preparing for release of datadog_gql_link 2.0.2.

### DIFF
--- a/packages/datadog_gql_link/CHANGELOG.md
+++ b/packages/datadog_gql_link/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+* Fix generating mismatched TracingContexts preventing correlation between APM and RUM.
+
 ## 2.0.1
 
 * Add GraphQL errors to resource events.


### PR DESCRIPTION
### What and why?

Cherry pick of changelog changes from gql 2.0.2 release

(cherry picked from commit 6f10db40de2fff77b48370094ad305474ce6bf63)

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
