### PR TITLE
fix: Support new versions of webview_flutter

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -137,8 +137,7 @@ scripts:
         - 'ios'
         - 'example/ios'
       # TODO: These packages should probably have platform unit tests
-      ignore: 
-        - 'datadog_webview_tracking'
+      ignore:         
         - 'datadog_inappwebview_tracking'
 
   unit_test:android:
@@ -149,8 +148,7 @@ scripts:
       dirExists: 
         - 'android'
         - 'example/android'
-      ignore:
-        - 'datadog_webview_tracking'
+      ignore:        
         - 'datadog_inappwebview_tracking'
 
   integration_test:ios:
@@ -170,7 +168,6 @@ scripts:
       dirExists:  'example/integration_test'
       ignore: 
         - 'datadog_flutter_plugin'
-        - 'datadog_webview_tracking'
 
   # Because the main package (datadog_flutter_plugin) is set up weird for integration tests,
   # have a separate target just for it that is called by `integration_test:ios``

--- a/packages/datadog_webview_tracking/.swiftlint.yml
+++ b/packages/datadog_webview_tracking/.swiftlint.yml
@@ -1,0 +1,11 @@
+disabled_rules:
+  - force_cast # used too often in deserializing
+
+included:
+  - ios
+  - example/ios
+
+excluded:
+  - example/ios/Pods
+  - example/ios/.symlinks
+  - example/ios/Flutter

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -61,11 +61,11 @@ dependencies {
 
     implementation project(":webview_flutter_android")
 
-    testImplementation(platform("org.junit:junit-bom:6.0.3"))
+    testImplementation(platform("org.junit:junit-bom:5.8.2"))
     testImplementation "org.junit.jupiter:junit-jupiter"
     testImplementation "com.github.xgouchet.Elmyr:core:1.3.1"
     testImplementation "com.github.xgouchet.Elmyr:junit5:1.3.1"
-    testImplementation "io.mockk:mockk:1.12.4"
+    testImplementation "io.mockk:mockk:1.13.7"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:0.25"
 }
 

