### PR TITLE
[FFL-2930] Add composable assignment request transport

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -14,6 +14,7 @@ test,flutter_dotenv,MIT,"Copyright 2015 mockturtl, Copyright 2016 James Collins"
 test,integration_test,BSD-3-Clause,Copyright 2014 The Flutter Authors
 import,collection,BSD-3-Clause,"Copyright (c) 2013, the Dart project authors"
 test,http,BSD-3-Clause,"Copyright (c) 2013, the Dart project authors"
+import,http_parser,BSD-3-Clause,"Copyright 2014, the Dart project authors"
 test,transparent_image,MIT,Copyright 2018 Brian Egan
 build,analyzer,BSD-3-Clause,"Copyright (c) 2013, the Dart project authors"
 build,args,BSD-3-Clause,"Copyright (c) 2013, the Dart project authors"

--- a/packages/datadog_flags/CHANGELOG.md
+++ b/packages/datadog_flags/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Add opt-in assignment-request timeout and retry configuration, cancellable
+  per-attempt requests, randomized exponential backoff, and bounded HTTP 503
+  `Retry-After` support. The default makes one initial request without retries.
+* Add an assignment-only HTTP client override and composable timeout and retry
+  client helpers for applications that need lower-level transport control.
+
 ## 1.0.1
 
 * Fix Flutter Web flag evaluation events failing with HTTP 403 errors caused by CORS preflight requests.

--- a/packages/datadog_flags/CHANGELOG.md
+++ b/packages/datadog_flags/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Limit each assignment request to one second and retry transient failures once by default. Add timeout and retry-count configuration.
+
 ## 1.0.0
 
 * Initial preview release of the native Dart Datadog Feature Flags and Experimentation SDK.

--- a/packages/datadog_flags/README.md
+++ b/packages/datadog_flags/README.md
@@ -121,6 +121,8 @@ DatadogFlagsConfiguration(
   trackExposures: true,
   trackEvaluations: true,
   evaluationFlushInterval: const Duration(seconds: 10),
+  assignmentRequestTimeout: const Duration(seconds: 2),
+  assignmentRequestRetryCount: 2,
   store: myStore,
 );
 ```
@@ -129,9 +131,56 @@ DatadogFlagsConfiguration(
 - `trackEvaluations` enables aggregated flag evaluation events.
 - `evaluationFlushInterval` controls periodic flag evaluation uploads and is
   bounded to 1-60 seconds.
+- `assignmentRequestTimeout` sets the timeout for each assignment request,
+  including response-body download. No SDK-added timeout is applied by default;
+  the underlying client or platform may still impose its own bounds. Set a
+  positive duration to enable one; `Duration.zero` disables it.
+- `assignmentRequestRetryCount` sets the retry count after the first attempt.
+  It defaults to zero (one initial request only) and supports values from zero
+  through ten.
 - `store` is optional last-known assignment storage.
-- `httpClient` and custom endpoints are available for tests and advanced
+- `httpClient` is the shared base client used for assignment requests and
+  telemetry. Custom endpoints are also available for tests and advanced
   embedding.
+
+For lower-level control, provide a fully composed client used only for
+assignment requests. This override is used verbatim, so it replaces the scalar
+timeout and retry settings above and never affects exposure or evaluation
+uploads:
+
+```dart
+import 'package:http/http.dart' as http;
+
+final assignmentClient = withAssignmentRequestRetry(
+  withAssignmentRequestTimeout(
+    http.Client(),
+    const Duration(seconds: 2),
+  ),
+  2,
+);
+
+await DatadogFlags.instance.enable(
+  configuration: DatadogFlagsConfiguration(
+    datadogConfig: datadogConfig,
+    assignmentRequestHttpClient: assignmentClient,
+  ),
+);
+
+// The application owns a supplied assignment client.
+await DatadogFlags.instance.disable();
+assignmentClient.close();
+```
+
+The timeout helper includes response-body download, and a zero duration returns
+the wrapped client unchanged. The retry helper creates a fresh request for each
+attempt and preserves the SDK's transient-status, `Retry-After`, and jitter
+policy.
+
+Retries use randomized exponential backoff for transport errors, timeouts,
+HTTP 408, and HTTP 5xx responses. HTTP 429 is not retried. For HTTP 503, a
+valid `Retry-After` value up to 30 seconds is used as a minimum delay before
+backoff is added; a longer delay prevents the retry. Each attempt creates a new
+request while preserving Datadog authentication and custom headers.
 
 If `enable()` is called without a `datadogConfig`, the SDK creates no live
 provider. Evaluations still return the caller-provided default with

--- a/packages/datadog_flags/README.md
+++ b/packages/datadog_flags/README.md
@@ -121,6 +121,8 @@ DatadogFlagsConfiguration(
   trackExposures: true,
   trackEvaluations: true,
   evaluationFlushInterval: const Duration(seconds: 10),
+  assignmentRequestTimeout: const Duration(seconds: 1),
+  assignmentRequestRetryCount: 1,
   store: myStore,
 );
 ```
