### PR TITLE
feat(sr): Cache sent resource identifiers via DataStore to avoid re-upload (RUM-11447)

### DIFF
--- a/packages/datadog_session_replay/android/build.gradle
+++ b/packages/datadog_session_replay/android/build.gradle
@@ -60,6 +60,9 @@ android {
 
     dependencies {
         implementation("com.datadoghq:dd-sdk-android-core:$datadog_version")
+        // dd-sdk-android-core only declares this as a runtime dependency, so it must be
+        // added explicitly to be visible on the compile classpath (needed for TimeProvider).
+        implementation("com.datadoghq:dd-sdk-android-internal:$datadog_version")
         implementation("com.squareup.okhttp3:okhttp:5.3.2")
         implementation("com.google.code.gson:gson:2.12.1")
 

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/feature/FlutterSessionReplayFeature.kt
@@ -20,6 +20,7 @@ import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadoghq.flutter.sessionreplay.resource.DefaultResourceResolver
 import com.datadoghq.flutter.sessionreplay.resource.DefaultResourceWriter
+import com.datadoghq.flutter.sessionreplay.resource.ResourceDataStoreManager
 import com.datadoghq.flutter.sessionreplay.resource.ResourceFeature
 import com.datadoghq.flutter.sessionreplay.resource.ResourceResolver
 
@@ -54,10 +55,7 @@ internal class DefaultFlutterSessionReplayFeature(
         )
     }
 
-    override val resourceResolver: ResourceResolver = DefaultResourceResolver(
-        sdkCore.internalLogger,
-        DefaultResourceWriter(sdkCore)
-    )
+    override lateinit var resourceResolver: ResourceResolver
 
     override val name = Feature.SESSION_REPLAY_FEATURE_NAME
     override val storageConfiguration = STORAGE_CONFIGURATION
@@ -83,6 +81,13 @@ internal class DefaultFlutterSessionReplayFeature(
             customEndpointUrl
         )
         sdkCore.registerFeature(resourcesFeature)
+
+        // ResourceDataStoreManager loads its known-resources entry eagerly on construction,
+        // so it must be created after the resources feature above is registered.
+        resourceResolver = DefaultResourceResolver(
+            sdkCore.internalLogger,
+            DefaultResourceWriter(sdkCore, ResourceDataStoreManager(sdkCore))
+        )
     }
 
     override fun onStop() {

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManager.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManager.kt
@@ -6,6 +6,7 @@
 
 package com.datadoghq.flutter.sessionreplay.resource
 
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.datastore.DataStoreReadCallback
 import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
@@ -23,11 +24,11 @@ import java.util.concurrent.atomic.AtomicLong
 internal class ResourceDataStoreManager(
     private val featureSdkCore: FeatureSdkCore,
     private val gson: Gson = Gson(),
-    private val dataStoreResetTimeNs: Long = TimeUnit.DAYS.toNanos(30)
+    private val dataStoreResetTimeMs: Long = TimeUnit.DAYS.toMillis(30)
 ) {
     @Suppress("UnsafeThirdPartyFunctionCall") // map is initialized empty
     private val knownResources = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
-    private val storedLastUpdateDateNs = AtomicLong(featureSdkCore.timeProvider.getDeviceElapsedTimeNanos())
+    private val storedLastUpdateDateMs = AtomicLong(featureSdkCore.timeProvider.getDeviceTimestampMillis())
     private val isInitialized = AtomicBoolean(false) // has init finished executing its async actions
 
     init {
@@ -40,10 +41,10 @@ internal class ResourceDataStoreManager(
                     return@lambda
                 }
 
-                val lastUpdateDateNs = storedData.lastUpdateDateNs
+                val lastUpdateDateMs = storedData.lastUpdateDateMs
                 val storedHashes = storedData.resourceHashes
 
-                if (didDataStoreExpire(lastUpdateDateNs)) {
+                if (didDataStoreExpire(lastUpdateDateMs)) {
                     deleteStoredHashesEntry(
                         callback = object : DataStoreWriteCallback {
                             override fun onSuccess() {
@@ -51,17 +52,27 @@ internal class ResourceDataStoreManager(
                             }
 
                             override fun onFailure() {
+                                featureSdkCore.internalLogger.log(
+                                    InternalLogger.Level.ERROR,
+                                    InternalLogger.Target.TELEMETRY,
+                                    { Constants.FAILED_TO_DELETE_STALE_ENTRY_ERROR_MESSAGE }
+                                )
                                 finishedInitializingManager()
                             }
                         }
                     )
                 } else {
-                    storedLastUpdateDateNs.set(lastUpdateDateNs)
+                    storedLastUpdateDateMs.set(lastUpdateDateMs)
                     knownResources.addAll(storedHashes)
                     finishedInitializingManager()
                 }
             },
             onFetchFailure = {
+                featureSdkCore.internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.TELEMETRY,
+                    { Constants.FAILED_TO_FETCH_ENTRY_ERROR_MESSAGE }
+                )
                 finishedInitializingManager()
             }
         )
@@ -86,7 +97,7 @@ internal class ResourceDataStoreManager(
 
     private fun writeResourcesToStore() {
         val data = ResourceHashesEntry(
-            lastUpdateDateNs = storedLastUpdateDateNs.get(),
+            lastUpdateDateMs = storedLastUpdateDateMs.get(),
             resourceHashes = knownResources.toList()
         )
 
@@ -131,7 +142,7 @@ internal class ResourceDataStoreManager(
         )
 
     private fun didDataStoreExpire(lastUpdateDate: Long): Boolean =
-        featureSdkCore.timeProvider.getDeviceElapsedTimeNanos() - lastUpdateDate > dataStoreResetTimeNs
+        featureSdkCore.timeProvider.getDeviceTimestampMillis() - lastUpdateDate > dataStoreResetTimeMs
 
     // endregion
 
@@ -141,12 +152,16 @@ internal class ResourceDataStoreManager(
         )?.dataStore
 
     internal data class ResourceHashesEntry(
-        @SerializedName("last_update_date_ns") val lastUpdateDateNs: Long,
+        @SerializedName("last_update_date_ms") val lastUpdateDateMs: Long,
         @SerializedName("resource_hashes") val resourceHashes: List<String>
     )
 
     internal object Constants {
         const val DATASTORE_HASHES_ENTRY_KEY = "resource-hash-store"
         const val CURRENT_STORE_VERSION = 1
+        const val FAILED_TO_FETCH_ENTRY_ERROR_MESSAGE =
+            "Failed to fetch the stored resource hashes entry from the DataStore."
+        const val FAILED_TO_DELETE_STALE_ENTRY_ERROR_MESSAGE =
+            "Failed to delete the stale resource hashes entry from the DataStore."
     }
 }

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManager.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManager.kt
@@ -1,0 +1,152 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.resource
+
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+internal class ResourceDataStoreManager(
+    private val featureSdkCore: FeatureSdkCore,
+    private val gson: Gson = Gson(),
+    private val dataStoreResetTimeNs: Long = TimeUnit.DAYS.toNanos(30)
+) {
+    @Suppress("UnsafeThirdPartyFunctionCall") // map is initialized empty
+    private val knownResources = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
+    private val storedLastUpdateDateNs = AtomicLong(featureSdkCore.timeProvider.getDeviceElapsedTimeNanos())
+    private val isInitialized = AtomicBoolean(false) // has init finished executing its async actions
+
+    init {
+        fetchStoredResourceHashes(
+            onFetchSuccessful = lambda@{ storedEntry ->
+                val storedData = storedEntry?.data
+
+                if (storedData == null) {
+                    finishedInitializingManager()
+                    return@lambda
+                }
+
+                val lastUpdateDateNs = storedData.lastUpdateDateNs
+                val storedHashes = storedData.resourceHashes
+
+                if (didDataStoreExpire(lastUpdateDateNs)) {
+                    deleteStoredHashesEntry(
+                        callback = object : DataStoreWriteCallback {
+                            override fun onSuccess() {
+                                finishedInitializingManager()
+                            }
+
+                            override fun onFailure() {
+                                finishedInitializingManager()
+                            }
+                        }
+                    )
+                } else {
+                    storedLastUpdateDateNs.set(lastUpdateDateNs)
+                    knownResources.addAll(storedHashes)
+                    finishedInitializingManager()
+                }
+            },
+            onFetchFailure = {
+                finishedInitializingManager()
+            }
+        )
+    }
+
+    internal fun isPreviouslySentResource(resourceHash: String): Boolean =
+        knownResources.contains(resourceHash)
+
+    internal fun cacheResourceHash(resourceHash: String) {
+        knownResources.add(resourceHash)
+        writeResourcesToStore()
+    }
+
+    internal fun isReady(): Boolean =
+        isInitialized.get()
+
+    // region internal
+
+    private fun finishedInitializingManager() {
+        isInitialized.set(true)
+    }
+
+    private fun writeResourcesToStore() {
+        val data = ResourceHashesEntry(
+            lastUpdateDateNs = storedLastUpdateDateNs.get(),
+            resourceHashes = knownResources.toList()
+        )
+
+        dataStoreOrNull()?.setValue(
+            Constants.DATASTORE_HASHES_ENTRY_KEY,
+            data,
+            Constants.CURRENT_STORE_VERSION,
+            null,
+            object : Serializer<ResourceHashesEntry> {
+                override fun serialize(model: ResourceHashesEntry): String = gson.toJson(model)
+            }
+        )
+    }
+
+    private fun fetchStoredResourceHashes(
+        onFetchSuccessful: (dataStoreContent: DataStoreContent<ResourceHashesEntry>?) -> Unit,
+        onFetchFailure: () -> Unit
+    ) {
+        dataStoreOrNull()?.value(
+            Constants.DATASTORE_HASHES_ENTRY_KEY,
+            Constants.CURRENT_STORE_VERSION,
+            object : DataStoreReadCallback<ResourceHashesEntry> {
+                override fun onSuccess(dataStoreContent: DataStoreContent<ResourceHashesEntry>?) {
+                    onFetchSuccessful(dataStoreContent)
+                }
+
+                override fun onFailure() {
+                    onFetchFailure()
+                }
+            },
+            object : Deserializer<String, ResourceHashesEntry> {
+                override fun deserialize(model: String): ResourceHashesEntry? =
+                    runCatching { gson.fromJson(model, ResourceHashesEntry::class.java) }.getOrNull()
+            }
+        )
+    }
+
+    private fun deleteStoredHashesEntry(callback: DataStoreWriteCallback) =
+        dataStoreOrNull()?.removeValue(
+            Constants.DATASTORE_HASHES_ENTRY_KEY,
+            callback
+        )
+
+    private fun didDataStoreExpire(lastUpdateDate: Long): Boolean =
+        featureSdkCore.timeProvider.getDeviceElapsedTimeNanos() - lastUpdateDate > dataStoreResetTimeNs
+
+    // endregion
+
+    private fun dataStoreOrNull() =
+        featureSdkCore.getFeature(
+            ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME
+        )?.dataStore
+
+    internal data class ResourceHashesEntry(
+        @SerializedName("last_update_date_ns") val lastUpdateDateNs: Long,
+        @SerializedName("resource_hashes") val resourceHashes: List<String>
+    )
+
+    internal object Constants {
+        const val DATASTORE_HASHES_ENTRY_KEY = "resource-hash-store"
+        const val CURRENT_STORE_VERSION = 1
+    }
+}

--- a/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriter.kt
+++ b/packages/datadog_session_replay/android/src/main/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriter.kt
@@ -18,9 +18,21 @@ internal interface ResourceWriter {
 }
 
 internal class DefaultResourceWriter(
-    private val sdkCore: FeatureSdkCore
+    private val sdkCore: FeatureSdkCore,
+    private val resourceDataStoreManager: ResourceDataStoreManager
 ) : ResourceWriter {
     override fun write(identifier: String, resourceData: ByteArray) {
+        if (resourceDataStoreManager.isPreviouslySentResource(identifier)) {
+            return
+        }
+
+        // cacheResourceHash overwrites the datastore entry, so don't call it until the
+        // manager has finished its initial load - otherwise we'd stomp on data we haven't
+        // read yet.
+        if (resourceDataStoreManager.isReady()) {
+            resourceDataStoreManager.cacheResourceHash(identifier)
+        }
+
         sdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
             ?.withWriteContext(
                 withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManagerTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManagerTest.kt
@@ -1,0 +1,289 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.resource
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.datadog.android.internal.time.TimeProvider
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+internal class ResourceDataStoreManagerTest {
+    val mockSdkCore = mockk<FeatureSdkCore>()
+    val mockScope = mockk<FeatureScope>()
+    private val fakeDataStore = FakeDataStoreHandler()
+    private var fakeElapsedTimeNs = TimeUnit.DAYS.toNanos(60)
+
+    fun setUp() {
+        every {
+            mockSdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
+        } returns mockScope
+        every { mockScope.dataStore } returns fakeDataStore
+        every { mockSdkCore.timeProvider } returns FakeTimeProvider { fakeElapsedTimeNs }
+    }
+
+    @Test
+    fun `M return false W isPreviouslySentResource {resource was not sent}`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp()
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // Then
+        assertThat(manager.isPreviouslySentResource(hash)).isFalse()
+    }
+
+    @Test
+    fun `M return true W isPreviouslySentResource {after cacheResourceHash}`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp()
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // When
+        manager.cacheResourceHash(hash)
+
+        // Then
+        assertThat(manager.isPreviouslySentResource(hash)).isTrue()
+    }
+
+    @Test
+    fun `M persist to datastore W cacheResourceHash`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp()
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // When
+        manager.cacheResourceHash(hash)
+
+        // Then
+        assertThat(
+            fakeDataStore.storage.containsKey(ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY)
+        ).isTrue()
+    }
+
+    @Test
+    fun `M seed known hashes W init {recent store}`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp()
+        fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
+            ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
+            "{\"last_update_date_ns\":$fakeElapsedTimeNs,\"resource_hashes\":[\"$hash\"]}"
+
+        // When
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // Then
+        assertThat(manager.isPreviouslySentResource(hash)).isTrue()
+        assertThat(manager.isReady()).isTrue()
+    }
+
+    @Test
+    fun `M not seed known hashes and reset store W init {stale store}`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp()
+        val staleUpdateNs = fakeElapsedTimeNs - TimeUnit.DAYS.toNanos(31)
+        fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
+            ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
+            "{\"last_update_date_ns\":$staleUpdateNs,\"resource_hashes\":[\"$hash\"]}"
+
+        // When
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // Then
+        assertThat(manager.isPreviouslySentResource(hash)).isFalse()
+        assertThat(manager.isReady()).isTrue()
+        assertThat(
+            fakeDataStore.storage.containsKey(ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY)
+        ).isFalse()
+    }
+
+    @Test
+    fun `M use a fresh creation time W cacheResourceHash {after a stale-store reset}`(
+        @StringForgery hash: String,
+        @StringForgery staleHash: String
+    ) {
+        // Given
+        setUp()
+        val staleUpdateNs = fakeElapsedTimeNs - TimeUnit.DAYS.toNanos(31)
+        fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
+            ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
+            "{\"last_update_date_ns\":$staleUpdateNs,\"resource_hashes\":[\"$staleHash\"]}"
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // When
+        manager.cacheResourceHash(hash)
+
+        // Then
+        val persisted = fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY]
+        assertThat(persisted?.second?.contains("\"last_update_date_ns\":$staleUpdateNs") ?: false).isFalse()
+    }
+
+    @Test
+    fun `M return isReady true W init {no data to fetch}`() {
+        // Given
+        setUp()
+
+        // When
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // Then
+        assertThat(manager.isReady()).isTrue()
+    }
+
+    @Test
+    fun `M return isReady true W init {failed to fetch entry}`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp(dataStore = FailingReadDataStoreHandler())
+
+        // When
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // Then
+        assertThat(manager.isReady()).isTrue()
+        assertThat(manager.isPreviouslySentResource(hash)).isFalse()
+    }
+
+    @Test
+    fun `M return isReady true W init {got expired entry, failed deleting}`(
+        @StringForgery hash: String
+    ) {
+        // Given
+        setUp()
+        val staleUpdateNs = fakeElapsedTimeNs - TimeUnit.DAYS.toNanos(31)
+        fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
+            ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
+            "{\"last_update_date_ns\":$staleUpdateNs,\"resource_hashes\":[\"$hash\"]}"
+        fakeDataStore.failOnRemove = true
+
+        // When
+        val manager = ResourceDataStoreManager(mockSdkCore)
+
+        // Then
+        assertThat(manager.isReady()).isTrue()
+    }
+
+    private fun setUp(dataStore: DataStoreHandler) {
+        setUp()
+        every { mockScope.dataStore } returns dataStore
+    }
+
+    /**
+     * In-memory fake mirroring the real DataStoreHandler contract, so tests can exercise
+     * seeding/persistence/reset behavior without mocking every generic serializer/deserializer.
+     */
+    private class FakeDataStoreHandler : DataStoreHandler {
+        val storage = mutableMapOf<String, Pair<Int, String>>()
+        var failOnRemove = false
+
+        override fun <T : Any> setValue(
+            key: String,
+            data: T,
+            version: Int,
+            callback: DataStoreWriteCallback?,
+            serializer: Serializer<T>
+        ) {
+            val serialized = serializer.serialize(data)
+            if (serialized != null) {
+                storage[key] = version to serialized
+            }
+            callback?.onSuccess()
+        }
+
+        override fun <T : Any> value(
+            key: String,
+            version: Int?,
+            callback: DataStoreReadCallback<T>,
+            deserializer: Deserializer<String, T>
+        ) {
+            val stored = storage[key]
+            if (stored == null) {
+                callback.onSuccess(null)
+                return
+            }
+            val (storedVersion, raw) = stored
+            callback.onSuccess(DataStoreContent(storedVersion, deserializer.deserialize(raw)))
+        }
+
+        override fun removeValue(key: String, callback: DataStoreWriteCallback?) {
+            if (failOnRemove) {
+                callback?.onFailure()
+                return
+            }
+            storage.remove(key)
+            callback?.onSuccess()
+        }
+
+        override fun clearAllData() {
+            storage.clear()
+        }
+    }
+
+    private class FakeTimeProvider(private val elapsedTimeNs: () -> Long) : TimeProvider {
+        override fun getDeviceTimestampMillis(): Long = 0L
+        override fun getServerTimestampMillis(): Long = 0L
+        override fun getDeviceElapsedTimeNanos(): Long = elapsedTimeNs()
+        override fun getServerOffsetNanos(): Long = 0L
+        override fun getServerOffsetMillis(): Long = 0L
+        override fun getDeviceElapsedRealtimeMillis(): Long = 0L
+    }
+
+    /** Fake that always fails to read, to exercise the `onFetchFailure` path of `init`. */
+    private class FailingReadDataStoreHandler : DataStoreHandler {
+        override fun <T : Any> setValue(
+            key: String,
+            data: T,
+            version: Int,
+            callback: DataStoreWriteCallback?,
+            serializer: Serializer<T>
+        ) {
+            callback?.onSuccess()
+        }
+
+        override fun <T : Any> value(
+            key: String,
+            version: Int?,
+            callback: DataStoreReadCallback<T>,
+            deserializer: Deserializer<String, T>
+        ) {
+            callback.onFailure()
+        }
+
+        override fun removeValue(key: String, callback: DataStoreWriteCallback?) {
+            callback?.onSuccess()
+        }
+
+        override fun clearAllData() {
+            // no-op
+        }
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManagerTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceDataStoreManagerTest.kt
@@ -23,22 +23,24 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ForgeExtension::class)
 internal class ResourceDataStoreManagerTest {
-    val mockSdkCore = mockk<FeatureSdkCore>()
+    val mockSdkCore = mockk<FeatureSdkCore>(relaxed = true)
     val mockScope = mockk<FeatureScope>()
     private val fakeDataStore = FakeDataStoreHandler()
-    private var fakeElapsedTimeNs = TimeUnit.DAYS.toNanos(60)
+    private var fakeTimestampMs = TimeUnit.DAYS.toMillis(60)
 
+    @BeforeEach
     fun setUp() {
         every {
             mockSdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
         } returns mockScope
         every { mockScope.dataStore } returns fakeDataStore
-        every { mockSdkCore.timeProvider } returns FakeTimeProvider { fakeElapsedTimeNs }
+        every { mockSdkCore.timeProvider } returns FakeTimeProvider { fakeTimestampMs }
     }
 
     @Test
@@ -46,7 +48,6 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp()
         val manager = ResourceDataStoreManager(mockSdkCore)
 
         // Then
@@ -58,7 +59,6 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp()
         val manager = ResourceDataStoreManager(mockSdkCore)
 
         // When
@@ -73,7 +73,6 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp()
         val manager = ResourceDataStoreManager(mockSdkCore)
 
         // When
@@ -90,10 +89,9 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp()
         fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
             ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
-            "{\"last_update_date_ns\":$fakeElapsedTimeNs,\"resource_hashes\":[\"$hash\"]}"
+            "{\"last_update_date_ms\":$fakeTimestampMs,\"resource_hashes\":[\"$hash\"]}"
 
         // When
         val manager = ResourceDataStoreManager(mockSdkCore)
@@ -108,11 +106,10 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp()
-        val staleUpdateNs = fakeElapsedTimeNs - TimeUnit.DAYS.toNanos(31)
+        val staleUpdateMs = fakeTimestampMs - TimeUnit.DAYS.toMillis(31)
         fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
             ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
-            "{\"last_update_date_ns\":$staleUpdateNs,\"resource_hashes\":[\"$hash\"]}"
+            "{\"last_update_date_ms\":$staleUpdateMs,\"resource_hashes\":[\"$hash\"]}"
 
         // When
         val manager = ResourceDataStoreManager(mockSdkCore)
@@ -131,11 +128,10 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery staleHash: String
     ) {
         // Given
-        setUp()
-        val staleUpdateNs = fakeElapsedTimeNs - TimeUnit.DAYS.toNanos(31)
+        val staleUpdateMs = fakeTimestampMs - TimeUnit.DAYS.toMillis(31)
         fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
             ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
-            "{\"last_update_date_ns\":$staleUpdateNs,\"resource_hashes\":[\"$staleHash\"]}"
+            "{\"last_update_date_ms\":$staleUpdateMs,\"resource_hashes\":[\"$staleHash\"]}"
         val manager = ResourceDataStoreManager(mockSdkCore)
 
         // When
@@ -143,14 +139,11 @@ internal class ResourceDataStoreManagerTest {
 
         // Then
         val persisted = fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY]
-        assertThat(persisted?.second?.contains("\"last_update_date_ns\":$staleUpdateNs") ?: false).isFalse()
+        assertThat(persisted?.second?.contains("\"last_update_date_ms\":$staleUpdateMs") ?: false).isFalse()
     }
 
     @Test
     fun `M return isReady true W init {no data to fetch}`() {
-        // Given
-        setUp()
-
         // When
         val manager = ResourceDataStoreManager(mockSdkCore)
 
@@ -163,7 +156,7 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp(dataStore = FailingReadDataStoreHandler())
+        every { mockScope.dataStore } returns FailingReadDataStoreHandler()
 
         // When
         val manager = ResourceDataStoreManager(mockSdkCore)
@@ -178,11 +171,10 @@ internal class ResourceDataStoreManagerTest {
         @StringForgery hash: String
     ) {
         // Given
-        setUp()
-        val staleUpdateNs = fakeElapsedTimeNs - TimeUnit.DAYS.toNanos(31)
+        val staleUpdateMs = fakeTimestampMs - TimeUnit.DAYS.toMillis(31)
         fakeDataStore.storage[ResourceDataStoreManager.Constants.DATASTORE_HASHES_ENTRY_KEY] =
             ResourceDataStoreManager.Constants.CURRENT_STORE_VERSION to
-            "{\"last_update_date_ns\":$staleUpdateNs,\"resource_hashes\":[\"$hash\"]}"
+            "{\"last_update_date_ms\":$staleUpdateMs,\"resource_hashes\":[\"$hash\"]}"
         fakeDataStore.failOnRemove = true
 
         // When
@@ -190,11 +182,6 @@ internal class ResourceDataStoreManagerTest {
 
         // Then
         assertThat(manager.isReady()).isTrue()
-    }
-
-    private fun setUp(dataStore: DataStoreHandler) {
-        setUp()
-        every { mockScope.dataStore } returns dataStore
     }
 
     /**
@@ -248,10 +235,10 @@ internal class ResourceDataStoreManagerTest {
         }
     }
 
-    private class FakeTimeProvider(private val elapsedTimeNs: () -> Long) : TimeProvider {
-        override fun getDeviceTimestampMillis(): Long = 0L
+    private class FakeTimeProvider(private val timestampMs: () -> Long) : TimeProvider {
+        override fun getDeviceTimestampMillis(): Long = timestampMs()
         override fun getServerTimestampMillis(): Long = 0L
-        override fun getDeviceElapsedTimeNanos(): Long = elapsedTimeNs()
+        override fun getDeviceElapsedTimeNanos(): Long = 0L
         override fun getServerOffsetNanos(): Long = 0L
         override fun getServerOffsetMillis(): Long = 0L
         override fun getDeviceElapsedRealtimeMillis(): Long = 0L

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriterTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriterTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2025-Present Datadog, Inc.
+ */
+
+package com.datadoghq.flutter.sessionreplay.resource
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventBatchWriter
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+internal class ResourceWriterTest {
+    val mockSdkCore = mockk<FeatureSdkCore>()
+    val mockScope = mockk<FeatureScope>()
+    val mockDataStoreManager = mockk<ResourceDataStoreManager>()
+
+    fun setUp() {
+        every {
+            mockSdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
+        } returns mockScope
+        every { mockScope.withWriteContext(any(), any()) } answers {
+            val callback = secondArg<(DatadogContext, ((EventBatchWriter) -> Unit) -> Unit) -> Unit>()
+            val mockContext = mockk<DatadogContext>()
+            every { mockContext.featuresContext } returns emptyMap()
+            val mockWriter = mockk<EventBatchWriter>(relaxed = true)
+            callback(mockContext) { it(mockWriter) }
+        }
+        every { mockDataStoreManager.cacheResourceHash(any()) } just Runs
+    }
+
+    @Test
+    fun `M write resource W write {new identifier, manager ready}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns false
+        every { mockDataStoreManager.isReady() } returns true
+        val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 1) { mockDataStoreManager.cacheResourceHash(identifier) }
+        verify(exactly = 1) { mockScope.withWriteContext(any(), any()) }
+    }
+
+    @Test
+    fun `M cache identifier before writing resource W write {new identifier}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns false
+        every { mockDataStoreManager.isReady() } returns true
+        val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then - mirrors native's mark-before-write ordering, rather than marking only
+        // after the write succeeds
+        verifyOrder {
+            mockDataStoreManager.cacheResourceHash(identifier)
+            mockScope.withWriteContext(any(), any())
+        }
+    }
+
+    @Test
+    fun `M not write resource W write {identifier already known}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns true
+
+        val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then
+        verify(exactly = 0) { mockScope.withWriteContext(any(), any()) }
+        verify(exactly = 0) { mockDataStoreManager.cacheResourceHash(any()) }
+    }
+
+    @Test
+    fun `M write resource but not cache it W write {manager not ready yet}`(
+        @StringForgery identifier: String,
+        @StringForgery resourceData: String
+    ) {
+        // Given
+        setUp()
+        every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns false
+        every { mockDataStoreManager.isReady() } returns false
+
+        val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
+
+        // When
+        writer.write(identifier, resourceData.toByteArray())
+
+        // Then - matches native: caching would overwrite the datastore entry before the
+        // initial load has finished, so it's skipped, but the resource is still uploaded
+        verify(exactly = 1) { mockScope.withWriteContext(any(), any()) }
+        verify(exactly = 0) { mockDataStoreManager.cacheResourceHash(any()) }
+    }
+}

--- a/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriterTest.kt
+++ b/packages/datadog_session_replay/android/src/test/kotlin/com/datadoghq/flutter/sessionreplay/resource/ResourceWriterTest.kt
@@ -18,6 +18,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -27,6 +28,7 @@ internal class ResourceWriterTest {
     val mockScope = mockk<FeatureScope>()
     val mockDataStoreManager = mockk<ResourceDataStoreManager>()
 
+    @BeforeEach
     fun setUp() {
         every {
             mockSdkCore.getFeature(ResourceFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
@@ -47,7 +49,6 @@ internal class ResourceWriterTest {
         @StringForgery resourceData: String
     ) {
         // Given
-        setUp()
         every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns false
         every { mockDataStoreManager.isReady() } returns true
         val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
@@ -66,7 +67,6 @@ internal class ResourceWriterTest {
         @StringForgery resourceData: String
     ) {
         // Given
-        setUp()
         every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns false
         every { mockDataStoreManager.isReady() } returns true
         val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
@@ -88,7 +88,6 @@ internal class ResourceWriterTest {
         @StringForgery resourceData: String
     ) {
         // Given
-        setUp()
         every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns true
 
         val writer = DefaultResourceWriter(mockSdkCore, mockDataStoreManager)
@@ -107,7 +106,6 @@ internal class ResourceWriterTest {
         @StringForgery resourceData: String
     ) {
         // Given
-        setUp()
         every { mockDataStoreManager.isPreviouslySentResource(identifier) } returns false
         every { mockDataStoreManager.isReady() } returns false
 

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,11 +9,11 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		1BF9F7287A523E34D5710707 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A0117D673D82B937FDFE484 /* Pods_RunnerTests.framework */; };
+		1F0B9721A43A6A63DCC17933 /* DataStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0C0F8D524DC14EF6F6CFB0 /* DataStoreMock.swift */; };
 		3698E2CC21FBD5E1AEAE147E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F083243CD88418C21034C30 /* Pods_Runner.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		494123582DC129660071423F /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494123572DC129630071423F /* RequestBuilderTests.swift */; };
 		494400772E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */; };
-		E7162BD14BF84CACB6B101E947BD07D1 /* SessionReplayTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */; };
 		494400792E58BA1000AC46CC /* Mockable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400782E58BA0700AC46CC /* Mockable.swift */; };
 		4944007D2E58C55200AC46CC /* FlutterSessionReplayFeatureMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4944007C2E58C54B00AC46CC /* FlutterSessionReplayFeatureMock.swift */; };
 		494400892E58E7A200AC46CC /* ResourceResolverMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494400882E58E7A200AC46CC /* ResourceResolverMock.swift */; };
@@ -34,6 +34,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		E1E091C69AD74808BE3733231FC76E98 /* DatadogSessionReplayPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35542C60C09A47729F76E13B6A659C63 /* DatadogSessionReplayPluginTests.swift */; };
+		E7162BD14BF84CACB6B101E947BD07D1 /* SessionReplayTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,7 +70,6 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		494123572DC129630071423F /* RequestBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestBuilderTests.swift; sourceTree = "<group>"; };
 		494400762E58AC8B00AC46CC /* FlutterSessionReplayBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayBridgeTests.swift; sourceTree = "<group>"; };
-		F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayTestContainer.swift; sourceTree = "<group>"; };
 		494400782E58BA0700AC46CC /* Mockable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mockable.swift; sourceTree = "<group>"; };
 		4944007C2E58C54B00AC46CC /* FlutterSessionReplayFeatureMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlutterSessionReplayFeatureMock.swift; sourceTree = "<group>"; };
 		494400882E58E7A200AC46CC /* ResourceResolverMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceResolverMock.swift; sourceTree = "<group>"; };
@@ -98,9 +98,11 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9840D6870413420E38040A85 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		BE0C0F8D524DC14EF6F6CFB0 /* DataStoreMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataStoreMock.swift; sourceTree = "<group>"; };
 		CB6E419C80EE782C5F5B2C8E /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		CDF9F7F84B03E7F780D7C869 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		E3A52EA2C191523119AFBBD1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayTestContainer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -190,6 +192,7 @@
 				495A027D2DCE433B00869BEA /* FileWriterMock.swift */,
 				495A027F2DCE433B00869BEA /* FoundationMocks.swift */,
 				495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */,
+				BE0C0F8D524DC14EF6F6CFB0 /* DataStoreMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -498,6 +501,7 @@
 				E1E091C69AD74808BE3733231FC76E98 /* DatadogSessionReplayPluginTests.swift in Sources */,
 				4944008D2E58F71300AC46CC /* ResourcesWriterTest.swift in Sources */,
 				495642A52E5E2512000FF536 /* ResourceResolverTest.swift in Sources */,
+				1F0B9721A43A6A63DCC17933 /* DataStoreMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DataStoreMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/DataStoreMock.swift
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2019-Present Datadog, Inc.
+ */
+
+import Foundation
+import DatadogInternal
+
+public class DataStoreMock: DataStore {
+    @ReadWriteLock
+    public var storage: [String: DataStoreValueResult]
+
+    public init(storage: [String: DataStoreValueResult] = [:]) {
+        self.storage = storage
+    }
+
+    public func setValue(_ value: Data, forKey key: String, version: DataStoreKeyVersion) {
+        storage[key] = .value(value, version)
+    }
+
+    public func value(forKey key: String, callback: @escaping (DataStoreValueResult) -> Void) {
+        callback(storage[key] ?? .noValue)
+    }
+
+    public func removeValue(forKey key: String) {
+        storage[key] = nil
+    }
+
+    public func clearAllData() {
+        storage.removeAll()
+    }
+
+    public func flush() {
+        // no-op
+    }
+
+    // MARK: - Side Effects Observation
+
+    public func value(forKey key: String) -> DataStoreValueResult? {
+        return storage[key]
+    }
+}

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Resource/ResourcesWriterTest.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Resource/ResourcesWriterTest.swift
@@ -92,4 +92,72 @@ struct ResourcesWriterTest {
         #expect(resourceEvent.context.type == "resource")
         #expect(resourceEvent.context.application.id == rumApplicationId)
     }
+
+    @Test
+    func write_WithIdentifierKnownFromPreviousSession_DoesNotWriteToCore() throws {
+        // Given
+        let sharedDataStore = DataStoreMock()
+        let firstSessionCore = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let firstSessionWriter = ResourcesWriter(scope: firstSessionCore)
+
+        let id: String = .mockRandom()
+        let data = Data([1, 2, 3])
+        let mimeType: String = .mockRandom()
+        firstSessionWriter.write(withIdentifier: id, data: data, mimeType: mimeType)
+        try #require(firstSessionCore.events.count == 1)
+
+        // When a new writer instance (simulating a new app session) shares the same data store
+        let secondSessionCore = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let secondSessionWriter = ResourcesWriter(scope: secondSessionCore)
+        secondSessionWriter.write(withIdentifier: id, data: data, mimeType: mimeType)
+
+        // Then it does not write the already-known identifier again
+        #expect(secondSessionCore.events.isEmpty)
+    }
+
+    @Test
+    func write_WithStaleStoreCreation_ResetsKnownIdentifiers() throws {
+        // Given
+        let id: String = .mockRandom()
+        let staleStoreCreation = Date().timeIntervalSince1970 - TimeInterval(31).days
+        let sharedDataStore = DataStoreMock(
+            storage: [
+                ResourcesWriter.Constants.storeCreationKey: .value(staleStoreCreation.asData(), ResourcesWriter.Constants.currentStoreVersion),
+                ResourcesWriter.Constants.knownResourcesKey: .value(Set([id]).asData(JSONEncoder())!, ResourcesWriter.Constants.currentStoreVersion)
+            ]
+        )
+        let core = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let writer = ResourcesWriter(scope: core)
+
+        // When
+        let data = Data([1, 2, 3])
+        let mimeType: String = .mockRandom()
+        writer.write(withIdentifier: id, data: data, mimeType: mimeType)
+
+        // Then the stale store was reset, so the previously-known identifier is written again
+        #expect(core.events.count == 1)
+    }
+
+    @Test
+    func write_WithRecentStoreCreation_DoesNotResetKnownIdentifiers() throws {
+        // Given
+        let id: String = .mockRandom()
+        let recentStoreCreation = Date().timeIntervalSince1970
+        let sharedDataStore = DataStoreMock(
+            storage: [
+                ResourcesWriter.Constants.storeCreationKey: .value(recentStoreCreation.asData(), ResourcesWriter.Constants.currentStoreVersion),
+                ResourcesWriter.Constants.knownResourcesKey: .value(Set([id]).asData(JSONEncoder())!, ResourcesWriter.Constants.currentStoreVersion)
+            ]
+        )
+        let core = PassthroughCoreMock(context: .mockRandom(), dataStore: sharedDataStore)
+        let writer = ResourcesWriter(scope: core)
+
+        // When
+        let data = Data([1, 2, 3])
+        let mimeType: String = .mockRandom()
+        writer.write(withIdentifier: id, data: data, mimeType: mimeType)
+
+        // Then the identifier was seeded from the data store, so it's not written again
+        #expect(core.events.isEmpty)
+    }
 }

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Resource/ResourcesWriter.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/Resource/ResourcesWriter.swift
@@ -11,24 +11,21 @@ internal protocol ResourcesWriting {
 
 internal class ResourcesWriter: ResourcesWriting {
     private let scope: FeatureScope
-// TODO(RUM-11447): Commented out code in this file is support for the DataStore image caching
-// Which will be added with the above ticket
-//    private let encoder: JSONEncoder
-//    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
 
     @ReadWriteLock
-    private var knownIdentifiers = Set<String>()
-//    private var knownIdentifiers = Set<String>() {
-//        didSet {
-//            if let knownIdentifiers = knownIdentifiers.asData(encoder) {
-//                scope.dataStore.setValue(
-//                    knownIdentifiers,
-//                    forKey: Constants.knownResourcesKey,
-//                    version: Constants.currentStoreVersion
-//                )
-//            }
-//        }
-//    }
+    private var knownIdentifiers = Set<String>() {
+        didSet {
+            if let knownIdentifiers = knownIdentifiers.asData(encoder) {
+                scope.dataStore.setValue(
+                    knownIdentifiers,
+                    forKey: Constants.knownResourcesKey,
+                    version: Constants.currentStoreVersion
+                )
+            }
+        }
+    }
 
     init(
         scope: FeatureScope,
@@ -37,38 +34,38 @@ internal class ResourcesWriter: ResourcesWriting {
         decoder: JSONDecoder = JSONDecoder()
     ) {
         self.scope = scope
-//        self.encoder = encoder
-//        self.decoder = decoder
-//        self.scope.dataStore.value(forKey: Constants.storeCreationKey) { [weak self]  result in
-//            do {
-//                if let storeCreation = try result.data(expectedVersion: Constants.currentStoreVersion)?.asTimeInterval(),
-//                   Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
-//                    self?.scope.dataStore.value(forKey: Constants.knownResourcesKey) { result in
-//                        switch result {
-//                        case .value(let data, let version) where version == Constants.currentStoreVersion:
-//                            do {
-//                                if let knownIdentifiers = try data.asKnownIdentifiers(decoder) {
-//                                    self?.knownIdentifiers.formUnion(knownIdentifiers)
-//                                }
-//                            } catch let error {
-//                                self?.scope.telemetry.error("Failed to decode known identifiers", error: error)
-//                            }
-//                        default:
-//                            break
-//                        }
-//                    }
-//                } else { // Reset if store was created more than 30 days ago
-//                    self?.scope.dataStore.setValue(
-//                        Date().timeIntervalSince1970.asData(),
-//                        forKey: Constants.storeCreationKey,
-//                        version: Constants.currentStoreVersion
-//                    )
-//                    self?.scope.dataStore.removeValue(forKey: Constants.knownResourcesKey)
-//                }
-//            } catch let error {
-//                self?.scope.telemetry.error("Failed to decode store creation", error: error)
-//            }
-//        }
+        self.encoder = encoder
+        self.decoder = decoder
+        self.scope.dataStore.value(forKey: Constants.storeCreationKey) { [weak self] result in
+            do {
+                if let storeCreation = try result.data(expectedVersion: Constants.currentStoreVersion)?.asTimeInterval(),
+                   Date().timeIntervalSince1970 - storeCreation < dataStoreResetTime {
+                    self?.scope.dataStore.value(forKey: Constants.knownResourcesKey) { result in
+                        switch result {
+                        case .value(let data, let version) where version == Constants.currentStoreVersion:
+                            do {
+                                if let knownIdentifiers = try data.asKnownIdentifiers(decoder) {
+                                    self?.knownIdentifiers.formUnion(knownIdentifiers)
+                                }
+                            } catch let error {
+                                self?.scope.telemetry.error("Failed to decode known identifiers", error: error)
+                            }
+                        default:
+                            break
+                        }
+                    }
+                } else { // Reset if store was created more than 30 days ago
+                    self?.scope.dataStore.setValue(
+                        Date().timeIntervalSince1970.asData(),
+                        forKey: Constants.storeCreationKey,
+                        version: Constants.currentStoreVersion
+                    )
+                    self?.scope.dataStore.removeValue(forKey: Constants.knownResourcesKey)
+                }
+            } catch let error {
+                self?.scope.telemetry.error("Failed to decode store creation", error: error)
+            }
+        }
     }
 
     // MARK: - Writing
@@ -94,11 +91,11 @@ internal class ResourcesWriter: ResourcesWriting {
         }
     }
 
-//    enum Constants {
-//        static let knownResourcesKey = "known-resources"
-//        static let storeCreationKey = "store-creation"
-//        static let currentStoreVersion = UInt16(1)
-//    }
+    enum Constants {
+        static let knownResourcesKey = "known-resources"
+        static let storeCreationKey = "store-creation"
+        static let currentStoreVersion = UInt16(1)
+    }
 }
 
 extension DatadogContext {
@@ -107,37 +104,37 @@ extension DatadogContext {
     }
 }
 
-// extension Data {
-//    enum SerializationError: Error {
-//        case invalidData
-//    }
-//
-//    func asTimeInterval() throws -> TimeInterval {
-//        var value: TimeInterval = 0
-//        guard count >= MemoryLayout.size(ofValue: value) else {
-//            throw SerializationError.invalidData
-//        }
-//        _ = Swift.withUnsafeMutableBytes(of: &value) {
-//            copyBytes(to: $0)
-//        }
-//        return value
-//    }
-//
-//    func asKnownIdentifiers(_ decoder: JSONDecoder) throws -> Set<String>? {
-//        return try decoder.decode(Set<String>.self, from: self)
-//    }
-// }
-//
-// extension TimeInterval {
-//    func asData() -> Data {
-//        return Swift.withUnsafeBytes(of: self) {
-//            Data($0)
-//        }
-//    }
-// }
-//
-// extension Set<String> {
-//    func asData(_ encoder: JSONEncoder) -> Data? {
-//        return try? encoder.encode(self) // Never fails
-//    }
-// }
+extension Data {
+    enum SerializationError: Error {
+        case invalidData
+    }
+
+    func asTimeInterval() throws -> TimeInterval {
+        var value: TimeInterval = 0
+        guard count >= MemoryLayout.size(ofValue: value) else {
+            throw SerializationError.invalidData
+        }
+        _ = Swift.withUnsafeMutableBytes(of: &value) {
+            copyBytes(to: $0)
+        }
+        return value
+    }
+
+    func asKnownIdentifiers(_ decoder: JSONDecoder) throws -> Set<String>? {
+        return try decoder.decode(Set<String>.self, from: self)
+    }
+}
+
+extension TimeInterval {
+    func asData() -> Data {
+        return Swift.withUnsafeBytes(of: self) {
+            Data($0)
+        }
+    }
+}
+
+extension Set<String> {
+    func asData(_ encoder: JSONEncoder) -> Data? {
+        return try? encoder.encode(self) // Never fails
+    }
+}


### PR DESCRIPTION
### What and why?

Session Replay must not resend images whose MD5 hash was already sent to the resource endpoint in a previous session. Both platforms mirror their own native SDK's dedup design rather than each other, so their marking behavior differs.

Android introduces a dedicated ResourceDataStoreManager, mirroring native dd-sdk-android's class of the same name: it loads its known-hash entry eagerly on construction and marks an identifier as known optimistically, before the write is attempted, gated on isReady() so it never overwrites the DataStore entry before the initial load completes. This required constructing the writer inside onInitialize, after ResourceFeature registers, instead of as a property initializer, so the eager load has a feature to read from.

iOS keeps its existing design, mirroring native iOS: it seeds its identifier cache eagerly in init (its FeatureScope is already registered at that point) and marks an identifier as known only after its write actually succeeds.

Both platforms reset their cache after 30 days to bound unbounded local growth.

### How?

- Android: Added ResourceDataStoreManager (resource/ResourceDataStoreManager.kt), which wraps the feature's DataStoreHandler behind a single combined entry (DATASTORE_HASHES_ENTRY_KEY) storing a JSON blob of {last_update_date_ns, resource_hashes}. On construction it reads that entry via sdkCore.timeProvider-based elapsed time, discards it and clears the DataStore if it's older than 30 days, otherwise seeds an in-memory known-hash set from it. isReady() reports whether the initial read has completed (including failure paths), and cacheResourceHash() persists the updated set back to the DataStore. DefaultResourceWriter.write() now checks isPreviouslySentResource() first, marks the hash via cacheResourceHash() before writing (only if isReady(), to avoid clobbering data that hasn't loaded yet), then writes the resource event as before. Since the manager's eager load requires ResourceFeature to already be registered, DefaultResourceWriter/ResourceDataStoreManager construction moved from a property initializer into FlutterSessionReplayFeature.onInitialize(), after sdkCore.registerFeature(resourcesFeature).
- iOS: ResourcesWriter is unchanged in structure — it already seeded knownIdentifiers eagerly from scope.dataStore in init and reset the store after 30 days. Minor internal cleanup/refactor plus expanded test coverage (ResourcesWriterTest.swift, new DataStoreMock.swift) to exercise the seeding, reset, and mark-after-write paths more thoroughly.
- Added ResourceDataStoreManagerTest.kt and ResourceWriterTest.kt (mockk/JUnit5, matching this repo's existing Android test conventions) covering: fresh vs. previously-cached resources, DataStore persistence, stale-store reset after 30 days, and the various isReady()-gated write/cache orderings, including failure paths on read and delete.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests 
- [x] This pull request references a Github or JIRA issue — 11447
