### PR TITLE
fix(sr): Ensure proper exception handling in ImageRecorder.

### DIFF
--- a/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
+++ b/packages/datadog_session_replay/lib/src/capture/element_recorders/image_recorder.dart
@@ -3,7 +3,6 @@
 // Copyright 2025-Present Datadog, Inc.
 
 import 'dart:async' show TimeoutException;
-
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
@@ -222,7 +221,7 @@ class ImageRecorder implements ElementRecorder {
       scaled = await _downscale(image, scaledWidth, scaledHeight)
           .timeout(_downscaleTimeout);
       _downscalingCircuitBreaker.recordSuccess();
-      return _persistImageAsResourceNode(
+      return await _persistImageAsResourceNode(
         elementId,
         attributes,
         sourceImageForKeyGen: image,


### PR DESCRIPTION
### What and why?

New versions of Flutter warn about not awaiting a Future in a `try` block as this can lead to the future not properly reporting failures into the `catch`. `ImageRecorder` has an instance of this in the downscaling where it returns the future out of the `try` without awaiting it, which is valid but would prevent proper handling in `_captureImage` if `_persistImageAsResourceNode` throws for any reason.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
