### PR TITLE
chore: Fix web integration tests by supplying a service.

### DIFF
--- a/packages/datadog_dio/example/lib/main.dart
+++ b/packages/datadog_dio/example/lib/main.dart
@@ -52,6 +52,7 @@ Future<void> main() async {
   final configuration = DatadogConfiguration(
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
+    service: 'com.datadoghq.flutter.dio.integration',
     site: DatadogSite.us1,
     uploadFrequency: UploadFrequency.frequent,
     batchSize: BatchSize.small,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/scenario_runner.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/integration_test_app/lib/auto_integration_scenarios/scenario_runner.dart
@@ -28,6 +28,7 @@ Future<void> runScenario({
   final configuration = DatadogConfiguration(
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
+    service: 'com.datadoghq.flutter.integration',
     site: DatadogSite.us1,
     uploadFrequency: UploadFrequency.frequent,
     batchSize: BatchSize.small,

--- a/packages/datadog_tracking_http_client/example/lib/main.dart
+++ b/packages/datadog_tracking_http_client/example/lib/main.dart
@@ -75,6 +75,7 @@ Future<void> main() async {
   final configuration = DatadogConfiguration(
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
+    service: 'com.datadoghq.flutter.tracking_http_client.integration',
     site: DatadogSite.us1,
     uploadFrequency: UploadFrequency.frequent,
     batchSize: BatchSize.small,


### PR DESCRIPTION
### What and why?

v7 requires a service be set if distributed tracing is enabled. The `auto_rum` scenario didn't set a service and so the integration tests broke on web.

### How?

Add a `service` for all integration tests.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
