### PR TITLE
feat(datadog_flags): add dogfooding example

### DIFF
--- a/examples/simple_example/android/app/src/main/AndroidManifest.xml
+++ b/examples/simple_example/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
    <application
         android:label="test_app"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/examples/simple_example/android/app/src/main/res/xml/network_security_config.xml
+++ b/examples/simple_example/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>localhost</domain>
+        <domain>127.0.0.1</domain>
+        <domain>10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/examples/simple_example/android/gradle.properties
+++ b/examples/simple_example/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx3000M
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin_version=2.1.0
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/examples/simple_example/ios/Podfile.lock
+++ b/examples/simple_example/ios/Podfile.lock
@@ -18,19 +18,19 @@ PODS:
     - DatadogWebViewTracking (~> 3)
     - Flutter
     - webview_flutter_wkwebview
-  - DatadogCore (3.9.1):
-    - DatadogInternal (= 3.9.1)
-  - DatadogCrashReporting (3.9.1):
-    - DatadogInternal (= 3.9.1)
+  - DatadogCore (3.11.1):
+    - DatadogInternal (= 3.11.1)
+  - DatadogCrashReporting (3.11.1):
+    - DatadogInternal (= 3.11.1)
     - KSCrash/Filters (= 2.5.0)
     - KSCrash/Recording (= 2.5.0)
-  - DatadogInternal (3.9.1)
-  - DatadogLogs (3.9.1):
-    - DatadogInternal (= 3.9.1)
-  - DatadogRUM (3.9.1):
-    - DatadogInternal (= 3.9.1)
-  - DatadogWebViewTracking (3.9.1):
-    - DatadogInternal (= 3.9.1)
+  - DatadogInternal (3.11.1)
+  - DatadogLogs (3.11.1):
+    - DatadogInternal (= 3.11.1)
+  - DatadogRUM (3.11.1):
+    - DatadogInternal (= 3.11.1)
+  - DatadogWebViewTracking (3.11.1):
+    - DatadogInternal (= 3.11.1)
   - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - KSCrash/Core (2.5.0)
