### PR TITLE
fix(flags): avoid Flutter Web intake preflights

### DIFF
--- a/packages/datadog_flags/lib/src/evaluation_aggregator.dart
+++ b/packages/datadog_flags/lib/src/evaluation_aggregator.dart
@@ -259,7 +259,9 @@ class EvaluationAggregator {
   Map<String, Object?> _webDatadogContext() {
     final applicationId = runtime.datadogConfig.applicationId;
     return _removeNullValues({
+      'env': runtime.datadogConfig.env,
       'service': runtime.datadogConfig.service,
+      'version': runtime.datadogConfig.version,
       'rum': applicationId == null
           ? null
           : {

--- a/packages/datadog_flags/lib/src/evaluation_aggregator.dart
+++ b/packages/datadog_flags/lib/src/evaluation_aggregator.dart
@@ -171,16 +171,15 @@ class EvaluationAggregator {
     List<_AggregatedEvaluation> evaluations, {
     required bool rescheduleOnFailure,
   }) async {
-    final nativeBody = jsonEncode({
-      'context': _datadogContext(),
-      'flagEvaluations': evaluations.map((e) => e.toJson()).toList(),
-    });
     final request = buildFlagsIntakeRequest(
       endpoint: _evaluationEndpoint(),
       clientToken: runtime.datadogConfig.clientToken,
       nativeContentType: 'application/json',
-      nativeBody: nativeBody,
-      webBody: evaluations.map(_webEvaluationJson).join('\n'),
+      nativeBodyBuilder: () => jsonEncode({
+        'context': _datadogContext(),
+        'flagEvaluations': evaluations.map((e) => e.toJson()).toList(),
+      }),
+      webBodyBuilder: () => evaluations.map(_webEvaluationJson).join('\n'),
     );
 
     try {

--- a/packages/datadog_flags/lib/src/evaluation_aggregator.dart
+++ b/packages/datadog_flags/lib/src/evaluation_aggregator.dart
@@ -7,13 +7,12 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
-import 'package:uuid/uuid.dart';
 
 import 'assignment.dart';
 import 'evaluation_context.dart';
 import 'flags_runtime.dart';
+import 'intake_request.dart';
 import 'json_value.dart';
-import 'sdk_metadata.dart';
 
 class EvaluationAggregator {
   static const int defaultMaxBatchSize = 1000;
@@ -172,24 +171,24 @@ class EvaluationAggregator {
     List<_AggregatedEvaluation> evaluations, {
     required bool rescheduleOnFailure,
   }) async {
-    final endpoint = _evaluationEndpoint();
-    final body = jsonEncode({
+    final nativeBody = jsonEncode({
       'context': _datadogContext(),
       'flagEvaluations': evaluations.map((e) => e.toJson()).toList(),
     });
+    final request = buildFlagsIntakeRequest(
+      endpoint: _evaluationEndpoint(),
+      clientToken: runtime.datadogConfig.clientToken,
+      nativeContentType: 'application/json',
+      nativeBody: nativeBody,
+      webBody: evaluations.map(_webEvaluationJson).join('\n'),
+    );
 
     try {
       final response = await runtime.httpClient
           .post(
-            endpoint,
-            headers: {
-              'Content-Type': 'application/json',
-              'DD-API-KEY': runtime.datadogConfig.clientToken,
-              'DD-EVP-ORIGIN': datadogFlagsSource,
-              'DD-EVP-ORIGIN-VERSION': datadogFlagsSdkVersion,
-              'DD-REQUEST-ID': const Uuid().v4(),
-            },
-            body: body,
+            request.endpoint,
+            headers: request.headers,
+            body: request.body,
           )
           .timeout(uploadTimeout);
       if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -239,14 +238,34 @@ class EvaluationAggregator {
 
   Uri _evaluationEndpoint() {
     final datadogConfig = runtime.datadogConfig;
-    final endpoint = runtime.configuration.customEvaluationEndpoint ??
+    return runtime.configuration.customEvaluationEndpoint ??
         datadogConfig.intakeEndpoint().replace(path: '/api/v2/flagevaluation');
-    return endpoint.replace(
-      queryParameters: {
-        ...endpoint.queryParameters,
-        'ddsource': datadogFlagsSource,
-      },
-    );
+  }
+
+  String _webEvaluationJson(_AggregatedEvaluation evaluation) {
+    final event = evaluation.toJson();
+    final eventContext = switch (event['context']) {
+      Map<String, Object?> context => Map<String, Object?>.from(context),
+      _ => <String, Object?>{},
+    };
+    final datadogContext = _webDatadogContext();
+    if (datadogContext.isNotEmpty) {
+      eventContext['dd'] = datadogContext;
+      event['context'] = eventContext;
+    }
+    return jsonEncode(event);
+  }
+
+  Map<String, Object?> _webDatadogContext() {
+    final applicationId = runtime.datadogConfig.applicationId;
+    return _removeNullValues({
+      'service': runtime.datadogConfig.service,
+      'rum': applicationId == null
+          ? null
+          : {
+              'application': {'id': applicationId},
+            },
+    });
   }
 
   Map<String, Object?> _datadogContext() {

--- a/packages/datadog_flags/lib/src/evaluation_aggregator.dart
+++ b/packages/datadog_flags/lib/src/evaluation_aggregator.dart
@@ -247,26 +247,12 @@ class EvaluationAggregator {
       Map<String, Object?> context => Map<String, Object?>.from(context),
       _ => <String, Object?>{},
     };
-    final datadogContext = _webDatadogContext();
+    final datadogContext = _datadogContext();
     if (datadogContext.isNotEmpty) {
       eventContext['dd'] = datadogContext;
       event['context'] = eventContext;
     }
     return jsonEncode(event);
-  }
-
-  Map<String, Object?> _webDatadogContext() {
-    final applicationId = runtime.datadogConfig.applicationId;
-    return _removeNullValues({
-      'env': runtime.datadogConfig.env,
-      'service': runtime.datadogConfig.service,
-      'version': runtime.datadogConfig.version,
-      'rum': applicationId == null
-          ? null
-          : {
-              'application': {'id': applicationId},
-            },
-    });
   }
 
   Map<String, Object?> _datadogContext() {

--- a/packages/datadog_flags/lib/src/exposure_logger.dart
+++ b/packages/datadog_flags/lib/src/exposure_logger.dart
@@ -149,8 +149,8 @@ class ExposureLogger {
       endpoint: _exposureEndpoint(),
       clientToken: runtime.datadogConfig.clientToken,
       nativeContentType: 'text/plain;charset=UTF-8',
-      nativeBody: body,
-      webBody: body,
+      nativeBodyBuilder: () => body,
+      webBodyBuilder: () => body,
     );
     try {
       final response = await runtime.httpClient

--- a/packages/datadog_flags/lib/src/exposure_logger.dart
+++ b/packages/datadog_flags/lib/src/exposure_logger.dart
@@ -7,13 +7,12 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
-import 'package:uuid/uuid.dart';
 
 import 'assignment.dart';
 import 'evaluation_context.dart';
 import 'flags_runtime.dart';
+import 'intake_request.dart';
 import 'json_value.dart';
-import 'sdk_metadata.dart';
 
 class ExposureLogger {
   static const Duration defaultUploadTimeout = Duration(seconds: 15);
@@ -145,18 +144,20 @@ class ExposureLogger {
     List<Map<String, Object?>> exposures, {
     required bool rescheduleOnFailure,
   }) async {
+    final body = exposures.map(jsonEncode).join('\n');
+    final request = buildFlagsIntakeRequest(
+      endpoint: _exposureEndpoint(),
+      clientToken: runtime.datadogConfig.clientToken,
+      nativeContentType: 'text/plain;charset=UTF-8',
+      nativeBody: body,
+      webBody: body,
+    );
     try {
       final response = await runtime.httpClient
           .post(
-            _exposureEndpoint(),
-            headers: {
-              'Content-Type': 'text/plain;charset=UTF-8',
-              'DD-API-KEY': runtime.datadogConfig.clientToken,
-              'DD-EVP-ORIGIN': datadogFlagsSource,
-              'DD-EVP-ORIGIN-VERSION': datadogFlagsSdkVersion,
-              'DD-REQUEST-ID': const Uuid().v4(),
-            },
-            body: exposures.map(jsonEncode).join('\n'),
+            request.endpoint,
+            headers: request.headers,
+            body: request.body,
           )
           .timeout(uploadTimeout);
       if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -224,14 +225,8 @@ class ExposureLogger {
 
   Uri _exposureEndpoint() {
     final datadogConfig = runtime.datadogConfig;
-    final endpoint = runtime.configuration.customExposureEndpoint ??
+    return runtime.configuration.customExposureEndpoint ??
         datadogConfig.intakeEndpoint().replace(path: '/api/v2/exposures');
-    return endpoint.replace(
-      queryParameters: {
-        ...endpoint.queryParameters,
-        'ddsource': datadogFlagsSource,
-      },
-    );
   }
 }
 

--- a/packages/datadog_flags/lib/src/intake_platform.dart
+++ b/packages/datadog_flags/lib/src/intake_platform.dart
@@ -3,5 +3,5 @@
 // developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-export 'intake_platform_native.dart'
-    if (dart.library.js_interop) 'intake_platform_web.dart';
+export 'intake_platform_web.dart'
+    if (dart.library.io) 'intake_platform_native.dart';

--- a/packages/datadog_flags/lib/src/intake_platform.dart
+++ b/packages/datadog_flags/lib/src/intake_platform.dart
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+export 'intake_platform_native.dart'
+    if (dart.library.js_interop) 'intake_platform_web.dart';

--- a/packages/datadog_flags/lib/src/intake_platform_native.dart
+++ b/packages/datadog_flags/lib/src/intake_platform_native.dart
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+const isWebFlagsIntake = false;

--- a/packages/datadog_flags/lib/src/intake_platform_web.dart
+++ b/packages/datadog_flags/lib/src/intake_platform_web.dart
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+const isWebFlagsIntake = true;

--- a/packages/datadog_flags/lib/src/intake_request.dart
+++ b/packages/datadog_flags/lib/src/intake_request.dart
@@ -26,8 +26,8 @@ FlagsIntakeRequest buildFlagsIntakeRequest({
   required Uri endpoint,
   required String clientToken,
   required String nativeContentType,
-  required String nativeBody,
-  required String webBody,
+  required String Function() nativeBodyBuilder,
+  required String Function() webBodyBuilder,
 }) {
   final requestId = const Uuid().v4();
   final queryParameters = {
@@ -47,7 +47,7 @@ FlagsIntakeRequest buildFlagsIntakeRequest({
     return FlagsIntakeRequest(
       endpoint: endpoint.replace(queryParameters: queryParameters),
       headers: const {'Content-Type': 'text/plain'},
-      body: webBody,
+      body: webBodyBuilder(),
     );
   }
 
@@ -60,6 +60,6 @@ FlagsIntakeRequest buildFlagsIntakeRequest({
       'DD-EVP-ORIGIN-VERSION': datadogFlagsSdkVersion,
       'DD-REQUEST-ID': requestId,
     },
-    body: nativeBody,
+    body: nativeBodyBuilder(),
   );
 }

--- a/packages/datadog_flags/lib/src/intake_request.dart
+++ b/packages/datadog_flags/lib/src/intake_request.dart
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
+
+import 'intake_platform.dart';
+import 'sdk_metadata.dart';
+
+@immutable
+final class FlagsIntakeRequest {
+  final Uri endpoint;
+  final Map<String, String> headers;
+  final String body;
+
+  const FlagsIntakeRequest({
+    required this.endpoint,
+    required this.headers,
+    required this.body,
+  });
+}
+
+FlagsIntakeRequest buildFlagsIntakeRequest({
+  required Uri endpoint,
+  required String clientToken,
+  required String nativeContentType,
+  required String nativeBody,
+  required String webBody,
+}) {
+  final requestId = const Uuid().v4();
+  final queryParameters = {
+    ...endpoint.queryParameters,
+    'ddsource': datadogFlagsSource,
+    if (isWebFlagsIntake) ...{
+      'dd-api-key': clientToken,
+      'dd-evp-origin-version': datadogFlagsSdkVersion,
+      'dd-evp-origin': datadogFlagsSource,
+      'dd-request-id': requestId,
+    },
+  };
+
+  if (isWebFlagsIntake) {
+    // Match the Browser SDK transport so the browser does not send an OPTIONS
+    // CORS preflight before each intake request.
+    return FlagsIntakeRequest(
+      endpoint: endpoint.replace(queryParameters: queryParameters),
+      headers: const {'Content-Type': 'text/plain'},
+      body: webBody,
+    );
+  }
+
+  return FlagsIntakeRequest(
+    endpoint: endpoint.replace(queryParameters: queryParameters),
+    headers: {
+      'Content-Type': nativeContentType,
+      'DD-API-KEY': clientToken,
+      'DD-EVP-ORIGIN': datadogFlagsSource,
+      'DD-EVP-ORIGIN-VERSION': datadogFlagsSdkVersion,
+      'DD-REQUEST-ID': requestId,
+    },
+    body: nativeBody,
+  );
+}

--- a/packages/datadog_flags/test/datadog_flags_test.dart
+++ b/packages/datadog_flags/test/datadog_flags_test.dart
@@ -10,6 +10,7 @@ import 'package:datadog_flags/datadog_flags.dart';
 import 'package:datadog_flags/src/evaluation_aggregator.dart';
 import 'package:datadog_flags/src/exposure_logger.dart';
 import 'package:datadog_flags/src/flags_store.dart';
+import 'package:datadog_flags/src/intake_platform.dart';
 import 'package:datadog_flags/src/sdk_metadata.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -339,14 +340,13 @@ void main() {
       expect(_exposureRequests(requests), hasLength(1));
       final request = _exposureRequests(requests).single;
       expect(
-        request.url.toString(),
-        'https://browser-intake-datadoghq.com/api/v2/exposures?ddsource=dart-client',
+        '${request.url.origin}${request.url.path}',
+        'https://browser-intake-datadoghq.com/api/v2/exposures',
       );
-      expect(request.headers['Content-Type'], 'text/plain;charset=UTF-8');
-      expect(request.headers['DD-API-KEY'], 'client-token');
-      expect(request.headers['DD-EVP-ORIGIN'], 'dart-client');
-      expect(request.headers['DD-EVP-ORIGIN-VERSION'], datadogFlagsSdkVersion);
-      expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
+      _expectIntakeMetadata(
+        request,
+        nativeContentType: 'text/plain;charset=UTF-8',
+      );
 
       final exposure = _exposureEvents(request).single;
       expect(exposure, {
@@ -750,20 +750,17 @@ void main() {
 
       final request = _evaluationRequests(requests).single;
       expect(
-        request.url.toString(),
-        'https://browser-intake-datadoghq.com/api/v2/flagevaluation?ddsource=dart-client',
+        '${request.url.origin}${request.url.path}',
+        'https://browser-intake-datadoghq.com/api/v2/flagevaluation',
       );
-      expect(request.headers['Content-Type'], 'application/json');
-      expect(request.headers['DD-API-KEY'], 'client-token');
-      expect(request.headers['DD-EVP-ORIGIN'], 'dart-client');
-      expect(request.headers['DD-EVP-ORIGIN-VERSION'], datadogFlagsSdkVersion);
-      expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
+      _expectIntakeMetadata(request, nativeContentType: 'application/json');
 
-      final body = jsonDecode(request.body) as Map<String, Object?>;
-      expect(body['context'], _datadogEventContext());
+      if (!isWebFlagsIntake) {
+        final body = jsonDecode(request.body) as Map<String, Object?>;
+        expect(body['context'], _datadogEventContext());
+      }
 
-      final evaluations = (body['flagEvaluations'] as List<Object?>)
-          .cast<Map<String, Object?>>();
+      final evaluations = _flagEvaluationEvents(request);
       expect(evaluations, hasLength(3));
 
       final success = _evaluation(
@@ -780,6 +777,13 @@ void main() {
       expect(success['targeting_key'], 'user-123');
       expect(success['context'], {
         'evaluation': {'plan': 'pro'},
+        if (isWebFlagsIntake)
+          'dd': {
+            'service': 'shopping-cart',
+            'rum': {
+              'application': {'id': 'application-id'},
+            },
+          },
       });
       expect(success.containsKey('runtime_default_used'), isFalse);
 
@@ -821,9 +825,7 @@ void main() {
     await client.shutdown();
 
     final request = _evaluationRequests(requests).single;
-    final body = jsonDecode(request.body) as Map<String, Object?>;
-    final evaluations =
-        (body['flagEvaluations'] as List<Object?>).cast<Map<String, Object?>>();
+    final evaluations = _flagEvaluationEvents(request);
 
     final evaluation = evaluations.single;
     expect(evaluation['flag'], {'key': 'show-paywall'});
@@ -985,10 +987,8 @@ void main() {
     await client.shutdown();
 
     expect(_evaluationRequests(requests), hasLength(2));
-    final secondBody = jsonDecode(_evaluationRequests(requests).last.body)
-        as Map<String, Object?>;
-    final secondEvaluations = (secondBody['flagEvaluations'] as List<Object?>)
-        .cast<Map<String, Object?>>();
+    final secondEvaluations =
+        _flagEvaluationEvents(_evaluationRequests(requests).last);
     expect(secondEvaluations.single['flag'], {'key': 'theme'});
   });
 
@@ -1518,6 +1518,50 @@ List<Map<String, Object?>> _exposureEvents(http.Request request) {
       .where((line) => line.isNotEmpty)
       .map((line) => jsonDecode(line) as Map<String, Object?>)
       .toList();
+}
+
+List<Map<String, Object?>> _flagEvaluationEvents(http.Request request) {
+  if (isWebFlagsIntake) {
+    return request.body
+        .split('\n')
+        .where((line) => line.isNotEmpty)
+        .map((line) => jsonDecode(line) as Map<String, Object?>)
+        .toList();
+  }
+  final body = jsonDecode(request.body) as Map<String, Object?>;
+  return (body['flagEvaluations'] as List<Object?>)
+      .cast<Map<String, Object?>>();
+}
+
+void _expectIntakeMetadata(
+  http.Request request, {
+  required String nativeContentType,
+}) {
+  expect(request.url.queryParameters['ddsource'], datadogFlagsSource);
+  if (isWebFlagsIntake) {
+    expect(request.headers['Content-Type'], startsWith('text/plain'));
+    expect(request.headers['DD-API-KEY'], isNull);
+    expect(request.headers['DD-EVP-ORIGIN'], isNull);
+    expect(request.headers['DD-EVP-ORIGIN-VERSION'], isNull);
+    expect(request.headers['DD-REQUEST-ID'], isNull);
+    expect(request.url.queryParameters['dd-api-key'], 'client-token');
+    expect(request.url.queryParameters['dd-evp-origin'], datadogFlagsSource);
+    expect(
+      request.url.queryParameters['dd-evp-origin-version'],
+      datadogFlagsSdkVersion,
+    );
+    expect(request.url.queryParameters['dd-request-id'], isNotEmpty);
+    return;
+  }
+
+  expect(request.headers['Content-Type'], nativeContentType);
+  expect(request.headers['DD-API-KEY'], 'client-token');
+  expect(request.headers['DD-EVP-ORIGIN'], datadogFlagsSource);
+  expect(
+    request.headers['DD-EVP-ORIGIN-VERSION'],
+    datadogFlagsSdkVersion,
+  );
+  expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
 }
 
 Map<String, Object?> _datadogEventContext() {

--- a/packages/datadog_flags/test/datadog_flags_test.dart
+++ b/packages/datadog_flags/test/datadog_flags_test.dart
@@ -779,7 +779,9 @@ void main() {
         'evaluation': {'plan': 'pro'},
         if (isWebFlagsIntake)
           'dd': {
+            'env': 'staging',
             'service': 'shopping-cart',
+            'version': '1.2.3',
             'rum': {
               'application': {'id': 'application-id'},
             },

--- a/packages/datadog_flags/test/evaluation_aggregator_test.dart
+++ b/packages/datadog_flags/test/evaluation_aggregator_test.dart
@@ -81,7 +81,9 @@ void main() {
       },
       if (isWebFlagsIntake)
         'dd': {
+          'env': 'staging',
           'service': 'shopping-cart',
+          'version': '1.2.3',
           'rum': {
             'application': {'id': 'application-id'},
           },

--- a/packages/datadog_flags/test/evaluation_aggregator_test.dart
+++ b/packages/datadog_flags/test/evaluation_aggregator_test.dart
@@ -10,6 +10,8 @@ import 'package:datadog_flags/datadog_flags.dart';
 import 'package:datadog_flags/src/assignment.dart';
 import 'package:datadog_flags/src/evaluation_aggregator.dart';
 import 'package:datadog_flags/src/flags_runtime.dart';
+import 'package:datadog_flags/src/intake_platform.dart';
+import 'package:datadog_flags/src/sdk_metadata.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
@@ -62,10 +64,7 @@ void main() {
     await aggregator.flush();
 
     final request = _evaluationRequests(requests).single;
-    expect(request.headers['Content-Type'], 'application/json');
-    expect(request.headers['DD-API-KEY'], 'client-token');
-    expect(request.headers['DD-EVP-ORIGIN'], 'dart-client');
-    expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
+    _expectIntakeMetadata(request, nativeContentType: 'application/json');
 
     final evaluation = _flagEvaluations(request).single;
     expect(evaluation['flag'], {'key': 'checkout.enabled'});
@@ -80,6 +79,13 @@ void main() {
         'companyId': '1',
         'plan': 'pro',
       },
+      if (isWebFlagsIntake)
+        'dd': {
+          'service': 'shopping-cart',
+          'rum': {
+            'application': {'id': 'application-id'},
+          },
+        },
     });
     expect(evaluation.containsKey('runtime_default_used'), isFalse);
   });
@@ -315,9 +321,47 @@ List<http.Request> _evaluationRequests(List<http.Request> requests) {
 }
 
 List<Map<String, Object?>> _flagEvaluations(http.Request request) {
+  if (isWebFlagsIntake) {
+    return request.body
+        .split('\n')
+        .where((line) => line.isNotEmpty)
+        .map((line) => jsonDecode(line) as Map<String, Object?>)
+        .toList();
+  }
   final body = jsonDecode(request.body) as Map<String, Object?>;
   return (body['flagEvaluations'] as List<Object?>)
       .cast<Map<String, Object?>>();
+}
+
+void _expectIntakeMetadata(
+  http.Request request, {
+  required String nativeContentType,
+}) {
+  expect(request.url.queryParameters['ddsource'], datadogFlagsSource);
+  if (isWebFlagsIntake) {
+    expect(request.headers['Content-Type'], startsWith('text/plain'));
+    expect(request.headers['DD-API-KEY'], isNull);
+    expect(request.headers['DD-EVP-ORIGIN'], isNull);
+    expect(request.headers['DD-EVP-ORIGIN-VERSION'], isNull);
+    expect(request.headers['DD-REQUEST-ID'], isNull);
+    expect(request.url.queryParameters['dd-api-key'], 'client-token');
+    expect(request.url.queryParameters['dd-evp-origin'], datadogFlagsSource);
+    expect(
+      request.url.queryParameters['dd-evp-origin-version'],
+      datadogFlagsSdkVersion,
+    );
+    expect(request.url.queryParameters['dd-request-id'], isNotEmpty);
+    return;
+  }
+
+  expect(request.headers['Content-Type'], nativeContentType);
+  expect(request.headers['DD-API-KEY'], 'client-token');
+  expect(request.headers['DD-EVP-ORIGIN'], datadogFlagsSource);
+  expect(
+    request.headers['DD-EVP-ORIGIN-VERSION'],
+    datadogFlagsSdkVersion,
+  );
+  expect(request.headers['DD-REQUEST-ID'], isNotEmpty);
 }
 
 Future<void> _waitUntil(

--- a/packages/datadog_flags/test/intake_request_test.dart
+++ b/packages/datadog_flags/test/intake_request_test.dart
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:datadog_flags/src/intake_platform.dart';
+import 'package:datadog_flags/src/intake_request.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('only builds the request body for the current platform', () {
+    var nativeBodyBuildCount = 0;
+    var webBodyBuildCount = 0;
+
+    final request = buildFlagsIntakeRequest(
+      endpoint: Uri.parse('https://example.com/api/v2/flagevaluation'),
+      clientToken: 'client-token',
+      nativeContentType: 'application/json',
+      nativeBodyBuilder: () {
+        nativeBodyBuildCount += 1;
+        return 'native-body';
+      },
+      webBodyBuilder: () {
+        webBodyBuildCount += 1;
+        return 'web-body';
+      },
+    );
+
+    if (isWebFlagsIntake) {
+      expect(request.body, 'web-body');
+      expect(nativeBodyBuildCount, 0);
+      expect(webBodyBuildCount, 1);
+    } else {
+      expect(request.body, 'native-body');
+      expect(nativeBodyBuildCount, 1);
+      expect(webBodyBuildCount, 0);
+    }
+  });
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/flags_intake_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/flags_intake_test.dart
@@ -40,9 +40,9 @@ void main() {
     );
 
     flags.sharedClient().getBooleanDetails(
-      key: 'web-intake-test',
-      defaultValue: false,
-    );
+          key: 'web-intake-test',
+          defaultValue: false,
+        );
     await flags.disable();
 
     final recordedRequests = <RequestLog>[];

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/flags_intake_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/flags_intake_test.dart
@@ -31,6 +31,7 @@ void main() {
           site: DatadogFlagsSite.us1,
           applicationId: 'application-id',
           service: 'integration-service',
+          version: '1.2.3',
         ),
         customEvaluationEndpoint: Uri.parse(
           '${recordingServer.sessionEndpoint}api/v2/flagevaluation',
@@ -87,5 +88,14 @@ void main() {
     expect(event['flag'], {'key': 'web-intake-test'});
     expect(event['runtime_default_used'], isTrue);
     expect(event['error'], {'message': 'PROVIDER_NOT_READY'});
+    final context = event['context'] as Map<String, Object?>;
+    expect(context['dd'], {
+      'env': 'integration',
+      'service': 'integration-service',
+      'version': '1.2.3',
+      'rum': {
+        'application': {'id': 'application-id'},
+      },
+    });
   }, skip: !kIsWeb);
 }

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/flags_intake_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/flags_intake_test.dart
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flags/datadog_flags.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'common.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('flag evaluation intake does not send a CORS preflight request', (
+    WidgetTester tester,
+  ) async {
+    final recordingServer = await startMockServer();
+    final flags = DatadogFlags();
+    addTearDown(flags.disable);
+
+    await flags.enable(
+      configuration: DatadogFlagsConfiguration(
+        datadogConfig: const DatadogFlagsConfig(
+          clientToken: 'client-token',
+          env: 'integration',
+          site: DatadogFlagsSite.us1,
+          applicationId: 'application-id',
+          service: 'integration-service',
+        ),
+        customEvaluationEndpoint: Uri.parse(
+          '${recordingServer.sessionEndpoint}api/v2/flagevaluation',
+        ),
+        trackExposures: false,
+      ),
+    );
+
+    flags.sharedClient().getBooleanDetails(
+      key: 'web-intake-test',
+      defaultValue: false,
+    );
+    await flags.disable();
+
+    final recordedRequests = <RequestLog>[];
+    await recordingServer.pollSessionRequests(const Duration(seconds: 15), (
+      requests,
+    ) {
+      recordedRequests.addAll(requests);
+      return recordedRequests.any(
+        (request) =>
+            request.requestedUrl.contains('/api/v2/flagevaluation') &&
+            request.requestMethod == 'POST',
+      );
+    });
+
+    final intakeRequests = recordedRequests
+        .where(
+          (request) => request.requestedUrl.contains('/api/v2/flagevaluation'),
+        )
+        .toList();
+    debugPrint(
+      'Recorded flag evaluation intake methods: '
+      '${intakeRequests.map((request) => request.requestMethod).toList()}',
+    );
+    expect(intakeRequests.map((request) => request.requestMethod), ['POST']);
+
+    final request = intakeRequests.single;
+    expect(
+      request.requestHeaders['content-type']?.single,
+      startsWith('text/plain'),
+    );
+    expect(request.requestHeaders, isNot(contains('dd-api-key')));
+    expect(request.requestHeaders, isNot(contains('dd-evp-origin')));
+    expect(request.requestHeaders, isNot(contains('dd-evp-origin-version')));
+    expect(request.requestHeaders, isNot(contains('dd-request-id')));
+    expect(request.queryParameters['dd-api-key'], 'client-token');
+    expect(request.queryParameters['dd-evp-origin'], 'dart-client');
+    expect(request.queryParameters['dd-evp-origin-version'], isNotEmpty);
+    expect(request.queryParameters['dd-request-id'], isNotEmpty);
+    expect(request.queryParameters['ddsource'], 'dart-client');
+
+    final event = jsonDecode(request.data) as Map<String, Object?>;
+    expect(event['flag'], {'key': 'web-intake-test'});
+    expect(event['runtime_default_used'], isTrue);
+    expect(event['error'], {'message': 'PROVIDER_NOT_READY'});
+  }, skip: !kIsWeb);
+}

--- a/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
+++ b/packages/datadog_flutter_plugin/integration_test_app/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
 
   datadog_flutter_plugin:
     path: ../
+  datadog_flags:
+    path: ../../datadog_flags
   datadog_common_test:
     path: ../../datadog_common_test
   http: ">=0.13.4 <2.0.0"


### PR DESCRIPTION
## Motivation

Flutter Web sends Flags intake requests with custom Datadog headers. Browsers send an OPTIONS preflight, and intake returns HTTP 403. Evaluation and exposure telemetry then fail.

## Changes and Decisions

This change matches the browser intake transport. Web requests use text/plain and put public intake metadata in query parameters. Evaluation uploads use newline-delimited JSON with Datadog context on each event. Native request headers and payloads remain unchanged. A Chrome integration test records cross-origin requests and rejects any OPTIONS request.

## Validation

Ran the new test in Chrome against the local recording server. The recorder received one POST to flagevaluation and no OPTIONS request.