@@ -129,6 +131,8 @@ DatadogFlagsConfiguration(
 - `trackEvaluations` enables aggregated flag evaluation events.
 - `evaluationFlushInterval` controls periodic flag evaluation uploads and is
   bounded to 1-60 seconds.
+- `assignmentRequestTimeout` sets the timeout for each assignment request.
+- `assignmentRequestRetryCount` sets the retry count after the first attempt.
 - `store` is optional last-known assignment storage.
 - `httpClient` and custom endpoints are available for tests and advanced
   embedding.

--- a/packages/datadog_flags/lib/datadog_flags.dart
+++ b/packages/datadog_flags/lib/datadog_flags.dart
@@ -13,6 +13,8 @@ library;
 export 'src/datadog_flags_config.dart'
     show DatadogFlagsConfig, DatadogFlagsSite;
 export 'src/datadog_flags.dart' show DatadogFlags;
+export 'src/assignment_request_client.dart'
+    show withAssignmentRequestRetry, withAssignmentRequestTimeout;
 export 'src/flags_client.dart' show DatadogFlagsClient, FlagDetails;
 export 'src/flags_configuration.dart' show DatadogFlagsConfiguration;
 export 'src/flags_error.dart' show FlagEvaluationError;

--- a/packages/datadog_flags/lib/src/assignment_request_client.dart
+++ b/packages/datadog_flags/lib/src/assignment_request_client.dart
@@ -1,0 +1,414 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:async';
+import 'dart:math';
+
+import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart' show parseHttpDate;
+
+const _initialRetryBackoff = Duration(milliseconds: 100);
+const _maxRetryBackoff = Duration(seconds: 30);
+const _maxRetryAfter = Duration(seconds: 30);
+const _maxRetries = 10;
+
+/// Wraps [inner] with a timeout for each assignment request attempt.
+///
+/// The timeout includes receiving the complete response body. A [timeout] of
+/// [Duration.zero] returns [inner] unchanged and applies no timeout. Closing
+/// the returned client closes [inner]. This wrapper is intentionally scoped to
+/// Datadog assignment requests and accepts the [http.Request] subtype created
+/// by the SDK.
+http.Client withAssignmentRequestTimeout(
+  http.Client inner,
+  Duration timeout,
+) {
+  if (timeout.isNegative) {
+    throw ArgumentError.value(timeout, 'timeout', 'must not be negative');
+  }
+  if (timeout == Duration.zero) {
+    return inner;
+  }
+  return _AssignmentRequestTimeoutClient(inner, timeout);
+}
+
+/// Wraps [inner] with retries for transient assignment request failures.
+///
+/// [retries] is the number of retries after the first attempt and must be
+/// between zero and ten. Transport errors, timeouts, HTTP 408, and HTTP 5xx
+/// responses are retried. HTTP 429 and caller cancellation are not retried.
+/// Closing the returned client closes [inner]. This wrapper is intentionally
+/// scoped to Datadog assignment requests and accepts the [http.Request]
+/// subtype created by the SDK.
+http.Client withAssignmentRequestRetry(
+  http.Client inner,
+  int retries,
+) {
+  return buildAssignmentRequestClient(
+    inner,
+    timeout: Duration.zero,
+    retries: retries,
+  );
+}
+
+/// Builds the assignment request policy used by the public wrappers and SDK.
+///
+/// The dependency hooks keep retry timing deterministic in unit tests. This
+/// function lives under `src/` and is not part of the package's public API.
+http.Client buildAssignmentRequestClient(
+  http.Client inner, {
+  required Duration timeout,
+  required int retries,
+  Future<void> Function(Duration)? delay,
+  double Function()? randomDouble,
+  DateTime Function()? dateProvider,
+}) {
+  if (timeout.isNegative) {
+    throw ArgumentError.value(timeout, 'timeout', 'must not be negative');
+  }
+  if (retries < 0 || retries > _maxRetries) {
+    throw RangeError.range(retries, 0, _maxRetries, 'retries');
+  }
+
+  final timedClient = withAssignmentRequestTimeout(inner, timeout);
+  if (retries == 0) {
+    return timedClient;
+  }
+  return _AssignmentRequestRetryClient(
+    timedClient,
+    retries: retries,
+    delay: delay ?? _defaultDelay,
+    randomDouble: randomDouble ?? Random().nextDouble,
+    dateProvider: dateProvider ?? DateTime.now,
+  );
+}
+
+final class _AssignmentRequestTimeoutClient extends http.BaseClient {
+  final http.Client _inner;
+  final Duration _timeout;
+
+  _AssignmentRequestTimeoutClient(this._inner, this._timeout);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final replayable = await _ReplayableRequest.from(request);
+    final timeoutAbort = Completer<void>();
+    final timeoutResult = Completer<http.StreamedResponse>();
+    var timedOut = false;
+    final timer = Timer(_timeout, () {
+      timedOut = true;
+      if (!timeoutAbort.isCompleted) {
+        timeoutAbort.complete();
+      }
+      if (!timeoutResult.isCompleted) {
+        timeoutResult.completeError(
+          TimeoutException(
+            'The assignment request timed out after '
+            '${_timeout.inMilliseconds} ms.',
+            _timeout,
+          ),
+        );
+      }
+    });
+
+    final operation = () async {
+      try {
+        final response = await _inner.send(
+          replayable.create(additionalAbortTrigger: timeoutAbort.future),
+        );
+        return await _bufferResponse(response);
+      } on http.RequestAbortedException {
+        if (timedOut) {
+          throw TimeoutException(
+            'The assignment request timed out after '
+            '${_timeout.inMilliseconds} ms.',
+            _timeout,
+          );
+        }
+        rethrow;
+      }
+    }();
+
+    try {
+      return await Future.any([
+        operation,
+        timeoutResult.future,
+        if (replayable.abortTrigger != null)
+          _abortAsError<http.StreamedResponse>(
+            replayable.abortTrigger!,
+            request.url,
+          ),
+      ]);
+    } finally {
+      timer.cancel();
+    }
+  }
+
+  @override
+  void close() => _inner.close();
+}
+
+final class _AssignmentRequestRetryClient extends http.BaseClient {
+  final http.Client _inner;
+  final int _retries;
+  final Future<void> Function(Duration) _delay;
+  final double Function() _randomDouble;
+  final DateTime Function() _dateProvider;
+
+  _AssignmentRequestRetryClient(
+    this._inner, {
+    required int retries,
+    required Future<void> Function(Duration) delay,
+    required double Function() randomDouble,
+    required DateTime Function() dateProvider,
+  })  : _retries = retries,
+        _delay = delay,
+        _randomDouble = randomDouble,
+        _dateProvider = dateProvider;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final replayable = await _ReplayableRequest.from(request);
+    var callerAborted = false;
+    final callerAbort = replayable.abortTrigger;
+    if (callerAbort != null) {
+      unawaited(
+        callerAbort.then<void>(
+          (_) => callerAborted = true,
+          onError: (Object _, StackTrace __) {
+            // Abort triggers must not fail according to package:http's
+            // contract. Treat a broken trigger as cancellation without
+            // leaking an unhandled asynchronous error.
+            callerAborted = true;
+          },
+        ),
+      );
+    }
+
+    for (var attempt = 0; attempt <= _retries; attempt++) {
+      if (callerAborted) {
+        throw http.RequestAbortedException(request.url);
+      }
+
+      http.StreamedResponse response;
+      try {
+        response = await _bufferResponse(
+          await _inner.send(replayable.create()),
+        );
+      } catch (error) {
+        if (callerAborted || !_isRetryableError(error) || attempt == _retries) {
+          rethrow;
+        }
+        await _waitForRetry(
+          _retryBackoff(attempt, _randomDouble()),
+          callerAbort,
+          request.url,
+          _delay,
+        );
+        continue;
+      }
+
+      if (!_isRetryableStatus(response.statusCode) ||
+          attempt == _retries ||
+          callerAborted) {
+        return response;
+      }
+
+      final retryAfter = _retryAfter(response, _dateProvider());
+      if (retryAfter != null && retryAfter > _maxRetryAfter) {
+        return response;
+      }
+      await _waitForRetry(
+        (retryAfter ?? Duration.zero) + _retryBackoff(attempt, _randomDouble()),
+        callerAbort,
+        request.url,
+        _delay,
+      );
+    }
+
+    throw StateError('Assignment request retry loop completed unexpectedly.');
+  }
+
+  @override
+  void close() => _inner.close();
+}
+
+final class _ReplayableRequest {
+  final String method;
+  final Uri url;
+  final Map<String, String> headers;
+  final List<int> bodyBytes;
+  final bool followRedirects;
+  final int maxRedirects;
+  final bool persistentConnection;
+  final Future<void>? abortTrigger;
+
+  const _ReplayableRequest({
+    required this.method,
+    required this.url,
+    required this.headers,
+    required this.bodyBytes,
+    required this.followRedirects,
+    required this.maxRedirects,
+    required this.persistentConnection,
+    required this.abortTrigger,
+  });
+
+  static Future<_ReplayableRequest> from(http.BaseRequest request) async {
+    if (request is! http.Request) {
+      throw ArgumentError.value(
+        request,
+        'request',
+        'assignment request clients support http.Request only',
+      );
+    }
+    return _ReplayableRequest(
+      method: request.method,
+      url: request.url,
+      headers: Map.of(request.headers),
+      bodyBytes: await request.finalize().toBytes(),
+      followRedirects: request.followRedirects,
+      maxRedirects: request.maxRedirects,
+      persistentConnection: request.persistentConnection,
+      abortTrigger: request is http.Abortable
+          ? (request as http.Abortable).abortTrigger
+          : null,
+    );
+  }
+
+  http.BaseRequest create({Future<void>? additionalAbortTrigger}) {
+    final abort = _combineAbortTriggers(abortTrigger, additionalAbortTrigger);
+    final http.Request request = abort == null
+        ? http.Request(method, url)
+        : http.AbortableRequest(method, url, abortTrigger: abort);
+    request
+      ..followRedirects = followRedirects
+      ..maxRedirects = maxRedirects
+      ..persistentConnection = persistentConnection
+      ..headers.addAll(headers)
+      ..bodyBytes = bodyBytes;
+    return request;
+  }
+}
+
+Future<void>? _combineAbortTriggers(
+  Future<void>? first,
+  Future<void>? second,
+) {
+  if (first == null) {
+    return second == null ? null : _asCancellation(second);
+  }
+  if (second == null) return _asCancellation(first);
+  return Future.any<void>([
+    _asCancellation(first),
+    _asCancellation(second),
+  ]);
+}
+
+Future<void> _asCancellation(Future<void> trigger) async {
+  try {
+    await trigger;
+  } catch (_) {
+    // Abort triggers are required not to fail. Normalize a broken trigger to
+    // ordinary cancellation before forwarding it to an HTTP client.
+  }
+}
+
+Future<void> _waitForRetry(
+  Duration duration,
+  Future<void>? abortTrigger,
+  Uri requestUrl,
+  Future<void> Function(Duration) delay,
+) async {
+  if (abortTrigger == null) {
+    await delay(duration);
+    return;
+  }
+  await Future.any<void>([
+    delay(duration),
+    _abortAsError(abortTrigger, requestUrl),
+  ]);
+}
+
+Future<T> _abortAsError<T>(
+  Future<void> abortTrigger,
+  Uri requestUrl,
+) async {
+  try {
+    await abortTrigger;
+  } catch (_) {
+    // See the caller-abort listener above. A failing trigger is invalid but is
+    // still treated as cancellation so it cannot start another attempt.
+  }
+  throw http.RequestAbortedException(requestUrl);
+}
+
+Future<http.StreamedResponse> _bufferResponse(
+  http.StreamedResponse response,
+) async {
+  final bytes = await response.stream.toBytes();
+  return http.StreamedResponse(
+    Stream.value(bytes),
+    response.statusCode,
+    contentLength: bytes.length,
+    request: response.request,
+    headers: response.headers,
+    isRedirect: response.isRedirect,
+    persistentConnection: response.persistentConnection,
+    reasonPhrase: response.reasonPhrase,
+  );
+}
+
+bool _isRetryableStatus(int statusCode) {
+  return statusCode == 408 || (statusCode >= 500 && statusCode <= 599);
+}
+
+bool _isRetryableError(Object error) {
+  if (error is http.RequestAbortedException) {
+    return false;
+  }
+  return error is TimeoutException || error is http.ClientException;
+}
+
+Duration _retryBackoff(int attempt, double randomDouble) {
+  final exponentialMilliseconds =
+      _initialRetryBackoff.inMilliseconds * (1 << attempt);
+  final maximumMilliseconds = min(
+    exponentialMilliseconds,
+    _maxRetryBackoff.inMilliseconds,
+  );
+  final boundedRandom = randomDouble.clamp(0.0, 1.0);
+  return Duration(
+    microseconds: (boundedRandom * maximumMilliseconds * 1000).floor(),
+  );
+}
+
+Duration? _retryAfter(http.BaseResponse response, DateTime now) {
+  if (response.statusCode != 503) {
+    return null;
+  }
+
+  final value = response.headers['retry-after']?.trim();
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+
+  if (RegExp(r'^\d+$').hasMatch(value)) {
+    final seconds = int.tryParse(value);
+    if (seconds == null || seconds > _maxRetryAfter.inSeconds) {
+      return _maxRetryAfter + const Duration(microseconds: 1);
+    }
+    return Duration(seconds: seconds);
+  }
+
+  try {
+    final delay = parseHttpDate(value).difference(now);
+    return delay.isNegative ? Duration.zero : delay;
+  } on FormatException {
+    return null;
+  }
+}
+
+Future<void> _defaultDelay(Duration duration) => Future<void>.delayed(duration);

