### PR TITLE
fix: Update Kotlin versions to 2.2.20

### DIFF
--- a/examples/native-hybrid-app/android/build.gradle
+++ b/examples/native-hybrid-app/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 plugins {
     id 'com.android.application' version '8.9.1' apply false
     id 'com.android.library' version '8.9.1' apply false
-    id 'org.jetbrains.kotlin.android' version '2.1.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.20' apply false
 }
 
 subprojects {

--- a/examples/simple_example/android/gradle.properties
+++ b/examples/simple_example/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx3000M
 android.useAndroidX=true
-kotlin_version=2.1.0
+kotlin_version=2.2.20
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/packages/datadog_flutter_plugin/android/build.gradle
+++ b/packages/datadog_flutter_plugin/android/build.gradle
@@ -10,7 +10,7 @@ group "com.datadoghq.flutter"
 version "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "2.1.0"
+    ext.kotlin_version = "2.2.20"
     ext.datadog_version = "3+"
 
     repositories {

--- a/packages/datadog_flutter_plugin/e2e_test_app/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/e2e_test_app/android/gradle.properties
@@ -6,7 +6,7 @@
 
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-kotlin_version=2.1.0
+kotlin_version=2.2.20
 
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false

--- a/packages/datadog_flutter_plugin/example/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/example/android/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx12800M
 android.useAndroidX=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=true
-kotlin_version=2.2.0
+kotlin_version=2.2.20
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/build.gradle
@@ -5,7 +5,7 @@
  */
 
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/datadog_flutter_plugin/integration_test_app/android/gradle.properties
+++ b/packages/datadog_flutter_plugin/integration_test_app/android/gradle.properties
@@ -6,7 +6,7 @@
 
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-kotlin_version=2.1.0
+kotlin_version=2.2.20
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/packages/datadog_inappwebview_tracking/android/build.gradle
+++ b/packages/datadog_inappwebview_tracking/android/build.gradle
@@ -5,7 +5,7 @@ group = "com.datadoghq.flutter.inappwebviewtracking"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "2.1.0"
+    ext.kotlin_version = "2.2.20"
     ext.datadog_version = "3.0.0"
 
     repositories {

--- a/packages/datadog_inappwebview_tracking/example/android/settings.gradle
+++ b/packages/datadog_inappwebview_tracking/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/packages/datadog_session_replay/android/build.gradle
+++ b/packages/datadog_session_replay/android/build.gradle
@@ -5,7 +5,7 @@ group = "com.datadoghq.datadog_session_replay"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "2.1.0"
+    ext.kotlin_version = "2.2.20"
     ext.datadog_version = "3.11.0"
 
     repositories {

--- a/packages/datadog_tracking_http_client/example/android/gradle.properties
+++ b/packages/datadog_tracking_http_client/example/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-kotlin_version=2.1.0
+kotlin_version=2.2.20
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/packages/datadog_webview_tracking/android/build.gradle
+++ b/packages/datadog_webview_tracking/android/build.gradle
@@ -5,7 +5,7 @@ group 'com.datadoghq.flutter.webview'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.2.20'
     ext.datadog_version = "3.0.0"
 
     repositories {

--- a/packages/datadog_webview_tracking/example/android/build.gradle
+++ b/packages/datadog_webview_tracking/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/datadog_webview_tracking/example/android/gradle.properties
+++ b/packages/datadog_webview_tracking/example/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx2536M
 android.useAndroidX=true
-kotlin_version=2.1.0
+kotlin_version=2.2.20
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/test_apps/stress_test/android/build.gradle
+++ b/test_apps/stress_test/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()

--- a/test_apps/stress_test/android/gradle.properties
+++ b/test_apps/stress_test/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-kotlin_version=2.1.0
+kotlin_version=2.2.20
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator


### PR DESCRIPTION
### What and why?

Latest Flutter betas require Kotlin 2.2.20+. This is a temporary fix as Flutter will require higher versions soon, but hopefully by then we can require AGP 9 and use it's built-in Kotlin.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
