### PR TITLE
feat(rum): parse route query string into view.url and url_query attributes

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -15,9 +15,8 @@ class RumViewInfo {
 
   /// An optional path or URL for the view, reported as `view.url`. When this
   /// contains a query string (for example `/products?category=shoes`), Datadog
-  /// parses it server-side into the standard `@view.url_query.*` facets, the
-  /// same way it does for the browser SDK. When `null`, [name] is used as the
-  /// key and the previous behavior is preserved.
+  /// derives the standard `@view.url_query.*` facets from it server-side. When
+  /// `null`, [name] is used as the view key.
   final String? path;
 
   /// Any attributes to be associated with this view
@@ -35,8 +34,7 @@ class RumViewInfo {
   String get viewKey => path ?? name;
 
   /// The display name passed to [DatadogRum.startView]. Returns `null` when no
-  /// distinct [path] is provided, preserving the original behavior where the
-  /// view key and name were identical.
+  /// distinct [path] is provided, so the view key is used as the name.
   String? get viewName => path != null ? name : null;
 }
 
@@ -66,15 +64,12 @@ RumViewInfo? defaultViewInfoExtractor(Route<dynamic> route) {
 /// it contains.
 ///
 /// When [routeName] includes a query string (for example
-/// `/products?category=shoes&id=123`):
-///   * `view.url` carries the full path + query string, letting Datadog derive
-///     the standard `@view.url_query.*` facets server-side (as it does on web);
-///   * each query parameter is additionally reported as a `url_query.<key>`
-///     view attribute (surfaced as `@context.url_query.<key>`), a guaranteed
-///     fallback that does not depend on backend URL parsing.
+/// `/products?category=shoes&id=123`) the `view.url` will carry the full path +
+/// query string, which Datadog will add to its standard `@view.url_query.*` facets.
+/// Additionally, each parameter will be reported as a `url_query.<key>` view
+/// attribute, accessible through `@context.url_query.<key>`.
 ///
-/// Routes without a query string keep the previous behavior exactly: the name
-/// is used as-is and no extra attributes are added.
+/// Routes without a query string use the name as-is and add no extra attributes.
 RumViewInfo rumViewInfoFromRouteName(String routeName) {
   if (!routeName.contains('?')) {
     return RumViewInfo(name: routeName);

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -66,8 +66,6 @@ RumViewInfo? defaultViewInfoExtractor(Route<dynamic> route) {
 /// When [routeName] includes a query string (for example
 /// `/products?category=shoes&id=123`) the `view.url` will carry the full path +
 /// query string, which Datadog will add to its standard `@view.url_query.*` facets.
-/// Additionally, each parameter will be reported as a `url_query.<key>` view
-/// attribute, accessible through `@context.url_query.<key>`.
 ///
 /// Routes without a query string use the name as-is and add no extra attributes.
 RumViewInfo rumViewInfoFromRouteName(String routeName) {
@@ -89,17 +87,9 @@ RumViewInfo rumViewInfoFromRouteName(String routeName) {
   // The path without the query string, used as the human-readable view name.
   final viewName = uri.path.isNotEmpty ? uri.path : routeName.split('?').first;
 
-  // Decompose the query string into per-parameter attributes. Multi-valued
-  // parameters (for example `?id=1&id=2`) are reported as a list.
-  final attributes = <String, Object?>{};
-  uri.queryParametersAll.forEach((key, values) {
-    attributes['url_query.$key'] = values.length == 1 ? values.first : values;
-  });
-
   return RumViewInfo(
     name: viewName.isNotEmpty ? viewName : routeName,
     path: routeName,
-    attributes: attributes,
   );
 }
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/navigation_observer.dart
@@ -10,10 +10,14 @@ import '../../datadog_internal.dart';
 
 /// Information about a View that will be passed to [DatadogRum.startView]
 class RumViewInfo {
-  /// The name of the view
+  /// The name of the view, reported as `view.name` in the RUM explorer.
   final String name;
 
-  /// A path to the view
+  /// An optional path or URL for the view, reported as `view.url`. When this
+  /// contains a query string (for example `/products?category=shoes`), Datadog
+  /// parses it server-side into the standard `@view.url_query.*` facets, the
+  /// same way it does for the browser SDK. When `null`, [name] is used as the
+  /// key and the previous behavior is preserved.
   final String? path;
 
   /// Any attributes to be associated with this view
@@ -24,6 +28,16 @@ class RumViewInfo {
     this.path,
     this.attributes = const {},
   });
+
+  /// The key that identifies this view to RUM, reported as `view.url`. Prefers
+  /// [path] (which may include a query string, so the backend can derive
+  /// `@view.url_query.*`) and falls back to [name].
+  String get viewKey => path ?? name;
+
+  /// The display name passed to [DatadogRum.startView]. Returns `null` when no
+  /// distinct [path] is provided, preserving the original behavior where the
+  /// view key and name were identical.
+  String? get viewName => path != null ? name : null;
 }
 
 /// A function that can be used to supply custom information to
@@ -36,16 +50,62 @@ class RumViewInfo {
 typedef ViewInfoExtractor = RumViewInfo? Function(Route<dynamic> route);
 
 /// The function that provides the default route naming behavior for
-/// [DatadogNavigationObserver]. If the supplied route is a PageRoute and contains
-/// a name, it returns a [RumViewInfo] with the supplied name. Otherwise it returns
-/// `null`.
+/// [DatadogNavigationObserver]. If the supplied route contains a name, it
+/// returns a [RumViewInfo] built from that name via [rumViewInfoFromRouteName].
+/// Otherwise it returns `null`.
 RumViewInfo? defaultViewInfoExtractor(Route<dynamic> route) {
-  var name = route.settings.name;
-  if (name != null) {
-    return RumViewInfo(name: name);
+  final name = route.settings.name;
+  if (name == null) {
+    return null;
   }
 
-  return null;
+  return rumViewInfoFromRouteName(name);
+}
+
+/// Builds a [RumViewInfo] from a raw route name, parsing any URL query string
+/// it contains.
+///
+/// When [routeName] includes a query string (for example
+/// `/products?category=shoes&id=123`):
+///   * `view.url` carries the full path + query string, letting Datadog derive
+///     the standard `@view.url_query.*` facets server-side (as it does on web);
+///   * each query parameter is additionally reported as a `url_query.<key>`
+///     view attribute (surfaced as `@context.url_query.<key>`), a guaranteed
+///     fallback that does not depend on backend URL parsing.
+///
+/// Routes without a query string keep the previous behavior exactly: the name
+/// is used as-is and no extra attributes are added.
+RumViewInfo rumViewInfoFromRouteName(String routeName) {
+  if (!routeName.contains('?')) {
+    return RumViewInfo(name: routeName);
+  }
+
+  final Uri uri;
+  try {
+    uri = Uri.parse(routeName);
+  } on FormatException {
+    return RumViewInfo(name: routeName);
+  }
+
+  if (uri.queryParameters.isEmpty) {
+    return RumViewInfo(name: routeName);
+  }
+
+  // The path without the query string, used as the human-readable view name.
+  final viewName = uri.path.isNotEmpty ? uri.path : routeName.split('?').first;
+
+  // Decompose the query string into per-parameter attributes. Multi-valued
+  // parameters (for example `?id=1&id=2`) are reported as a list.
+  final attributes = <String, Object?>{};
+  uri.queryParametersAll.forEach((key, values) {
+    attributes['url_query.$key'] = values.length == 1 ? values.first : values;
+  });
+
+  return RumViewInfo(
+    name: viewName.isNotEmpty ? viewName : routeName,
+    path: routeName,
+    attributes: attributes,
+  );
 }
 
 /// This class can be added to a MaterialApp to automatically start and stop RUM
@@ -125,9 +185,10 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>>
             }
           });
         } else {
-          datadogSdk.rum?.startView(viewInfo.name, null, viewInfo.attributes);
+          datadogSdk.rum?.startView(
+              viewInfo.viewKey, viewInfo.viewName, viewInfo.attributes);
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            datadogSdk.rum?.markViewFirstBuildComplete(viewInfo.name);
+            datadogSdk.rum?.markViewFirstBuildComplete(viewInfo.viewKey);
           });
         }
       } else {
@@ -138,7 +199,7 @@ class DatadogNavigationObserver extends RouteObserver<ModalRoute<dynamic>>
 
   void _stopView(RumViewInfo? viewInfo) {
     if (viewInfo != null) {
-      datadogSdk.rum?.stopView(viewInfo.name);
+      datadogSdk.rum?.stopView(viewInfo.viewKey);
     }
     _currentView = null;
   }
@@ -280,9 +341,9 @@ mixin DatadogRouteAwareMixin<T extends StatefulWidget> on State<T>, RouteAware {
       final info = rumViewInfo;
       final rum = _routeObserver?.datadogSdk.rum;
       if (rum != null) {
-        rum.startView(info.name, null, info.attributes);
+        rum.startView(info.viewKey, info.viewName, info.attributes);
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          rum.markViewFirstBuildComplete(info.name);
+          rum.markViewFirstBuildComplete(info.viewKey);
         });
       }
     }
