### PR TITLE
feat!: Rename all "featureOperations" to new "operations" naming.

### DIFF
--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -12,8 +12,8 @@ import 'package:flutter/material.dart';
 import '../main.dart';
 
 const fakeRootUrl = 'https://fake_url';
-const onboardingFeatureOperation = 'Onboarding';
-const firstDownloadFeatureOperation = 'First Screen Download';
+const onboardingOperation = 'Onboarding';
+const firstDownloadOperation = 'First Screen Download';
 
 class RumManualInstrumentationScenario extends StatefulWidget {
   const RumManualInstrumentationScenario({Key? key}) : super(key: key);
@@ -65,8 +65,8 @@ class _RumManualInstrumentationScenarioState
   @override
   void didPush() {
     DatadogSdk.instance.rum?.startView(_viewKey);
-    DatadogSdk.instance.rum?.startFeatureOperation(
-      onboardingFeatureOperation,
+    DatadogSdk.instance.rum?.startOperation(
+      onboardingOperation,
       operationKey: 'key_a',
       attributes: {'start_state': 1},
     );
@@ -113,7 +113,7 @@ class _RumManualInstrumentationScenarioState
 
   void _simulateResourceDownload() async {
     final rum = DatadogSdk.instance.rum;
-    rum?.startFeatureOperation(firstDownloadFeatureOperation);
+    rum?.startOperation(firstDownloadOperation);
 
     rum?.addTiming('first-interaction');
     rum?.addAction(RumActionType.tap, 'Tapped Download');
@@ -140,10 +140,7 @@ class _RumManualInstrumentationScenarioState
       'ErrorLoading',
     );
 
-    rum?.failFeatureOperation(
-      firstDownloadFeatureOperation,
-      RumFeatureOperationFailureReason.error,
-    );
+    rum?.failOperation(firstDownloadOperation, RumOperationFailureReason.error);
 
     setState(() {
       _contentReady = true;
@@ -301,8 +298,8 @@ class _RumManualInstrumentation2State extends State<RumManualInstrumentation2>
 
   void _onNextTapped() {
     DatadogSdk.instance.rum?.addAction(RumActionType.tap, 'Next Screen');
-    DatadogSdk.instance.rum?.succeedFeatureOperation(
-      onboardingFeatureOperation,
+    DatadogSdk.instance.rum?.succeedOperation(
+      onboardingOperation,
       operationKey: 'key_a',
     );
     Navigator.push<void>(

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -29,7 +29,7 @@ import 'package:datadog_flutter_plugin_platform_interface/datadog_flutter_plugin
         ResourceHeadersExtractor,
         RumActionType,
         RumErrorSource,
-        RumFeatureOperationFailureReason,
+        RumOperationFailureReason,
         RumHttpMethod,
         RumResourceType,
         TraceContextInjection;
@@ -40,7 +40,7 @@ export 'package:datadog_flutter_plugin_platform_interface/datadog_flutter_plugin
     show
         RumActionType,
         RumErrorSource,
-        RumFeatureOperationFailureReason,
+        RumOperationFailureReason,
         RumHttpMethod,
         RumResourceType;
 
@@ -591,22 +591,22 @@ class DatadogRum {
     });
   }
 
-  /// Starts a feature operation with the given [name].
+  /// Starts an operation with the given [name].
   ///
   /// You can also provide an optional [operationKey], which allows you to track
   /// multiple operations of the same [name]. For example, multiple network
   /// requests for the same URL.
   ///
-  /// Additional custom attributes can be attached to this feature operation
+  /// Additional custom attributes can be attached to this operation
   /// through [attributes].
-  void startFeatureOperation(
+  void startOperation(
     String name, {
     String? operationKey,
     Map<String, Object?> attributes = const {},
   }) {
-    wrap('rum.startFeatureOperation', logger, attributes, () {
+    wrap('rum.startOperation', logger, attributes, () {
       final currentTime = timeProvider.now();
-      return _platform.startFeatureOperation(
+      return _platform.startOperation(
         currentTime,
         name,
         operationKey,
@@ -615,22 +615,22 @@ class DatadogRum {
     });
   }
 
-  /// Finishes a feature operation with the given [name] with a successful
+  /// Finishes an operation with the given [name] with a successful
   /// status.
   ///
-  /// If you provided an [operationKey] to [startFeatureOperation], the same
+  /// If you provided an [operationKey] to [startOperation], the same
   /// [operationKey] should be provided here.
   ///
   /// Additional custom attributes such as additional result data, can be
-  /// attached to this feature operation through [attributes].
-  void succeedFeatureOperation(
+  /// attached to this operation through [attributes].
+  void succeedOperation(
     String name, {
     String? operationKey,
     Map<String, Object?> attributes = const {},
   }) {
-    wrap('rum.succeedFeatureOperation', logger, attributes, () {
+    wrap('rum.succeedOperation', logger, attributes, () {
       final currentTime = timeProvider.now();
-      return _platform.succeedFeatureOperation(
+      return _platform.succeedOperation(
         currentTime,
         name,
         operationKey,
@@ -639,23 +639,23 @@ class DatadogRum {
     });
   }
 
-  /// Finishes a feature operation with the given [name] with a failure
+  /// Finishes an operation with the given [name] with a failure
   /// status and the given [failureReason].
   ///
-  /// If you provided an [operationKey] to [startFeatureOperation], the same
+  /// If you provided an [operationKey] to [startOperation], the same
   /// [operationKey] should be provided here.
   ///
   /// Additional custom attributes such as additional result data, can be
-  /// attached to this feature operation through [attributes].
-  void failFeatureOperation(
+  /// attached to this operation through [attributes].
+  void failOperation(
     String name,
-    RumFeatureOperationFailureReason failureReason, {
+    RumOperationFailureReason failureReason, {
     String? operationKey,
     Map<String, Object?> attributes = const {},
   }) {
-    wrap('rum.failFeatureOperation', logger, attributes, () {
+    wrap('rum.failOperation', logger, attributes, () {
       final currentTime = timeProvider.now();
-      return _platform.failFeatureOperation(
+      return _platform.failOperation(
         currentTime,
         name,
         operationKey,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -24,8 +24,8 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
+import com.datadog.android.rum.operations.FailureReason
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -132,9 +132,9 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
                 "reportLongTask" -> reportLongTask(call, result)
                 "updatePerformanceMetrics" -> updatePerformanceMetrics(call, result)
                 "addFeatureFlagEvaluation" -> addFeatureFlagEvaluation(call, result)
-                "startFeatureOperation" -> startFeatureOperation(call, result)
-                "succeedFeatureOperation" -> succeedFeatureOperation(call, result)
-                "failFeatureOperation" -> failFeatureOperation(call, result)
+                "startOperation" -> startOperation(call, result)
+                "succeedOperation" -> succeedOperation(call, result)
+                "failOperation" -> failOperation(call, result)
                 "setInternalViewAttribute" -> setInternalViewAttribute(call, result)
                 "stopSession" -> stopSession(call, result)
                 else -> {
@@ -498,38 +498,38 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
         }
     }
 
-    private fun startFeatureOperation(call: MethodCall, result: Result) {
+    private fun startOperation(call: MethodCall, result: Result) {
         val name = call.argument<String>(PARAM_NAME)
         val operationName = call.argument<String>(PARAM_OPERATION_KEY)
         val attributes = call.argument<Map<String, Any?>>(PARAM_ATTRIBUTES)
         if (name != null && attributes != null) {
-            rum?.startFeatureOperation(name, operationName, attributes)
+            rum?.startOperation(name, operationName, attributes = attributes)
             result.success(null)
         } else {
             result.missingParameter(call.method)
         }
     }
 
-    private fun succeedFeatureOperation(call: MethodCall, result: Result) {
+    private fun succeedOperation(call: MethodCall, result: Result) {
         val name = call.argument<String>(PARAM_NAME)
         val operationName = call.argument<String>(PARAM_OPERATION_KEY)
         val attributes = call.argument<Map<String, Any?>>(PARAM_ATTRIBUTES)
         if (name != null && attributes != null) {
-            rum?.succeedFeatureOperation(name, operationName, attributes)
+            rum?.succeedOperation(name, operationName, attributes)
             result.success(null)
         } else {
             result.missingParameter(call.method)
         }
     }
 
-    private fun failFeatureOperation(call: MethodCall, result: Result) {
+    private fun failOperation(call: MethodCall, result: Result) {
         val name = call.argument<String>(PARAM_NAME)
         val operationName = call.argument<String>(PARAM_OPERATION_KEY)
         val failureReasonStr = call.argument<String>(PARAM_FAILURE_REASON)
         val attributes = call.argument<Map<String, Any?>>(PARAM_ATTRIBUTES)
         if (name != null && failureReasonStr != null && attributes != null) {
             val failureReason = parseFailureReason(failureReasonStr)
-            rum?.failFeatureOperation(name, operationName, failureReason, attributes)
+            rum?.failOperation(name, operationName, failureReason, attributes)
             result.success(null)
         } else {
             result.missingParameter(call.method)
@@ -666,9 +666,9 @@ fun parseRumActionType(value: String): RumActionType {
 
 fun parseFailureReason(value: String): FailureReason {
     return when (value) {
-        "RumFeatureOperationFailureReason.error" -> FailureReason.ERROR
-        "RumFeatureOperationFailureReason.abandoned" -> FailureReason.ABANDONED
-        "RumFeatureOperationFailureReason.other" -> FailureReason.OTHER
+        "RumOperationFailureReason.error" -> FailureReason.ERROR
+        "RumOperationFailureReason.abandoned" -> FailureReason.ABANDONED
+        "RumOperationFailureReason.other" -> FailureReason.OTHER
         else -> FailureReason.OTHER
     }
 }

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -19,8 +19,9 @@ import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
+import com.datadog.android.rum.operations.FailureReason
+import com.datadog.android.rum.operations.OperationOptions
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
@@ -163,9 +164,9 @@ class DatadogRumPluginTest {
 
     @Test
     fun `M convert all failure reasons W parseFailureReason`() {
-        val error = parseFailureReason("RumFeatureOperationFailureReason.error")
-        val abandoned = parseFailureReason("RumFeatureOperationFailureReason.abandoned")
-        val other = parseFailureReason("RumFeatureOperationFailureReason.other")
+        val error = parseFailureReason("RumOperationFailureReason.error")
+        val abandoned = parseFailureReason("RumOperationFailureReason.abandoned")
+        val other = parseFailureReason("RumOperationFailureReason.other")
         val unknown = parseFailureReason("unknown")
 
         assertThat(error).isEqualTo(FailureReason.ERROR)
@@ -797,14 +798,14 @@ class DatadogRumPluginTest {
     }
 
     @Test
-    fun `M call monitor startFeatureOperation W startFeatureOperation is called`(
+    fun `M call monitor startOperation W startOperation is called`(
         @StringForgery name: String,
         @StringForgery operationKey: String,
         @StringForgery attributeKey: String,
         @StringForgery attributeValue: String
     ){
         // GIVEN
-        val call = MethodCall("startFeatureOperation", mapOf(
+        val call = MethodCall("startOperation", mapOf(
             "name" to name,
             "operationKey" to operationKey,
             "attributes" to mapOf(
@@ -818,21 +819,21 @@ class DatadogRumPluginTest {
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        verify { monitorProxy.mockMonitor.startFeatureOperation(name, operationKey, mapOf(
+        verify { monitorProxy.mockMonitor.startOperation(name, operationKey, OperationOptions.Empty, mapOf(
             attributeKey to attributeValue
         )) }
         verify { mockResult.success(null) }
     }
 
     @Test
-    fun `M call monitor succeedFeatureOperation W succeedFeatureOperation is called`(
+    fun `M call monitor succeedOperation W succeedOperation is called`(
         @StringForgery name: String,
         @StringForgery operationKey: String,
         @StringForgery attributeKey: String,
         @StringForgery attributeValue: String
     ){
         // GIVEN
-        val call = MethodCall("succeedFeatureOperation", mapOf(
+        val call = MethodCall("succeedOperation", mapOf(
             "name" to name,
             "operationKey" to operationKey,
             "attributes" to mapOf(
@@ -846,24 +847,24 @@ class DatadogRumPluginTest {
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        verify { monitorProxy.mockMonitor.succeedFeatureOperation(name, operationKey, mapOf(
+        verify { monitorProxy.mockMonitor.succeedOperation(name, operationKey, mapOf(
             attributeKey to attributeValue
         )) }
         verify { mockResult.success(null) }
     }
 
     @Test
-    fun `M call monitor failFeatureOperation W failFeatureOperation is called`(
+    fun `M call monitor failOperation W failOperation is called`(
         @StringForgery name: String,
         @StringForgery operationKey: String,
         @StringForgery attributeKey: String,
         @StringForgery attributeValue: String
     ){
         // GIVEN
-        val call = MethodCall("failFeatureOperation", mapOf(
+        val call = MethodCall("failOperation", mapOf(
             "name" to name,
             "operationKey" to operationKey,
-            "failureReason" to "RumFeatureOperationFailureReason.abandoned",
+            "failureReason" to "RumOperationFailureReason.abandoned",
             "attributes" to mapOf(
                 attributeKey to attributeValue
             )
@@ -875,7 +876,7 @@ class DatadogRumPluginTest {
         plugin.onMethodCall(call, mockResult)
 
         // THEN
-        verify { monitorProxy.mockMonitor.failFeatureOperation(name, operationKey, FailureReason.ABANDONED, mapOf(
+        verify { monitorProxy.mockMonitor.failOperation(name, operationKey, FailureReason.ABANDONED, mapOf(
             attributeKey to attributeValue
         )) }
         verify { mockResult.success(null) }
@@ -1053,15 +1054,15 @@ class DatadogRumPluginTest {
             "key" to ContractParameter.Type(SupportedContractType.STRING),
             "value" to ContractParameter.Type(SupportedContractType.ANY),
         )),
-        Contract("startFeatureOperation", mapOf(
+        Contract("startOperation", mapOf(
             "name" to ContractParameter.Type(SupportedContractType.STRING),
             "attributes" to ContractParameter.Type(SupportedContractType.MAP)
         )),
-        Contract("succeedFeatureOperation", mapOf(
+        Contract("succeedOperation", mapOf(
             "name" to ContractParameter.Type(SupportedContractType.STRING),
             "attributes" to ContractParameter.Type(SupportedContractType.MAP)
         )),
-        Contract("failFeatureOperation", mapOf(
+        Contract("failOperation", mapOf(
             "name" to ContractParameter.Type(SupportedContractType.STRING),
             "failureReason" to ContractParameter.Type(SupportedContractType.STRING),
             "attributes" to ContractParameter.Type(SupportedContractType.MAP)

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/lib/src/rum/ddrum_method_channel.dart
@@ -343,14 +343,14 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> startFeatureOperation(
+  Future<void> startOperation(
     DateTime at,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   ) {
     final timestampMs = at.millisecondsSinceEpoch;
-    return methodChannel.invokeMethod('startFeatureOperation', {
+    return methodChannel.invokeMethod('startOperation', {
       'name': name,
       'operationKey': operationKey,
       'attributes': {
@@ -361,14 +361,14 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> succeedFeatureOperation(
+  Future<void> succeedOperation(
     DateTime at,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   ) {
     final timestampMs = at.millisecondsSinceEpoch;
-    return methodChannel.invokeMethod('succeedFeatureOperation', {
+    return methodChannel.invokeMethod('succeedOperation', {
       'name': name,
       'operationKey': operationKey,
       'attributes': {
@@ -379,15 +379,15 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> failFeatureOperation(
+  Future<void> failOperation(
     DateTime at,
     String name,
     String? operationKey,
-    RumFeatureOperationFailureReason failureReason,
+    RumOperationFailureReason failureReason,
     Map<String, Object?> attributes,
   ) {
     final timestampMs = at.millisecondsSinceEpoch;
-    return methodChannel.invokeMethod('failFeatureOperation', {
+    return methodChannel.invokeMethod('failOperation', {
       'name': name,
       'operationKey': operationKey,
       'failureReason': failureReason.toString(),

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/test/rum/ddrum_method_channel_test.dart
@@ -529,17 +529,17 @@ void main() {
     expect(log, [isMethodCall('stopSession', arguments: <String, Object?>{})]);
   });
 
-  test('startFeatureOperation calls to platform', () async {
+  test('startOperation calls to platform', () async {
     final timestamp = randomTimestamp();
     final name = randomString();
     final operationKey = randomString();
-    await ddRumPlatform.startFeatureOperation(timestamp, name, operationKey, {
+    await ddRumPlatform.startOperation(timestamp, name, operationKey, {
       'attribute_name': 'attribute_value',
     });
 
     expect(log, [
       isMethodCall(
-        'startFeatureOperation',
+        'startOperation',
         arguments: {
           'name': name,
           'operationKey': operationKey,
@@ -552,17 +552,17 @@ void main() {
     ]);
   });
 
-  test('succeedFeatureOperation calls to platform', () async {
+  test('succeedOperation calls to platform', () async {
     final timestamp = randomTimestamp();
     final name = randomString();
     final operationKey = randomString();
-    await ddRumPlatform.succeedFeatureOperation(timestamp, name, operationKey, {
+    await ddRumPlatform.succeedOperation(timestamp, name, operationKey, {
       'attribute_name': 'attribute_value',
     });
 
     expect(log, [
       isMethodCall(
-        'succeedFeatureOperation',
+        'succeedOperation',
         arguments: {
           'name': name,
           'operationKey': operationKey,
@@ -575,25 +575,25 @@ void main() {
     ]);
   });
 
-  test('failFeatureOperation calls to platform', () async {
+  test('failOperation calls to platform', () async {
     final timestamp = randomTimestamp();
     final name = randomString();
     final operationKey = randomString();
-    await ddRumPlatform.failFeatureOperation(
+    await ddRumPlatform.failOperation(
       timestamp,
       name,
       operationKey,
-      RumFeatureOperationFailureReason.abandoned,
+      RumOperationFailureReason.abandoned,
       {'attribute_name': 'attribute_value'},
     );
 
     expect(log, [
       isMethodCall(
-        'failFeatureOperation',
+        'failOperation',
         arguments: {
           'name': name,
           'operationKey': operationKey,
-          'failureReason': 'RumFeatureOperationFailureReason.abandoned',
+          'failureReason': 'RumOperationFailureReason.abandoned',
           'attributes': {
             'attribute_name': 'attribute_value',
             '_dd.timestamp': timestamp.millisecondsSinceEpoch,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/example/ios/RunnerTests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/example/ios/RunnerTests/DatadogRumPluginTests.swift
@@ -101,9 +101,9 @@ class DatadogRumPluginTests: XCTestCase {
     }
 
     func testAllFailureReasons_AreParsedCorrectly() {
-        let error = RUMFeatureOperationFailureReason.parseFromFlutter("RumFeatureOperationFailureReason.error")
-        let abandoned = RUMFeatureOperationFailureReason.parseFromFlutter("RumFeatureOperationFailureReason.abandoned")
-        let other = RUMFeatureOperationFailureReason.parseFromFlutter("RumFeatureOperationFailureReason.other")
+        let error = RUMFeatureOperationFailureReason.parseFromFlutter("RumOperationFailureReason.error")
+        let abandoned = RUMFeatureOperationFailureReason.parseFromFlutter("RumOperationFailureReason.abandoned")
+        let other = RUMFeatureOperationFailureReason.parseFromFlutter("RumOperationFailureReason.other")
         let unknown = RUMFeatureOperationFailureReason.parseFromFlutter("unknown")
 
         XCTAssertEqual(error, .error)
@@ -183,15 +183,15 @@ class DatadogRumPluginTests: XCTestCase {
             "key": .string,
             "value": .string
         ]),
-        Contract(methodName: "startFeatureOperation", requiredParameters: [
+        Contract(methodName: "startOperation", requiredParameters: [
             "name": .string,
             "attributes": .map
         ]),
-        Contract(methodName: "succeedFeatureOperation", requiredParameters: [
+        Contract(methodName: "succeedOperation", requiredParameters: [
             "name": .string,
             "attributes": .map
         ]),
-        Contract(methodName: "failFeatureOperation", requiredParameters: [
+        Contract(methodName: "failOperation", requiredParameters: [
             "name": .string,
             "failureReason": .string,
             "attributes": .map
@@ -625,8 +625,8 @@ class DatadogRumPluginTests: XCTestCase {
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    func testStartFeatureOperation_CallsRumMonitor() {
-        let call = FlutterMethodCall(methodName: "startFeatureOperation", arguments: [
+    func testStartOperation_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "startOperation", arguments: [
             "name": "operation_name",
             "operationKey": "operation_key",
             "attributes": [
@@ -640,15 +640,15 @@ class DatadogRumPluginTests: XCTestCase {
         }
 
         XCTAssertEqual(mock.callLog, [
-            .startFeatureOperation(name: "operation_name", operationKey: "operation_key", attributes: [
+            .startOperation(name: "operation_name", operationKey: "operation_key", attributes: [
                 "attribute_key": "attribute_value"
             ])
         ])
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    func testSucceedFeatureOperation_CallsRumMonitor() {
-        let call = FlutterMethodCall(methodName: "succeedFeatureOperation", arguments: [
+    func testSucceedOperation_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "succeedOperation", arguments: [
             "name": "operation_name",
             "operationKey": "operation_key",
             "attributes": [
@@ -662,18 +662,18 @@ class DatadogRumPluginTests: XCTestCase {
         }
 
         XCTAssertEqual(mock.callLog, [
-            .succeedFeatureOperation(name: "operation_name", operationKey: "operation_key", attributes: [
+            .succeedOperation(name: "operation_name", operationKey: "operation_key", attributes: [
                 "attribute_key": "attribute_value"
             ])
         ])
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 
-    func testFailFeatureOperation_CallsRumMonitor() {
-        let call = FlutterMethodCall(methodName: "failFeatureOperation", arguments: [
+    func testFailOperation_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "failOperation", arguments: [
             "name": "operation_name",
             "operationKey": "operation_key",
-            "failureReason": "RumFeatureOperationFailureReason.abandoned",
+            "failureReason": "RumOperationFailureReason.abandoned",
             "attributes": [
                 "attribute_key": "attribute_value"
             ]
@@ -685,7 +685,7 @@ class DatadogRumPluginTests: XCTestCase {
         }
 
         XCTAssertEqual(mock.callLog, [
-            .failFeatureOperation(
+            .failOperation(
                 name: "operation_name",
                 operationKey: "operation_key",
                 failureReason: .abandoned,
@@ -815,9 +815,9 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         case removeViewAttributes(keys: [DatadogInternal.AttributeKey])
         case addFeatureFlagEvaluation(name: String, value: Encodable)
         case stopSession
-        case startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue])
-        case succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue])
-        case failFeatureOperation(name: String, operationKey: String?, failureReason: RUMFeatureOperationFailureReason,
+        case startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue])
+        case succeedOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue])
+        case failOperation(name: String, operationKey: String?, failureReason: RUMFeatureOperationFailureReason,
                                   attributes: [AttributeKey: AttributeValue])
         case reportAppFullyDisplayed
     }
@@ -950,18 +950,19 @@ class MockRUMMonitor: RUMMonitorProtocol, RUMCommandSubscriber {
         callLog.append(.removeViewAttributes(keys: keys))
     }
 
-    func startFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
-        callLog.append(.startFeatureOperation(name: name, operationKey: operationKey, attributes: attributes))
+    func startOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue],
+                        options: OperationOptions?) {
+        callLog.append(.startOperation(name: name, operationKey: operationKey, attributes: attributes))
     }
 
-    func succeedFeatureOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
-        callLog.append(.succeedFeatureOperation(name: name, operationKey: operationKey, attributes: attributes))
+    func succeedOperation(name: String, operationKey: String?, attributes: [AttributeKey: AttributeValue]) {
+        callLog.append(.succeedOperation(name: name, operationKey: operationKey, attributes: attributes))
     }
 
-    func failFeatureOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason,
-                              attributes: [AttributeKey: AttributeValue]) {
+    func failOperation(name: String, operationKey: String?, reason: RUMFeatureOperationFailureReason,
+                       attributes: [AttributeKey: AttributeValue]) {
         callLog.append(
-            .failFeatureOperation(name: name, operationKey: operationKey, failureReason: reason, attributes: attributes)
+            .failOperation(name: name, operationKey: operationKey, failureReason: reason, attributes: attributes)
         )
     }
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/datadog_flutter_plugin_ios/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/datadog_flutter_plugin_ios/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
@@ -366,12 +366,12 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                     FlutterError.missingParameter(methodName: call.method)
                 )
             }
-        case "startFeatureOperation":
-            startFeatureOperation(call: call, arguments: arguments, result: result)
-        case "succeedFeatureOperation":
-            succeedFeatureOperation(call: call, arguments: arguments, result: result)
-        case "failFeatureOperation":
-            failFeatureOperation(call: call, arguments: arguments, result: result)
+        case "startOperation":
+            startOperation(call: call, arguments: arguments, result: result)
+        case "succeedOperation":
+            succeedOperation(call: call, arguments: arguments, result: result)
+        case "failOperation":
+            failOperation(call: call, arguments: arguments, result: result)
         case "stopSession":
             rum?.stopSession()
             result(nil)
@@ -449,7 +449,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func startFeatureOperation(
+    private func startOperation(
         call: FlutterMethodCall,
         arguments: [String: Any?],
         result: @escaping FlutterResult
@@ -458,7 +458,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
            let attributes = arguments["attributes"] as? [String: Any?] {
             let encodedAttributes = castFlutterAttributesToSwift(attributes)
             let operationKey = arguments["operationKey"] as? String
-            rum?.startFeatureOperation(name: name, operationKey: operationKey, attributes: encodedAttributes)
+            rum?.startOperation(name: name, operationKey: operationKey, attributes: encodedAttributes, options: nil)
             result(nil)
         } else {
             result(
@@ -467,7 +467,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func succeedFeatureOperation(
+    private func succeedOperation(
         call: FlutterMethodCall,
         arguments: [String: Any?],
         result: @escaping FlutterResult
@@ -476,7 +476,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
            let attributes = arguments["attributes"] as? [String: Any?] {
             let encodedAttributes = castFlutterAttributesToSwift(attributes)
             let operationKey = arguments["operationKey"] as? String
-            rum?.succeedFeatureOperation(name: name, operationKey: operationKey, attributes: encodedAttributes)
+            rum?.succeedOperation(name: name, operationKey: operationKey, attributes: encodedAttributes)
             result(nil)
         } else {
             result(
@@ -485,7 +485,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private func failFeatureOperation(
+    private func failOperation(
         call: FlutterMethodCall,
         arguments: [String: Any?],
         result: @escaping FlutterResult
@@ -496,7 +496,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
             let encodedAttributes = castFlutterAttributesToSwift(attributes)
             let failureReason = RUMFeatureOperationFailureReason.parseFromFlutter(failureReasonStr)
             let operationKey = arguments["operationKey"] as? String
-            rum?.failFeatureOperation(
+            rum?.failOperation(
                 name: name,
                 operationKey: operationKey,
                 reason: failureReason,
@@ -943,9 +943,9 @@ public extension RUM.Configuration.VitalsFrequency {
 public extension RUMFeatureOperationFailureReason {
     static func parseFromFlutter(_ value: String) -> RUMFeatureOperationFailureReason {
         switch value {
-        case "RumFeatureOperationFailureReason.error": return .error
-        case "RumFeatureOperationFailureReason.abandoned": return .abandoned
-        case "RumFeatureOperationFailureReason.other": return .other
+        case "RumOperationFailureReason.error": return .error
+        case "RumOperationFailureReason.abandoned": return .abandoned
+        case "RumOperationFailureReason.other": return .other
         default: return .other
         }
     }

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/lib/src/rum/ddrum_method_channel.dart
@@ -343,14 +343,14 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> startFeatureOperation(
+  Future<void> startOperation(
     DateTime at,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   ) {
     final timestampMs = at.millisecondsSinceEpoch;
-    return methodChannel.invokeMethod('startFeatureOperation', {
+    return methodChannel.invokeMethod('startOperation', {
       'name': name,
       'operationKey': operationKey,
       'attributes': {
@@ -361,14 +361,14 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> succeedFeatureOperation(
+  Future<void> succeedOperation(
     DateTime at,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   ) {
     final timestampMs = at.millisecondsSinceEpoch;
-    return methodChannel.invokeMethod('succeedFeatureOperation', {
+    return methodChannel.invokeMethod('succeedOperation', {
       'name': name,
       'operationKey': operationKey,
       'attributes': {
@@ -379,15 +379,15 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
-  Future<void> failFeatureOperation(
+  Future<void> failOperation(
     DateTime at,
     String name,
     String? operationKey,
-    RumFeatureOperationFailureReason failureReason,
+    RumOperationFailureReason failureReason,
     Map<String, Object?> attributes,
   ) {
     final timestampMs = at.millisecondsSinceEpoch;
-    return methodChannel.invokeMethod('failFeatureOperation', {
+    return methodChannel.invokeMethod('failOperation', {
       'name': name,
       'operationKey': operationKey,
       'failureReason': failureReason.toString(),

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/test/rum/ddrum_method_channel_test.dart
@@ -529,17 +529,17 @@ void main() {
     expect(log, [isMethodCall('stopSession', arguments: <String, Object?>{})]);
   });
 
-  test('startFeatureOperation calls to platform', () async {
+  test('startOperation calls to platform', () async {
     final timestamp = randomTimestamp();
     final name = randomString();
     final operationKey = randomString();
-    await ddRumPlatform.startFeatureOperation(timestamp, name, operationKey, {
+    await ddRumPlatform.startOperation(timestamp, name, operationKey, {
       'attribute_name': 'attribute_value',
     });
 
     expect(log, [
       isMethodCall(
-        'startFeatureOperation',
+        'startOperation',
         arguments: {
           'name': name,
           'operationKey': operationKey,
@@ -552,17 +552,17 @@ void main() {
     ]);
   });
 
-  test('succeedFeatureOperation calls to platform', () async {
+  test('succeedOperation calls to platform', () async {
     final timestamp = randomTimestamp();
     final name = randomString();
     final operationKey = randomString();
-    await ddRumPlatform.succeedFeatureOperation(timestamp, name, operationKey, {
+    await ddRumPlatform.succeedOperation(timestamp, name, operationKey, {
       'attribute_name': 'attribute_value',
     });
 
     expect(log, [
       isMethodCall(
-        'succeedFeatureOperation',
+        'succeedOperation',
         arguments: {
           'name': name,
           'operationKey': operationKey,
@@ -575,25 +575,25 @@ void main() {
     ]);
   });
 
-  test('failFeatureOperation calls to platform', () async {
+  test('failOperation calls to platform', () async {
     final timestamp = randomTimestamp();
     final name = randomString();
     final operationKey = randomString();
-    await ddRumPlatform.failFeatureOperation(
+    await ddRumPlatform.failOperation(
       timestamp,
       name,
       operationKey,
-      RumFeatureOperationFailureReason.abandoned,
+      RumOperationFailureReason.abandoned,
       {'attribute_name': 'attribute_value'},
     );
 
     expect(log, [
       isMethodCall(
-        'failFeatureOperation',
+        'failOperation',
         arguments: {
           'name': name,
           'operationKey': operationKey,
-          'failureReason': 'RumFeatureOperationFailureReason.abandoned',
+          'failureReason': 'RumOperationFailureReason.abandoned',
           'attributes': {
             'attribute_name': 'attribute_value',
             '_dd.timestamp': timestamp.millisecondsSinceEpoch,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/rum/ddrum_noop_platform.dart
@@ -198,18 +198,18 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> failFeatureOperation(
+  Future<void> failOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
-    RumFeatureOperationFailureReason failureReason,
+    RumOperationFailureReason failureReason,
     Map<String, Object?> attributes,
   ) {
     return Future.value();
   }
 
   @override
-  Future<void> startFeatureOperation(
+  Future<void> startOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
@@ -219,7 +219,7 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
-  Future<void> succeedFeatureOperation(
+  Future<void> succeedOperation(
     DateTime timestamp,
     String name,
     String? operationKey,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/rum/ddrum_platform_interface.dart
@@ -124,23 +124,23 @@ abstract class DdRumPlatform extends PlatformInterface {
   Future<void> addFeatureFlagEvaluation(String name, Object value);
   Future<void> stopSession();
 
-  Future<void> startFeatureOperation(
+  Future<void> startOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   );
-  Future<void> succeedFeatureOperation(
+  Future<void> succeedOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   );
-  Future<void> failFeatureOperation(
+  Future<void> failOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
-    RumFeatureOperationFailureReason failureReason,
+    RumOperationFailureReason failureReason,
     Map<String, Object?> attributes,
   );
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/rum/rum_enums.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/rum/rum_enums.dart
@@ -41,8 +41,8 @@ enum RumResourceType {
   native,
 }
 
-/// Represents the possible reasons for a failed feature operation.
-enum RumFeatureOperationFailureReason {
+/// Represents the possible reasons for a failed operation.
+enum RumOperationFailureReason {
   /// Represents a failure caused by an error during execution.
   error,
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_web/lib/src/rum/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_web/lib/src/rum/ddrum_web.dart
@@ -424,46 +424,46 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
-  Future<void> startFeatureOperation(
+  Future<void> startOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   ) async {
     final context = attributesToJs(attributes, 'attributes');
-    DD_RUM?.startFeatureOperation(
+    DD_RUM?.startOperation(
       name,
-      _FeatureOperationOptions(operationKey: operationKey, context: context),
+      _OperationOptions(operationKey: operationKey, context: context),
     );
   }
 
   @override
-  Future<void> succeedFeatureOperation(
+  Future<void> succeedOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
     Map<String, Object?> attributes,
   ) async {
     final context = attributesToJs(attributes, 'attributes');
-    DD_RUM?.succeedFeatureOperation(
+    DD_RUM?.succeedOperation(
       name,
-      _FeatureOperationOptions(operationKey: operationKey, context: context),
+      _OperationOptions(operationKey: operationKey, context: context),
     );
   }
 
   @override
-  Future<void> failFeatureOperation(
+  Future<void> failOperation(
     DateTime timestamp,
     String name,
     String? operationKey,
-    RumFeatureOperationFailureReason failureReason,
+    RumOperationFailureReason failureReason,
     Map<String, Object?> attributes,
   ) async {
     final context = attributesToJs(attributes, 'attributes');
-    DD_RUM?.failFeatureOperation(
+    DD_RUM?.failOperation(
       name,
       failureReason.webValue(),
-      _FeatureOperationOptions(operationKey: operationKey, context: context),
+      _OperationOptions(operationKey: operationKey, context: context),
     );
   }
 
@@ -557,14 +557,14 @@ String _contextInjectionString(TraceContextInjection contextInjection) {
   }
 }
 
-extension on RumFeatureOperationFailureReason {
+extension on RumOperationFailureReason {
   String webValue() {
     switch (this) {
-      case RumFeatureOperationFailureReason.error:
+      case RumOperationFailureReason.error:
         return 'error';
-      case RumFeatureOperationFailureReason.abandoned:
+      case RumOperationFailureReason.abandoned:
         return 'abandoned';
-      case RumFeatureOperationFailureReason.other:
+      case RumOperationFailureReason.other:
         return 'other';
     }
   }
@@ -634,8 +634,8 @@ extension type _RumInternalContext._(JSObject _) implements JSObject {
   external String? session_id;
 }
 
-extension type _FeatureOperationOptions._(JSObject _) implements JSObject {
-  external factory _FeatureOperationOptions({
+extension type _OperationOptions._(JSObject _) implements JSObject {
+  external factory _OperationOptions({
     String? operationKey,
     JSObject? context,
     // ignore: unused_element_parameter
@@ -694,18 +694,12 @@ extension type _DdRum._(JSObject _) implements JSObject {
   external void setAccountProperty(String key, JSAny? value);
   external void clearAccount();
   external void setTrackingConsent(String consent);
-  external void startFeatureOperation(
-    String name,
-    _FeatureOperationOptions options,
-  );
-  external void succeedFeatureOperation(
-    String name,
-    _FeatureOperationOptions options,
-  );
-  external void failFeatureOperation(
+  external void startOperation(String name, _OperationOptions options);
+  external void succeedOperation(String name, _OperationOptions options);
+  external void failOperation(
     String name,
     String failureReason,
-    _FeatureOperationOptions options,
+    _OperationOptions options,
   );
   external void startAction(String name, _ActionOptions? options);
   external void stopAction(String name, _ActionOptions? options);


### PR DESCRIPTION
### What and why?

"Feature Operations" has been renamed "Operations" and the native APIs have deprecated the old "Feature Operations" names. Take v4 as our opportunity to perform the rename.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
