### PR TITLE
feat: Support CI for Linux

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -293,6 +293,22 @@ web-integration-test:
     - ./tools/ci/.tmp/chromedriver-linux64/chromedriver --port=4444 &
     - melos run integration_test:web
 
+linux-integration-test:
+  stage: integration-test
+  except: [ schedules ]
+  needs: [ build-linux ]
+  image: $CI_IMAGE_DOCKER
+  tags:
+    [ "arch:amd64" ]
+  script:
+    - !reference [.pre, script]
+    - melos run integration_test:linux
+  artifacts:
+    when: always
+    expire_in: "30 days"
+    reports:
+      junit: $CI_PROJECT_DIR/.build/test-results/*.xml
+
 # windows-integration-test:
 #   stage: integration-test
 #   except: [ schedules ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -302,7 +302,7 @@ linux-integration-test:
     [ "arch:amd64" ]
   script:
     - !reference [.pre, script]
-    - melos run integration_test:linux
+    - xvfb-run -a dbus-run-session -- melos run integration_test:linux
   artifacts:
     when: always
     expire_in: "30 days"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ include:
   - 'https://gitlab-templates.ddbuild.io/slack-notifier/v3-sdm/template.yml'
 
 variables:
-  CURRENT_CI_IMAGE: "10"
+  CURRENT_CI_IMAGE: "11"
   BUILD_STABLE_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   DISTRIBUTION_REGISTRY: registry.ddbuild.io
   # Linux CI Images
@@ -189,6 +189,21 @@ build-web:
     - !reference [.pre-web, script]
     - melos run build:web
     - melos run unit_test:web
+  artifacts:
+    when: always
+    expire_in: "30 days"
+    reports:
+      junit: $CI_PROJECT_DIR/.build/test-results/*.xml
+
+build-linux:
+  stage: build
+  except: [ schedules ]
+  image: $CI_IMAGE_DOCKER
+  tags: [ "arch:amd64" ]
+  script:
+    - !reference [.pre, script]
+    - melos run build:linux
+    - melos run unit_test:linux
   artifacts:
     when: always
     expire_in: "30 days"

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -43,6 +43,17 @@ RUN set -x \
     ca-certificates \
     zip
 
+ # Add Flutter Linux desktop build/test dependencies
+ RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    clang \
+    cmake \
+    ninja-build \
+    pkg-config \
+    libblkid-dev \
+    liblzma-dev \
+    xvfb \
+    dbus-x11
+
 ENV GRADLE_VERSION 8.1.1
 ENV ANDROID_COMPILE_SDK 34
 ENV ANDROID_BUILD_TOOLS 34.0.0

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -51,6 +51,7 @@ RUN set -x \
     pkg-config \
     libblkid-dev \
     liblzma-dev \
+    libcurl4-openssl-dev \
     xvfb \
     dbus-x11
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -300,7 +300,9 @@ scripts:
       cd example
       dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results
     packageFilters:
-      dirExists: 'example/integration_test'
+      dirExists: 
+        - 'example/integration_test'
+        - 'example/linux'
       ignore:
         - 'datadog_flutter_plugin'
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -55,6 +55,13 @@ scripts:
     packageFilters:
       dirExists: example/windows
 
+  build:linux:
+    exec:
+      concurrency: 1
+    run: cd example && flutter build linux --release
+    packageFilters:
+      dirExists: example/linux
+
   dartfmt_check:
     exec: dart format --output=none --set-exit-if-changed .
   
@@ -131,6 +138,15 @@ scripts:
         - 'datadog_flutter_plugin_web'
 
   unit_test:windows:
+    exec:
+      concurrency: 1
+    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/$MELOS_PACKAGE_NAME_unit.xml -- flutter test --machine
+    packageFilters:
+      dirExists: 'test'
+      ignore:
+        - 'datadog_flutter_plugin_web'
+
+  unit_test:linux:
     exec:
       concurrency: 1
     run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/$MELOS_PACKAGE_NAME_unit.xml -- flutter test --machine
@@ -268,6 +284,32 @@ scripts:
   # have a separate target just for it that is called by `integration_test:windows``
   integration_test:windows:main:
     exec: cd integration_test_app && dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results
+    packageFilters:
+      scope: 'datadog_flutter_plugin'
+
+  integration_test:linux:
+    run: melos integration_test:linux:main && melos integration_test:linux:other
+
+  # Desktop platforms can't run the whole integration_test directory in one `flutter test`
+  # invocation, so this uses tools/ci/bin/desktop_integration_tests.dart to run each
+  # test file individually, same idea as web's per-file `flutter drive` runner.
+  integration_test:linux:other:
+    exec:
+      concurrency: 1
+    run: |
+      cd example
+      dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results
+    packageFilters:
+      dirExists: 'example/integration_test'
+      ignore:
+        - 'datadog_flutter_plugin'
+
+  # Because the main package (datadog_flutter_plugin) is set up weird for integration tests,
+  # have a separate target just for it that is called by `integration_test:linux``
+  integration_test:linux:main:
+    exec: |
+      cd integration_test_app
+      dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results
     packageFilters:
       scope: 'datadog_flutter_plugin'
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -194,13 +194,15 @@ void main() {
 
     // Verify user in all events, except for the first view event
     // Verify user in all events, except for the first few view events
-    bool sawUser = false;
+    bool sawRealUser = false;
     for (final viewEvent in view1.viewEvents) {
-      // It's okay for view events to not have a user for the first few,
+      // It's okay for view events to not have a real user for the first few,
       // so long as it remains consistent after the first event. This can happen
-      // if long tasks are reported during boot.
-      if (viewEvent.user != null || sawUser) {
-        sawUser = true;
+      // if long tasks are reported during boot. Events may still have an
+      // anonymous user (usr.anonymous_id) before a real user is set, which
+      // doesn't count as "seeing" a user.
+      if (viewEvent.user?.id != null || sawRealUser) {
+        sawRealUser = true;
         verifyUser(viewEvent);
       }
     }

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -193,8 +193,16 @@ void main() {
     expect(view1.vitalStepEvents[2].vitalFailureReason, 'error');
 
     // Verify user in all events, except for the first view event
-    for (final viewEvent in view1.viewEvents.sublist(1)) {
-      verifyUser(viewEvent);
+    // Verify user in all events, except for the first few view events
+    bool sawUser = false;
+    for (final viewEvent in view1.viewEvents) {
+      // It's okay for view events to not have a user for the first few,
+      // so long as it remains consistent after the first event. This can happen
+      // if long tasks are reported during boot.
+      if (viewEvent.user != null || sawUser) {
+        sawUser = true;
+        verifyUser(viewEvent);
+      }
     }
     for (final actionEvent in view1.actionEvents) {
       verifyUser(actionEvent);
@@ -205,6 +213,7 @@ void main() {
     for (final errorEvent in view1.errorEvents) {
       verifyUser(errorEvent);
     }
+    // Everything after the first vital should contain a user.
     for (final vitalEvent in view1.vitalStepEvents.sublist(1)) {
       verifyUser(vitalEvent);
     }


### PR DESCRIPTION
### What and why?

Add support for Linux CI for unit and integration testing.

Integration tests on Desktop must be run one file at a time because of a bug in the Flutter tool. This uses the one previously created for Windows.

refs: RUM-17632

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
