### PR TITLE
fix(gql): Fix GQL errors to omit unused properties.

### DIFF
--- a/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
+++ b/packages/datadog_gql_link/lib/src/datadog_gql_link.dart
@@ -288,13 +288,14 @@ class DatadogGqlLink extends Link {
     final serializedErrors = response.errors!.map((e) {
       return {
         'message': e.message,
-        'locations': e.locations
-            ?.map((l) => {
-                  'line': l.line,
-                  'column': l.column,
-                })
-            .toList(),
-        'path': e.path,
+        if (e.locations != null)
+          'locations': e.locations!
+              .map((l) => {
+                    'line': l.line,
+                    'column': l.column,
+                  })
+              .toList(),
+        if (e.path != null) 'path': e.path,
         if (e.extensions?['code'] != null) 'code': e.extensions!['code'],
       };
     }).toList();

--- a/packages/datadog_gql_link/test/datadog_gql_link_test.dart
+++ b/packages/datadog_gql_link/test/datadog_gql_link_test.dart
@@ -753,6 +753,39 @@ query UserInfo($id: ID!) {
       expect(errors[0].containsKey('code'), isFalse);
     });
 
+    test('link omits locations and path when null in serialized errors',
+        () async {
+      // Given
+      final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));
+      final request = Request(
+          operation: Operation(document: query, operationName: 'UserInfo'));
+      final response = MockResponse();
+      when(() => response.context).thenReturn(const Context());
+      when(() => response.errors).thenReturn([
+        const GraphQLError(message: 'Server Error'),
+      ]);
+
+      // When
+      final responseController = StreamController<Response>();
+      final stream = link.request(request, (request) {
+        return responseController.stream;
+      });
+
+      responseController.sink.add(response);
+      unawaited(responseController.sink.close());
+      await stream.drain();
+
+      // Then
+      final captured = verify(() => mockRum.stopResource(
+          any(), any(), RumResourceType.native, any(), captureAny()));
+      final capturedAttrs = captured.captured[0] as Map<String, dynamic>;
+      final errors =
+          json.decode(capturedAttrs['_dd.graphql.errors']) as List<dynamic>;
+      expect(errors.length, 1);
+      expect(errors[0].containsKey('locations'), isFalse);
+      expect(errors[0].containsKey('path'), isFalse);
+    });
+
     test('link does not add payload attribute by default', () {
       // Given
       final link = DatadogGqlLink(mockDatadog, Uri.parse('https://test_uri'));


### PR DESCRIPTION
### What and why?

When the Android SDK deserializes the GQL Errors property, JSON `null`s are deserialized as JSonNull, not a Kotlin null, which breaks its translation into the Attributes map.

The easy fix is to omit any properties that are missing, which makes them null on the Kotlin side.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