--- a/packages/datadog_webview_tracking/android/src/main/kotlin/com/datadoghq/flutter/webview/DatadogFlutterWebViewPlugin.kt
+++ b/packages/datadog_webview_tracking/android/src/main/kotlin/com/datadoghq/flutter/webview/DatadogFlutterWebViewPlugin.kt
@@ -59,13 +59,9 @@ class DatadogFlutterWebViewPlugin : FlutterPlugin, MethodCallHandler {
     }
 
     private fun initWebView(webViewIdentifier: Long, allowedHosts: List<String>) {
-        // The webview Plugin only accepts a FlutterEngine and this is the only way
-        // I know how to get it.
-        @Suppress("DEPRECATION")
-        val engine = binding?.flutterEngine
-        if (engine != null) {
+        binding?.let {
             val webView = WebViewFlutterAndroidExternalApi.getWebView(
-                engine,
+                it,
                 webViewIdentifier
             )
             if (webView != null) {

--- a/packages/datadog_webview_tracking/example/android/gradle.properties
+++ b/packages/datadog_webview_tracking/example/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx2536M
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin_version=2.1.0
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/packages/datadog_webview_tracking/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/datadog_webview_tracking/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/packages/datadog_webview_tracking/example/ios/Podfile.lock
+++ b/packages/datadog_webview_tracking/example/ios/Podfile.lock
@@ -8,26 +8,38 @@ PODS:
     - DictionaryCoder (= 1.2.0)
     - Flutter
   - datadog_webview_tracking (0.0.1):
+    - DatadogCore (~> 3)
     - DatadogWebViewTracking (~> 3)
     - Flutter
     - webview_flutter_wkwebview
-  - DatadogCore (3.0.0):
-    - DatadogInternal (= 3.0.0)
-  - DatadogCrashReporting (3.0.0):
-    - DatadogInternal (= 3.0.0)
-    - PLCrashReporter (~> 1.12.0)
-  - DatadogInternal (3.0.0)
-  - DatadogLogs (3.0.0):
-    - DatadogInternal (= 3.0.0)
-  - DatadogRUM (3.0.0):
-    - DatadogInternal (= 3.0.0)
-  - DatadogWebViewTracking (3.0.0):
-    - DatadogInternal (= 3.0.0)
+  - DatadogCore (3.11.1):
+    - DatadogInternal (= 3.11.1)
+  - DatadogCrashReporting (3.11.1):
+    - DatadogInternal (= 3.11.1)
+    - KSCrash/Filters (= 2.5.0)
+    - KSCrash/Recording (= 2.5.0)
+  - DatadogInternal (3.11.1)
+  - DatadogLogs (3.11.1):
+    - DatadogInternal (= 3.11.1)
+  - DatadogRUM (3.11.1):
+    - DatadogInternal (= 3.11.1)
+  - DatadogWebViewTracking (3.11.1):
+    - DatadogInternal (= 3.11.1)
   - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - PLCrashReporter (1.12.0)
+  - KSCrash/Core (2.5.0)
+  - KSCrash/Filters (2.5.0):
+    - KSCrash/Recording
+    - KSCrash/RecordingCore
+    - KSCrash/ReportingCore
+  - KSCrash/Recording (2.5.0):
+    - KSCrash/RecordingCore
+  - KSCrash/RecordingCore (2.5.0):
+    - KSCrash/Core
+  - KSCrash/ReportingCore (2.5.0):
+    - KSCrash/Core
   - webview_flutter_wkwebview (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -48,7 +60,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - DictionaryCoder
-    - PLCrashReporter
+    - KSCrash
 
 EXTERNAL SOURCES:
   datadog_flutter_plugin:
@@ -82,38 +94,38 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   DatadogCore:
-    :commit: 234dddd00614dc5b4339af196bf0223f765b1241
+    :commit: d578e2f342404e52e7efdafaa2a36ad06d8e347e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogCrashReporting:
-    :commit: 234dddd00614dc5b4339af196bf0223f765b1241
+    :commit: d578e2f342404e52e7efdafaa2a36ad06d8e347e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogInternal:
-    :commit: 234dddd00614dc5b4339af196bf0223f765b1241
+    :commit: d578e2f342404e52e7efdafaa2a36ad06d8e347e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogLogs:
-    :commit: 234dddd00614dc5b4339af196bf0223f765b1241
+    :commit: d578e2f342404e52e7efdafaa2a36ad06d8e347e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogRUM:
-    :commit: 234dddd00614dc5b4339af196bf0223f765b1241
+    :commit: d578e2f342404e52e7efdafaa2a36ad06d8e347e
     :git: https://github.com/DataDog/dd-sdk-ios
   DatadogWebViewTracking:
-    :commit: 234dddd00614dc5b4339af196bf0223f765b1241
+    :commit: d578e2f342404e52e7efdafaa2a36ad06d8e347e
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
   datadog_flutter_plugin: 64adc7ef089a1328c78fd4fab24e49afa09d95a5
-  datadog_webview_tracking: ade692e16342ff2f21258ac3e30c25d306152a3d
-  DatadogCore: 0c39ba4ef3dee02071f235f2fb56af7e29f4ceb0
-  DatadogCrashReporting: 604e65e524cb2fc22cda39fd9c9ea5fd3bddf24e
-  DatadogInternal: 442673a7fb5329299b489b91ed705aa2085380f7
-  DatadogLogs: 0146a0e3140ba62fd42729593c0910d692aea5fd
-  DatadogRUM: f97fbd0290ecec5bc952fb03a6a1ae068649243f
-  DatadogWebViewTracking: fb9591c09fca82b143f3843a7164a7e782175c53
+  datadog_webview_tracking: 58ffca1b06ba88e0bd6dc0d0d1dada0e60e6d3d5
+  DatadogCore: ac5ffe0cb500e4c826fa08e63767ab3b4434c380
+  DatadogCrashReporting: 699c20e4af5798a39b14c81e26c0e92293d86a36
+  DatadogInternal: 4ee2f5bab0371f161c8010637fff5331f49542d7
+  DatadogLogs: 9f7f10c34ea9cc4c6699f98ab2420da843f78f4b
+  DatadogRUM: 14a5f96c465e85d56ec501508d728b7aea9c2980
+  DatadogWebViewTracking: 99631d80d34cb30cf6be9b620dc6659f7f5bd15f
   DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  PLCrashReporter: db59ef96fa3d25f3650040d02ec2798cffee75f2
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  KSCrash: 80e1e24eaefbe5134934ae11ca8d7746586bc2ed
+  webview_flutter_wkwebview: 29eb20d43355b48fe7d07113835b9128f84e3af4
 
 PODFILE CHECKSUM: 93609479835d96be1e50b18386849a31ac0889ab
 

--- a/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_webview_tracking/example/ios/Runner.xcodeproj/project.pbxproj
@@ -204,7 +204,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				4DDCC88BAFEC5A861590C0AB /* [CP] Embed Pods Frameworks */,
-				AFD551F4B1AC4021D9F4999F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -368,23 +367,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AFD551F4B1AC4021D9F4999F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BAE5972940F71CDEF389FF25 /* [CP] Check Pods Manifest.lock */ = {

--- a/packages/datadog_webview_tracking/example/ios/Runner/AppDelegate.swift
+++ b/packages/datadog_webview_tracking/example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,10 @@
-import UIKit
 import Flutter
+import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/packages/datadog_webview_tracking/example/ios/Runner/Info.plist
+++ b/packages/datadog_webview_tracking/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -43,9 +68,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/packages/datadog_webview_tracking/example/ios/Tests/DatadogWebviewTrackingPluginTests.swift
+++ b/packages/datadog_webview_tracking/example/ios/Tests/DatadogWebviewTrackingPluginTests.swift
@@ -14,7 +14,7 @@ enum ResultStatus: EquatableInTests {
 
 class FlutterSdkTests: XCTestCase {
     func testInitWebView_MissingIdentifier_ReturnsError() {
-        let plugin = DatadogWebViewTrackingPlugin(channel: .init())
+        let plugin = DatadogWebViewTrackingPlugin(registrar: MockFlutterPluginRegistrar(), channel: .init())
         let call = FlutterMethodCall(methodName: "initWebView", arguments: [
             "allowedHosts": []
         ])
@@ -37,7 +37,7 @@ class FlutterSdkTests: XCTestCase {
     }
 
     func testInitWebView_MissingAllowedHosts_ReturnsError() {
-        let plugin = DatadogWebViewTrackingPlugin(channel: .init())
+        let plugin = DatadogWebViewTrackingPlugin(registrar: MockFlutterPluginRegistrar(), channel: .init())
         let call = FlutterMethodCall(methodName: "initWebView", arguments: [
             "webViewIdentifier": 5
         ])
@@ -60,7 +60,7 @@ class FlutterSdkTests: XCTestCase {
     }
 
     func testInitWebView_WithValidParameters_ReturnsSuccess() {
-        let plugin = DatadogWebViewTrackingPlugin(channel: .init())
+        let plugin = DatadogWebViewTrackingPlugin(registrar: MockFlutterPluginRegistrar(), channel: .init())
         let call = FlutterMethodCall(methodName: "initWebView", arguments: [
             "webViewIdentifier": 5,
             "allowedHosts": []
@@ -72,5 +72,73 @@ class FlutterSdkTests: XCTestCase {
         })
 
         XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+}
+
+class MockFlutterPluginRegistrar: NSObject, FlutterPluginRegistrar {
+    var viewController: UIViewController?
+
+    func publish(_ value: NSObject) {}
+
+    func addMethodCallDelegate(_ delegate: any FlutterPlugin, channel: FlutterMethodChannel) {}
+
+    func addApplicationDelegate(_ delegate: any FlutterPlugin) {}
+
+    func addSceneDelegate(_ delegate: any FlutterSceneLifeCycleDelegate) {}
+
+    func lookupKey(forAsset asset: String) -> String {
+        return ""
+    }
+
+    func lookupKey(forAsset asset: String, fromPackage package: String) -> String {
+        return ""
+    }
+
+    func valuePublished(byPlugin pluginKey: String) -> NSObject? {
+        return nil
+    }
+
+    func messenger() -> any FlutterBinaryMessenger {
+        return MockFlutterBinaryMessenger()
+    }
+
+    func textures() -> any FlutterTextureRegistry {
+        return MockFlutterTextureRegistry()
+    }
+
+    func register(_ factory: any FlutterPlatformViewFactory, withId factoryId: String) {}
+
+    func register(_ factory: any FlutterPlatformViewFactory, withId factoryId: String, gestureRecognizersBlockingPolicy: FlutterPlatformViewGestureRecognizersBlockingPolicy) {}
+}
+
+class MockFlutterBinaryMessenger: NSObject, FlutterBinaryMessenger {
+    func send(onChannel channel: String, message: Data?) {
+
+    }
+
+    func send(onChannel channel: String, message: Data?, binaryReply callback: FlutterBinaryReply? = nil) {
+
+    }
+
+    func setMessageHandlerOnChannel(_ channel: String, binaryMessageHandler handler: FlutterBinaryMessageHandler? = nil) -> FlutterBinaryMessengerConnection {
+        return 0
+    }
+
+    func cleanUpConnection(_ connection: FlutterBinaryMessengerConnection) {
+
+    }
+}
+
+class MockFlutterTextureRegistry: NSObject, FlutterTextureRegistry {
+    func register(_ texture: any FlutterTexture) -> Int64 {
+        return 0
+    }
+
+    func textureFrameAvailable(_ textureId: Int64) {
+
+    }
+
+    func unregisterTexture(_ textureId: Int64) {
+
     }
 }

--- a/packages/datadog_webview_tracking/example/ios/Tests/DatadogWebviewTrackingPluginTests.swift
+++ b/packages/datadog_webview_tracking/example/ios/Tests/DatadogWebviewTrackingPluginTests.swift
@@ -108,7 +108,11 @@ class MockFlutterPluginRegistrar: NSObject, FlutterPluginRegistrar {
 
     func register(_ factory: any FlutterPlatformViewFactory, withId factoryId: String) {}
 
-    func register(_ factory: any FlutterPlatformViewFactory, withId factoryId: String, gestureRecognizersBlockingPolicy: FlutterPlatformViewGestureRecognizersBlockingPolicy) {}
+    func register(
+        _ factory: any FlutterPlatformViewFactory,
+        withId factoryId: String,
+        gestureRecognizersBlockingPolicy: FlutterPlatformViewGestureRecognizersBlockingPolicy
+    ) {}
 }
 
 class MockFlutterBinaryMessenger: NSObject, FlutterBinaryMessenger {
@@ -120,7 +124,10 @@ class MockFlutterBinaryMessenger: NSObject, FlutterBinaryMessenger {
 
     }
 
-    func setMessageHandlerOnChannel(_ channel: String, binaryMessageHandler handler: FlutterBinaryMessageHandler? = nil) -> FlutterBinaryMessengerConnection {
+    func setMessageHandlerOnChannel(
+        _ channel: String,
+        binaryMessageHandler handler: FlutterBinaryMessageHandler? = nil
+    ) -> FlutterBinaryMessengerConnection {
         return 0
     }
 

--- a/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Sources/DatadogWebviewTrackingPlugin.swift
+++ b/packages/datadog_webview_tracking/ios/datadog_webview_tracking/Sources/DatadogWebviewTrackingPlugin.swift
@@ -10,16 +10,18 @@ import DatadogWebViewTracking
 import webview_flutter_wkwebview
 
 public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
+    let registrar: FlutterPluginRegistrar
     let channel: FlutterMethodChannel
 
-    public init(channel: FlutterMethodChannel) {
+    public init(registrar: FlutterPluginRegistrar, channel: FlutterMethodChannel) {
+        self.registrar = registrar
         self.channel = channel
         super.init()
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "datadog_webview_tracking", binaryMessenger: registrar.messenger())
-        let instance = DatadogWebViewTrackingPlugin(channel: channel)
+        let instance = DatadogWebViewTrackingPlugin(registrar: registrar, channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
@@ -38,28 +40,16 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
                let allowedHosts = arguments["allowedHosts"] as? [String] {
                 let webViewIdentifier = number.int64Value
 
-                if let registry = getPluginRegistry(),
-                   // FWFWebviewFlutterWKWebViewExternalAPI does a force cast, which can crash,
-                   // so to try to avoid that, we're going to check to make sure the plugin is there first.
-                   let _ = registry.valuePublished(byPlugin: "WebViewFlutterPlugin") as? WebViewFlutterPlugin,
-                   let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(
-                        forIdentifier: webViewIdentifier,
-                        withPluginRegistry: registry) {
-                    WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
+               if let webview = FWFWebViewFlutterWKWebViewExternalAPI.webView(
+                    forIdentifier: webViewIdentifier, withPluginRegistrar: registrar) {
+                   WebViewTracking.enable(webView: webview, hosts: Set(allowedHosts))
                 } else {
-                    Datadog._internal.telemetry.error(
-                        id: "webview_tracking_init_failed",
-                        message: "Failed to initialie WebViewTracking because a WebViewFlutterPlugin instance was not found",
-                        kind: "DependencyFailure",
-                        stack: nil
-                    )
+                    consolePrint(
+                        "⚠️ Could not find web view to enable Datadog tracking.",
+                        .warn)
                 }
                 result(nil)
             } else {
-                consolePrint(
-                    "⚠️ Could not find WebViewFlutterPlugin to enable Datadog tracking. This may be because of a change in Flutter. " +
-                    "Please report this issue to Datadog along with the version of flutter_webview and Flutter you are using.",
-                    .warn)
                 result(
                     FlutterError(code: "DatadogSdk:ContractViolation",
                                  message: "Missing parameter in call to \(call.method)",
@@ -69,23 +59,5 @@ public class DatadogWebViewTrackingPlugin: NSObject, FlutterPlugin {
         } else {
             result(FlutterMethodNotImplemented)
         }
-    }
-
-    private func getPluginRegistry() -> FlutterPluginRegistry? {
-        // swiftlint:disable:next todo
-        // TODO: Add to app scenario, search for a FlutterViewController to get the
-        // registry
-        // Note, in Flutter 3.38, registrars expose `viewController` which will be the
-        // correct way to get the plugin registry. To be compatibile with <= 3.37 and 3.38+,
-        // we're going to first try to se if the RootViewController is a plugin registry (3.38+),
-        // and if not, fall back to the delegate (<= 3.37).
-        let delegate = UIApplication.shared.delegate as? FlutterAppDelegate
-        if let rootViewController = delegate?.window?.rootViewController,
-           let pluginRegistry = rootViewController as? FlutterPluginRegistry {
-            return pluginRegistry
-        } else if let delegate = UIApplication.shared.delegate as? FlutterPluginRegistry {
-            return delegate
-        }
-        return nil
     }
 }

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -5,16 +5,16 @@ homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.8.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
     sdk: flutter
   datadog_flutter_plugin: ^3.0.0
-  webview_flutter: ^4.0.4
-  webview_flutter_android: '>=3.8.2 <5.0.0'
-  webview_flutter_wkwebview: ^3.18.0
+  webview_flutter: ^4.13.1
+  webview_flutter_android: '>=4.13.0 <5.0.0'
+  webview_flutter_wkwebview: ^3.26.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/datadog_webview_tracking/test/datadog_webview_tracking_test.dart
+++ b/packages/datadog_webview_tracking/test/datadog_webview_tracking_test.dart
@@ -39,8 +39,9 @@ void main() {
 
     final mockWebiewPlatform = MockWebviewPlatform();
     final mockAndroidController = MockAndroidWebViewController();
-    when(() => mockWebiewPlatform.createPlatformWebViewController(any()))
-        .thenReturn(mockAndroidController);
+    when(
+      () => mockWebiewPlatform.createPlatformWebViewController(any()),
+    ).thenReturn(mockAndroidController);
     when(() => mockAndroidController.webViewIdentifier).thenReturn(148221);
     WebViewPlatform.instance = mockWebiewPlatform;
 
@@ -49,17 +50,20 @@ void main() {
     ambiguate(TestDefaultBinaryMessengerBinding.instance)
         ?.defaultBinaryMessenger
         .setMockMethodCallHandler(methodChannel, (message) {
-      log.add(message);
-      return null;
-    });
+          log.add(message);
+          return null;
+        });
 
     WebViewController().trackDatadogEvents(mockDatadog, ['host_a', 'host_b']);
 
     expect(log, [
-      isMethodCall('initWebView', arguments: {
-        'webViewIdentifier': 148221,
-        'allowedHosts': ['host_a', 'host_b']
-      })
+      isMethodCall(
+        'initWebView',
+        arguments: {
+          'webViewIdentifier': 148221,
+          'allowedHosts': ['host_a', 'host_b'],
+        },
+      ),
     ]);
   });
 }


### PR DESCRIPTION
### What and why?

Flutter 3.44 and the newest versions of webview_flutter include ways to make communication between plugins easier, which allows us to remove some hacks and fix issues with Flutter 3.41.

Also update this project to newest Flutter conventions.

refs: #950

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
