### PR TITLE
test(android): mock RUM enable in plugin tests

### DIFF
--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -263,7 +263,7 @@ class DatadogRumPluginTest {
         forge: Forge
     ) {
         // GIVEN
-        mockkStatic(Rum::class)
+        mockRumEnable()
         val applicationId = forge.aString()
         val config = mapOf(
             "applicationId" to applicationId,
@@ -295,6 +295,7 @@ class DatadogRumPluginTest {
         forge: Forge
     ) {
         // GIVEN
+        mockRumEnable()
         mockkStatic(Log::class)
         Datadog.setVerbosity(Log.INFO)
 
@@ -335,6 +336,7 @@ class DatadogRumPluginTest {
         forge: Forge
     ) {
         // GIVEN
+        mockRumEnable()
         mockkStatic(Log::class)
         Datadog.setVerbosity(Log.INFO)
 
@@ -373,6 +375,13 @@ class DatadogRumPluginTest {
         verify(exactly = 1) {
             Log.e(DATADOG_FLUTTER_TAG, MESSAGE_INVALID_RUM_REINITIALIZATION)
         }
+    }
+
+    private fun mockRumEnable() {
+        mockkStatic(Rum::class)
+        every { Rum.enable(any()) } returns Unit
+        mockkStatic(GlobalRumMonitor::class)
+        every { GlobalRumMonitor.get() } returns monitorProxy
     }
 
     @Test


### PR DESCRIPTION
## Motivation

The Android unit test job can fail on `DatadogRumPluginTest` because the RUM enable-path tests invoke `Rum.enable(...)` without a fully initialized Android Datadog runtime. On fresh `origin/develop` at `e56c8f1b`, the focused test command completed with 35 tests and 3 failures, all `UninitializedPropertyAccessException: lateinit property appContext has not been initialized` from the three RUM enable/reinitialization tests.

This also reproduces in CI on the flags persistence PR:

- Source PR: [DataDog/dd-sdk-flutter#1051](https://github.com/DataDog/dd-sdk-flutter/pull/1051)
- Failing GitLab job: [dd-sdk-flutter job 1798372035](https://gitlab.ddbuild.io/DataDog/dd-sdk-flutter/-/jobs/1798372035)

That CI job runs `melos run unit_test:android`, which executes `cd example/android && ./gradlew --stacktrace --console=plain test`. The attached job output shows `71 tests completed, 3 failed` and the failure occurring in `:datadog_flutter_plugin:testDebugUnitTest`, including from the `datadog_webview_tracking` package execution path.

## Changes

This PR keeps the fix scoped to the Android test harness. The affected tests now use a small `mockRumEnable()` helper that stubs `Rum.enable(any())` and returns the existing `MockRumMonitor` from `GlobalRumMonitor.get()`.

## Decisions

Production RUM plugin code is unchanged because the failing path is a unit-test setup issue: these tests are validating Flutter method-channel behavior and reinitialization logging, not native RUM SDK startup. The existing `afterEach` cleanup already un-mocks `Rum` and `GlobalRumMonitor`, so the helper fits the test class' current lifecycle.

## Validation

Failing baseline on fresh `origin/develop` before the patch:

```bash
./gradlew --console=plain :datadog_flutter_plugin:testDebugUnitTest --tests 'com.datadoghq.flutter.DatadogRumPluginTest'
# 35 tests completed, 3 failed
```

Passing after this patch:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH" \
./gradlew --rerun-tasks --stacktrace --console=plain :datadog_flutter_plugin:testDebugUnitTest --tests 'com.datadoghq.flutter.DatadogRumPluginTest'
# BUILD SUCCESSFUL, 35 DatadogRumPluginTest tests passed
```

Also ran `git diff --check`.
