### PR TITLE
chore(datadog_flags_flutter): bump next development version

### DIFF
--- a/packages/datadog_flags_flutter/pubspec.yaml
+++ b/packages/datadog_flags_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datadog_flags_flutter
 description: Flutter integration for the Datadog Feature Flags and Experimentation SDK.
-version: 1.0.0
+version: 1.1.0
 repository: https://github.com/DataDog/dd-sdk-flutter
 homepage: https://datadoghq.com
 issue_tracker: https://github.com/DataDog/dd-sdk-flutter/issues


### PR DESCRIPTION
## Motivation

`datadog_flags_flutter` 1.0.0 is public, but `develop` still identifies the next build as 1.0.0. This state makes future release preparation ambiguous.

## Changes and Decisions

This change advances only the package version to 1.1.0. It matches the existing monorepo process after a 1.0.0 release.