### PR TITLE
chore(datadog_flags): bump next development version

### DIFF
--- a/packages/datadog_flags/lib/src/version.dart
+++ b/packages/datadog_flags/lib/src/version.dart
@@ -3,4 +3,4 @@
 // developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-const ddPackageVersion = '1.0.0';
+const ddPackageVersion = '1.1.0';

--- a/packages/datadog_flags/pubspec.yaml
+++ b/packages/datadog_flags/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_flags
 description: Datadog Feature Flags and Experimentation SDK for client applications.
-version: 1.0.0
+version: 1.1.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 issue_tracker: https://github.com/DataDog/dd-sdk-flutter/issues

--- a/packages/datadog_flags/test/datadog_flags_test.dart
+++ b/packages/datadog_flags/test/datadog_flags_test.dart
@@ -10,6 +10,7 @@ import 'package:datadog_flags/datadog_flags.dart';
 import 'package:datadog_flags/src/evaluation_aggregator.dart';
 import 'package:datadog_flags/src/exposure_logger.dart';
 import 'package:datadog_flags/src/flags_store.dart';
+import 'package:datadog_flags/src/sdk_metadata.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -344,7 +345,7 @@ void main() {
       expect(request.headers['Content-Type'], 'text/plain;charset=UTF-8');
       expect(request.headers['DD-API-KEY'], 'client-token');
       expect(request.headers['DD-EVP-ORIGIN'], 'dart-client');
-      expect(request.headers['DD-EVP-ORIGIN-VERSION'], '1.0.0');
+      expect(request.headers['DD-EVP-ORIGIN-VERSION'], datadogFlagsSdkVersion);
       expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
 
       final exposure = _exposureEvents(request).single;
@@ -755,7 +756,7 @@ void main() {
       expect(request.headers['Content-Type'], 'application/json');
       expect(request.headers['DD-API-KEY'], 'client-token');
       expect(request.headers['DD-EVP-ORIGIN'], 'dart-client');
-      expect(request.headers['DD-EVP-ORIGIN-VERSION'], '1.0.0');
+      expect(request.headers['DD-EVP-ORIGIN-VERSION'], datadogFlagsSdkVersion);
       expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
 
       final body = jsonDecode(request.body) as Map<String, Object?>;

--- a/packages/datadog_flags/test/precompute_core_test.dart
+++ b/packages/datadog_flags/test/precompute_core_test.dart
@@ -9,6 +9,7 @@ import 'package:datadog_flags/datadog_flags.dart';
 import 'package:datadog_flags/src/assignment.dart';
 import 'package:datadog_flags/src/flag_assignments_fetcher.dart';
 import 'package:datadog_flags/src/flags_error.dart';
+import 'package:datadog_flags/src/sdk_metadata.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -63,7 +64,7 @@ void main() {
               'env': {'dd_env': 'staging'},
               'source': {
                 'sdk_name': 'dd-sdk-dart',
-                'sdk_version': '1.0.0',
+                'sdk_version': datadogFlagsSdkVersion,
               },
               'subject': {
                 'targeting_key': 'precomputed-user',
@@ -123,7 +124,7 @@ void main() {
             'env': {'dd_env': 'dev'},
             'source': {
               'sdk_name': 'dd-sdk-dart',
-              'sdk_version': '1.0.0',
+              'sdk_version': datadogFlagsSdkVersion,
             },
             'subject': {
               'targeting_key': '',


### PR DESCRIPTION
## Motivation

After preparing `datadog_flags` 1.0.0 for release, the package on `develop` should move forward to the next development version.

## Changes

This bumps `packages/datadog_flags` from `1.0.0` to `1.1.0`, including the generated SDK version constant used by the package.

## Decisions

This PR is intentionally separate from the release artifact branch. The release branch stays pinned to `1.0.0` for validation, tagging, and publishing, while this PR keeps future development moving forward on `develop`.
