### PR TITLE
feat(sr): Cache sent resource identifiers via DataStore to avoid re-upload

### DIFF
--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriter.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriter.kt
@@ -11,16 +11,42 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.core.persistence.datastore.DataStoreContent
 import com.datadoghq.flutter.sessionreplay.models.ResourceEvent
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal interface ResourceWriter {
     fun write(identifier: String, resourceData: ByteArray)
 }
 
+/**
+ * Writes resolved image resources to the Session Replay resources feature, caching which
+ * MD5 identifiers have already been sent (in-memory, then seeded/persisted through the
+ * feature's [DataStoreHandler]) so the same image isn't re-uploaded across app sessions.
+ */
 internal class DefaultResourceWriter(
-    private val sdkCore: FeatureSdkCore
+    private val sdkCore: FeatureSdkCore,
+    private val gson: Gson = Gson(),
+    private val dataStoreResetTimeMs: Long = TimeUnit.DAYS.toMillis(30)
 ) : ResourceWriter {
+    private val knownIdentifiers: MutableSet<String> = mutableSetOf()
+    private val hasLoadedFromDataStore = AtomicBoolean(false)
+
     override fun write(identifier: String, resourceData: ByteArray) {
+        loadKnownIdentifiersIfNeeded()
+
+        val alreadyKnown = synchronized(knownIdentifiers) { knownIdentifiers.contains(identifier) }
+        if (alreadyKnown) {
+            return
+        }
+
         sdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
             ?.withWriteContext(
                 withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)
@@ -43,7 +69,105 @@ internal class DefaultResourceWriter(
                         )
                     }
                 }
+
+                synchronized(knownIdentifiers) { knownIdentifiers.add(identifier) }
+                persistKnownIdentifiers()
             }
+    }
+
+    private fun dataStoreOrNull(): DataStoreHandler? =
+        sdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)?.dataStore
+
+    /**
+     * [ResourceFeature] is registered after this writer is constructed (see
+     * `FlutterSessionReplayFeature.onInitialize`), so the data store can't be seeded eagerly
+     * in `init`. Instead, seed it lazily on first write, retrying on later writes until the
+     * feature is registered.
+     */
+    private fun loadKnownIdentifiersIfNeeded() {
+        if (!hasLoadedFromDataStore.compareAndSet(false, true)) {
+            return
+        }
+
+        val dataStore = dataStoreOrNull()
+        if (dataStore == null) {
+            hasLoadedFromDataStore.set(false)
+            return
+        }
+
+        dataStore.value(
+            Constants.STORE_CREATION_KEY,
+            Constants.CURRENT_STORE_VERSION,
+            object : DataStoreReadCallback<Long> {
+                override fun onSuccess(dataStoreContent: DataStoreContent<Long>?) {
+                    val storeCreation = dataStoreContent?.data
+                    if (storeCreation != null &&
+                        System.currentTimeMillis() - storeCreation < dataStoreResetTimeMs
+                    ) {
+                        loadKnownResources(dataStore)
+                    } else {
+                        // Missing or older than the reset window - start a fresh store.
+                        resetDataStore(dataStore)
+                    }
+                }
+
+                override fun onFailure() {
+                    // Leave knownIdentifiers empty; a future write will retry via persistKnownIdentifiers.
+                }
+            },
+            object : Deserializer<String, Long> {
+                override fun deserialize(model: String): Long? = model.toLongOrNull()
+            }
+        )
+    }
+
+    private fun loadKnownResources(dataStore: DataStoreHandler) {
+        dataStore.value(
+            Constants.KNOWN_RESOURCES_KEY,
+            Constants.CURRENT_STORE_VERSION,
+            object : DataStoreReadCallback<Set<String>> {
+                override fun onSuccess(dataStoreContent: DataStoreContent<Set<String>>?) {
+                    dataStoreContent?.data?.let {
+                        synchronized(knownIdentifiers) { knownIdentifiers.addAll(it) }
+                    }
+                }
+
+                override fun onFailure() {
+                    // No previously known resources to seed with.
+                }
+            },
+            object : Deserializer<String, Set<String>> {
+                override fun deserialize(model: String): Set<String>? =
+                    runCatching { gson.fromJson<Set<String>>(model, KNOWN_RESOURCES_TYPE) }.getOrNull()
+            }
+        )
+    }
+
+    private fun resetDataStore(dataStore: DataStoreHandler) {
+        dataStore.setValue(
+            Constants.STORE_CREATION_KEY,
+            System.currentTimeMillis(),
+            Constants.CURRENT_STORE_VERSION,
+            null,
+            object : Serializer<Long> {
+                override fun serialize(model: Long): String = model.toString()
+            }
+        )
+        dataStore.removeValue(Constants.KNOWN_RESOURCES_KEY, null)
+    }
+
+    private fun persistKnownIdentifiers() {
+        val dataStore = dataStoreOrNull() ?: return
+        val snapshot = synchronized(knownIdentifiers) { knownIdentifiers.toSet() }
+        dataStore.setValue(
+            Constants.KNOWN_RESOURCES_KEY,
+            snapshot,
+            Constants.CURRENT_STORE_VERSION,
+            null,
+            object : Serializer<Set<String>> {
+                override fun serialize(model: Set<String>): String = gson.toJson(model)
+            }
+        )
     }
 
     private val DatadogContext.rumApplicationId: String