--- a/packages/datadog_flags/lib/src/flag_assignments_fetcher.dart
+++ b/packages/datadog_flags/lib/src/flag_assignments_fetcher.dart
@@ -4,14 +4,16 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:http/http.dart' as http;
 
 import 'assignment.dart';
+import 'assignment_request_client.dart';
 import 'datadog_flags_config.dart';
-import 'flags_configuration.dart';
 import 'evaluation_context.dart';
 import 'flags_error.dart';
+import 'flags_configuration.dart';
 import 'precompute_request.dart';
 import 'precompute_response.dart';
 
@@ -19,36 +21,30 @@ class FlagAssignmentsFetcher {
   final DatadogFlagsConfig datadogConfig;
   final DatadogFlagsConfiguration configuration;
   final http.Client httpClient;
+  final Future<void> Function(Duration) _delay;
+  final double Function() _randomDouble;
 
   FlagAssignmentsFetcher({
     required this.datadogConfig,
     required this.configuration,
     required this.httpClient,
-  });
+    Future<void> Function(Duration)? delay,
+    double Function()? randomDouble,
+  })  : _delay = delay ?? _defaultDelay,
+        _randomDouble = randomDouble ?? Random().nextDouble;
 
   Future<PrecomputedAssignments> fetch(
     FlagsEvaluationContext evaluationContext,
   ) async {
     final endpoint = configuration.customFlagsEndpoint ??
         datadogConfig.flagsEndpoint().replace(path: '/precompute-assignments');
-    final http.Response response;
-    try {
-      response = await httpClient.post(
-        endpoint,
-        headers: _headers(),
-        body: jsonEncode(
-          PrecomputeRequest.fromContext(
-            datadogConfig: datadogConfig,
-            evaluationContext: evaluationContext,
-          ).toJson(),
-        ),
-      );
-    } catch (error) {
-      throw FlagsException.networkError(
-        'Failed to fetch flag assignments.',
-        cause: error,
-      );
-    }
+    final body = jsonEncode(
+      PrecomputeRequest.fromContext(
+        datadogConfig: datadogConfig,
+        evaluationContext: evaluationContext,
+      ).toJson(),
+    );
+    final response = await _fetchResponse(endpoint, body);
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw FlagsException.networkError(
@@ -83,7 +79,35 @@ class FlagAssignmentsFetcher {
       ...?configuration.customFlagsHeaders,
     };
   }
+
+  Future<http.Response> _fetchResponse(Uri endpoint, String body) async {
+    final customClient = configuration.assignmentRequestHttpClient;
+    final client = customClient ??
+        buildAssignmentRequestClient(
+          httpClient,
+          timeout: configuration.assignmentRequestTimeout,
+          retries: configuration.assignmentRequestRetryCount,
+          delay: _delay,
+          randomDouble: _randomDouble,
+          dateProvider: configuration.dateProvider,
+        );
+    final request = http.Request('POST', endpoint);
+    request.headers.addAll(_headers());
+    request.body = body;
+
+    try {
+      final streamedResponse = await client.send(request);
+      return await http.Response.fromStream(streamedResponse);
+    } catch (error) {
+      throw FlagsException.networkError(
+        'Failed to fetch flag assignments.',
+        cause: error,
+      );
+    }
+  }
 }
