### PR TITLE
chore(ci): Fix three flakey tests

### DIFF
--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -711,10 +711,12 @@ class DatadogRumPluginTests: XCTestCase {
             resultStatus = ResultStatus.called(value: result)
         }
 
-        let command = mock.commands.first as? RUMAddLongTaskCommand
-        XCTAssertNotNil(command)
-        XCTAssertEqual(command?.time.timeIntervalSince1970, startTimeInterval, accuracy: 0.001)
-        XCTAssertEqual(command?.duration, TimeInterval(Double(duration) / 1000.0), accuracy: 0.0001)
+        guard let command = mock.commands.first as? RUMAddLongTaskCommand else {
+            XCTFail("Expected RUMAddLongTaskCommand")
+            return
+        }
+        XCTAssertEqual(command.time.timeIntervalSince1970, startTimeInterval, accuracy: 0.001)
+        XCTAssertEqual(command.duration, TimeInterval(Double(duration) / 1000.0), accuracy: 0.0001)
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -698,8 +698,7 @@ class DatadogRumPluginTests: XCTestCase {
     }
 
     func testReportLongTask_CallsInternal() {
-        let startTime = Date.now
-        let startTimeInterval = startTime.timeIntervalSince1970
+        let startTimeInterval: TimeInterval = 1_000_000.0
         let duration = 340124
 
         let call = FlutterMethodCall(methodName: "reportLongTask", arguments: [
@@ -714,10 +713,8 @@ class DatadogRumPluginTests: XCTestCase {
 
         let command = mock.commands.first as? RUMAddLongTaskCommand
         XCTAssertNotNil(command)
-        XCTAssertEqual(command, RUMAddLongTaskCommand(time: Date(timeIntervalSince1970: startTimeInterval),
-                                                      attributes: [:],
-                                                      duration: TimeInterval(Double(duration) / 1000.0))
-        )
+        XCTAssertEqual(command?.time.timeIntervalSince1970, startTimeInterval, accuracy: 0.001)
+        XCTAssertEqual(command?.duration, TimeInterval(Double(duration) / 1000.0), accuracy: 0.0001)
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		494123582DC129660071423F /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494123572DC129630071423F /* RequestBuilderTests.swift */; };
 		494400772E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */; };
+		E7162BD14BF84CACB6B101E947BD07D1 /* SessionReplayTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */; };
 		494400792E58BA1000AC46CC /* Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400782E58BA0700AC46CC /* Mockable.swift */; };
 		4944007D2E58C55200AC46CC /* FlutterSessionReplayFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944007C2E58C54B00AC46CC /* FlutterSessionReplayFeatureMock.swift */; };
 		494400892E58E7A200AC46CC /* ResourceResolverMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400882E58E7A200AC46CC /* ResourceResolverMock.swift */; };
@@ -68,6 +69,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		494123572DC129630071423F /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
 		494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayBridgeTests.swift; sourceTree = "<group>"; };
+		F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayTestContainer.swift; sourceTree = "<group>"; };
 		494400782E58BA0700AC46CC /* Mockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mockable.swift; sourceTree = "<group>"; };
 		4944007C2E58C54B00AC46CC /* FlutterSessionReplayFeatureMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayFeatureMock.swift; sourceTree = "<group>"; };
 		494400882E58E7A200AC46CC /* ResourceResolverMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceResolverMock.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 				494123572DC129630071423F /* RequestBuilderTests.swift */,
 				49C3AB4E2DBBE4A7000D8F6E /* FlutterSessionReplayFeatureTests.swift */,
 				494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */,
+				F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */,
 				35542C60C09A47729F76E13B6A659C63 /* DatadogSessionReplayPluginTests.swift */,
 			);
 			path = RunnerTests;
@@ -491,6 +494,7 @@
 				494123582DC129660071423F /* RequestBuilderTests.swift in Sources */,
 				49C3AB4F2DBBE4B2000D8F6E /* FlutterSessionReplayFeatureTests.swift in Sources */,
 				494400772E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift in Sources */,
+				E7162BD14BF84CACB6B101E947BD07D1 /* SessionReplayTestContainer.swift in Sources */,
 				E1E091C69AD74808BE3733231FC76E98 /* DatadogSessionReplayPluginTests.swift in Sources */,
 				4944008D2E58F71300AC46CC /* ResourcesWriterTest.swift in Sources */,
 				495642A52E5E2512000FF536 /* ResourceResolverTest.swift in Sources */,

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -13,7 +13,8 @@ import Flutter
 /// because FFI plugins do not receive engine lifecycle events (Flutter issue #184124).
 /// We exercise the ownership flow via the underlying static API since creating a real
 /// `FlutterPluginRegistrar` requires a running engine.
-@Suite(.serialized)
+extension SessionReplayTestContainer {
+@Suite
 class DatadogSessionReplayPluginTests {
     init() { FlutterSessionReplay.shutdown() }
     deinit { FlutterSessionReplay.shutdown() }
@@ -49,3 +50,4 @@ class DatadogSessionReplayPluginTests {
         #expect(FlutterSessionReplay.listenerOwner === messengerA)
     }
 }
+} // extension SessionReplayTestContainer

--- a/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayBridgeTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/FlutterSessionReplayBridgeTests.swift
@@ -13,7 +13,8 @@ extension FlutterSessionReplay {
     }
 }
 
-@Suite(.serialized)
+extension SessionReplayTestContainer {
+@Suite
 class FlutterSessionReplayBridgeTests {
     init() { FlutterSessionReplay.shutdown() }
     deinit { FlutterSessionReplay.shutdown() }
@@ -242,3 +243,4 @@ class FlutterSessionReplayBridgeTests {
         #expect(mockCore.get(feature: DefaultFlutterSessionReplayFeature.self) == nil)
     }
 }
+} // extension SessionReplayTestContainer

--- a/packages/datadog_session_replay/example/ios/RunnerTests/RequestBuilderTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/RequestBuilderTests.swift
@@ -281,7 +281,7 @@ func zlibDecode(_ data: Data, capacity: Int = 1_000_000) -> Data? {
         // buffer to hold the entire decompressed output, the function writes the
         // first dst_size bytes to the buffer and returns dst_size. Note that this
         // behavior differs from that of `compression_encode_buffer(_:_:_:_:_:_:)`.
-        let size = compression_decode_buffer(buffer, capacity, ptr, data.count, nil, COMPRESSION_ZLIB)
+        let size = compression_decode_buffer(buffer, capacity, ptr, subdata.count, nil, COMPRESSION_ZLIB)
         return Data(bytes: buffer, count: size)
     }
 }

--- a/packages/datadog_session_replay/example/ios/RunnerTests/SessionReplayTestContainer.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/SessionReplayTestContainer.swift
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Testing
+
+/// Parent suite that serializes all tests sharing `FlutterSessionReplay` global static state.
+///
+/// Both `DatadogSessionReplayPluginTests` and `FlutterSessionReplayBridgeTests` mutate the same
+/// static properties on `FlutterSessionReplay`. Without a shared serialization boundary their
+/// `init()`/`deinit` calls to `shutdown()` can race with a sibling suite's test body, producing
+/// flaky failures. Nesting both suites here under `.serialized` prevents any two tests from those
+/// suites running concurrently.
+@Suite(.serialized)
+enum SessionReplayTestContainer {}


### PR DESCRIPTION
### What and why?
Three fixes for flakey tests:

The RUM plugin test checking reporting LongTasks could fail with float precision issues, so allow it to check with some amount of tolerance. Also use a specific value instead of DateTime.now

Fix a potential for an out of bounds read in zlib decode that could affect any test if they were run in parallel.

Fix an issue where some Session Replay tests that relied on shared state are serialized so they don't overlap

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
