### PR TITLE
feat(rum): use tooltips as action descriptions in RumUserActionDetector

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Use a widget's `Tooltip` message as a fallback description for actions detected by `RumUserActionDetector`. See [#1033](https://github.com/DataDog/dd-sdk-flutter/issues/1033).
+
 ## 3.4.1
 
 * Properly pin Android SDK version to 3.11.0.

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## Unreleased
-
-* Use a widget's `Tooltip` message as a fallback description for actions detected by `RumUserActionDetector`. See [#1033](https://github.com/DataDog/dd-sdk-flutter/issues/1033).
-* Report `FloatingActionButton` as its own element type in `RumUserActionDetector`, using its label text or tooltip as the description. Actions on these buttons were previously reported as their inner `InkWell`, so both the element type and description of existing actions may change.
-
 ## 3.4.1
 
 * Properly pin Android SDK version to 3.11.0.

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Use a widget's `Tooltip` message as a fallback description for actions detected by `RumUserActionDetector`. See [#1033](https://github.com/DataDog/dd-sdk-flutter/issues/1033).
+* Report `FloatingActionButton` as its own element type in `RumUserActionDetector`, using its label text or tooltip as the description. Actions on these buttons were previously reported as their inner `InkWell`, so both the element type and description of existing actions may change.
 
 ## 3.4.1
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -89,7 +89,9 @@ class _ElementDescription {
 /// For most Button types, the detector will look for a [Text] widget child,
 /// which it will use for the description of the action. In other cases, it will
 /// look for a child [Semantics] object, or an [Icon] with its [Icon.semanticsLabel]
-/// property set.
+/// property set. If none of these provide a description, the detector falls
+/// back to the tapped widget's own tooltip, like [IconButton.tooltip], or to
+/// the message of a [Tooltip] enclosing the tapped widget.
 ///
 /// Alternately, you can enclose any Widget tree with a
 /// [RumUserActionAnnotation], which will use the provided description when
@@ -270,6 +272,7 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     _ElementDescription? detectingElement;
 
     _RumTreeAnnotation? rumTreeAnnotation;
+    String? tooltipMessage;
     RenderObject? lastRenderObject;
 
     void elementVisitor(Element element) {
@@ -288,13 +291,19 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
       }
 
       if (ro == lastRenderObject) {
+        final previousAnnotation = rumTreeAnnotation;
+        final previousTooltipMessage = tooltipMessage;
+
         final widget = element.widget;
         if (widget is RumUserActionAnnotation) {
           rumTreeAnnotation =
               _RumTreeAnnotation(widget.description, widget.attributes);
         } else {
+          if (widget is Tooltip) {
+            tooltipMessage = _tooltipDescription(widget) ?? tooltipMessage;
+          }
           final checkElement = _getDetectingElementDescription(
-              element, targets, rumTreeAnnotation);
+              element, targets, rumTreeAnnotation, tooltipMessage);
           if (checkElement != null &&
               checkElement.betterThan(detectingElement)) {
             detectingElement = checkElement;
@@ -304,8 +313,9 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
         if (detectingElement?.tryForBetter != false) {
           element.visitChildElements(elementVisitor);
         }
-        // This annotation was only for this tree
-        rumTreeAnnotation = null;
+        // Any annotation or tooltip captured here only applied to this tree
+        rumTreeAnnotation = previousAnnotation;
+        tooltipMessage = previousTooltipMessage;
       } else {
         // RenderBoxes without size will assert in debug mode.
         if (ro is RenderBox && !ro.hasSize) return;
@@ -329,10 +339,14 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     return detectingElement;
   }
 
-  _ElementDescription? _getDetectingElementDescription(Element element,
-      List<HitTestEntry> targets, _RumTreeAnnotation? treeAnnotation) {
+  _ElementDescription? _getDetectingElementDescription(
+      Element element,
+      List<HitTestEntry> targets,
+      _RumTreeAnnotation? treeAnnotation,
+      String? ancestorTooltipMessage) {
     final widget = element.widget;
     String? elementName;
+    String? widgetTooltip;
     bool searchForBetter = false;
     bool searchForText = true;
 
@@ -358,6 +372,7 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
       if (widget.onPressed != null) {
         elementName = 'IconButton';
         searchForText = false;
+        widgetTooltip = _nonEmpty(widget.tooltip);
       }
     } else if (widget is Tab) {
       elementName = 'Tab';
@@ -395,14 +410,18 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     }
 
     if (elementName != null) {
-      // A user added annotation takes precedence over a search, but using
-      // semantic information from further up the tree is a last resort.
+      // A user added annotation takes precedence over a search. When neither
+      // provides a description, fall back to the widget's own tooltip, then
+      // to the message of a Tooltip enclosing the tapped widget.
       var elementDescription =
           treeAnnotation ?? _findElementInnerText(element, searchForText);
       return _ElementDescription(
         element: element,
         elementName: elementName,
-        elementDescription: elementDescription?.description ?? 'unknown',
+        elementDescription: elementDescription?.description ??
+            widgetTooltip ??
+            ancestorTooltipMessage ??
+            'unknown',
         tryForBetter: searchForBetter,
         attributes: elementDescription?.attributes,
       );
@@ -410,6 +429,12 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
 
     return null;
   }
+}
+
+String? _nonEmpty(String? value) => (value?.isNotEmpty ?? false) ? value : null;
+
+String? _tooltipDescription(Tooltip tooltip) {
+  return _nonEmpty(tooltip.message ?? tooltip.richMessage?.toPlainText());
 }
 
 Element? _findGestureDetectorElement(

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -72,8 +72,8 @@ class _ElementDescription {
 /// This wrapper widget automatically detects tap user actions that occur in its
 /// tree and sends them to RUM. It detects interactions with several common
 /// Flutter widgets, including [ElevatedButton], [TextButton],
-/// [CupertinoButton], [BottomNavigationBar], [TabBar], [InkWell], and
-/// [GestureDetector].
+/// [CupertinoButton], [FloatingActionButton], [BottomNavigationBar], [TabBar],
+/// [InkWell], and [GestureDetector].
 /// You can also provide a custom detection logic by passing [customGestureDetector]
 /// parameter to detect your custom tappable widgets. Example:
 ///
@@ -367,6 +367,11 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     } else if (widget is CupertinoButton) {
       if (widget.enabled) {
         elementName = 'Button';
+      }
+    } else if (widget is FloatingActionButton) {
+      if (widget.onPressed != null) {
+        elementName = 'FloatingActionButton';
+        widgetTooltip = _nonEmpty(widget.tooltip);
       }
     } else if (widget is IconButton) {
       if (widget.onPressed != null) {

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum_user_action_detector.dart
@@ -86,12 +86,14 @@ class _ElementDescription {
 /// }
 /// ```
 ///
-/// For most Button types, the detector will look for a [Text] widget child,
-/// which it will use for the description of the action. In other cases, it will
-/// look for a child [Semantics] object, or an [Icon] with its [Icon.semanticsLabel]
-/// property set. If none of these provide a description, the detector falls
-/// back to the tapped widget's own tooltip, like [IconButton.tooltip], or to
-/// the message of a [Tooltip] enclosing the tapped widget.
+/// For buttons that provide a tooltip, like [IconButton.tooltip] and
+/// [FloatingActionButton.tooltip], the detector will use the tooltip as the
+/// description of the action. For most other Button types, the detector will
+/// look for a [Text] widget child, which it will use for the description of
+/// the action. In other cases, it will look for a child [Semantics] object,
+/// or an [Icon] with its [Icon.semanticsLabel] property set. If none of these
+/// provide a description, the detector falls back to the message of a
+/// [Tooltip] enclosing the tapped widget.
 ///
 /// Alternately, you can enclose any Widget tree with a
 /// [RumUserActionAnnotation], which will use the provided description when
@@ -213,6 +215,7 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
   _RumTreeAnnotation? _findElementInnerText(Element element, bool allowText) {
     String? elementDescription;
     Map<String, Object?>? attributes;
+    bool fromUserAnnotation = false;
     // visitChildren will visit siblings for widget collections like Columns,
     // but if we encounter a RumUserActionAnnotation somewhere in the tree, that
     // is likely the text we want and siblings can be ignored.
@@ -242,6 +245,7 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
       } else if (widget is RumUserActionAnnotation) {
         elementDescription = widget.description;
         attributes = widget.attributes;
+        fromUserAnnotation = true;
         stopVisits = true;
         stopSiblingVisits = true;
       }
@@ -253,7 +257,8 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
 
     element.visitChildren(visitor);
 
-    return _RumTreeAnnotation(elementDescription, attributes);
+    return _RumTreeAnnotation(
+        elementDescription, attributes, fromUserAnnotation);
   }
 
   _ElementDescription? _getDetectingElementAtPosition(Offset position) {
@@ -297,7 +302,7 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
         final widget = element.widget;
         if (widget is RumUserActionAnnotation) {
           rumTreeAnnotation =
-              _RumTreeAnnotation(widget.description, widget.attributes);
+              _RumTreeAnnotation(widget.description, widget.attributes, true);
         } else {
           if (widget is Tooltip) {
             tooltipMessage = _tooltipDescription(widget) ?? tooltipMessage;
@@ -415,18 +420,24 @@ class _RumUserActionDetectorState extends State<RumUserActionDetector> {
     }
 
     if (elementName != null) {
-      // A user added annotation takes precedence over a search. When neither
-      // provides a description, fall back to the widget's own tooltip, then
-      // to the message of a Tooltip enclosing the tapped widget.
+      // A user added annotation takes precedence over everything else. The
+      // widget's own tooltip describes the button's action, so it is
+      // preferred over content found in its subtree, and the message of a
+      // Tooltip enclosing the tapped widget is a last resort.
       var elementDescription =
           treeAnnotation ?? _findElementInnerText(element, searchForText);
+      String? description;
+      if (elementDescription?.fromUserAnnotation ?? false) {
+        description = elementDescription?.description;
+      }
+      description ??= widgetTooltip ??
+          elementDescription?.description ??
+          ancestorTooltipMessage ??
+          'unknown';
       return _ElementDescription(
         element: element,
         elementName: elementName,
-        elementDescription: elementDescription?.description ??
-            widgetTooltip ??
-            ancestorTooltipMessage ??
-            'unknown',
+        elementDescription: description,
         tryForBetter: searchForBetter,
         attributes: elementDescription?.attributes,
       );
@@ -520,7 +531,13 @@ class _RumTreeAnnotation {
   final String? description;
   final Map<String, Object?>? attributes;
 
-  const _RumTreeAnnotation(this.description, [this.attributes]);
+  // Whether this description came from a user provided
+  // [RumUserActionAnnotation], which takes precedence over any other
+  // description source.
+  final bool fromUserAnnotation;
+
+  const _RumTreeAnnotation(this.description,
+      [this.attributes, this.fromUserAnnotation = false]);
 }
 
 /// Contains information about a gesture-detectable element.

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -504,6 +504,395 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
+  testWidgets('tap IconButton with tooltip reports tooltip message',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      IconButton(
+        onPressed: () {},
+        tooltip: tooltip,
+        icon: const Icon(Icons.ac_unit),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'IconButton($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap IconButton with semantic label and tooltip prefers semantic label',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final semanticLabel = randomString();
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      IconButton(
+        onPressed: () {},
+        tooltip: tooltip,
+        icon: Icon(
+          Icons.ac_unit,
+          semanticLabel: semanticLabel,
+        ),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'IconButton($semanticLabel)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap Material 2 IconButton with tooltip reports tooltip message',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Theme(
+        data: ThemeData(useMaterial3: false),
+        child: IconButton(
+          onPressed: () {},
+          tooltip: tooltip,
+          icon: const Icon(Icons.ac_unit),
+        ),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'IconButton($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap button wrapped in Tooltip uses tooltip message as fallback',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: tooltip,
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+        ),
+      ),
+    ));
+
+    final button = find.byType(ElevatedButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'Button($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap button with text wrapped in Tooltip prefers button text',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final buttonText = randomString();
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: tooltip,
+        child: ElevatedButton(
+          onPressed: () {},
+          child: Text(buttonText),
+        ),
+      ),
+    ));
+
+    final button = find.byType(ElevatedButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'Button($buttonText)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap button with annotation wrapped in Tooltip prefers annotation',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final annotation = randomString();
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: tooltip,
+        child: RumUserActionAnnotation(
+          description: annotation,
+          child: ElevatedButton(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ),
+    ));
+
+    final button = find.byType(ElevatedButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'Button($annotation)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap gesture detector wrapped in Tooltip reports tooltip message',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: tooltip,
+        child: GestureDetector(
+          onTap: () {},
+          child: _testWidgetBuilder(null),
+        ),
+      ),
+    ));
+
+    final detector = find.byType(GestureDetector);
+    await tester.tap(detector);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'GestureDetector($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap InkWell does not use tooltip of untapped descendant control',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    const tapTarget = Key('emptyRowSpace');
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      InkWell(
+        onTap: () {},
+        child: Row(
+          children: [
+            const SizedBox(key: tapTarget, width: 80, height: 48),
+            IconButton(
+              onPressed: () {},
+              tooltip: tooltip,
+              icon: const Icon(Icons.delete),
+            ),
+          ],
+        ),
+      ),
+    ));
+
+    // Tap the empty part of the row, not the IconButton
+    await tester.tap(find.byKey(tapTarget));
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'InkWell(unknown)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap button wrapped in Tooltip with richMessage uses plain text',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        richMessage: TextSpan(text: tooltip),
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+        ),
+      ),
+    ));
+
+    final button = find.byType(ElevatedButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'Button($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap IconButton with tooltip wrapped in Tooltip prefers its own tooltip',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final ownTooltip = randomString();
+    final outerTooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: outerTooltip,
+        child: IconButton(
+          onPressed: () {},
+          tooltip: ownTooltip,
+          icon: const Icon(Icons.ac_unit),
+        ),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(
+        () => mockRum.addAction(RumActionType.tap, 'IconButton($ownTooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap button in nested Tooltips uses nearest enclosing message',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final outerTooltip = randomString();
+    final innerTooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: outerTooltip,
+        child: Tooltip(
+          message: innerTooltip,
+          child: ElevatedButton(
+            onPressed: () {},
+            child: const Icon(Icons.add),
+          ),
+        ),
+      ),
+    ));
+
+    final button = find.byType(ElevatedButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'Button($innerTooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap button wrapped in Tooltip with empty message reports unknown',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: '',
+        child: ElevatedButton(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+        ),
+      ),
+    ));
+
+    final button = find.byType(ElevatedButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'Button(unknown)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap IconButton with empty tooltip reports unknown',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      IconButton(
+        onPressed: () {},
+        tooltip: '',
+        icon: const Icon(Icons.ac_unit),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(() => mockRum.addAction(RumActionType.tap, 'IconButton(unknown)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('Tooltip message applies to all hit branches of its subtree',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      Tooltip(
+        message: tooltip,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              const ColoredBox(color: Colors.red),
+              GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    final detector = find.byType(GestureDetector);
+    await tester.tap(detector);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'GestureDetector($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('annotation applies to all hit branches of its subtree',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final annotation = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      RumUserActionAnnotation(
+        description: annotation,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              const ColoredBox(color: Colors.red),
+              GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    final detector = find.byType(GestureDetector);
+    await tester.tap(detector);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'GestureDetector($annotation)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
   testWidgets('tap Radio reports tap with value', (tester) async {
     final mockRum = MockDdRum();
 

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -525,8 +525,7 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
-  testWidgets(
-      'tap IconButton with semantic label and tooltip prefers semantic label',
+  testWidgets('tap IconButton with semantic label and tooltip prefers tooltip',
       (tester) async {
     final mockRum = MockDdRum();
 
@@ -547,8 +546,61 @@ void main() {
     final button = find.byType(IconButton);
     await tester.tap(button);
 
-    verify(() =>
-        mockRum.addAction(RumActionType.tap, 'IconButton($semanticLabel)'));
+    verify(() => mockRum.addAction(RumActionType.tap, 'IconButton($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap IconButton with annotation in subtree prefers annotation over tooltip',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final annotation = randomString();
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      IconButton(
+        onPressed: () {},
+        tooltip: tooltip,
+        icon: RumUserActionAnnotation(
+          description: annotation,
+          child: const Icon(Icons.ac_unit),
+        ),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(
+        () => mockRum.addAction(RumActionType.tap, 'IconButton($annotation)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap IconButton wrapped in annotation prefers annotation over tooltip',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final annotation = randomString();
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      RumUserActionAnnotation(
+        description: annotation,
+        child: IconButton(
+          onPressed: () {},
+          tooltip: tooltip,
+          icon: const Icon(Icons.ac_unit),
+        ),
+      ),
+    ));
+
+    final button = find.byType(IconButton);
+    await tester.tap(button);
+
+    verify(
+        () => mockRum.addAction(RumActionType.tap, 'IconButton($annotation)'));
     verifyNoMoreInteractions(mockRum);
   });
 
@@ -936,7 +988,7 @@ void main() {
   });
 
   testWidgets(
-      'tap extended FloatingActionButton prefers label text over tooltip',
+      'tap extended FloatingActionButton prefers tooltip over label text',
       (tester) async {
     final mockRum = MockDdRum();
 
@@ -947,6 +999,27 @@ void main() {
       FloatingActionButton.extended(
         onPressed: () {},
         tooltip: tooltip,
+        label: Text(label),
+      ),
+    ));
+
+    final button = find.byType(FloatingActionButton);
+    await tester.tap(button);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'FloatingActionButton($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap extended FloatingActionButton without tooltip reports label',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final label = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      FloatingActionButton.extended(
+        onPressed: () {},
         label: Text(label),
       ),
     ));

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -893,6 +893,93 @@ void main() {
     verifyNoMoreInteractions(mockRum);
   });
 
+  testWidgets('tap FloatingActionButton with tooltip reports tooltip message',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      FloatingActionButton(
+        onPressed: () {},
+        tooltip: tooltip,
+        child: const Icon(Icons.add),
+      ),
+    ));
+
+    final button = find.byType(FloatingActionButton);
+    await tester.tap(button);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'FloatingActionButton($tooltip)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap FloatingActionButton without tooltip reports unknown',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      FloatingActionButton(
+        onPressed: () {},
+        child: const Icon(Icons.add),
+      ),
+    ));
+
+    final button = find.byType(FloatingActionButton);
+    await tester.tap(button);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'FloatingActionButton(unknown)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets(
+      'tap extended FloatingActionButton prefers label text over tooltip',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final label = randomString();
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      FloatingActionButton.extended(
+        onPressed: () {},
+        tooltip: tooltip,
+        label: Text(label),
+      ),
+    ));
+
+    final button = find.byType(FloatingActionButton);
+    await tester.tap(button);
+
+    verify(() =>
+        mockRum.addAction(RumActionType.tap, 'FloatingActionButton($label)'));
+    verifyNoMoreInteractions(mockRum);
+  });
+
+  testWidgets('tap disabled FloatingActionButton does not report tap',
+      (tester) async {
+    final mockRum = MockDdRum();
+
+    final tooltip = randomString();
+    await tester.pumpWidget(_buildSimpleApp(
+      mockRum,
+      FloatingActionButton(
+        onPressed: null,
+        tooltip: tooltip,
+        child: const Icon(Icons.add),
+      ),
+    ));
+
+    final button = find.byType(FloatingActionButton);
+    await tester.tap(button);
+
+    verifyNever(() => mockRum.addAction(any(), any()));
+    verifyNoMoreInteractions(mockRum);
+  });
+
   testWidgets('tap Radio reports tap with value', (tester) async {
     final mockRum = MockDdRum();
 


### PR DESCRIPTION
### What and why?

Closes #1033.

`RumUserActionDetector` builds action descriptions from `RumUserActionAnnotation`, child `Text`, `Semantics` labels, and `Icon.semanticsLabel`, but ignores tooltips. As a result, common buttons that only carry a `tooltip` — like the stock counter app's `FloatingActionButton(tooltip: 'Increment')` or an `IconButton(tooltip: ...)` — report `InkWell(unknown)` / `IconButton(unknown)`.

This PR uses tooltip messages as action descriptions, and recognizes `FloatingActionButton` as its own element type. With it, the `flutter create` counter app reports `FloatingActionButton(Increment)` out of the box.

### How?

The description priority is now: `RumUserActionAnnotation` → the tapped widget's own `tooltip` property (`IconButton`, `FloatingActionButton`) → child `Text` / `Semantics` label / `Icon.semanticsLabel` (unchanged relative order) → the message of a `Tooltip` enclosing the tapped widget on the hit-test path → `unknown`.

Per review feedback, the widget's own tooltip ranks directly below `RumUserActionAnnotation`: a button's tooltip describes the action being performed, while child content like an icon's semantic label describes the visuals. This also means an extended FAB with both a `label` and a `tooltip` reports the tooltip.

Two other deliberate design points:

* Tooltips are only read from the tapped widget's own `tooltip` property or from `Tooltip` widgets that *enclose* the tap position — never from an unbounded subtree search. This prevents a tap on a large `InkWell`/`GestureDetector` container from being misattributed to an embedded control's tooltip (e.g. a list row reporting `InkWell(Delete)` because of a trailing delete button, or `PopupMenuButton`'s default "Show menu" tooltip), and keeps the existing `searchForText: false` privacy behavior of generic containers intact. A regression test pins this.
* Hit-path capture of `RumUserActionAnnotation`/`Tooltip` is now scoped with save/restore instead of being cleared after the first completed subtree, so a value applies to *all* branches of its subtree even when the hit-test path crosses sibling render branches (e.g. a translucent tap layer inside a `Stack`). This also fixes a latent edge case for `RumUserActionAnnotation`, covered by new tests.

The `FloatingActionButton` recognition is a separate commit (it changes the reported element type for existing FAB actions) so it can be dropped independently if undesired.

`Tooltip.richMessage` is supported via `toPlainText()`, empty messages are ignored, and both Material 2 and Material 3 `IconButton` paths are covered. 22 new widget tests; `flutter analyze` and the full package unit suite pass.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests
- [x] This pull request references a Github or JIRA issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
