### PR TITLE
feat(datadog_flags): prepare package publishing

### DIFF
--- a/packages/datadog_flags/CHANGELOG.md
+++ b/packages/datadog_flags/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Add RUM feature flag reporting for successful typed evaluations.
 - Add exposure logging for successful `doLog` assignments.
 - Add aggregated flagevaluation metric logging with explicit flush support.
+- Add last-known assignment persistence scoped to the active evaluation context.

--- a/packages/datadog_flags/README.md
+++ b/packages/datadog_flags/README.md
@@ -76,6 +76,8 @@ final enabled = flags.getBooleanValue(
 - Successful, defaulted, and error evaluations are aggregated into
   flagevaluation metric events and sent on `flush()` or the configured batch
   boundary.
+- Last-known successful assignments are persisted and restored only when the
+  cached context matches the active evaluation context.
 
 ## Local Validation
 

--- a/packages/datadog_flags/README.md
+++ b/packages/datadog_flags/README.md
@@ -1,9 +1,8 @@
 # Datadog Flags for Flutter
 
 `datadog_flags` is a Dart-native package for Datadog feature flag assignments.
-This package is unpublished while the stacked MVP is being assembled. It
-currently contains precompute transport, typed local evaluation, and RUM feature
-flag reporting.
+It fetches precomputed assignments, resolves typed values locally, and reports
+RUM feature flag evaluations, exposures, and evaluation metrics.
 
 This package does not bridge to native iOS or Android flagging SDKs.
 

--- a/packages/datadog_flags/lib/datadog_flags.dart
+++ b/packages/datadog_flags/lib/datadog_flags.dart
@@ -15,6 +15,7 @@ export 'src/flags_configuration.dart';
 export 'src/flags_context.dart';
 export 'src/flags_details.dart';
 export 'src/flags_error.dart';
+export 'src/flags_store.dart';
 export 'src/json_value.dart';
 
 typedef FlagsClient = DatadogFlagsClient;

--- a/packages/datadog_flags/lib/src/datadog_flags.dart
+++ b/packages/datadog_flags/lib/src/datadog_flags.dart
@@ -5,6 +5,7 @@
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
 import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'datadog_context.dart';
 import 'default_flags_client.dart';
@@ -15,6 +16,7 @@ import 'flags_client.dart';
 import 'flags_configuration.dart';
 import 'flags_error.dart';
 import 'flags_repository.dart';
+import 'flags_store.dart';
 import 'rum_flag_evaluation_reporter.dart';
 
 class DatadogFlags {
@@ -23,6 +25,7 @@ class DatadogFlags {
   static DatadogFlagsContext? _datadogContext;
   static DatadogSdk? _sdk;
   static http.Client? _httpClient;
+  static DatadogFlagsStore? _store;
   static final Map<String, DatadogFlagsClient> _clients = {};
   static bool _enabled = false;
 
@@ -40,11 +43,16 @@ class DatadogFlags {
     final datadogSdk = sdk ?? DatadogSdk.instance;
     final datadogContext =
         configuration.datadogContext ?? DatadogFlagsContext.fromSdk(datadogSdk);
+    final prefs = configuration.store == null
+        ? await SharedPreferences.getInstance()
+        : null;
 
     _configuration = configuration;
     _datadogContext = datadogContext;
     _sdk = datadogSdk;
     _httpClient = configuration.httpClient ?? http.Client();
+    _store = configuration.store ??
+        SharedPreferencesDatadogFlagsStore(sharedPreferences: prefs!);
     _enabled = true;
     await createClient();
   }
@@ -59,11 +67,14 @@ class DatadogFlags {
 
     final runtime = _runtimeOrThrow();
     final repository = FlagsRepository(
+      clientName: name,
       fetcher: FlagAssignmentsFetcher(
         datadogContext: runtime.datadogContext,
         configuration: runtime.configuration,
         httpClient: runtime.httpClient,
       ),
+      store: runtime.store,
+      dateProvider: runtime.configuration.dateProvider,
     );
 
     final client = DefaultDatadogFlagsClient(
@@ -113,6 +124,7 @@ class DatadogFlags {
     _httpClient?.close();
     _httpClient = null;
     _sdk = null;
+    _store = null;
     _datadogContext = null;
     _enabled = false;
   }
@@ -126,10 +138,12 @@ class DatadogFlags {
     final datadogContext = _datadogContext;
     final httpClient = _httpClient;
     final sdk = _sdk;
+    final store = _store;
     if (!_enabled ||
         datadogContext == null ||
         httpClient == null ||
-        sdk == null) {
+        sdk == null ||
+        store == null) {
       throw FlagsException.clientNotInitialized(
         'Call DatadogFlags.enable() before creating a flags client.',
       );
@@ -140,6 +154,7 @@ class DatadogFlags {
       datadogContext: datadogContext,
       httpClient: httpClient,
       sdk: sdk,
+      store: store,
     );
   }
 }
@@ -149,11 +164,13 @@ class _FlagsRuntime {
   final DatadogFlagsContext datadogContext;
   final http.Client httpClient;
   final DatadogSdk sdk;
+  final DatadogFlagsStore store;
 
   const _FlagsRuntime({
     required this.configuration,
     required this.datadogContext,
     required this.httpClient,
     required this.sdk,
+    required this.store,
   });
 }

--- a/packages/datadog_flags/lib/src/flags_configuration.dart
+++ b/packages/datadog_flags/lib/src/flags_configuration.dart
@@ -6,6 +6,7 @@
 import 'package:http/http.dart' as http;
 
 import 'datadog_context.dart';
+import 'flags_store.dart';
 
 class DatadogFlagsConfiguration {
   final Uri? customFlagsEndpoint;
@@ -18,6 +19,7 @@ class DatadogFlagsConfiguration {
   final int evaluationMaxBatchSize;
   final http.Client? httpClient;
   final DatadogFlagsContext? datadogContext;
+  final DatadogFlagsStore? store;
   final bool rumIntegrationEnabled;
   final DateTime Function() dateProvider;
 
@@ -32,6 +34,7 @@ class DatadogFlagsConfiguration {
     this.evaluationMaxBatchSize = 1000,
     this.httpClient,
     this.datadogContext,
+    this.store,
     this.rumIntegrationEnabled = true,
     this.dateProvider = DateTime.now,
   });

--- a/packages/datadog_flags/lib/src/flags_repository.dart
+++ b/packages/datadog_flags/lib/src/flags_repository.dart
@@ -6,37 +6,65 @@
 import 'assignment.dart';
 import 'flag_assignments_fetcher.dart';
 import 'flags_context.dart';
+import 'flags_store.dart';
+import 'json_value.dart';
 
 class FlagsRepository {
+  final String clientName;
   final FlagAssignmentsFetcher fetcher;
+  final DatadogFlagsStore store;
+  final DateTime Function() dateProvider;
 
-  DatadogFlagsEvaluationContext? _context;
-  Map<String, FlagAssignment> _flags = const {};
+  FlagsData? _state;
   int _contextRequestId = 0;
 
   FlagsRepository({
+    required this.clientName,
     required this.fetcher,
+    required this.store,
+    required this.dateProvider,
   });
 
-  DatadogFlagsEvaluationContext? get context => _context;
+  DatadogFlagsEvaluationContext? get context => _state?.context;
 
-  FlagAssignment? flagAssignment(String key) => _flags[key];
+  FlagAssignment? flagAssignment(String key) => _state?.flags[key];
 
   Future<void> setEvaluationContext(
     DatadogFlagsEvaluationContext context,
   ) async {
     final requestId = ++_contextRequestId;
+    final cached = await store.read(clientName);
+    if (requestId != _contextRequestId) {
+      return;
+    }
+    if (cached != null && _contextsMatch(cached.context, context)) {
+      _state = cached;
+    }
+
     final flags = await fetcher.fetch(context);
     if (requestId != _contextRequestId) {
       return;
     }
 
-    _context = context;
-    _flags = flags;
+    _state = FlagsData(
+      flags: flags,
+      context: context,
+      date: dateProvider(),
+    );
+    await store.write(clientName, _state!);
   }
 
   Future<void> reset() async {
-    _context = null;
-    _flags = const {};
+    _state = null;
+    await store.delete(clientName);
   }
+}
+
+bool _contextsMatch(
+  DatadogFlagsEvaluationContext left,
+  DatadogFlagsEvaluationContext right,
+) {
+  return left.targetingKey == right.targetingKey &&
+      sortedJson(left.attributes).toString() ==
+          sortedJson(right.attributes).toString();
 }

--- a/packages/datadog_flags/lib/src/flags_store.dart
+++ b/packages/datadog_flags/lib/src/flags_store.dart
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'assignment.dart';
+import 'flags_context.dart';
+
+abstract class DatadogFlagsStore {
+  Future<FlagsData?> read(String clientName);
+  Future<void> write(String clientName, FlagsData data);
+  Future<void> delete(String clientName);
+}
+
+class FlagsData {
+  final Map<String, FlagAssignment> flags;
+  final DatadogFlagsEvaluationContext context;
+  final DateTime date;
+
+  const FlagsData({
+    required this.flags,
+    required this.context,
+    required this.date,
+  });
+
+  factory FlagsData.fromJson(Map<String, Object?> json) {
+    final flags = json['flags'] as Map<String, Object?>? ?? const {};
+    return FlagsData(
+      flags: flags.map((key, value) {
+        return MapEntry(
+          key,
+          FlagAssignment.fromJson(Map<String, Object?>.from(value as Map)),
+        );
+      }),
+      context: DatadogFlagsEvaluationContext.fromJson(
+        Map<String, Object?>.from(json['context'] as Map),
+      ),
+      date: DateTime.parse(json['date'] as String),
+    );
+  }
+
+  Map<String, Object?> toJson() {
+    return {
+      'flags': flags.map((key, value) => MapEntry(key, value.toJson())),
+      'context': context.toJson(),
+      'date': date.toIso8601String(),
+    };
+  }
+}
+
+class SharedPreferencesDatadogFlagsStore implements DatadogFlagsStore {
+  final SharedPreferences sharedPreferences;
+  final String namespace;
+
+  SharedPreferencesDatadogFlagsStore({
+    required this.sharedPreferences,
+    this.namespace = 'datadog_flags',
+  });
+
+  @override
+  Future<FlagsData?> read(String clientName) async {
+    final encoded = sharedPreferences.getString(_key(clientName));
+    if (encoded == null) {
+      return null;
+    }
+    final decoded = jsonDecode(encoded) as Map<String, Object?>;
+    return FlagsData.fromJson(decoded);
+  }
+
+  @override
+  Future<void> write(String clientName, FlagsData data) {
+    return sharedPreferences.setString(
+      _key(clientName),
+      jsonEncode(data.toJson()),
+    );
+  }
+
+  @override
+  Future<void> delete(String clientName) {
+    return sharedPreferences.remove(_key(clientName));
+  }
+
+  String _key(String clientName) => '$namespace.$clientName';
+}
+
+class InMemoryDatadogFlagsStore implements DatadogFlagsStore {
+  final Map<String, FlagsData> values = {};
+
+  @override
+  Future<FlagsData?> read(String clientName) async => values[clientName];
+
+  @override
+  Future<void> write(String clientName, FlagsData data) async {
+    values[clientName] = data;
+  }
+
+  @override
+  Future<void> delete(String clientName) async {
+    values.remove(clientName);
+  }
+}

--- a/packages/datadog_flags/pubspec.yaml
+++ b/packages/datadog_flags/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   datadog_flutter_plugin:
     path: ../datadog_flutter_plugin
   http: ^1.0.0
+  shared_preferences: ^2.3.0
   uuid: ^4.0.0
 
 dev_dependencies:

--- a/packages/datadog_flags/pubspec.yaml
+++ b/packages/datadog_flags/pubspec.yaml
@@ -1,9 +1,13 @@
 name: datadog_flags
-description: Native Dart precompute client for Datadog feature flag assignments.
+description: Native Flutter client for Datadog feature flag assignment evaluation.
 version: 0.0.1
-publish_to: none
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
+issue_tracker: https://github.com/DataDog/dd-sdk-flutter/issues
+topics:
+  - datadog
+  - feature-flags
+  - flutter
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
@@ -12,8 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin:
-    path: ../datadog_flutter_plugin
+  datadog_flutter_plugin: ^3.2.1
   http: ^1.0.0
   shared_preferences: ^2.3.0
   uuid: ^4.0.0

--- a/packages/datadog_flags/test/datadog_flags_test.dart
+++ b/packages/datadog_flags/test/datadog_flags_test.dart
@@ -15,8 +15,11 @@ import 'package:datadog_flags/src/rum_flag_evaluation_reporter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late List<http.Request> requests;
   late DateTime now;
 
@@ -35,6 +38,7 @@ void main() {
       configuration: DatadogFlagsConfiguration(
         datadogContext: datadogContext(),
         httpClient: clientWithResponse(requests, assignmentsResponse()),
+        store: InMemoryDatadogFlagsStore(),
       ),
     );
 
@@ -121,10 +125,11 @@ void main() {
     final first = client.setEvaluationContext(
       const DatadogFlagsEvaluationContext(targetingKey: 'user-first'),
     );
+    await waitUntil(() => responseCompleters.length == 1);
     final second = client.setEvaluationContext(
       const DatadogFlagsEvaluationContext(targetingKey: 'user-second'),
     );
-    await Future<void>.delayed(Duration.zero);
+    await waitUntil(() => responseCompleters.length == 2);
 
     expect(responseCompleters, hasLength(2));
     responseCompleters[1].complete(http.Response(
@@ -163,11 +168,14 @@ void main() {
       trackEvaluations: false,
     );
     final repository = FlagsRepository(
+      clientName: 'rum-test',
       fetcher: FlagAssignmentsFetcher(
         datadogContext: context,
         configuration: config,
         httpClient: httpClient,
       ),
+      store: InMemoryDatadogFlagsStore(),
+      dateProvider: () => now,
     );
     final fakeRum = FakeRumFlagEvaluationReporter();
     final client = DefaultDatadogFlagsClient(
@@ -200,9 +208,11 @@ void main() {
   });
 
   test('reset clears the current assignment state', () async {
+    final store = InMemoryDatadogFlagsStore();
     final client = await createClient(
       requests: requests,
       response: assignmentsResponse(),
+      store: store,
     );
     await client.setEvaluationContext(
       const DatadogFlagsEvaluationContext(targetingKey: 'user-123'),
@@ -219,6 +229,7 @@ void main() {
     );
     expect(details.value, isFalse);
     expect(details.error, FlagEvaluationError.providerNotReady);
+    expect(store.values, isEmpty);
   });
 
   test('counts exposure emissions at the HTTP boundary', () async {
@@ -463,6 +474,182 @@ void main() {
 
     expect(evaluationRequests(requests), hasLength(1));
   });
+
+  test('persists assignments and restores only for the matching context',
+      () async {
+    final store = InMemoryDatadogFlagsStore();
+    final client = await createClient(
+      requests: requests,
+      response: assignmentsResponse(),
+      store: store,
+      trackExposures: false,
+      trackEvaluations: false,
+    );
+    const context = DatadogFlagsEvaluationContext(
+      targetingKey: 'user-123',
+      attributes: {'plan': 'pro'},
+    );
+    await client.setEvaluationContext(context);
+
+    expect(store.values, contains(DatadogFlagsClient.defaultName));
+    await DatadogFlags.disable();
+
+    final responseCompleter = Completer<http.Response>();
+    final restored = await createClient(
+      requests: requests,
+      store: store,
+      trackExposures: false,
+      trackEvaluations: false,
+      httpClient: MockClient((request) {
+        requests.add(request);
+        return responseCompleter.future;
+      }),
+    );
+
+    final refresh = restored.setEvaluationContext(context);
+    await Future<void>.delayed(Duration.zero);
+    expect(
+      restored.getBooleanValue(key: 'show-paywall', defaultValue: false),
+      isTrue,
+    );
+
+    responseCompleter.complete(http.Response(
+      jsonEncode(assignmentsResponse(booleanValue: false)),
+      200,
+    ));
+    await refresh;
+    expect(
+      restored.getBooleanValue(key: 'show-paywall', defaultValue: true),
+      isFalse,
+    );
+  });
+
+  test('ignores cached assignments for a different context', () async {
+    final store = InMemoryDatadogFlagsStore();
+    final client = await createClient(
+      requests: requests,
+      response: assignmentsResponse(),
+      store: store,
+      trackExposures: false,
+      trackEvaluations: false,
+    );
+    await client.setEvaluationContext(
+      const DatadogFlagsEvaluationContext(targetingKey: 'user-123'),
+    );
+    await DatadogFlags.disable();
+
+    final responseCompleter = Completer<http.Response>();
+    final restored = await createClient(
+      requests: requests,
+      store: store,
+      trackExposures: false,
+      trackEvaluations: false,
+      httpClient: MockClient((request) {
+        requests.add(request);
+        return responseCompleter.future;
+      }),
+    );
+
+    final refresh = restored.setEvaluationContext(
+      const DatadogFlagsEvaluationContext(targetingKey: 'user-456'),
+    );
+    await Future<void>.delayed(Duration.zero);
+    final notReady = restored.getBooleanDetails(
+      key: 'show-paywall',
+      defaultValue: false,
+    );
+    expect(notReady.error, FlagEvaluationError.providerNotReady);
+
+    responseCompleter.complete(http.Response(
+      jsonEncode(assignmentsResponse(booleanValue: false)),
+      200,
+    ));
+    await refresh;
+    expect(
+      restored.getBooleanValue(key: 'show-paywall', defaultValue: true),
+      isFalse,
+    );
+  });
+
+  test('overlapping context fetches persist only the latest context', () async {
+    final store = InMemoryDatadogFlagsStore();
+    final responseCompleters = <Completer<http.Response>>[];
+    final client = await createClient(
+      requests: requests,
+      store: store,
+      trackExposures: false,
+      trackEvaluations: false,
+      httpClient: MockClient((request) {
+        requests.add(request);
+        final completer = Completer<http.Response>();
+        responseCompleters.add(completer);
+        return completer.future;
+      }),
+    );
+
+    final first = client.setEvaluationContext(
+      const DatadogFlagsEvaluationContext(targetingKey: 'user-first'),
+    );
+    await waitUntil(() => responseCompleters.length == 1);
+    final second = client.setEvaluationContext(
+      const DatadogFlagsEvaluationContext(targetingKey: 'user-second'),
+    );
+    await waitUntil(() => responseCompleters.length == 2);
+
+    responseCompleters[1].complete(http.Response(
+      jsonEncode(assignmentsResponse(
+        booleanVariationKey: 'second',
+        booleanValue: false,
+      )),
+      200,
+    ));
+    await second;
+
+    responseCompleters[0].complete(http.Response(
+      jsonEncode(assignmentsResponse(
+        booleanVariationKey: 'first',
+        booleanValue: true,
+      )),
+      200,
+    ));
+    await first;
+
+    final persisted = store.values[DatadogFlagsClient.defaultName]!;
+    expect(persisted.context.targetingKey, 'user-second');
+    expect(persisted.flags['show-paywall']!.variationKey, 'second');
+  });
+
+  test('shared preferences store round-trips persisted assignments', () async {
+    SharedPreferences.setMockInitialValues({});
+    final preferences = await SharedPreferences.getInstance();
+    final store = SharedPreferencesDatadogFlagsStore(
+      sharedPreferences: preferences,
+      namespace: 'test_flags',
+    );
+    final data = FlagsData(
+      flags: {
+        'show-paywall': const FlagAssignment(
+          allocationKey: 'allocation-a',
+          variationKey: 'enabled',
+          variationType: FlagVariationType.boolean,
+          variationValue: true,
+          reason: 'TARGETING_MATCH',
+          doLog: true,
+        ),
+      },
+      context: const DatadogFlagsEvaluationContext(targetingKey: 'user-123'),
+      date: now,
+    );
+
+    await store.write('client', data);
+    final restored = await store.read('client');
+
+    expect(restored!.context.targetingKey, 'user-123');
+    expect(restored.flags['show-paywall']!.variationValue, isTrue);
+
+    await store.delete('client');
+    expect(await store.read('client'), isNull);
+  });
 }
 
 Future<DatadogFlagsClient> createClient({
@@ -473,6 +660,7 @@ Future<DatadogFlagsClient> createClient({
   bool trackExposures = true,
   bool trackEvaluations = true,
   int evaluationMaxBatchSize = 1000,
+  DatadogFlagsStore? store,
 }) async {
   await DatadogFlags.enable(
     configuration: DatadogFlagsConfiguration(
@@ -483,6 +671,7 @@ Future<DatadogFlagsClient> createClient({
       trackExposures: trackExposures,
       trackEvaluations: trackEvaluations,
       evaluationMaxBatchSize: evaluationMaxBatchSize,
+      store: store ?? InMemoryDatadogFlagsStore(),
     ),
   );
   return DatadogFlagsClient.create();


### PR DESCRIPTION
## Motivation

After the SDK behavior is complete, the package should be ready for pub validation before the example app stack lands. This keeps release metadata and dependency decisions separate from the dogfooding UI work.

## System Scope

This PR prepares the package for pub validation by switching to hosted dependencies and polishing metadata, README, changelog, license, and exports.

```mermaid
flowchart LR
    app[Flutter app] --> package[datadog_flags package]
    package --> facade[DatadogFlags facade and client]
    facade --> typed[Typed evaluation API]
    facade --> context[Evaluation context]
    context --> precompute[Precompute assignments fetcher]
    precompute --> api[Datadog precompute API]
    precompute --> models[Assignment models and parser]
    typed --> store[Assignment repository and persistence]
    typed --> rum[RUM feature flag context]
    typed --> exposure[Exposure EVP intake]
    typed --> flageval[Flag-evaluation EVP intake]
    example[Example app flag screen] --> app
    example --> counter[Forwarding request counters]
    counter --> precompute
    counter --> exposure
    counter --> flageval
    publishing[Pub package metadata and docs] --> package

    classDef active fill:#fff4cc,stroke:#c37b00,stroke-width:3px,color:#111;
    class publishing active;
```

## Stack Position

```mermaid
flowchart LR
    pr1047[#1047<br/>Precompute core] --> pr1048[#1048<br/>Typed API]
    pr1048 --> pr1049[#1049<br/>Exposures]
    pr1049 --> pr1050[#1050<br/>Flagevals]
    pr1050 --> pr1051[#1051<br/>Persistence]
    pr1051 --> pr1052[#1052<br/>Publishing]
    pr1052 --> pr1053[#1053<br/>Example app]

    classDef current fill:#dff7ff,stroke:#087ea4,stroke-width:3px,color:#111;
    class pr1052 current;
```

## Changes

This removes `publish_to: none`, switches `datadog_flutter_plugin` from a monorepo path dependency to the hosted `^3.2.1` dependency, and polishes package metadata with a publishable description, issue tracker, and pub topics. The README now describes the package as the full native Flutter Datadog Flags client rather than an unpublished transport slice.

Validation:

- `flutter pub get` in `packages/datadog_flags`: passed using hosted `datadog_flutter_plugin 3.2.1`
- `dart format --set-exit-if-changed packages/datadog_flags`: passed, 0 changed
- `dart analyze packages/datadog_flags`: passed, no issues
- `flutter test test` in `packages/datadog_flags`: passed, 25 tests
- `flutter test --platform chrome test` in `packages/datadog_flags`: passed, 23 browser-safe tests
- `flutter pub publish --dry-run` in `packages/datadog_flags`: passed with 0 warnings

## Decisions

The hosted dependency is required because pub packages cannot depend on local path dependencies. The package compiles and tests against `datadog_flutter_plugin 3.2.1`, so this stack can make the package publishable without waiting for a newer sibling plugin release.

Example-app dogfooding remains out of scope for this PR and is handled in the final stack.