### PR TITLE
Add trackWatchdogTerminations to DatadogRumConfiguration

### DIFF
--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -214,6 +214,17 @@ class DatadogRumPluginTests: XCTestCase {
         XCTAssertEqual(config?.appHangThreshold, appHangThreshold)
     }
 
+    func testRumConfiguration_WithTrackWatchdogTerminations_IsSetCorrectly() {
+        let trackWatchdogTerminations = Bool.random()
+        let encoded: [String: Any?] = [
+            "applicationId": "fake-application-id",
+            "trackWatchdogTerminations": trackWatchdogTerminations
+        ]
+
+        let config = RUM.Configuration.init(fromEncoded: encoded)
+        XCTAssertEqual(config?.trackWatchdogTerminations, trackWatchdogTerminations)
+    }
+
     func testRumConfiguration_WithInitialResourceThreshold_IsSetCorrectly() throws {
         let initialResourceThreshold = Double.mockRandom()
         let encoded: [String: Any?] = [

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
@@ -28,6 +28,10 @@ public extension RUM.Configuration {
             self.appHangThreshold = appHangThreshold
         }
 
+        if let trackWatchdogTerminations = (encoded["trackWatchdogTerminations"] as? NSNumber)?.boolValue {
+            self.trackWatchdogTerminations = trackWatchdogTerminations
+        }
+
         if let customEndpoint = encoded["customEndpoint"] as? String {
             self.customEndpoint = URL(string: customEndpoint)
         }

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_configuration.dart
@@ -164,6 +164,18 @@ class DatadogRumConfiguration {
   /// Defaults to disabled (`null`).
   double? appHangThreshold;
 
+  /// Whether to track application terminations by the iOS watchdog as RUM
+  /// errors.
+  ///
+  /// This option is specific to iOS. Watchdog terminations require Crash
+  /// Reporting to be enabled ([DatadogConfiguration.nativeCrashReportEnabled])
+  /// and are reported on the next application launch. Read more about
+  /// watchdog terminations at
+  /// https://developer.apple.com/documentation/xcode/addressing-watchdog-terminations
+  ///
+  /// Defaults to `false`.
+  bool trackWatchdogTerminations;
+
   /// Enables collection of anonymous user ID across sessions.
   ///
   /// When enabled, the SDK generates a unique, non-personal anonymous user ID that is persisted across
@@ -243,6 +255,7 @@ class DatadogRumConfiguration {
     this.reportFlutterPerformance = false,
     this.trackNonFatalAnrs,
     this.appHangThreshold,
+    this.trackWatchdogTerminations = false,
     this.trackAnonymousUser = true,
     this.trackBackgroundEvents = false,
     this.initialResourceThreshold = 0.1,
@@ -271,6 +284,7 @@ class DatadogRumConfiguration {
       'reportFlutterPerformance': reportFlutterPerformance,
       'trackNonFatalAnrs': trackNonFatalAnrs,
       'appHangThreshold': appHangThreshold,
+      'trackWatchdogTerminations': trackWatchdogTerminations,
       'trackAnonymousUser': trackAnonymousUser,
       'trackBackgroundEvents': trackBackgroundEvents,
       'initialResourceThreshold': initialResourceThreshold,

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_test.dart
@@ -96,6 +96,7 @@ void main() {
     expect(configuration.reportFlutterPerformance, false);
     expect(configuration.trackNonFatalAnrs, isNull);
     expect(configuration.appHangThreshold, isNull);
+    expect(configuration.trackWatchdogTerminations, false);
     expect(configuration.trackAnonymousUser, true);
     expect(configuration.initialResourceThreshold, 0.1);
   });
@@ -116,6 +117,7 @@ void main() {
       vitalUpdateFrequency: vitalUpdateFrequency,
       trackNonFatalAnrs: false,
       appHangThreshold: 0.332,
+      trackWatchdogTerminations: true,
       trackAnonymousUser: false,
       trackBackgroundEvents: true,
       initialResourceThreshold: 1.23,
@@ -133,6 +135,7 @@ void main() {
     expect(encoded['trackAnonymousUser'], false);
     expect(encoded['trackBackgroundEvents'], true);
     expect(encoded['appHangThreshold'], 0.332);
+    expect(encoded['trackWatchdogTerminations'], true);
     expect(encoded['customEndpoint'], customEndpoint);
     expect(encoded['initialResourceThreshold'], 1.23);
   });


### PR DESCRIPTION
### What and why?

Exposes the iOS SDK's `RUM.Configuration.trackWatchdogTerminations` flag from the Flutter plugin. Watchdog terminations (OS-initiated kills for OOM / unresponsiveness) are supported by dd-sdk-ios since 2.14.0, but the Flutter plugin currently has no way to enable them. This leaves Flutter apps unable to track a whole error class that native iOS apps can.

### How?

Mirrors the existing `appHangThreshold` plumbing

- No Android change — watchdog termination is an iOS-only concept.
- Docs note the iOS-only scope, the Crash Reporting prerequisite, and next-launch reporting semantics.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue