### PR TITLE
chore: Remove deprecated Jetifier from all Android projects

### DIFF
--- a/examples/simple_example/android/gradle.properties
+++ b/examples/simple_example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx3000M
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin_version=2.1.0

--- a/packages/datadog_dio/example/android/gradle.properties
+++ b/packages/datadog_dio/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/datadog_flutter_plugin/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/android/gradle.properties
@@ -6,4 +6,3 @@
 
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/gradle.properties
@@ -6,5 +6,4 @@
 
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin_version=2.1.0

--- a/packages/datadog_flutter_plugin/example/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle.properties
@@ -6,7 +6,6 @@
 
 org.gradle.jvmargs=-Xmx12800M
 android.useAndroidX=true
-android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/packages/datadog_flutter_plugin/integration_test_app/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/gradle.properties
@@ -6,5 +6,4 @@
 
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin_version=2.1.0

--- a/packages/datadog_inappwebview_tracking/example/android/gradle.properties
+++ b/packages/datadog_inappwebview_tracking/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/datadog_session_replay/example/android/gradle.properties
+++ b/packages/datadog_session_replay/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/datadog_tracking_http_client/example/android/gradle.properties
+++ b/packages/datadog_tracking_http_client/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin_version=2.1.0

--- a/packages/datadog_webview_tracking/example/android/gradle.properties
+++ b/packages/datadog_webview_tracking/example/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx2536M
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin_version=2.1.0

--- a/test_apps/stress_test/android/gradle.properties
+++ b/test_apps/stress_test/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin_version=2.1.0


### PR DESCRIPTION
### What and why?

Jetifier has been deprecated since 2023 and all dependencies in this repo are AndroidX-native, so it has no work to do. Removing it also fixes the Android pipeline failure in #1054, where Jetifier crashes attempting to transform byte-buddy's Java 24 bytecode pulled in by the `mockk 1.13.7` bump.

### How?

Removed `android.enableJetifier=true` from all 11 `gradle.properties` files across the repo. The Gradle default is `false`, and `examples/native-hybrid-app` has been building without it already.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue