### PR TITLE
chore: Changes related to releasing datadog_webview_tracking 3.1.0

### DIFF
--- a/packages/datadog_webview_tracking/CHANGELOG.md
+++ b/packages/datadog_webview_tracking/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.0
+
+* Support new versions of webview_flutter and Flutter 3.44. See [#950](https://github.com/DataDog/dd-sdk-flutter/issues/950)
+
 ## 3.0.3
 
 * Loosen constraints on `webview_flutter_android`. See [#999](https://github.com/DataDog/dd-sdk-flutter/issues/999)

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_webview_tracking
 description: A package for tracking Datadog sessions in a webview
-version: 3.1.0
+version: 3.2.0
 homepage: http://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 


### PR DESCRIPTION
### What and why?

New version of `datadog_webview_tracking` to support new versions of `webview_flutter` and Flutter 3.44.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