@@ -291,7 +352,7 @@ mixin DatadogRouteAwareMixin<T extends StatefulWidget> on State<T>, RouteAware {
   void _stopView() {
     if (_routeObserver != null) {
       final info = rumViewInfo;
-      _routeObserver?.datadogSdk.rum?.stopView(info.name);
+      _routeObserver?.datadogSdk.rum?.stopView(info.viewKey);
     }
   }
 }

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -267,7 +267,8 @@ void main() {
   });
 
   group('rumViewInfoFromRouteName', () {
-    test('route without a query string keeps the previous behavior', () {
+    test('route without a query string uses the name as-is with no attributes',
+        () {
       final info = rumViewInfoFromRouteName('/home');
       expect(info.name, '/home');
       expect(info.path, isNull);

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -244,6 +244,65 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
+  testWidgets('pushing route with query string sends url and url_query',
+      (WidgetTester tester) async {
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await buildAndNavigateTo(
+      tester: tester,
+      routeName: '/products?category=shoes&id=123',
+      builder: (_) => Container(),
+    );
+
+    // view.url (the RUM key) carries the full path + query string so Datadog
+    // can derive the standard @view.url_query.* facets server-side, while
+    // view.name stays clean. Each query parameter is also sent as a
+    // url_query.* attribute (the @context.url_query.* fallback).
+    verify(() => mockRum.startView(
+          '/products?category=shoes&id=123',
+          '/products',
+          {'url_query.category': 'shoes', 'url_query.id': '123'},
+        ));
+    verify(() =>
+        mockRum.markViewFirstBuildComplete('/products?category=shoes&id=123'));
+  });
+
+  group('rumViewInfoFromRouteName', () {
+    test('route without a query string keeps the previous behavior', () {
+      final info = rumViewInfoFromRouteName('/home');
+      expect(info.name, '/home');
+      expect(info.path, isNull);
+      expect(info.viewKey, '/home');
+      expect(info.viewName, isNull);
+      expect(info.attributes, isEmpty);
+    });
+
+    test('route with a query string populates url and url_query attributes',
+        () {
+      final info = rumViewInfoFromRouteName('/products?category=shoes&id=123');
+      expect(info.name, '/products');
+      expect(info.path, '/products?category=shoes&id=123');
+      // view.url includes the query; view.name is the clean path.
+      expect(info.viewKey, '/products?category=shoes&id=123');
+      expect(info.viewName, '/products');
+      expect(info.attributes, {
+        'url_query.category': 'shoes',
+        'url_query.id': '123',
+      });
+    });
+
+    test('multi-valued query parameter is reported as a list', () {
+      final info = rumViewInfoFromRouteName('/search?tag=a&tag=b');
+      expect(info.attributes['url_query.tag'], ['a', 'b']);
+    });
+
+    test('empty query string falls back to the plain name', () {
+      final info = rumViewInfoFromRouteName('/foo?');
+      expect(info.path, isNull);
+      expect(info.viewKey, '/foo?');
+      expect(info.attributes, isEmpty);
+    });
+  });
+
   testWidgets('pushing to route using mixin calls startView',
       (WidgetTester tester) async {
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);

--- a/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/navigation_observer_test.dart
@@ -244,7 +244,7 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
-  testWidgets('pushing route with query string sends url and url_query',
+  testWidgets('pushing route with query string sends url',
       (WidgetTester tester) async {
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     await buildAndNavigateTo(
@@ -255,13 +255,9 @@ void main() {
 
     // view.url (the RUM key) carries the full path + query string so Datadog
     // can derive the standard @view.url_query.* facets server-side, while
-    // view.name stays clean. Each query parameter is also sent as a
-    // url_query.* attribute (the @context.url_query.* fallback).
-    verify(() => mockRum.startView(
-          '/products?category=shoes&id=123',
-          '/products',
-          {'url_query.category': 'shoes', 'url_query.id': '123'},
-        ));
+    // view.name stays clean.
+    verify(() =>
+        mockRum.startView('/products?category=shoes&id=123', '/products', {}));
     verify(() =>
         mockRum.markViewFirstBuildComplete('/products?category=shoes&id=123'));
   });
@@ -277,23 +273,21 @@ void main() {
       expect(info.attributes, isEmpty);
     });
 
-    test('route with a query string populates url and url_query attributes',
-        () {
+    test('route with a query string populates url', () {
       final info = rumViewInfoFromRouteName('/products?category=shoes&id=123');
       expect(info.name, '/products');
       expect(info.path, '/products?category=shoes&id=123');
       // view.url includes the query; view.name is the clean path.
       expect(info.viewKey, '/products?category=shoes&id=123');
       expect(info.viewName, '/products');
-      expect(info.attributes, {
-        'url_query.category': 'shoes',
-        'url_query.id': '123',
-      });
+      expect(info.attributes, isEmpty);
     });
 
-    test('multi-valued query parameter is reported as a list', () {
+    test('multi-valued query parameter stays in the url', () {
       final info = rumViewInfoFromRouteName('/search?tag=a&tag=b');
-      expect(info.attributes['url_query.tag'], ['a', 'b']);
+      expect(info.path, '/search?tag=a&tag=b');
+      expect(info.viewKey, '/search?tag=a&tag=b');
+      expect(info.attributes, isEmpty);
     });
 
     test('empty query string falls back to the plain name', () {


### PR DESCRIPTION
DatadogNavigationObserver only used `route.settings.name` as the view identifier, so mobile RUM views never populated `url_query` facets the way the browser SDK does.

`defaultViewInfoExtractor` now parses a query string in the route name:
- the full path+query is reported as `view.url` so Datadog can derive the standard `@view.url_query.*` facets server-side (as on web)
- each query parameter is also added as a `url_query.<key>` view attribute (`@context.url_query.<key>`) as a guaranteed fallback

Routes without a query string keep the previous behavior exactly.

### What and why?

`DatadogNavigationObserver` identifies RUM views solely by `route.settings.name`. On the browser SDK, Datadog derives the `@view.url_query.*` facets from the page URL, but on mobile a view's `url` is just the route name with no query component — so those facets are never available for mobile views.

This PR teaches the default view extractor to understand query strings in route names. Apps that navigate with query-bearing routes (for example `Navigator.pushNamed(context, '/products?category=shoes&id=123')`) can then search, filter, and group mobile RUM views by individual query parameters — the same workflow already available on web.

### How?

`defaultViewInfoExtractor` now delegates to a new `rumViewInfoFromRouteName` helper:

- **No query string** → behavior is unchanged: the route name is used as-is, with no extra attributes.
- **Has a query string** (for example `/products?category=shoes&id=123`):
  - `view.url` carries the full path + query (`/products?category=shoes&id=123`), letting Datadog derive the standard `@view.url_query.*` facets server-side.
  - `view.name` is the clean path (`/products`).
  - Each query parameter is additionally emitted as a `url_query.<key>` view attribute (surfaced as `@context.url_query.<key>`), a guaranteed fallback that does not rely on backend URL parsing. Multi-valued parameters (`?id=1&id=2`) are reported as a list.

`RumViewInfo` gains `viewKey` (→ `view.url`) and `viewName` (→ `view.name`) getters so `startView` / `stopView` / `markViewFirstBuildComplete` consistently key off the query-bearing URL. When there is no distinct path, `viewName` is `null`, keeping the previous `startView(name, null, attributes)` call identical. The same parsing also flows through `DatadogRouteAwareMixin`.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests
- [ ] This pull request references a Github or JIRA issue