@@ -49,6 +49,9 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -61,6 +64,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - objective_c (from `.symlinks/plugins/objective_c/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 SPEC REPOS:
@@ -89,26 +93,29 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/objective_c/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   webview_flutter_wkwebview:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  connectivity_plus: 18382e7311ba19efcaee94442b23b32507b20695
-  datadog_flutter_plugin: 64adc7ef089a1328c78fd4fab24e49afa09d95a5
-  datadog_session_replay: 8e4f4a520f20feb2916c623c011a53ba63f8d77f
-  datadog_webview_tracking: 58ffca1b06ba88e0bd6dc0d0d1dada0e60e6d3d5
-  DatadogCore: e27bba3c2f490ae41ac17d41aecadee85475fe6d
-  DatadogCrashReporting: 23da244e20c2af0d159097dd10cc9ce8ef954bcc
-  DatadogInternal: e9ff671207d5a14354364101d32d60897c48d13a
-  DatadogLogs: 664dbb3598f95817429db0025575289c1f63efbf
-  DatadogRUM: dd30158552e5b48898cc2e6084eda1754c03ad6e
-  DatadogWebViewTracking: b8c35c23ac90ee4ba2b3879577451e27ec86ebcd
+  connectivity_plus: 2256d3e20624a7749ed21653aafe291a46446fee
+  datadog_flutter_plugin: ece4fa34fdd699f4c36547df450da4417f904580
+  datadog_session_replay: 29f1e456d30632bb22ad1dd0eceb15811d2fbc6c
+  datadog_webview_tracking: d92b870c96d7e646ac838f9c4a79d5fd70468139
+  DatadogCore: ac5ffe0cb500e4c826fa08e63767ab3b4434c380
+  DatadogCrashReporting: 699c20e4af5798a39b14c81e26c0e92293d86a36
+  DatadogInternal: 4ee2f5bab0371f161c8010637fff5331f49542d7
+  DatadogLogs: 9f7f10c34ea9cc4c6699f98ab2420da843f78f4b
+  DatadogRUM: 14a5f96c465e85d56ec501508d728b7aea9c2980
+  DatadogWebViewTracking: 99631d80d34cb30cf6be9b620dc6659f7f5bd15f
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   KSCrash: 80e1e24eaefbe5134934ae11ca8d7746586bc2ed
-  objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  objective_c: 89e720c30d716b036faf9c9684022048eee1eee2
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 

--- a/examples/simple_example/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/simple_example/ios/Runner.xcodeproj/project.pbxproj
@@ -140,7 +140,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				50E793F5A550121A16F6AF72 /* [CP] Embed Pods Frameworks */,
-				C5A6A31AA8D394C2AA220E42 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -268,23 +267,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		C5A6A31AA8D394C2AA220E42 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/examples/simple_example/ios/Runner/Info.plist
+++ b/examples/simple_example/ios/Runner/Info.plist
@@ -22,6 +22,11 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/examples/simple_example/lib/app.dart
+++ b/examples/simple_example/lib/app.dart
@@ -9,14 +9,21 @@ import 'package:go_router/go_router.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'main_screen.dart';
+import 'flags/flags_demo_runtime.dart';
+import 'screens/flags_screen.dart';
 import 'screens/crash_screen.dart';
 import 'screens/graph_ql_screen.dart';
 import 'screens/network_screen.dart';
 
 class MyApp extends StatefulWidget {
   final GraphQLClient graphQLClient;
+  final FlagsDemoRuntime flagsRuntime;
 
-  const MyApp({super.key, required this.graphQLClient});
+  const MyApp({
+    super.key,
+    required this.graphQLClient,
+    required this.flagsRuntime,
+  });
 
   @override
   State<MyApp> createState() => _MyAppState();
@@ -25,41 +32,46 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   var captureKey = GlobalKey();
 
-  final router = GoRouter(
-    observers: [DatadogNavigationObserver(datadogSdk: DatadogSdk.instance)],
-    routes: [
-      GoRoute(
-        path: '/',
-        builder: (context, state) {
-          return const MainScreen();
-        },
-      ),
-      GoRoute(
-        path: '/home',
-        builder: (context, state) {
-          return const MyHomePage(title: 'Home');
-        },
-      ),
-      GoRoute(
-        path: '/network',
-        builder: (context, state) {
-          return const NetworkScreen();
-        },
-      ),
-      GoRoute(
-        path: '/graphql',
-        builder: (context, state) {
-          return const GraphQlScreen();
-        },
-      ),
-      GoRoute(
-        path: '/crash',
-        builder: (context, state) {
-          return const CrashTestScreen();
-        },
-      ),
-    ],
-  );
+  late final router = GoRouter(observers: [
+    DatadogNavigationObserver(datadogSdk: DatadogSdk.instance)
+  ], routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) {
+        return const MainScreen();
+      },
+    ),
+    GoRoute(
+      path: '/home',
+      builder: (context, state) {
+        return const MyHomePage(title: 'Home');
+      },
+    ),
+    GoRoute(
+      path: '/network',
+      builder: (context, state) {
+        return const NetworkScreen();
+      },
+    ),
+    GoRoute(
+      path: '/graphql',
+      builder: (context, state) {
+        return const GraphQlScreen();
+      },
+    ),
+    GoRoute(
+      path: '/crash',
+      builder: (context, state) {
+        return const CrashTestScreen();
+      },
+    ),
+    GoRoute(
+      path: '/flags',
+      builder: (context, state) {
+        return FlagsScreen(runtime: widget.flagsRuntime);
+      },
+    ),
+  ]);
 
   @override
   Widget build(BuildContext context) {

--- a/examples/simple_example/lib/flags/flags_demo_runtime.dart
+++ b/examples/simple_example/lib/flags/flags_demo_runtime.dart
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:datadog_flags/datadog_flags.dart';
+import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+
+import 'flags_request_counter.dart';
+import 'forwarding_flags_counter.dart';
+
+const _externalFlagsEndpoint = String.fromEnvironment('FLAGS_ENDPOINT');
+const _externalExposureEndpoint =
+    String.fromEnvironment('FLAGS_EXPOSURE_ENDPOINT');
+const _externalEvaluationEndpoint =
+    String.fromEnvironment('FLAGS_EVALUATION_ENDPOINT');
+const _countRequests =
+    bool.fromEnvironment('FLAGS_COUNT_REQUESTS', defaultValue: true);
+
+class FlagsDemoRuntime {
+  final FlagsRequestCounter? counter;
+  final DatadogFlagsConfiguration configuration;
+
+  const FlagsDemoRuntime._({
+    required this.counter,
+    required this.configuration,
+  });
+
+  Future<void> stop() async {
+    await counter?.stop();
+  }
+
+  static Future<FlagsDemoRuntime> create({
+    String? clientToken,
+    String? env,
+    String? siteName,
+    String? applicationId,
+  }) async {
+    final externalFlagsEndpoint = _uriFromEnvironment(_externalFlagsEndpoint);
+    final externalExposureEndpoint =
+        _uriFromEnvironment(_externalExposureEndpoint);
+    final externalEvaluationEndpoint =
+        _uriFromEnvironment(_externalEvaluationEndpoint);
+
+    final useDatad0g = siteName == 'datad0g.com';
+    final counter = _countRequests ? ForwardingFlagsCounter.create() : null;
+
+    return FlagsDemoRuntime._(
+      counter: counter,
+      configuration: DatadogFlagsConfiguration(
+        customFlagsEndpoint: externalFlagsEndpoint ??
+            (useDatad0g
+                ? Uri.https(
+                    'preview.ff-cdn.datad0g.com',
+                    '/precompute-assignments',
+                  )
+                : null),
+        customExposureEndpoint: externalExposureEndpoint ??
+            (useDatad0g
+                ? Uri.parse(
+                    'https://browser-intake-datad0g.com/api/v2/exposures?ddsource=flutter',
+                  )
+                : null),
+        customEvaluationEndpoint: externalEvaluationEndpoint ??
+            (useDatad0g
+                ? Uri.parse(
+                    'https://browser-intake-datad0g.com/api/v2/flagevaluation?ddsource=flutter',
+                  )
+                : null),
+        httpClient:
+            counter is ForwardingFlagsCounter ? counter.httpClient : null,
+        datadogContext: _datadogContext(
+          useDatad0g: useDatad0g,
+          clientToken: clientToken,
+          env: env,
+          applicationId: applicationId,
+        ),
+        evaluationFlushInterval: const Duration(seconds: 1),
+      ),
+    );
+  }
+}
+
+DatadogFlagsContext? _datadogContext({
+  required bool useDatad0g,
+  required String? clientToken,
+  required String? env,
+  required String? applicationId,
+}) {
+  if (!useDatad0g) {
+    return null;
+  }
+
+  return DatadogFlagsContext(
+    clientToken: clientToken ?? '',
+    env: env ?? 'staging',
+    site: DatadogFlagsSite.us1,
+    service: 'simple-example',
+    version: '1.0.0',
+    applicationId: _emptyToNull(applicationId),
+    sdkVersion: DatadogSdk.sdkVersion,
+  );
+}
+
+Uri? _uriFromEnvironment(String value) {
+  if (value.isEmpty) {
+    return null;
+  }
+  return Uri.parse(value);
+}
+
+String? _emptyToNull(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  return value;
+}

--- a/examples/simple_example/lib/flags/flags_request_counter.dart
+++ b/examples/simple_example/lib/flags/flags_request_counter.dart
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+abstract interface class FlagsRequestCounter {
+  int get precomputeRequestCount;
+  int get exposureCount;
+  int get evaluationRequestCount;
+  int get evaluationEventCount;
+
+  Future<void> stop();
+}

--- a/examples/simple_example/lib/flags/forwarding_flags_counter.dart
+++ b/examples/simple_example/lib/flags/forwarding_flags_counter.dart
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'flags_request_counter.dart';
+
+class ForwardingFlagsCounter implements FlagsRequestCounter {
+  final CountingFlagsHttpClient httpClient;
+
+  ForwardingFlagsCounter._(this.httpClient);
+
+  factory ForwardingFlagsCounter.create() {
+    return ForwardingFlagsCounter._(CountingFlagsHttpClient(http.Client()));
+  }
+
+  @override
+  int get precomputeRequestCount => httpClient.precomputeRequestCount;
+
+  @override
+  int get exposureCount => httpClient.exposureCount;
+
+  @override
+  int get evaluationRequestCount => httpClient.evaluationRequestCount;
+
+  @override
+  int get evaluationEventCount => httpClient.evaluationEventCount;
+
+  @override
+  Future<void> stop() async {
+    httpClient.close();
+  }
+}
+
+class CountingFlagsHttpClient extends http.BaseClient {
+  final http.Client _inner;
+
+  int precomputeRequestCount = 0;
+  int exposureCount = 0;
+  int evaluationRequestCount = 0;
+  int evaluationEventCount = 0;
+
+  CountingFlagsHttpClient(this._inner);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    final body = request is http.Request ? request.body : '';
+    final path = request.url.path;
+    if (path == '/precompute-assignments') {
+      precomputeRequestCount += 1;
+    } else if (path == '/api/v2/exposures') {
+      exposureCount += _countExposureBody(body);
+    } else if (path == '/api/v2/flagevaluation') {
+      evaluationRequestCount += 1;
+      evaluationEventCount += _tryCountEvaluationEvents(body);
+    }
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    _inner.close();
+    super.close();
+  }
+}
+
+int _countExposureBody(String body) {
+  return body.split('\n').where((line) => line.trim().isNotEmpty).length;
+}
+
+int _tryCountEvaluationEvents(String body) {
+  try {
+    final decoded = jsonDecode(body) as Map<String, Object?>;
+    final evaluations = decoded['flagEvaluations'] as List<Object?>;
+    return evaluations.length;
+  } catch (_) {
+    return 0;
+  }
+}

--- a/examples/simple_example/lib/main.dart
+++ b/examples/simple_example/lib/main.dart
@@ -3,6 +3,7 @@
 // Copyright 2023-Present Datadog, Inc.
 
 import 'package:datadog_flutter_plugin/datadog_flutter_plugin.dart';
+import 'package:datadog_flags/datadog_flags.dart';
 import 'package:datadog_gql_link/datadog_gql_link.dart';
 import 'package:datadog_session_replay/datadog_session_replay.dart';
 import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
@@ -12,11 +13,16 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'app.dart';
+import 'flags/flags_demo_runtime.dart';
 import 'url_strategy_stub.dart' if (dart.library.html) 'url_strategy_web.dart';
 
 const graphQlUrl = 'http://localhost:3000/graphql';
+const ddClientToken = String.fromEnvironment('DD_CLIENT_TOKEN');
+const ddApplicationId = String.fromEnvironment('DD_APPLICATION_ID');
+const ddEnv = String.fromEnvironment('DD_ENV');
+const ddSite = String.fromEnvironment('DD_SITE', defaultValue: 'us1');
 
-void main() async {
+Future<void> main() async {
   await dotenv.load();
 
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,14 +30,36 @@ void main() async {
 
   DatadogSdk.instance.sdkVerbosity = CoreLoggerLevel.debug;
 
+  final siteName = _configValue(
+    'DD_SITE',
+    defineValue: ddSite,
+    defaultValue: 'us1',
+  );
+  final intakeEndpoint = _intakeEndpointForSite(siteName);
+  final applicationId = _configValue(
+    'DD_APPLICATION_ID',
+    defineValue: ddApplicationId,
+    defaultValue: '',
+  );
+  final env = _configValue(
+    'DD_ENV',
+    defineValue: ddEnv,
+    defaultValue: siteName == 'datad0g.com' ? 'staging' : 'dev',
+  );
   final datadogConfig = DatadogConfiguration(
-    clientToken: dotenv.get('DD_CLIENT_TOKEN', fallback: ''),
-    env: dotenv.get('DD_ENV', fallback: ''),
-    site: DatadogSite.us1,
-    loggingConfiguration: DatadogLoggingConfiguration(),
+    clientToken: _configValue(
+      'DD_CLIENT_TOKEN',
+      defineValue: ddClientToken,
+      defaultValue: '',
+    ),
+    env: env,
+    site: _siteForName(siteName),
+    loggingConfiguration:
+        DatadogLoggingConfiguration(customEndpoint: intakeEndpoint),
     firstPartyHosts: ['localhost'],
     rumConfiguration: DatadogRumConfiguration(
-        applicationId: dotenv.get('DD_APPLICATION_ID', fallback: ''),
+        applicationId: applicationId,
+        customEndpoint: intakeEndpoint,
         traceSampleRate: 100.0,
         trackResourceHeaders: ResourceHeadersExtractor(
           captureHeaders: [
@@ -62,10 +90,51 @@ void main() async {
   // runUsingRunApp(datadogConfig);
   runUsingAlternativeInit(
     datadogConfig,
+    siteName: siteName,
   );
 }
 
-Future<void> runUsingAlternativeInit(DatadogConfiguration datadogConfig) async {
+String _configValue(
+  String name, {
+  required String defineValue,
+  required String defaultValue,
+}) {
+  if (defineValue.isNotEmpty) {
+    return defineValue;
+  }
+  final value = dotenv.maybeGet(name);
+  if (value != null && value.isNotEmpty) {
+    return value;
+  }
+  return defaultValue;
+}
+
+DatadogSite _siteForName(String siteName) {
+  return switch (siteName) {
+    'us3' || 'us3.datadoghq.com' => DatadogSite.us3,
+    'us5' || 'us5.datadoghq.com' => DatadogSite.us5,
+    'eu1' || 'datadoghq.eu' => DatadogSite.eu1,
+    'ap1' || 'ap1.datadoghq.com' => DatadogSite.ap1,
+    'ap2' || 'ap2.datadoghq.com' => DatadogSite.ap2,
+    'us1_fed' || 'ddog-gov.com' => DatadogSite.us1Fed,
+    // The Flutter plugin does not expose a staging enum. Use custom endpoints
+    // for staging intake and flags while keeping the closest SDK site value.
+    'datad0g.com' => DatadogSite.us1,
+    _ => DatadogSite.us1,
+  };
+}
+
+String? _intakeEndpointForSite(String siteName) {
+  return switch (siteName) {
+    'datad0g.com' => 'https://browser-intake-datad0g.com',
+    _ => null,
+  };
+}
+
+Future<void> runUsingAlternativeInit(
+  DatadogConfiguration datadogConfig, {
+  required String siteName,
+}) async {
   final originalOnError = FlutterError.onError;
   FlutterError.onError = (details) {
     FlutterError.presentError(details);
@@ -84,6 +153,13 @@ Future<void> runUsingAlternativeInit(DatadogConfiguration datadogConfig) async {
   };
 
   await DatadogSdk.instance.initialize(datadogConfig, TrackingConsent.granted);
+  final flagsRuntime = await FlagsDemoRuntime.create(
+    clientToken: datadogConfig.clientToken,
+    env: datadogConfig.env,
+    siteName: siteName,
+    applicationId: datadogConfig.rumConfiguration?.applicationId,
+  );
+  await DatadogFlags.enable(configuration: flagsRuntime.configuration);
   final link = Link.from([
     DatadogGqlLink(DatadogSdk.instance, Uri.parse(graphQlUrl)),
     HttpLink(graphQlUrl),
@@ -92,19 +168,36 @@ Future<void> runUsingAlternativeInit(DatadogConfiguration datadogConfig) async {
   final graphQlClient = GraphQLClient(link: link, cache: GraphQLCache());
   runApp(MyApp(
     graphQLClient: graphQlClient,
+    flagsRuntime: flagsRuntime,
   ));
 }
 
 Future<void> runUsingRunApp(DatadogConfiguration datadogConfig) async {
   await DatadogSdk.runApp(datadogConfig, TrackingConsent.granted, () {
-    final link = Link.from([
-      DatadogGqlLink(DatadogSdk.instance, Uri.parse(graphQlUrl)),
-      HttpLink(graphQlUrl),
-    ]);
-    final graphQlClient = GraphQLClient(link: link, cache: GraphQLCache());
+    // This path is not used by default, but keep flags configured for parity
+    // if the example is switched back to DatadogSdk.runApp.
+    final siteName = _configValue(
+      'DD_SITE',
+      defineValue: ddSite,
+      defaultValue: 'us1',
+    );
+    FlagsDemoRuntime.create(
+      clientToken: datadogConfig.clientToken,
+      env: datadogConfig.env,
+      siteName: siteName,
+      applicationId: datadogConfig.rumConfiguration?.applicationId,
+    ).then((flagsRuntime) async {
+      await DatadogFlags.enable(configuration: flagsRuntime.configuration);
+      final link = Link.from([
+        DatadogGqlLink(DatadogSdk.instance, Uri.parse(graphQlUrl)),
+        HttpLink(graphQlUrl),
+      ]);
+      final graphQlClient = GraphQLClient(link: link, cache: GraphQLCache());
 
-    runApp(MyApp(
-      graphQLClient: graphQlClient,
-    ));
+      runApp(MyApp(
+        graphQLClient: graphQlClient,
+        flagsRuntime: flagsRuntime,
+      ));
+    });
   });
 }

--- a/examples/simple_example/lib/main_screen.dart
+++ b/examples/simple_example/lib/main_screen.dart
@@ -43,6 +43,7 @@ class _MainScreenState extends State<MainScreen> {
               _paddedNavButton('Home', '/home'),
               _paddedNavButton('Network', '/network'),
               _paddedNavButton('GraphQl', '/graphql'),
+              _paddedNavButton('Flags', '/flags'),
               _paddedNavButton('Crash', '/crash'),
             ],
           ),

--- a/examples/simple_example/lib/screens/flags_screen.dart
+++ b/examples/simple_example/lib/screens/flags_screen.dart
@@ -1,0 +1,360 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:datadog_flags/datadog_flags.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../flags/flags_demo_runtime.dart';
+
+class FlagsScreen extends StatefulWidget {
+  final FlagsDemoRuntime runtime;
+
+  const FlagsScreen({super.key, required this.runtime});
+
+  @override
+  State<FlagsScreen> createState() => _FlagsScreenState();
+}
+
+class _FlagsScreenState extends State<FlagsScreen> {
+  static const _targetingKey = String.fromEnvironment('FLAGS_TARGETING_KEY',
+      defaultValue: 'test_subject4');
+  static const _targetingAttributesJson = String.fromEnvironment(
+    'FLAGS_TARGETING_ATTRIBUTES_JSON',
+    defaultValue: '{"attr1":"value1","companyId":"1"}',
+  );
+  static const _booleanKeys = String.fromEnvironment('FLAGS_BOOLEAN_KEYS');
+  static const _stringKeys = String.fromEnvironment('FLAGS_STRING_KEYS');
+  static const _integerKeys = String.fromEnvironment('FLAGS_INTEGER_KEYS');
+  static const _doubleKeys = String.fromEnvironment('FLAGS_DOUBLE_KEYS');
+  static const _objectKeys = String.fromEnvironment('FLAGS_OBJECT_KEYS');
+  static const _exposureProbeKey = String.fromEnvironment(
+    'FLAGS_EXPOSURE_PROBE_KEY',
+    defaultValue: 'android-mobile-app-aa-test',
+  );
+
+  late final DatadogFlagsClient _client;
+  Timer? _counterRefreshTimer;
+  String _assignmentState = 'idle';
+  int _recordedEvaluationCount = 0;
+  List<_EvaluatedFlag> _flags = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _client = DatadogFlagsClient.shared();
+    if (widget.runtime.counter != null) {
+      _counterRefreshTimer = Timer.periodic(
+        const Duration(milliseconds: 500),
+        (_) {
+          if (mounted) {
+            setState(() {});
+          }
+        },
+      );
+    }
+    _refreshFlags();
+  }
+
+  @override
+  void dispose() {
+    _counterRefreshTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _refreshFlags() async {
+    setState(() {
+      _assignmentState = 'fetching';
+    });
+    try {
+      await _client.setEvaluationContext(DatadogFlagsEvaluationContext(
+        targetingKey: _targetingKey,
+        attributes: _targetingAttributes(),
+      ));
+      _evaluate();
+      setState(() {
+        _assignmentState = 'ready';
+      });
+    } catch (error) {
+      setState(() {
+        _assignmentState = 'fetch failed: $error';
+        _flags = [];
+      });
+    }
+  }
+
+  void _evaluate() {
+    final flags = <_EvaluatedFlag>[];
+    for (final key
+        in _keys(_booleanKeys, const ['ffe-dogfooding-boolean-flag'])) {
+      flags.add(_EvaluatedFlag(
+        label: 'Boolean',
+        key: key,
+        details: _client.getBooleanDetails(
+          key: key,
+          defaultValue: false,
+        ),
+      ));
+    }
+    for (final key
+        in _keys(_stringKeys, const ['ffe-dogfooding-string-flag'])) {
+      flags.add(_EvaluatedFlag(
+        label: 'String',
+        key: key,
+        details: _client.getStringDetails(
+          key: key,
+          defaultValue: 'Fallback title',
+        ),
+      ));
+    }
+    for (final key
+        in _keys(_integerKeys, const ['ffe-dogfooding-integer-flag'])) {
+      flags.add(_EvaluatedFlag(
+        label: 'Integer',
+        key: key,
+        details: _client.getIntegerDetails(
+          key: key,
+          defaultValue: 0,
+        ),
+      ));
+    }
+    for (final key in _keys(_doubleKeys, const ['ffe-dogfooding-float-flag'])) {
+      flags.add(_EvaluatedFlag(
+        label: 'Float',
+        key: key,
+        details: _client.getDoubleDetails(
+          key: key,
+          defaultValue: 0,
+        ),
+      ));
+    }
+    for (final key in _keys(_objectKeys, const ['ffe-dogfooding-json-flag'])) {
+      flags.add(_EvaluatedFlag(
+        label: 'JSON',
+        key: key,
+        details: _client.getObjectDetails(
+          key: key,
+          defaultValue: const {},
+        ),
+      ));
+    }
+    var evaluationCount = flags.length;
+    final exposureProbeKey = _exposureProbeKey.trim();
+    if (exposureProbeKey.isNotEmpty &&
+        !flags.any((flag) => flag.key == exposureProbeKey)) {
+      _client.getStringDetails(
+        key: exposureProbeKey,
+        defaultValue: '',
+      );
+      evaluationCount += 1;
+    }
+    setState(() {
+      _flags = flags;
+      _recordedEvaluationCount += evaluationCount;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final counter = widget.runtime.counter;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Flags'),
+        actions: [
+          IconButton(
+            key: const Key('flags-home-button'),
+            tooltip: 'Home',
+            icon: const Icon(Icons.home),
+            onPressed: () => context.go('/home'),
+          ),
+        ],
+      ),
+      body: DefaultTextStyle.merge(
+        style: const TextStyle(fontSize: 14),
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+          children: [
+            _Row(label: 'Assignments', value: _assignmentState),
+            const _Row(label: 'Targeting key', value: _targetingKey),
+            _Row(
+              label: 'Eval calls',
+              value: '$_recordedEvaluationCount',
+              valueKey: const Key('flags-recorded-evaluation-count'),
+            ),
+            if (counter != null) ...[
+              _Row(
+                label: 'Exposures',
+                value: '${counter.exposureCount}',
+                valueKey: const Key('flags-exposure-count'),
+              ),
+              _Row(
+                label: 'Flag eval events',
+                value: '${counter.evaluationEventCount}',
+                valueKey: const Key('flags-evaluation-event-count'),
+              ),
+            ],
+            const SizedBox(height: 8),
+            for (final flag in _flags)
+              _DetailsRow(
+                label: flag.label,
+                keyName: flag.key,
+                details: flag.details,
+              ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _refreshFlags,
+                    child: const Text('Refresh'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _evaluate,
+                    child: const Text('Evaluate'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<String> _keys(String configured, List<String> defaultKeys) {
+    if (configured.trim().isNotEmpty) {
+      return configured
+          .split(',')
+          .map((key) => key.trim())
+          .where((key) => key.isNotEmpty)
+          .toList(growable: false);
+    }
+    return defaultKeys;
+  }
+
+  static Map<String, Object?> _targetingAttributes() {
+    try {
+      final decoded = jsonDecode(_targetingAttributesJson);
+      if (decoded is Map<String, Object?>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, Object?>.from(decoded);
+      }
+    } catch (_) {
+      return const {};
+    }
+    return const {};
+  }
+}
+
+class _EvaluatedFlag {
+  final String label;
+  final String key;
+  final FlagDetails<dynamic> details;
+
+  const _EvaluatedFlag({
+    required this.label,
+    required this.key,
+    required this.details,
+  });
+}
+
+class _DetailsRow extends StatelessWidget {
+  final String label;
+  final String keyName;
+  final FlagDetails<dynamic>? details;
+
+  const _DetailsRow({
+    required this.label,
+    required this.keyName,
+    required this.details,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final value = details;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 72,
+            child: Text(
+              label,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  keyName,
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value == null ? '-' : _formatValue(value.value),
+                  softWrap: true,
+                ),
+                if (value?.error != null) ...[
+                  const SizedBox(height: 1),
+                  Text(
+                    'error=${value?.error?.name}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                    softWrap: true,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatValue(Object? value) {
+    if (value is Map || value is List) {
+      return jsonEncode(value);
+    }
+    return '$value';
+  }
+}
+
+class _Row extends StatelessWidget {
+  final String label;
+  final String value;
+  final Key? valueKey;
+
+  const _Row({required this.label, required this.value, this.valueKey});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 140,
+            child: Text(
+              label,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
+          Expanded(child: Text(value, key: valueKey)),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/simple_example/pubspec.lock
+++ b/examples/simple_example/pubspec.lock
@@ -81,6 +81,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  datadog_flags:
+    dependency: "direct main"
+    description:
+      path: "../../packages/datadog_flags"
+      relative: true
+    source: path
+    version: "0.0.1"
   datadog_flutter_plugin:
     dependency: "direct main"
     description:
@@ -140,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -276,7 +291,7 @@ packages:
     source: hosted
     version: "2.2.3"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
@@ -499,6 +514,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "67724122431ea01d9318ad1ce08b6ca79f77a38366826f01a45a8ac61b693a01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.24"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -556,10 +627,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   transparent_image:
     dependency: "direct main"
     description:
@@ -681,5 +752,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.32.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/examples/simple_example/pubspec.yaml
+++ b/examples/simple_example/pubspec.yaml
@@ -23,8 +23,11 @@ dependencies:
     path: ../../packages/datadog_gql_link
   datadog_session_replay:
     path: ../../packages/datadog_session_replay
+  datadog_flags:
+    path: ../../packages/datadog_flags
     
   go_router: ^14.7.0
+  http: ^1.0.0
   path_provider: ^2.1.0
   flutter_dotenv: ^5.1.0
   transparent_image: ^2.0.1
@@ -33,6 +36,8 @@ dependencies:
 dependency_overrides:
   datadog_flutter_plugin:
     path: ../../packages/datadog_flutter_plugin
+  datadog_flags:
+    path: ../../packages/datadog_flags
 
 dev_dependencies:
   flutter_test:

--- a/examples/simple_example/test/flags_request_counter_test.dart
+++ b/examples/simple_example/test/flags_request_counter_test.dart
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test_app/flags/forwarding_flags_counter.dart';
+
+void main() {
+  test('forwarding counter records flag request attempts and forwards them',
+      () async {
+    final forwarded = <http.Request>[];
+    final client = CountingFlagsHttpClient(MockClient((request) async {
+      forwarded.add(request);
+      return http.Response('{}', 202);
+    }));
+
+    await client.post(
+      Uri.https(
+        'preview.ff-cdn.datad0g.com',
+        '/precompute-assignments',
+      ),
+      body: '{}',
+    );
+    await client.post(
+      Uri.https(
+        'browser-intake-datad0g.com',
+        '/api/v2/exposures',
+        {'ddsource': 'flutter'},
+      ),
+      body: '{"flag":{"key":"flag-a"}}',
+    );
+    await client.post(
+      Uri.https(
+        'browser-intake-datad0g.com',
+        '/api/v2/flagevaluation',
+        {'ddsource': 'flutter'},
+      ),
+      body: jsonEncode({
+        'flagEvaluations': [
+          {'flag_key': 'flag-a'},
+          {'flag_key': 'flag-b'},
+        ],
+      }),
+    );
+
+    expect(forwarded, hasLength(3));
+    expect(client.precomputeRequestCount, 1);
+    expect(client.exposureCount, 1);
+    expect(client.evaluationRequestCount, 1);
+    expect(client.evaluationEventCount, 2);
+  });
+}


### PR DESCRIPTION
## Motivation

The flags SDK stack needs a real app surface that exercises the same runtime path customers will use: Datadog SDK initialization, precompute assignment fetches, typed flag evaluation, exposure logging, flag-evaluation aggregation, and mobile navigation. Keeping this as the final stack slice lets the library PRs stay focused while still preserving the end-to-end dogfooding proof from the original POC.

## System Scope

This PR adds the simple example Flags screen, live datad0g runtime wiring, forwarding counters, and iOS/Android/web dogfooding validation.

```mermaid
flowchart LR
    app[Flutter app] --> package[datadog_flags package]
    package --> facade[DatadogFlags facade and client]
    facade --> typed[Typed evaluation API]
    facade --> context[Evaluation context]
    context --> precompute[Precompute assignments fetcher]
    precompute --> api[Datadog precompute API]
    precompute --> models[Assignment models and parser]
    typed --> store[Assignment repository and persistence]
    typed --> rum[RUM feature flag context]
    typed --> exposure[Exposure EVP intake]
    typed --> flageval[Flag-evaluation EVP intake]
    example[Example app flag screen] --> app
    example --> counter[Forwarding request counters]
    counter --> precompute
    counter --> exposure
    counter --> flageval
    publishing[Pub package metadata and docs] --> package

    classDef active fill:#fff4cc,stroke:#c37b00,stroke-width:3px,color:#111;
    class example,counter active;
```

## Stack Position

```mermaid
flowchart LR
    pr1047[#1047<br/>Precompute core] --> pr1048[#1048<br/>Typed API]
    pr1048 --> pr1049[#1049<br/>Exposures]
    pr1049 --> pr1050[#1050<br/>Flagevals]
    pr1050 --> pr1051[#1051<br/>Persistence]
    pr1051 --> pr1052[#1052<br/>Publishing]
    pr1052 --> pr1053[#1053<br/>Example app]

    classDef current fill:#dff7ff,stroke:#087ea4,stroke-width:3px,color:#111;
    class pr1053 current;
```

## Changes

This adds a Flags screen to `examples/simple_example` and wires the example app to initialize `datadog_flags` next to the existing Datadog Flutter plugin setup. The screen fetches live precompute assignments, renders the five dogfooding flags for string, boolean, integer, float, and JSON values, and keeps the values under the flag keys so the mobile layout stays scannable.

The example also adds a forwarding HTTP client used only by the demo runtime. It forwards requests to the real endpoints while counting exposures and flag-evaluation events so the app can show emission evidence without replacing the backend path with a fake local mode.

## Decisions

The datad0g staging path uses custom flags and EVP intake endpoints because the Flutter plugin does not expose a staging site enum. The screen defaults to the staging dogfood environment when `DD_SITE=datad0g.com` so all five dogfood flags are present.

The current staging assignment for `ffe-dogfooding-string-flag` is in a split but has `doLog: false`, so the exposure counter uses a configurable `FLAGS_EXPOSURE_PROBE_KEY` and defaults it to a staging `doLog: true` string assignment. The visible rows remain the requested dogfood flags, while the counters prove exposure and flag-evaluation emission.

## Validation

- `flutter analyze` in `examples/simple_example`: no issues found.
- `flutter test test` in `examples/simple_example`: 1 test passed.
- `flutter build web --no-wasm-dry-run --no-tree-shake-icons ...`: built `build/web`.
- Live datad0g staging precompute response returned all five dogfood flags for `test_subject4`.
- iOS simulator run on `/flags` showed `Assignments=ready`, `Eval calls=6`, `Exposures=1`, `Flag eval events=6`, and all five dogfood rows.
- Android emulator run showed the same flags and counters; tapping the home icon returned to the app home screen.
- Android emulator was shut down after validation.