+
+Future<void> _defaultDelay(Duration duration) => Future<void>.delayed(duration);
 
 Map<String, Object?> _asObject(Object? value, String name) {
   if (value is Map) {

--- a/packages/datadog_flags/lib/src/flag_assignments_fetcher.dart
+++ b/packages/datadog_flags/lib/src/flag_assignments_fetcher.dart
@@ -3,6 +3,7 @@
 // developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
@@ -31,24 +32,13 @@ class FlagAssignmentsFetcher {
   ) async {
     final endpoint = configuration.customFlagsEndpoint ??
         datadogConfig.flagsEndpoint().replace(path: '/precompute-assignments');
-    final http.Response response;
-    try {
-      response = await httpClient.post(
-        endpoint,
-        headers: _headers(),
-        body: jsonEncode(
-          PrecomputeRequest.fromContext(
-            datadogConfig: datadogConfig,
-            evaluationContext: evaluationContext,
-          ).toJson(),
-        ),
-      );
-    } catch (error) {
-      throw FlagsException.networkError(
-        'Failed to fetch flag assignments.',
-        cause: error,
-      );
-    }
+    final body = jsonEncode(
+      PrecomputeRequest.fromContext(
+        datadogConfig: datadogConfig,
+        evaluationContext: evaluationContext,
+      ).toJson(),
+    );
+    final response = await _fetchResponse(endpoint, body);
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw FlagsException.networkError(
@@ -83,6 +73,43 @@ class FlagAssignmentsFetcher {
       ...?configuration.customFlagsHeaders,
     };
   }
+
+  Future<http.Response> _fetchResponse(Uri endpoint, String body) async {
+    final configuredTimeout = configuration.assignmentRequestTimeout;
+    final timeout = configuredTimeout > Duration.zero
+        ? configuredTimeout
+        : DatadogFlagsConfiguration.defaultAssignmentRequestTimeout;
+    final configuredRetryCount = configuration.assignmentRequestRetryCount;
+    final retryCount = configuredRetryCount >= 0 ? configuredRetryCount : 0;
+
+    for (var attempt = 0; attempt <= retryCount; attempt++) {
+      try {
+        final response = await httpClient
+            .post(endpoint, headers: _headers(), body: body)
+            .timeout(timeout);
+        if (!_isRetryableStatus(response.statusCode) || attempt == retryCount) {
+          return response;
+        }
+      } catch (error) {
+        final canRetry =
+            error is TimeoutException || error is http.ClientException;
+        if (!canRetry || attempt == retryCount) {
+          throw FlagsException.networkError(
+            'Failed to fetch flag assignments.',
+            cause: error,
+          );
+        }
+      }
+    }
+
+    throw StateError('Assignment request retry loop completed unexpectedly.');
+  }
+}
+
+bool _isRetryableStatus(int statusCode) {
+  return statusCode == 408 ||
+      statusCode == 429 ||
+      (statusCode >= 500 && statusCode <= 599);
 }
 
 Map<String, Object?> _asObject(Object? value, String name) {

--- a/packages/datadog_flags/lib/src/flags_configuration.dart
+++ b/packages/datadog_flags/lib/src/flags_configuration.dart
@@ -6,6 +6,7 @@
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
+import 'assignment_request_client.dart';
 import 'datadog_flags_config.dart';
 import 'flags_store.dart';
 
@@ -21,11 +22,28 @@ final class DatadogFlagsConfiguration {
   /// Largest supported flag evaluation telemetry flush interval.
   static const maxEvaluationFlushInterval = Duration(seconds: 60);
 
+  /// Default number of retries after the first assignment request attempt.
+  static const defaultAssignmentRequestRetryCount = 0;
+
+  /// Largest supported number of retries after the first request attempt.
+  static const maxAssignmentRequestRetryCount = 10;
+
   /// Overrides the precompute assignments endpoint.
   final Uri? customFlagsEndpoint;
 
   /// Additional headers sent with precompute assignment requests.
   final Map<String, String>? customFlagsHeaders;
+
+  /// Timeout for each precomputed assignment request.
+  ///
+  /// A value of [Duration.zero] disables the timeout. Negative values are
+  /// rejected when an assignment request is made.
+  final Duration assignmentRequestTimeout;
+
+  /// Number of retries after a transient assignment request failure.
+  ///
+  /// Must be between zero and [maxAssignmentRequestRetryCount], inclusive.
+  final int assignmentRequestRetryCount;
 
   /// Overrides the exposure intake endpoint.
   final Uri? customExposureEndpoint;
@@ -43,8 +61,19 @@ final class DatadogFlagsConfiguration {
 
   /// HTTP client used for assignments and telemetry.
   ///
-  /// When omitted, [DatadogFlags] creates and owns a default client.
+  /// When omitted, [DatadogFlags] creates and owns a default client. When
+  /// [assignmentRequestHttpClient] is also provided, this client is used only for
+  /// exposure and evaluation telemetry.
   final http.Client? httpClient;
+
+  /// Fully configured HTTP client used only for assignment requests.
+  ///
+  /// When provided, this client is used verbatim and
+  /// [assignmentRequestTimeout] and [assignmentRequestRetryCount] are not
+  /// applied. Compose [withAssignmentRequestTimeout] and
+  /// [withAssignmentRequestRetry] to add those policies explicitly. The caller
+  /// owns this client and must close it after disabling [DatadogFlags].
+  final http.Client? assignmentRequestHttpClient;
 
   /// Datadog organization, environment, and site configuration.
   final DatadogFlagsConfig? datadogConfig;
@@ -59,12 +88,15 @@ final class DatadogFlagsConfiguration {
   const DatadogFlagsConfiguration({
     this.customFlagsEndpoint,
     this.customFlagsHeaders,
+    this.assignmentRequestTimeout = Duration.zero,
+    this.assignmentRequestRetryCount = defaultAssignmentRequestRetryCount,
     this.customExposureEndpoint,
     this.trackExposures = true,
     this.customEvaluationEndpoint,
     this.trackEvaluations = true,
     Duration evaluationFlushInterval = defaultEvaluationFlushInterval,
     this.httpClient,
+    this.assignmentRequestHttpClient,
     this.datadogConfig,
     this.store,
     this.dateProvider = DateTime.now,

--- a/packages/datadog_flags/lib/src/flags_configuration.dart
+++ b/packages/datadog_flags/lib/src/flags_configuration.dart
@@ -21,11 +21,27 @@ final class DatadogFlagsConfiguration {
   /// Largest supported flag evaluation telemetry flush interval.
   static const maxEvaluationFlushInterval = Duration(seconds: 60);
 
+  /// Default timeout for each precomputed assignment request.
+  static const defaultAssignmentRequestTimeout = Duration(seconds: 1);
+
+  /// Default number of retries after the first assignment request attempt.
+  static const defaultAssignmentRequestRetryCount = 1;
+
   /// Overrides the precompute assignments endpoint.
   final Uri? customFlagsEndpoint;
 
   /// Additional headers sent with precompute assignment requests.
   final Map<String, String>? customFlagsHeaders;
+
+  /// Timeout for each precomputed assignment request.
+  ///
+  /// Values less than or equal to zero use [defaultAssignmentRequestTimeout].
+  final Duration assignmentRequestTimeout;
+
+  /// Number of retries after a transient assignment request failure.
+  ///
+  /// Negative values are treated as zero.
+  final int assignmentRequestRetryCount;
 
   /// Overrides the exposure intake endpoint.
   final Uri? customExposureEndpoint;
@@ -59,6 +75,8 @@ final class DatadogFlagsConfiguration {
   const DatadogFlagsConfiguration({
     this.customFlagsEndpoint,
     this.customFlagsHeaders,
+    this.assignmentRequestTimeout = defaultAssignmentRequestTimeout,
+    this.assignmentRequestRetryCount = defaultAssignmentRequestRetryCount,
     this.customExposureEndpoint,
     this.trackExposures = true,
     this.customEvaluationEndpoint,

--- a/packages/datadog_flags/pubspec.yaml
+++ b/packages/datadog_flags/pubspec.yaml
@@ -13,7 +13,8 @@ environment:
   sdk: ">=3.6.0 <4.0.0"
 
 dependencies:
-  http: ^1.0.0
+  http: ^1.5.0
+  http_parser: ^4.0.0
   json_annotation: ^4.9.0
   meta: ^1.0.0
   uuid: ^4.0.0

--- a/packages/datadog_flags/test/assignment_request_reliability_test.dart
+++ b/packages/datadog_flags/test/assignment_request_reliability_test.dart
@@ -1,0 +1,843 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:datadog_flags/datadog_flags.dart';
+import 'package:datadog_flags/src/assignment_request_client.dart' as internal;
+import 'package:datadog_flags/src/flag_assignments_fetcher.dart';
+import 'package:datadog_flags/src/flags_error.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assignment request reliability', () {
+    group('configuration', () {
+      test('defaults to no timeout and no retries', () {
+        const configuration = DatadogFlagsConfiguration();
+
+        expect(
+          configuration.assignmentRequestTimeout,
+          Duration.zero,
+        );
+        expect(configuration.assignmentRequestRetryCount, 0);
+      });
+
+      test('default configuration makes exactly one initial request', () async {
+        var attempts = 0;
+        final fetcher = _fetcher(
+          client: MockClient((_) async {
+            attempts++;
+            return http.Response('retryable', 500);
+          }),
+        );
+
+        await expectLater(_fetch(fetcher), throwsA(isA<FlagsException>()));
+
+        expect(attempts, 1);
+      });
+
+      test('zero-timeout helper is a pass-through', () {
+        final client = MockClient((_) async => _successResponse());
+
+        expect(
+          withAssignmentRequestTimeout(client, Duration.zero),
+          same(client),
+        );
+      });
+
+      test('zero-retry helper is a pass-through', () {
+        final client = MockClient((_) async => _successResponse());
+
+        expect(withAssignmentRequestRetry(client, 0), same(client));
+      });
+
+      test('assignment client override bypasses scalar policy', () async {
+        var sharedAttempts = 0;
+        var assignmentAttempts = 0;
+        final assignmentClient = MockClient((_) async {
+          assignmentAttempts++;
+          return _successResponse();
+        });
+        final fetcher = _fetcher(
+          configuration: DatadogFlagsConfiguration(
+            assignmentRequestHttpClient: assignmentClient,
+            // Invalid scalar values prove that the fully composed override is
+            // used verbatim rather than wrapped in the convenience policy.
+            assignmentRequestTimeout: const Duration(milliseconds: -1),
+            assignmentRequestRetryCount: 11,
+          ),
+          client: MockClient((_) async {
+            sharedAttempts++;
+            return _successResponse();
+          }),
+        );
+
+        await _fetch(fetcher);
+
+        expect(assignmentAttempts, 1);
+        expect(sharedAttempts, 0);
+      });
+
+      test('SDK does not close a caller-owned assignment client', () async {
+        final assignmentClient = _CloseTrackingClient(
+          MockClient((_) async => _successResponse()),
+        );
+        final sharedClient = MockClient((_) async => _successResponse());
+        final flags = DatadogFlags();
+
+        await flags.enable(
+          configuration: DatadogFlagsConfiguration(
+            datadogConfig: const DatadogFlagsConfig(
+              clientToken: 'token',
+              env: 'dev',
+              site: DatadogFlagsSite.us1,
+            ),
+            httpClient: sharedClient,
+            assignmentRequestHttpClient: assignmentClient,
+          ),
+        );
+        await flags.disable();
+
+        expect(assignmentClient.closed, isFalse);
+        assignmentClient.close();
+      });
+
+      test('assignment override is isolated from telemetry', () async {
+        var assignmentAttempts = 0;
+        final telemetryRequests = <http.Request>[];
+        final flags = DatadogFlags();
+        await flags.enable(
+          configuration: DatadogFlagsConfiguration(
+            datadogConfig: const DatadogFlagsConfig(
+              clientToken: 'token',
+              env: 'dev',
+              site: DatadogFlagsSite.us1,
+            ),
+            assignmentRequestHttpClient: MockClient((_) async {
+              assignmentAttempts++;
+              return _successResponse();
+            }),
+            httpClient: MockClient((request) async {
+              telemetryRequests.add(request);
+              return http.Response('', 202);
+            }),
+          ),
+        );
+
+        final client = flags.sharedClient();
+        await client.initialize(
+          const FlagsEvaluationContext(targetingKey: 'subject'),
+        );
+        client.getBooleanDetails(key: 'missing', defaultValue: false);
+        await flags.disable();
+
+        expect(assignmentAttempts, 1);
+        expect(telemetryRequests, isNotEmpty);
+        expect(
+          telemetryRequests,
+          everyElement(
+            isA<http.Request>().having(
+              (request) => request.url.path,
+              'path',
+              isNot(contains('precompute-assignments')),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('retry classification', () {
+      test('retries transient client failures', () async {
+        for (final error in [
+          http.ClientException('offline'),
+          TimeoutException('timed out'),
+        ]) {
+          var attempts = 0;
+          final fetcher = _fetcher(
+            configuration: const DatadogFlagsConfiguration(
+              assignmentRequestRetryCount: 1,
+            ),
+            client: MockClient((_) async {
+              attempts++;
+              if (attempts == 1) {
+                throw error;
+              }
+              return _successResponse();
+            }),
+          );
+
+          await _fetch(fetcher);
+
+          expect(attempts, 2, reason: '$error should be retried');
+        }
+      });
+
+      test('does not retry non-transport failures', () async {
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 3,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            throw StateError('invalid client state');
+          }),
+        );
+
+        await expectLater(
+          _fetch(fetcher),
+          throwsA(
+            isA<FlagsException>().having(
+              (error) => error.cause,
+              'cause',
+              isA<StateError>(),
+            ),
+          ),
+        );
+
+        expect(attempts, 1);
+      });
+
+      for (final statusCode in [408, 500, 503, 599]) {
+        test('retries HTTP $statusCode', () async {
+          var attempts = 0;
+          final fetcher = _fetcher(
+            configuration: const DatadogFlagsConfiguration(
+              assignmentRequestRetryCount: 1,
+            ),
+            client: MockClient((_) async {
+              attempts++;
+              return attempts == 1
+                  ? http.Response('retry', statusCode)
+                  : _successResponse();
+            }),
+          );
+
+          await _fetch(fetcher);
+
+          expect(attempts, 2);
+        });
+      }
+
+      for (final statusCode in [400, 429]) {
+        test('does not retry HTTP $statusCode', () async {
+          var attempts = 0;
+          final fetcher = _fetcher(
+            configuration: const DatadogFlagsConfiguration(
+              assignmentRequestRetryCount: 3,
+            ),
+            client: MockClient((_) async {
+              attempts++;
+              return http.Response('do not retry', statusCode);
+            }),
+          );
+
+          await expectLater(_fetch(fetcher), throwsA(isA<FlagsException>()));
+
+          expect(attempts, 1);
+        });
+      }
+
+      test('uses the configured retry count after the first attempt', () async {
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 2,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return http.Response('retry', 500);
+          }),
+        );
+
+        await expectLater(_fetch(fetcher), throwsA(isA<FlagsException>()));
+
+        expect(attempts, 3);
+      });
+    });
+
+    group('timeout and request replay', () {
+      test('public helpers compose timeout inside retry', () async {
+        final stalledBody = StreamController<List<int>>();
+        addTearDown(stalledBody.close);
+        final requests = <http.BaseRequest>[];
+        final transport = withAssignmentRequestRetry(
+          withAssignmentRequestTimeout(
+            MockClient.streaming((request, _) async {
+              requests.add(request);
+              return requests.length == 1
+                  ? http.StreamedResponse(stalledBody.stream, 200)
+                  : _streamedSuccessResponse();
+            }),
+            const Duration(milliseconds: 10),
+          ),
+          1,
+        );
+        final fetcher = _fetcher(
+          configuration: DatadogFlagsConfiguration(
+            assignmentRequestHttpClient: transport,
+          ),
+          client: MockClient((_) async => throw StateError('not used')),
+        );
+
+        await _fetch(fetcher);
+
+        expect(requests, hasLength(2));
+        expect(requests, everyElement(isA<http.AbortableRequest>()));
+      });
+
+      test('caller cancellation interrupts retry backoff', () async {
+        final abort = Completer<void>();
+        final delayStarted = Completer<void>();
+        final blockedDelay = Completer<void>();
+        var attempts = 0;
+        final transport = internal.buildAssignmentRequestClient(
+          MockClient((_) async {
+            attempts++;
+            return http.Response('retry', 500);
+          }),
+          timeout: Duration.zero,
+          retries: 1,
+          delay: (_) {
+            delayStarted.complete();
+            return blockedDelay.future;
+          },
+        );
+        final request = http.AbortableRequest(
+          'POST',
+          Uri.parse('https://example.com/assignments'),
+          abortTrigger: abort.future,
+        )..body = '{}';
+
+        final response = transport.send(request);
+        await delayStarted.future;
+        abort.complete();
+
+        await expectLater(
+            response, throwsA(isA<http.RequestAbortedException>()));
+        expect(attempts, 1);
+      });
+
+      test('caller cancellation does not depend on inner client support',
+          () async {
+        final abort = Completer<void>();
+        final requestStarted = Completer<void>();
+        final pending = Completer<http.StreamedResponse>();
+        final transport = withAssignmentRequestTimeout(
+          MockClient.streaming((_, __) {
+            requestStarted.complete();
+            return pending.future;
+          }),
+          const Duration(seconds: 30),
+        );
+        final request = http.AbortableRequest(
+          'POST',
+          Uri.parse('https://example.com/assignments'),
+          abortTrigger: abort.future,
+        )..body = '{}';
+
+        final response = transport.send(request);
+        await requestStarted.future;
+        abort.complete();
+
+        await expectLater(
+          response,
+          throwsA(isA<http.RequestAbortedException>()),
+        );
+      });
+
+      test('a failing abort trigger is contained as cancellation', () async {
+        final abort = Completer<void>();
+        final delayStarted = Completer<void>();
+        final blockedDelay = Completer<void>();
+        var attempts = 0;
+        final transport = internal.buildAssignmentRequestClient(
+          MockClient((_) async {
+            attempts++;
+            return http.Response('retry', 500);
+          }),
+          timeout: Duration.zero,
+          retries: 1,
+          delay: (_) {
+            delayStarted.complete();
+            return blockedDelay.future;
+          },
+        );
+        final request = http.AbortableRequest(
+          'POST',
+          Uri.parse('https://example.com/assignments'),
+          abortTrigger: abort.future,
+        )..body = '{}';
+
+        final response = transport.send(request);
+        await delayStarted.future;
+        abort.completeError(StateError('broken abort trigger'));
+
+        await expectLater(
+            response, throwsA(isA<http.RequestAbortedException>()));
+        expect(attempts, 1);
+      });
+
+      test('helpers reject non-assignment request subtypes', () async {
+        var attempts = 0;
+        final transport = withAssignmentRequestRetry(
+          MockClient.streaming((_, __) async {
+            attempts++;
+            return _streamedSuccessResponse();
+          }),
+          1,
+        );
+        final request = http.StreamedRequest(
+          'POST',
+          Uri.parse('https://example.com/assignments'),
+        );
+        request.sink.close();
+
+        await expectLater(transport.send(request), throwsArgumentError);
+        expect(attempts, 0);
+      });
+
+      test('the default disables the per-attempt timeout', () async {
+        final requestTypes = <Type>[];
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 0,
+          ),
+          client: MockClient.streaming((request, _) async {
+            requestTypes.add(request.runtimeType);
+            return _streamedSuccessResponse();
+          }),
+        );
+
+        await _fetch(fetcher);
+
+        expect(requestTypes, [http.Request]);
+      });
+
+      test('an explicit zero disables the per-attempt timeout', () async {
+        final requestTypes = <Type>[];
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestTimeout: Duration.zero,
+            assignmentRequestRetryCount: 0,
+          ),
+          client: MockClient.streaming((request, _) async {
+            requestTypes.add(request.runtimeType);
+            return _streamedSuccessResponse();
+          }),
+        );
+
+        await _fetch(fetcher);
+
+        expect(requestTypes, [http.Request]);
+      });
+
+      test('timeout includes downloading the complete response body', () async {
+        final responseBody = StreamController<List<int>>();
+        addTearDown(responseBody.close);
+        http.BaseRequest? request;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestTimeout: Duration(milliseconds: 10),
+            assignmentRequestRetryCount: 0,
+          ),
+          client: MockClient.streaming((attempt, _) async {
+            request = attempt;
+            return http.StreamedResponse(responseBody.stream, 200);
+          }),
+        );
+
+        await expectLater(
+          _fetch(fetcher),
+          throwsA(
+            isA<FlagsException>().having(
+              (error) => error.cause,
+              'cause',
+              isA<TimeoutException>(),
+            ),
+          ),
+        );
+
+        expect(request, isA<http.AbortableRequest>());
+        await expectLater(
+          (request as http.AbortableRequest).abortTrigger,
+          completes,
+        );
+      });
+
+      test('applies the timeout independently to each attempt', () async {
+        final stalledBody = StreamController<List<int>>();
+        addTearDown(stalledBody.close);
+        final requests = <http.BaseRequest>[];
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestTimeout: Duration(milliseconds: 10),
+            assignmentRequestRetryCount: 1,
+          ),
+          client: MockClient.streaming((request, _) async {
+            requests.add(request);
+            return requests.length == 1
+                ? http.StreamedResponse(stalledBody.stream, 200)
+                : _streamedSuccessResponse();
+          }),
+        );
+
+        await _fetch(fetcher);
+
+        expect(requests, hasLength(2));
+        expect(identical(requests.first, requests.last), isFalse);
+        await expectLater(
+          (requests.first as http.AbortableRequest).abortTrigger,
+          completes,
+        );
+      });
+
+      test(
+        'creates a fresh request and preserves its body and headers',
+        () async {
+          final requests = <http.BaseRequest>[];
+          final bodies = <String>[];
+          final fetcher = _fetcher(
+            configuration: const DatadogFlagsConfiguration(
+              customFlagsHeaders: {'x-custom': 'value'},
+              assignmentRequestRetryCount: 1,
+            ),
+            client: MockClient.streaming((request, body) async {
+              requests.add(request);
+              bodies.add(utf8.decode(await body.toBytes()));
+              return requests.length == 1
+                  ? http.StreamedResponse(const Stream.empty(), 500)
+                  : _streamedSuccessResponse();
+            }),
+          );
+
+          await _fetch(fetcher);
+
+          expect(requests, hasLength(2));
+          expect(identical(requests.first, requests.last), isFalse);
+          expect(bodies.first, bodies.last);
+          for (final request in requests) {
+            expect(request.headers['dd-client-token'], 'token');
+            expect(request.headers['x-custom'], 'value');
+            expect(request.headers['content-type'], 'application/vnd.api+json');
+          }
+        },
+      );
+    });
+
+    group('retry delay', () {
+      test('uses bounded exponential full-jitter backoff', () async {
+        final delays = <Duration>[];
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 10,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return attempts == 11
+                ? _successResponse()
+                : http.Response('retry', 500);
+          }),
+          delays: delays,
+          randomDouble: () => 0.5,
+        );
+
+        await _fetch(fetcher);
+
+        expect(delays, [
+          const Duration(milliseconds: 50),
+          const Duration(milliseconds: 100),
+          const Duration(milliseconds: 200),
+          const Duration(milliseconds: 400),
+          const Duration(milliseconds: 800),
+          const Duration(milliseconds: 1600),
+          const Duration(milliseconds: 3200),
+          const Duration(milliseconds: 6400),
+          const Duration(milliseconds: 12800),
+          const Duration(milliseconds: 15000),
+        ]);
+      });
+
+      test('uses Retry-After seconds as a floor before jitter', () async {
+        final delays = <Duration>[];
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 1,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return attempts == 1
+                ? http.Response('retry', 503, headers: {'retry-after': '1'})
+                : _successResponse();
+          }),
+          delays: delays,
+          randomDouble: () => 0.5,
+        );
+
+        await _fetch(fetcher);
+
+        expect(delays, [const Duration(milliseconds: 1050)]);
+      });
+
+      test('uses Retry-After HTTP dates as a floor before jitter', () async {
+        final delays = <Duration>[];
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 1,
+            dateProvider: () => DateTime.utc(2026, 8, 28, 16),
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return attempts == 1
+                ? http.Response(
+                    'retry',
+                    503,
+                    headers: {'retry-after': 'Fri, 28 Aug 2026 16:00:01 GMT'},
+                  )
+                : _successResponse();
+          }),
+          delays: delays,
+          randomDouble: () => 0.5,
+        );
+
+        await _fetch(fetcher);
+
+        expect(delays, [const Duration(milliseconds: 1050)]);
+      });
+
+      for (final retryAfter in [
+        '0',
+        'Wed, 21 Oct 2015 07:28:00 GMT',
+      ]) {
+        test('uses jitter when Retry-After is immediate or past', () async {
+          final delays = <Duration>[];
+          var attempts = 0;
+          final fetcher = _fetcher(
+            configuration: DatadogFlagsConfiguration(
+              assignmentRequestRetryCount: 1,
+              dateProvider: () => DateTime.utc(2026, 8, 28, 16),
+            ),
+            client: MockClient((_) async {
+              attempts++;
+              return attempts == 1
+                  ? http.Response(
+                      'retry',
+                      503,
+                      headers: {'retry-after': retryAfter},
+                    )
+                  : _successResponse();
+            }),
+            delays: delays,
+            randomDouble: () => 0.5,
+          );
+
+          await _fetch(fetcher);
+
+          expect(delays, [const Duration(milliseconds: 50)]);
+        });
+      }
+
+      for (final retryAfter in ['31', 'Fri, 28 Aug 2026 16:00:31 GMT']) {
+        test('does not retry when Retry-After exceeds 30 seconds', () async {
+          var attempts = 0;
+          final fetcher = _fetcher(
+            configuration: DatadogFlagsConfiguration(
+              assignmentRequestRetryCount: 1,
+              dateProvider: () => DateTime.utc(2026, 8, 28, 16),
+            ),
+            client: MockClient((_) async {
+              attempts++;
+              return http.Response(
+                'maintenance',
+                503,
+                headers: {'retry-after': retryAfter},
+              );
+            }),
+          );
+
+          await expectLater(_fetch(fetcher), throwsA(isA<FlagsException>()));
+
+          expect(attempts, 1);
+        });
+      }
+
+      test('does not retry an out-of-range Retry-After integer', () async {
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 1,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return http.Response(
+              'maintenance',
+              503,
+              headers: {
+                'retry-after': '999999999999999999999999999999999999999999',
+              },
+            );
+          }),
+        );
+
+        await expectLater(_fetch(fetcher), throwsA(isA<FlagsException>()));
+
+        expect(attempts, 1);
+      });
+
+      test('falls back to jitter for malformed Retry-After', () async {
+        final delays = <Duration>[];
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 1,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return attempts == 1
+                ? http.Response('retry', 503, headers: {'retry-after': '1.5'})
+                : _successResponse();
+          }),
+          delays: delays,
+          randomDouble: () => 0.5,
+        );
+
+        await _fetch(fetcher);
+
+        expect(delays, [const Duration(milliseconds: 50)]);
+      });
+
+      test('ignores Retry-After on statuses other than 503', () async {
+        final delays = <Duration>[];
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestRetryCount: 1,
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return attempts == 1
+                ? http.Response('retry', 500, headers: {'retry-after': '10'})
+                : _successResponse();
+          }),
+          delays: delays,
+          randomDouble: () => 0.5,
+        );
+
+        await _fetch(fetcher);
+
+        expect(delays, [const Duration(milliseconds: 50)]);
+      });
+    });
+
+    group('input validation', () {
+      test('rejects a negative timeout before sending a request', () async {
+        var attempts = 0;
+        final fetcher = _fetcher(
+          configuration: const DatadogFlagsConfiguration(
+            assignmentRequestTimeout: Duration(milliseconds: -1),
+          ),
+          client: MockClient((_) async {
+            attempts++;
+            return _successResponse();
+          }),
+        );
+
+        await expectLater(_fetch(fetcher), throwsArgumentError);
+
+        expect(attempts, 0);
+      });
+
+      for (final retryCount in [-1, 11]) {
+        test(
+          'rejects retry count $retryCount before sending a request',
+          () async {
+            var attempts = 0;
+            final fetcher = _fetcher(
+              configuration: DatadogFlagsConfiguration(
+                assignmentRequestRetryCount: retryCount,
+              ),
+              client: MockClient((_) async {
+                attempts++;
+                return _successResponse();
+              }),
+            );
+
+            await expectLater(_fetch(fetcher), throwsRangeError);
+
+            expect(attempts, 0);
+          },
+        );
+      }
+    });
+  });
+}
+
+FlagAssignmentsFetcher _fetcher({
+  required http.Client client,
+  DatadogFlagsConfiguration configuration = const DatadogFlagsConfiguration(),
+  List<Duration>? delays,
+  double Function()? randomDouble,
+}) {
+  return FlagAssignmentsFetcher(
+    datadogConfig: const DatadogFlagsConfig(
+      clientToken: 'token',
+      env: 'dev',
+      site: DatadogFlagsSite.us1,
+    ),
+    configuration: configuration,
+    httpClient: client,
+    delay: delays == null
+        ? (_) async {}
+        : (duration) async {
+            delays.add(duration);
+          },
+    randomDouble: randomDouble ?? () => 0,
+  );
+}
+
+Future<void> _fetch(FlagAssignmentsFetcher fetcher) async {
+  await fetcher.fetch(const FlagsEvaluationContext(targetingKey: 'subject'));
+}
+
+http.Response _successResponse() {
+  return http.Response(jsonEncode({'data': _emptyAssignments()}), 200);
+}
+
+http.StreamedResponse _streamedSuccessResponse() {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode({'data': _emptyAssignments()}))),
+    200,
+  );
+}
+
+Map<String, Object?> _emptyAssignments() {
+  return {
+    'attributes': {'flags': <String, Object?>{}},
+  };
+}
+
+final class _CloseTrackingClient extends http.BaseClient {
+  final http.Client _inner;
+  bool closed = false;
+
+  _CloseTrackingClient(this._inner);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    closed = true;
+    _inner.close();
+  }
+}

