### PR TITLE
chore: Fix beta compat for datadog_inappwebview_tracking

### DIFF
--- a/packages/datadog_inappwebview_tracking/example/android/app/build.gradle
+++ b/packages/datadog_inappwebview_tracking/example/android/app/build.gradle
@@ -8,7 +8,9 @@ plugins {
 }
 
 def agpMajor = Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlin = agpMajor >= 9 &&
+    project.findProperty('android.builtInKotlin')?.toString() != 'false'
+if (!builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 

--- a/packages/datadog_inappwebview_tracking/example/android/settings.gradle
+++ b/packages/datadog_inappwebview_tracking/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.1" apply false
+    id "com.android.application" version "8.11.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 


### PR DESCRIPTION
### What and why?

Fix Flutter beta compatibility for `datadog_inappwebview_tracking`


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