@@ -51,4 +175,14 @@ internal class DefaultResourceWriter(
             featuresContext[Feature.RUM_FEATURE_NAME]
                 ?.get("application_id") as? String
             ).orEmpty()
+
+    private companion object {
+        val KNOWN_RESOURCES_TYPE = object : TypeToken<Set<String>>() {}.type
+    }
+
+    internal object Constants {
+        const val KNOWN_RESOURCES_KEY = "known-resources"
+        const val STORE_CREATION_KEY = "store-creation"
+        const val CURRENT_STORE_VERSION = 1
+    }
 }

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriterTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriterTest.kt
@@ -1,0 +1,191 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.resource
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.core.persistence.datastore.DataStoreContent
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+internal class ResourceWriterTest {
+    val mockSdkCore = mockk<FeatureSdkCore>()
+    val mockScope = mockk<FeatureScope>()
+    private val fakeDataStore = FakeDataStoreHandler()
+
+    fun setUp() {
+        every {
+            mockSdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
+        } returns mockScope
+        every { mockScope.dataStore } returns fakeDataStore
+        every { mockScope.withWriteContext(any(), any()) } answers {
+            val callback = secondArg<(DatadogContext, ((EventBatchWriter) -> Unit) -> Unit) -> Unit>()
+            val mockContext = mockk<DatadogContext>()
+            every { mockContext.featuresContext } returns emptyMap()
+            val mockWriter = mockk<EventBatchWriter>(relaxed = true)
+            callback(mockContext) { it(mockWriter) }
+        }
+    }
+
+    @Test
+    fun `M write resource W write {new identifier}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        val writer = DefaultResourceWriter(mockSdkCore)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 1) { mockScope.withWriteContext(any(), any()) }
+    }
+
+    @Test
+    fun `M write resource only once W write {same identifier, same instance}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        val writer = DefaultResourceWriter(mockSdkCore)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 1) { mockScope.withWriteContext(any(), any()) }
+    }
+
+    @Test
+    fun `M not write resource W write {identifier known from previous session}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        val firstSessionWriter = DefaultResourceWriter(mockSdkCore)
+        firstSessionWriter.write(identifier, resourceData.toByteArray())
+
+        // When - a new writer instance simulates a new app session sharing the same data store
+        val secondSessionWriter = DefaultResourceWriter(mockSdkCore)
+        secondSessionWriter.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 1) { mockScope.withWriteContext(any(), any()) }
+    }
+
+    @Test
+    fun `M write resource W write {identifier known, but store creation is stale}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        val resetTimeMs = TimeUnit.SECONDS.toMillis(1)
+        val staleStoreCreation = System.currentTimeMillis() - resetTimeMs * 2
+        fakeDataStore.storage[DefaultResourceWriter.Constants.STORE_CREATION_KEY] =
+            DefaultResourceWriter.Constants.CURRENT_STORE_VERSION to staleStoreCreation.toString()
+        fakeDataStore.storage[DefaultResourceWriter.Constants.KNOWN_RESOURCES_KEY] =
+            DefaultResourceWriter.Constants.CURRENT_STORE_VERSION to "[\"$identifier\"]"
+        val writer = DefaultResourceWriter(mockSdkCore, dataStoreResetTimeMs = resetTimeMs)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 1) { mockScope.withWriteContext(any(), any()) }
+        assertThat(fakeDataStore.storage.containsKey(DefaultResourceWriter.Constants.KNOWN_RESOURCES_KEY))
+            .isEqualTo(true)
+    }
+
+    @Test
+    fun `M not write resource W write {identifier known, store creation is recent}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        val resetTimeMs = TimeUnit.DAYS.toMillis(30)
+        fakeDataStore.storage[DefaultResourceWriter.Constants.STORE_CREATION_KEY] =
+            DefaultResourceWriter.Constants.CURRENT_STORE_VERSION to System.currentTimeMillis().toString()
+        fakeDataStore.storage[DefaultResourceWriter.Constants.KNOWN_RESOURCES_KEY] =
+            DefaultResourceWriter.Constants.CURRENT_STORE_VERSION to "[\"$identifier\"]"
+        val writer = DefaultResourceWriter(mockSdkCore, dataStoreResetTimeMs = resetTimeMs)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 0) { mockScope.withWriteContext(any(), any()) }
+    }
+
+    /**
+     * In-memory fake mirroring the real DataStoreHandler contract, so tests can exercise
+     * seeding/persistence/reset behavior without mocking every generic serializer/deserializer.
+     */
+    private class FakeDataStoreHandler : DataStoreHandler {
+        val storage = mutableMapOf<String, Pair<Int, String>>()
+
+        override fun <T : Any> setValue(
+            key: String,
+            data: T,
+            version: Int,
+            callback: DataStoreWriteCallback?,
+            serializer: Serializer<T>
+        ) {
+            val serialized = serializer.serialize(data)
+            if (serialized != null) {
+                storage[key] = version to serialized
+            }
+            callback?.onSuccess()
+        }
+
+        override fun <T : Any> value(
+            key: String,
+            version: Int?,
+            callback: DataStoreReadCallback<T>,
+            deserializer: Deserializer<String, T>
+        ) {
+            val stored = storage[key]
+            if (stored == null) {
+                callback.onSuccess(null)
+                return
+            }
+            val (storedVersion, raw) = stored
+            callback.onSuccess(DataStoreContent(storedVersion, deserializer.deserialize(raw)))
+        }
+
+        override fun removeValue(key: String, callback: DataStoreWriteCallback?) {
+            storage.remove(key)
+            callback?.onSuccess()
+        }
+
+        override fun clearAllData() {
+            storage.clear()
+        }
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Resource/ResourcesWriterTest.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Resource/ResourcesWriterTest.swift
@@ -92,4 +92,72 @@ struct ResourcesWriterTest {
         #expect(resourceEvent.context.type == "resource")
         #expect(resourceEvent.context.application.id == rumApplicationId)
     }
+
+    @Test
+    func write_WithIdentifierKnownFromPreviousSession_DoesNotWriteToCore() throws {
+        // Given
+        let sharedDataStore = DataStoreMock()
+        let firstSessionCore = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let firstSessionWriter = ResourcesWriter(scope: firstSessionCore)
+
+        let id: String = .mockRandom()
+        let data = Data([1, 2, 3])
+        let mimeType: String = .mockRandom()
+        firstSessionWriter.write(withIdentifier: id, data: data, mimeType: mimeType)
+        try #require(firstSessionCore.events.count == 1)
+
+        // When a new writer instance (simulating a new app session) shares the same data store
+        let secondSessionCore = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let secondSessionWriter = ResourcesWriter(scope: secondSessionCore)
+        secondSessionWriter.write(withIdentifier: id, data: data, mimeType: mimeType)
+
+        // Then it does not write the already-known identifier again
+        #expect(secondSessionCore.events.isEmpty)
+    }
+
+    @Test
+    func write_WithStaleStoreCreation_ResetsKnownIdentifiers() throws {
+        // Given
+        let id: String = .mockRandom()
+        let staleStoreCreation = Date().timeIntervalSince1970 - TimeInterval(31).days
+        let sharedDataStore = DataStoreMock(
+            storage: [
+                ResourcesWriter.Constants.storeCreationKey: .value(staleStoreCreation.asData(), ResourcesWriter.Constants.currentStoreVersion),
+                ResourcesWriter.Constants.knownResourcesKey: .value(Set([id]).asData(JSONEncoder())!, ResourcesWriter.Constants.currentStoreVersion)
+            ]
+        )
+        let core = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let writer = ResourcesWriter(scope: core)
+
+        // When
+        let data = Data([1, 2, 3])
+        let mimeType: String = .mockRandom()
+        writer.write(withIdentifier: id, data: data, mimeType: mimeType)
+
+        // Then the stale store was reset, so the previously-known identifier is written again
+        #expect(core.events.count == 1)
+    }
+
+    @Test
+    func write_WithRecentStoreCreation_DoesNotResetKnownIdentifiers() throws {
+        // Given
+        let id: String = .mockRandom()
+        let recentStoreCreation = Date().timeIntervalSince1970
+        let sharedDataStore = DataStoreMock(
+            storage: [
+                ResourcesWriter.Constants.storeCreationKey: .value(recentStoreCreation.asData(), ResourcesWriter.Constants.currentStoreVersion),
+                ResourcesWriter.Constants.knownResourcesKey: .value(Set([id]).asData(JSONEncoder())!, ResourcesWriter.Constants.currentStoreVersion)
+            ]
+        )
+        let core = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let writer = ResourcesWriter(scope: core)
+
+        // When
+        let data = Data([1, 2, 3])
+        let mimeType: String = .mockRandom()
+        writer.write(withIdentifier: id, data: data, mimeType: mimeType)
+
+        // Then the identifier was seeded from the data store, so it's not written again
+        #expect(core.events.isEmpty)
+    }
 }

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Resource/ResourcesWriter.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Resource/ResourcesWriter.swift
@@ -11,24 +11,21 @@ internal protocol ResourcesWriting {
 
 internal class ResourcesWriter: ResourcesWriting {
     private let scope: FeatureScope
-// TODO(RUM-11447): Commented out code in this file is support for the DataStore image caching
-// Which will be added with the above ticket
-//    private let encoder: JSONEncoder
-//    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
 
     @ReadWriteLock
-    private var knownIdentifiers = Set<String>()
-//    private var knownIdentifiers = Set<String>() {
-//        didSet {
-//            if let knownIdentifiers = knownIdentifiers.asData(encoder) {
-//                scope.dataStore.setValue(
-//                    knownIdentifiers,
-//                    forKey: Constants.knownResourcesKey,
-//                    version: Constants.currentStoreVersion
-//                )
-//            }
-//        }
-//    }
+    private var knownIdentifiers = Set<String>() {
+        didSet {
+            if let knownIdentifiers = knownIdentifiers.asData(encoder) {
+                scope.dataStore.setValue(
+                    knownIdentifiers,
+                    forKey: Constants.knownResourcesKey,
+                    version: Constants.currentStoreVersion
+                )
+            }
+        }
+    }
 
     init(
         scope: FeatureScope,
@@ -37,38 +34,38 @@ internal class ResourcesWriter: ResourcesWriting {
         decoder: JSONDecoder = JSONDecoder()
     ) {
         self.scope = scope
-//        self.encoder = encoder
-//        self.decoder = decoder
-//        self.scope.dataStore.value(forKey: Constants.storeCreationKey) { [weak self]  result in
-//            do {
-//                if let storeCreation = try result.data(expectedVersion: Constants.currentStoreVersion)?.asTimeInterval(),
-//                   Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
-//                    self?.scope.dataStore.value(forKey: Constants.knownResourcesKey) { result in
-//                        switch result {
-//                        case .value(let data, let version) where version == Constants.currentStoreVersion:
-//                            do {
-//                                if let knownIdentifiers = try data.asKnownIdentifiers(decoder) {
-//                                    self?.knownIdentifiers.formUnion(knownIdentifiers)
-//                                }
-//                            } catch let error {
-//                                self?.scope.telemetry.error("Failed to decode known identifiers", error: error)
-//                            }
-//                        default:
-//                            break
-//                        }
-//                    }
-//                } else { // Reset if store was created more than 30 days ago
-//                    self?.scope.dataStore.setValue(
-//                        Date().timeIntervalSince1970.asData(),
-//                        forKey: Constants.storeCreationKey,
-//                        version: Constants.currentStoreVersion
-//                    )
-//                    self?.scope.dataStore.removeValue(forKey: Constants.knownResourcesKey)
-//                }
-//            } catch let error {
-//                self?.scope.telemetry.error("Failed to decode store creation", error: error)
-//            }
-//        }
+        self.encoder = encoder
+        self.decoder = decoder
+        self.scope.dataStore.value(forKey: Constants.storeCreationKey) { [weak self] result in
+            do {
+                if let storeCreation = try result.data(expectedVersion: Constants.currentStoreVersion)?.asTimeInterval(),
+                   Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
+                    self?.scope.dataStore.value(forKey: Constants.knownResourcesKey) { result in
+                        switch result {
+                        case .value(let data, let version) where version == Constants.currentStoreVersion:
+                            do {
+                                if let knownIdentifiers = try data.asKnownIdentifiers(decoder) {
+                                    self?.knownIdentifiers.formUnion(knownIdentifiers)
+                                }
+                            } catch let error {
+                                self?.scope.telemetry.error("Failed to decode known identifiers", error: error)
+                            }
+                        default:
+                            break
+                        }
+                    }
+                } else { // Reset if store was created more than 30 days ago
+                    self?.scope.dataStore.setValue(
+                        Date().timeIntervalSince1970.asData(),
+                        forKey: Constants.storeCreationKey,
+                        version: Constants.currentStoreVersion
+                    )
+                    self?.scope.dataStore.removeValue(forKey: Constants.knownResourcesKey)
+                }
+            } catch let error {
+                self?.scope.telemetry.error("Failed to decode store creation", error: error)
+            }
+        }
     }
 
     // MARK: - Writing
@@ -94,11 +91,11 @@ internal class ResourcesWriter: ResourcesWriting {
         }
     }
 
-//    enum Constants {
-//        static let knownResourcesKey = "known-resources"
-//        static let storeCreationKey = "store-creation"
-//        static let currentStoreVersion = UInt16(1)
-//    }
+    enum Constants {
+        static let knownResourcesKey = "known-resources"
+        static let storeCreationKey = "store-creation"
+        static let currentStoreVersion = UInt16(1)
+    }
 }
 
 extension DatadogContext {
@@ -107,37 +104,37 @@ extension DatadogContext {
     }
 }
 
-// extension Data {
-//    enum SerializationError: Error {
-//        case invalidData
-//    }
-//
-//    func asTimeInterval() throws -> TimeInterval {
-//        var value: TimeInterval = 0
-//        guard count >= MemoryLayout.size(ofValue: value) else {
-//            throw SerializationError.invalidData
-//        }
-//        _ = Swift.withUnsafeMutableBytes(of: &value) {
-//            copyBytes(to: $0)
-//        }
-//        return value
-//    }
-//
-//    func asKnownIdentifiers(_ decoder: JSONDecoder) throws -> Set<String>? {
-//        return try decoder.decode(Set<String>.self, from: self)
-//    }
-// }
-//
-// extension TimeInterval {
-//    func asData() -> Data {
-//        return Swift.withUnsafeBytes(of: self) {
-//            Data($0)
-//        }
-//    }
-// }
-//
-// extension Set<String> {
-//    func asData(_ encoder: JSONEncoder) -> Data? {
-//        return try? encoder.encode(self) // Never fails
-//    }
-// }
+extension Data {
+    enum SerializationError: Error {
+        case invalidData
+    }
+
+    func asTimeInterval() throws -> TimeInterval {
+        var value: TimeInterval = 0
+        guard count >= MemoryLayout.size(ofValue: value) else {
+            throw SerializationError.invalidData
+        }
+        _ = Swift.withUnsafeMutableBytes(of: &value) {
+            copyBytes(to: $0)
+        }
+        return value
+    }
+
+    func asKnownIdentifiers(_ decoder: JSONDecoder) throws -> Set<String>? {
+        return try decoder.decode(Set<String>.self, from: self)
+    }
+}
+
+extension TimeInterval {
+    func asData() -> Data {
+        return Swift.withUnsafeBytes(of: self) {
+            Data($0)
+        }
+    }
+}
+
+extension Set<String> {
+    func asData(_ encoder: JSONEncoder) -> Data? {
+        return try? encoder.encode(self) // Never fails
+    }
+}


### PR DESCRIPTION
### What and why?

Session Replay must not resend images whose MD5 hash was already sent to the resource endpoint in a previous session. Both platforms now seed an in-memory identifier cache from the feature's DataStore, mark an identifier as known only after its write actually succeeds, and reset the cache after 30 days to bound unbounded local growth.

Android seeds the cache lazily on first write (ResourceFeature registers after DefaultResourceWriter is constructed), while iOS seeds it eagerly in init since its FeatureScope is already registered at that point.

What changes does this pull request introduce and why is it necessary?

### How?

- Added an in-memory `Set<String>` of known identifiers on both platforms, seeded from the data store and consulted before every write.
- An identifier is only added to the known set (and persisted) **after** its corresponding write actually succeeds, avoiding marking a resource "sent" if the underlying write never happens.
- A `store-creation` timestamp key is checked on load; if missing or older than 30 days, the known-identifiers store is reset to bound unbounded local growth.
- Android: `DefaultResourceWriter` (`ResourceWriter.kt`) seeds lazily on first `write()` call with a retry guard, since `ResourceFeature` registers with the SDK core after the writer is constructed. Covered by 5 new tests in `ResourceWriterTest.kt` using an in-memory `FakeDataStoreHandler`.
- iOS: `ResourcesWriter.swift` seeds eagerly in `init`, since its `FeatureScope`/`DataStore` is already registered by construction time. Added 3 new tests to `ResourcesWriterTest.swift` covering cross-session dedup, stale-store reset, and recent-store retention, using `DataStoreMock`.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue — 11447
