### PR TITLE
chore: Fix releaser to properly pin android versions.

### DIFF
--- a/tools/releaser/lib/gradle_util.dart
+++ b/tools/releaser/lib/gradle_util.dart
@@ -34,13 +34,15 @@ class UpdateGradleFilesCommand extends Command {
       bool inMavenBlock = false;
       bool writeMavenBlock = true;
       await transformFile(file, logger, args.dryRun, (line) {
-        // If we're shipping datadog_flutter_plugin, use tighter constraints
-        if (args.packages.contains((e) => e.name == 'datadog_flutter_plugin')) {
+        // For the datadog_flutter_plugin, use a tighter constraint
+        if (file.path.contains('datadog_flutter_plugin')) {
           final versionMatch = versionRegex.firstMatch(line);
           if (versionMatch != null) {
             final oldVersion = versionMatch.group(1);
-            line = line.replaceFirst('$versionPrefix = "$oldVersion"',
-                '$versionPrefix = "${args.androidRelease}"');
+            line = line.replaceFirst(
+              '$versionPrefix = "$oldVersion"',
+              '$versionPrefix = "${args.androidRelease}"',
+            );
           }
         }
 


### PR DESCRIPTION
### What and why?

Releaser was not properly checking whether it was modifying the gradle files for `datadog_flutter_plugin` when performing a release, so it was not properly pinning the Android SDK during a release.

The fix is to check if the path being modified contains the name of the plugin, and pinning the strict version if it does.

refs: #1085

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
