### PR TITLE
feat: Loosen version constraints to allow v4 of datadog_flutter_plugin

### DIFF
--- a/packages/datadog_dio/pubspec.yaml
+++ b/packages/datadog_dio/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.3.0
+  datadog_flutter_plugin: ">=3.3.0 <5.0.0"
   dio: ^5.0.0
   uuid: ^4.0.0
   

--- a/packages/datadog_flags_flutter/pubspec.yaml
+++ b/packages/datadog_flags_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   datadog_flags: ^1.0.0
-  datadog_flutter_plugin: ^3.4.0
+  datadog_flutter_plugin: ">=3.4.0 <5.0.0"
   meta: ^1.0.0
 
 dev_dependencies:

--- a/packages/datadog_gql_link/pubspec.yaml
+++ b/packages/datadog_gql_link/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ">=3.0.0 <5.0.0"
   gql_exec: ^1.0.0
   gql_link: ^1.0.0
   uuid: ^4.0.0

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ">=3.0.0 <5.0.0"
   grpc: ">=3.0.2 <5.0.0"
   uuid: ^4.0.0
 

--- a/packages/datadog_inappwebview_tracking/pubspec.yaml
+++ b/packages/datadog_inappwebview_tracking/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ">=3.0.0 <5.0.0"
   plugin_platform_interface: ^2.0.2
   flutter_inappwebview: ^6.1.0
 

--- a/packages/datadog_tracking_http_client/pubspec.yaml
+++ b/packages/datadog_tracking_http_client/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.3.0
+  datadog_flutter_plugin: ">=3.3.0 <5.0.0"
   uuid: ^4.0.0
   http: ^1.0.0
 

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  datadog_flutter_plugin: ^3.0.0
+  datadog_flutter_plugin: ">=3.0.0 <5.0.0"
   webview_flutter: ^4.13.1
   webview_flutter_android: '>=4.13.0 <5.0.0'
   webview_flutter_wkwebview: ^3.26.0


### PR DESCRIPTION
### What and why?

There are not many breaking API changes in v4, and even fewer breaking internal API changes, so new versions of the various secondary packages aren't required. This loosens the constraints on most of the packages so they can use v3 or v4.

The exception to this is Session Replay, which will not be able to use v4 without a breaking change, so it remains with a version constraint of `^3`.

refs: RUM-17627

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
