### PR TITLE
feat!: Require a `service` name when configuring Datadog

### DIFF
--- a/examples/simple_example/lib/main.dart
+++ b/examples/simple_example/lib/main.dart
@@ -43,6 +43,7 @@ void main() async {
           clientToken: clientToken,
           env: env,
           site: siteConfig.datadogSite,
+          service: 'com.datadoghq.example.flutter',
           loggingConfiguration: DatadogLoggingConfiguration(
             customEndpoint: siteConfig.logsCustomEndpoint,
           ),

--- a/packages/datadog_dio/README.md
+++ b/packages/datadog_dio/README.md
@@ -22,6 +22,7 @@ import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
 
 final configuration = DatadogConfiguration(
   // configuration
+  service: '<SERVICE_NAME>',
   firstPartyHosts: ['example.com'],
 )
 ```

--- a/packages/datadog_flags_flutter/README.md
+++ b/packages/datadog_flags_flutter/README.md
@@ -28,6 +28,7 @@ final configuration = DatadogConfiguration(
   clientToken: '<CLIENT_TOKEN>',
   env: '<ENV_NAME>',
   site: DatadogSite.us1,
+  service: '<SERVICE_NAME>',
   rumConfiguration: DatadogRumConfiguration(
     applicationId: '<RUM_APPLICATION_ID>',
   ),
@@ -64,6 +65,7 @@ final configuration = DatadogConfiguration(
   clientToken: '<CLIENT_TOKEN>',
   env: '<ENV_NAME>',
   site: DatadogSite.us1,
+  service: '<SERVICE_NAME>',
 )..addPlugin(
     const DatadogFlagsPluginConfiguration(
       rumIntegrationEnabled: false,

--- a/packages/datadog_flags_flutter/example/lib/main.dart
+++ b/packages/datadog_flags_flutter/example/lib/main.dart
@@ -31,6 +31,7 @@ Future<void> main() async {
       clientToken: _clientToken,
       env: _env,
       site: _datadogSiteFor(_site),
+      service: 'com.datadoghq.flutter.flags.example',
       rumConfiguration: _applicationId.isEmpty
           ? null
           : DatadogRumConfiguration(applicationId: _applicationId),

--- a/packages/datadog_flags_flutter/test/datadog_flags_plugin_test.dart
+++ b/packages/datadog_flags_flutter/test/datadog_flags_plugin_test.dart
@@ -88,6 +88,7 @@ void main() {
       clientToken: 'sdk-token',
       env: 'prod',
       site: DatadogSite.us1,
+      service: 'sdk-service',
     );
     when(() => mockSdk.configuration).thenReturn(configuration);
 
@@ -140,6 +141,7 @@ void main() {
       clientToken: 'client-token',
       env: 'prod',
       site: DatadogSite.us1Fed,
+      service: 'client-service',
     );
     when(() => mockSdk.configuration).thenReturn(configuration);
 
@@ -162,6 +164,7 @@ void main() {
       clientToken: 'client-token',
       env: 'prod',
       site: DatadogSite.us1,
+      service: 'client-service',
     );
     when(() => mockSdk.configuration).thenReturn(configuration);
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/MIGRATING.md
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/MIGRATING.md
@@ -1,5 +1,9 @@
 # Migration from 3.x to 4.0
 
+## SDK Configuration Changes
+
+`DatadogConfiguration.service` is no longer optional; it must now be provided when constructing `DatadogConfiguration`.
+
 ## Flutter Web Changes
 
 Clients using Flutter Web should update to using the Datadog Browser SDK v7. Change the following import in your `index.html`:

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/README.md
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/README.md
@@ -60,6 +60,7 @@ final configuration = DatadogConfiguration(
   clientToken: '<CLIENT_TOKEN>',
   env: '<ENV_NAME>',
   site: DatadogSite.us1,
+  service: '<SERVICE_NAME>',
   nativeCrashReportEnabled: true,
   loggingConfiguration: DatadogLoggingConfiguration(),
   rumConfiguration: DatadogRumConfiguration(

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/e2e_test_app/integration_test/test_utils.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/e2e_test_app/integration_test/test_utils.dart
@@ -34,13 +34,13 @@ Future<void> initializeDatadog({
           clientToken: clientToken,
           env: env,
           site: DatadogSite.us1,
+          service: 'com.datadog.flutter.nightly',
         )
         ..loggingConfiguration = DatadogLoggingConfiguration()
         ..rumConfiguration = DatadogRumConfiguration(
           applicationId: applicationId,
           detectLongTasks: false,
-        )
-        ..service = 'com.datadog.flutter.nightly';
+        );
 
   if (configCallback != null) {
     configCallback(configuration);

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/test/datadog_sdk_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/test/datadog_sdk_test.dart
@@ -158,6 +158,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
     );
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
 
@@ -177,6 +178,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
     )..addPlugin(pluginConfiguration);
 
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
@@ -190,6 +192,7 @@ void main() {
       clientToken: 'fake-client-token',
       env: 'prod',
       site: DatadogSite.us1,
+      service: 'test-service',
     );
     final encoded = configuration.encode();
     expect(encoded, {
@@ -197,7 +200,7 @@ void main() {
       'env': 'prod',
       'site': 'DatadogSite.us1',
       'nativeCrashReportEnabled': false,
-      'service': null,
+      'service': 'test-service',
       'batchSize': null,
       'uploadFrequency': null,
       'batchProcessingLevel': null,
@@ -211,6 +214,7 @@ void main() {
             clientToken: 'fakeClientToken',
             env: 'environment',
             site: DatadogSite.us1,
+            service: 'test-service',
           )
           ..batchSize = BatchSize.small
           ..uploadFrequency = UploadFrequency.frequent
@@ -242,6 +246,7 @@ void main() {
       clientToken: 'fakeClientToken',
       env: 'fake-env',
       site: DatadogSite.us1,
+      service: 'test-service',
       version: '1.9.8+123',
     );
 
@@ -256,6 +261,7 @@ void main() {
       clientToken: 'fakeClientToken',
       env: 'fake-env',
       site: DatadogSite.us1,
+      service: 'test-service',
       flavor: 'strawberry',
     );
 
@@ -275,6 +281,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       loggingConfiguration: loggingConfiguration,
     );
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
@@ -308,6 +315,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       rumConfiguration: rumConfiguration,
     );
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
@@ -394,6 +402,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       firstPartyHosts: ['example.com', 'datadoghq.com'],
     );
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
@@ -416,6 +425,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       firstPartyHostsWithTracingHeaders: {
         'example.com': {TracingHeaderType.b3},
         'datadoghq.com': {TracingHeaderType.datadog},
@@ -437,6 +447,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       firstPartyHosts: ['datadoghq.com'],
       firstPartyHostsWithTracingHeaders: {
         'example.com': {TracingHeaderType.b3},
@@ -459,6 +470,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
     );
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
 
@@ -475,6 +487,7 @@ void main() {
         clientToken: 'clientToken',
         env: 'env',
         site: DatadogSite.us1,
+        service: 'test-service',
         firstPartyHosts: firstPartyHosts,
       );
       await datadogSdk.initialize(configuration, TrackingConsent.pending);
@@ -496,6 +509,7 @@ void main() {
         clientToken: 'clientToken',
         env: 'env',
         site: DatadogSite.us1,
+        service: 'test-service',
         firstPartyHosts: firstPartyHosts,
       );
       await datadogSdk.initialize(configuration, TrackingConsent.pending);
@@ -517,6 +531,7 @@ void main() {
         clientToken: 'clientToken',
         env: 'env',
         site: DatadogSite.us1,
+        service: 'test-service',
         firstPartyHosts: firstPartyHosts,
       );
       await datadogSdk.initialize(configuration, TrackingConsent.granted);
@@ -533,6 +548,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       firstPartyHosts: firstPartyHosts,
     );
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
@@ -551,6 +567,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       firstPartyHostsWithTracingHeaders: firstPartyHosts,
     );
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
@@ -573,6 +590,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       firstPartyHostsWithTracingHeaders: firstPartyHosts,
     );
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
@@ -693,6 +711,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
       loggingConfiguration: loggingConfig,
     );
     await datadogSdk.initialize(configuration, TrackingConsent.granted);
@@ -719,6 +738,7 @@ void main() {
         clientToken: 'fake_token',
         env: 'env',
         site: DatadogSite.us1,
+        service: 'test-service',
       )..addPlugin(mockPluginConfig);
 
       await datadogSdk.initialize(config, TrackingConsent.pending);
@@ -759,6 +779,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
     );
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
 
@@ -788,6 +809,7 @@ void main() {
       clientToken: 'clientToken',
       env: 'env',
       site: DatadogSite.us1,
+      service: 'test-service',
     );
     await datadogSdk.initialize(configuration, TrackingConsent.pending);
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_android/test/datadog_sdk_method_channel_test.dart
@@ -39,6 +39,7 @@ void main() {
       clientToken: 'fakeClientToken',
       env: 'environment',
       site: DatadogSite.us1,
+      service: 'fake-service',
     );
     await ddSdkPlatform.initialize(
       configuration,
@@ -64,6 +65,7 @@ void main() {
       clientToken: 'fakeClientToken',
       env: 'environment',
       site: DatadogSite.us1,
+      service: 'fake-service',
     );
     await ddSdkPlatform.initialize(
       configuration,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/lib/src/desktop_platform.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/lib/src/desktop_platform.dart
@@ -72,9 +72,7 @@ class DatadogDesktopPlatform extends DatadogSdkPlatform {
       _sdk.dd_core_config_init(
         cfg,
         configuration.clientToken.toNativeChar(allocator: arena),
-        (configuration.service ?? _defaultServiceName()).toNativeChar(
-          allocator: arena,
-        ),
+        configuration.service.toNativeChar(allocator: arena),
         configuration.env.toNativeChar(allocator: arena),
       );
 
@@ -122,7 +120,7 @@ class DatadogDesktopPlatform extends DatadogSdkPlatform {
 
       _sdk.dd_core_config_set_site(cfg, _siteToC(configuration.site));
 
-      final storagePath = _storagePath(configuration.service ?? 'datadog');
+      final storagePath = _storagePath(configuration.service);
       Directory(storagePath).createSync(recursive: true);
       _sdk.dd_core_config_set_application_storage_path(
         cfg,
@@ -480,13 +478,6 @@ class DatadogDesktopPlatform extends DatadogSdkPlatform {
       base = base.substring(0, base.length - 1);
     }
     return base;
-  }
-
-  String _defaultServiceName() {
-    var name = Platform.resolvedExecutable.split(Platform.pathSeparator).last;
-    final dot = name.lastIndexOf('.');
-    if (dot > 0) name = name.substring(0, dot);
-    return name;
   }
 
   String _storagePath(String service) {

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/test/datadog_sdk_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/test/datadog_sdk_method_channel_test.dart
@@ -39,6 +39,7 @@ void main() {
       clientToken: 'fakeClientToken',
       env: 'environment',
       site: DatadogSite.us1,
+      service: 'fake-service',
     );
     await ddSdkPlatform.initialize(
       configuration,
@@ -64,6 +65,7 @@ void main() {
       clientToken: 'fakeClientToken',
       env: 'environment',
       site: DatadogSite.us1,
+      service: 'fake-service',
     );
     await ddSdkPlatform.initialize(
       configuration,

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/datadog_configuration.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_platform_interface/lib/src/datadog_configuration.dart
@@ -160,7 +160,7 @@ class DatadogConfiguration {
   DatadogSite site;
 
   /// The service name for this application
-  String? service;
+  String service;
 
   /// Sets the preferred size of batched data uploaded to Datadog servers. This
   /// value impacts the size and number of requests performed by the SDK.
@@ -293,8 +293,8 @@ class DatadogConfiguration {
     required this.clientToken,
     required this.env,
     required this.site,
+    required this.service,
     this.nativeCrashReportEnabled = false,
-    this.service,
     this.uploadFrequency,
     this.batchSize,
     this.batchProcessingLevel,

--- a/packages/datadog_gql_link/README.md
+++ b/packages/datadog_gql_link/README.md
@@ -31,6 +31,7 @@ and APM traces may be broken. You can ignore your GraphQL endpoint by using the
 ```dart
 final datadogConfig = DatadogConfiguration(
     // Your configuration
+    service: '<SERVICE_NAME>',
   )..enableHttpTracking(
       ignoreUrlPatterns: [
         RegExp('example.com/graphql'),

--- a/packages/datadog_grpc_interceptor/README.md
+++ b/packages/datadog_grpc_interceptor/README.md
@@ -14,7 +14,8 @@ import 'package:datadog_grpc_interceptor/datadog_grpc_interceptor.dart'
 // to enable Datadog Distributed Tracing
 final config = DatadogConfiguration(
   // ...
-  firstParthHosts = ['localhost']
+  service: '<SERVICE_NAME>',
+  firstPartyHosts: ['localhost'],
 )
 
 // Create the gRPC channel

--- a/packages/datadog_inappwebview_tracking/example/lib/main.dart
+++ b/packages/datadog_inappwebview_tracking/example/lib/main.dart
@@ -23,6 +23,7 @@ Future<void> main() async {
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
     site: DatadogSite.us1,
+    service: 'com.datadoghq.flutter.inappwebview_tracking.integration',
     uploadFrequency: UploadFrequency.frequent,
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,

--- a/packages/datadog_session_replay/README.md
+++ b/packages/datadog_session_replay/README.md
@@ -33,9 +33,10 @@ import 'package:datadog_session_replay/datadog_session_replay.dart';
 final configuration = DatadogConfiguration(
     // Normal Datadog configuration
     clientToken: 'client-token',
+    service: '<SERVICE_NAME>',
     // RUM is required to use Datadog Session Replay
-    rumConfiguration: RumConfiguration(
-        applicationId: '<application-id'>
+    rumConfiguration: DatadogRumConfiguration(
+        applicationId: '<application-id>'
     ),
 )..enableSessionReplay(
     DatadogSessionReplayConfiguration(

--- a/packages/datadog_tracking_http_client/README.md
+++ b/packages/datadog_tracking_http_client/README.md
@@ -12,6 +12,7 @@ import 'package:datadog_tracking_http_client/datadog_tracking_http_client.dart';
 
 final configuration = DatadogConfiguration(
   // configuration
+  service: '<SERVICE_NAME>',
   firstPartyHosts: ['example.com'],
 )..enableHttpTracking()
 ```
@@ -36,6 +37,7 @@ import 'package:http/http.dart' as http;
 final configuration = DatadogConfiguration(
   // specifying firstPartyHosts is still necessary to
   // enable distributed tracing
+  service: '<SERVICE_NAME>',
   firstPartyHosts: ['example.com'],
 )
 

--- a/packages/datadog_webview_tracking/example/lib/main.dart
+++ b/packages/datadog_webview_tracking/example/lib/main.dart
@@ -26,6 +26,7 @@ Future<void> main() async {
     clientToken: clientToken,
     env: dotenv.get('DD_ENV', fallback: ''),
     site: DatadogSite.us1,
+    service: 'com.datadoghq.flutter.webview_tracking.integration',
     uploadFrequency: UploadFrequency.frequent,
     batchSize: BatchSize.small,
     nativeCrashReportEnabled: true,

--- a/test_apps/stress_test/lib/main.dart
+++ b/test_apps/stress_test/lib/main.dart
@@ -20,6 +20,7 @@ void main() async {
     clientToken: dotenv.get('DD_CLIENT_TOKEN', fallback: ''),
     env: dotenv.get('DD_ENV', fallback: ''),
     site: DatadogSite.us1,
+    service: 'com.datadoghq.flutter.stress_test',
     nativeCrashReportEnabled: true,
     loggingConfiguration: DatadogLoggingConfiguration(
       eventMapper: (event) => event,


### PR DESCRIPTION
### What and why?

Service is required for Datadog, but we attempt to find a sensible default for most SDKs. Unfortunately, Browser does not really have an available "sensible default", and the default we're using on Desktop is the name of the executable, which isn't ideal.

To prevent any confusing issues, v4 is now going to require a service be set instead of trying to guess at a sensible value.

refs: RUM-17896

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