--- a/packages/datadog_flags/test/precompute_core_test.dart
+++ b/packages/datadog_flags/test/precompute_core_test.dart
@@ -3,6 +3,7 @@
 // developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:datadog_flags/datadog_flags.dart';
@@ -377,6 +378,99 @@ void main() {
         );
       },
     );
+
+    test('retries a transient assignment request once by default', () async {
+      var attemptCount = 0;
+      final fetcher = FlagAssignmentsFetcher(
+        datadogConfig: _contextFor(DatadogFlagsSite.us1),
+        configuration: const DatadogFlagsConfiguration(),
+        httpClient: MockClient((_) async {
+          attemptCount++;
+          if (attemptCount == 1) {
+            throw TimeoutException('timed out');
+          }
+          return http.Response(jsonEncode({'data': _emptyAssignments()}), 200);
+        }),
+      );
+
+      await fetcher.fetch(
+        const FlagsEvaluationContext(targetingKey: 'subject'),
+      );
+
+      expect(attemptCount, 2);
+    });
+
+    test('uses the configured assignment request retry count', () async {
+      var attemptCount = 0;
+      final fetcher = FlagAssignmentsFetcher(
+        datadogConfig: _contextFor(DatadogFlagsSite.us1),
+        configuration: const DatadogFlagsConfiguration(
+          assignmentRequestTimeout: Duration(seconds: 2),
+          assignmentRequestRetryCount: 2,
+        ),
+        httpClient: MockClient((_) async {
+          attemptCount++;
+          if (attemptCount < 3) {
+            return http.Response('retry', 500);
+          }
+          return http.Response(jsonEncode({'data': _emptyAssignments()}), 200);
+        }),
+      );
+
+      await fetcher.fetch(
+        const FlagsEvaluationContext(targetingKey: 'subject'),
+      );
+
+      expect(attemptCount, 3);
+      expect(fetcher.configuration.assignmentRequestTimeout,
+          const Duration(seconds: 2));
+    });
+
+    test('applies the configured timeout to the complete request', () async {
+      final fetcher = FlagAssignmentsFetcher(
+        datadogConfig: _contextFor(DatadogFlagsSite.us1),
+        configuration: const DatadogFlagsConfiguration(
+          assignmentRequestTimeout: Duration(milliseconds: 1),
+          assignmentRequestRetryCount: 0,
+        ),
+        httpClient: MockClient((_) => Completer<http.Response>().future),
+      );
+
+      await expectLater(
+        fetcher.fetch(
+          const FlagsEvaluationContext(targetingKey: 'subject'),
+        ),
+        throwsA(
+          isA<FlagsException>().having(
+            (error) => error.cause,
+            'cause',
+            isA<TimeoutException>(),
+          ),
+        ),
+      );
+    });
+
+    test('does not retry a non-transient assignment response', () async {
+      var attemptCount = 0;
+      final fetcher = FlagAssignmentsFetcher(
+        datadogConfig: _contextFor(DatadogFlagsSite.us1),
+        configuration: const DatadogFlagsConfiguration(
+          assignmentRequestRetryCount: 3,
+        ),
+        httpClient: MockClient((_) async {
+          attemptCount++;
+          return http.Response('bad request', 400);
+        }),
+      );
+
+      await expectLater(
+        fetcher.fetch(
+          const FlagsEvaluationContext(targetingKey: 'subject'),
+        ),
+        throwsA(isA<FlagsException>()),
+      );
+      expect(attemptCount, 1);
+    });
 
     test('reports invalid response errors for malformed envelopes', () async {
       final fetcher = FlagAssignmentsFetcher(


### PR DESCRIPTION
## Motivation

Applications need opt-in assignment-request timeout and retry policy without changing default request behavior. Advanced Dart and Flutter callers also need a normal `http.Client` building block for assignment-specific transport composition.

## Changes

- Add scalar `assignmentRequestTimeout` with default `Duration.zero` and `assignmentRequestRetryCount` with default `0`.
- Add assignment-only `assignmentRequestHttpClient`.
- Export composable `withAssignmentRequestTimeout(http.Client, Duration)` and `withAssignmentRequestRetry(http.Client, int)` helpers.
- Buffer complete responses, replay a fresh plain `http.Request` for every retry, preserve caller cancellation, and make retry backoff cancellable.
- Add grouped configuration, ownership, telemetry isolation, timeout, retry, replay, cancellation, and unsupported-request-boundary tests.

## Decisions

- Upgrading preserves request behavior: the SDK adds no assignment timeout or retry unless opted into, and default configuration makes one initial request.
- A supplied assignment client is used verbatim and replaces scalar convenience policy. The caller owns and closes it; telemetry retains the SDK client.
- Helpers intentionally support SDK-style plain `http.Request` values and reject unsupported request subtypes rather than silently replaying them incorrectly.
- Retry `TimeoutException`, `http.ClientException`, HTTP 408, and HTTP 5xx; never retry HTTP 429. Honor bounded HTTP 503 `Retry-After` plus full jitter.

## Validation

- `dart analyze .`: no issues.
- Full `datadog_flags` package suite: 100 tests passed, including a default-policy one-request regression and zero-policy pass-through tests.
- `dart format --output=none --set-exit-if-changed` and `git diff --check` pass.

## Jira

FFL-2930
