### PR TITLE
fix(ci): Don't warn on missing SourceLines annotation.

### DIFF
--- a/packages/datadog_flutter_plugin/android/consumer-rules.pro
+++ b/packages/datadog_flutter_plugin/android/consumer-rules.pro
@@ -9,3 +9,4 @@
 -keep class com.datadoghq.flutter.DatadogRumPlugin$Companion { *; }
 -keep class com.datadoghq.flutter.DatadogRumEventMapper { *; }
 -keep class com.datadoghq.flutter.DatadogRumEventMapper$EventMapper { *; }
+-dontwarn datadog.compiler.annotations.*


### PR DESCRIPTION
### What and why?

Provide the same fix as https://github.com/DataDog/dd-sdk-android/pull/3601 for our builds.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
