### PR TITLE
fix(android): clear static event mapper on engine detach

### DIFF
--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-* Fix a native crash (`SIGSEGV` in JNI `CallObjectMethod`) on Android when a RUM or Logs event
-  mapper is invoked from a background writer thread after the Flutter engine that registered it
-  has been detached (e.g. app backgrounded and killed, hot restart, or Activity recreation).
-
 ## 3.4.1
 
 * Properly pin Android SDK version to 3.11.0.

--- a/packages/datadog_flutter_plugin/CHANGELOG.md
+++ b/packages/datadog_flutter_plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Fix a native crash (`SIGSEGV` in JNI `CallObjectMethod`) on Android when a RUM or Logs event
+  mapper is invoked from a background writer thread after the Flutter engine that registered it
+  has been detached (e.g. app backgrounded and killed, hot restart, or Activity recreation).
+
 ## 3.4.1
 
 * Properly pin Android SDK version to 3.11.0.

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogEventMapper.kt
@@ -19,6 +19,7 @@ class DatadogLogEventMapper {
         fun mapLogEvent(encodedEvent: String): String?
     }
 
+    @Volatile
     var eventMapper: EventMapper? = null
 
     fun attachMapper(config: LogsConfiguration.Builder): LogsConfiguration.Builder {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogLogsPlugin.kt
@@ -60,6 +60,9 @@ class DatadogLogsPlugin internal constructor() : MethodChannel.MethodCallHandler
 
     fun detachFromEngine() {
         channel.setMethodCallHandler(null)
+        // Clear the static event mapper reference so a background Logs writer thread can't
+        // invoke a JNI callback tied to this (now detached) engine's Dart isolate. See RUMS-6227.
+        eventMapper.eventMapper = null
     }
 
     internal fun addLogger(loggerHandle: String, logger: Logger) {

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumEventMapper.kt
@@ -31,6 +31,7 @@ class DatadogRumEventMapper {
         fun mapVitalOperationStepEvent(encodedEvent: String): String?
     }
 
+    @Volatile
     var eventMapper: EventMapper? = null
 
     fun attachMappers(

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -98,6 +98,9 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
 
     fun detachFromEngine() {
         channel.setMethodCallHandler(null)
+        // Clear the static event mapper reference so a background RUM writer thread can't
+        // invoke a JNI callback tied to this (now detached) engine's Dart isolate. See RUMS-6227.
+        eventMapper.eventMapper = null
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import com.datadog.android.Datadog
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
@@ -28,6 +29,7 @@ import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.mockk.Called
@@ -41,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 
@@ -64,6 +67,25 @@ class DatadogRumPluginTest {
         unmockkStatic(Log::class)
         unmockkStatic(Rum::class)
         unmockkStatic(GlobalRumMonitor::class)
+    }
+
+    @Test
+    fun `M clear the static event mapper W detachFromEngine`() {
+        // Given
+        val mockFlutterPluginBinding = mock<FlutterPlugin.FlutterPluginBinding>()
+        whenever(mockFlutterPluginBinding.binaryMessenger).thenReturn(mock())
+        plugin.attachToEngine(mockFlutterPluginBinding)
+
+        val mockMapper = mock<DatadogRumEventMapper.EventMapper>()
+        DatadogRumPlugin.setRumEventMapper(mockMapper)
+
+        // When
+        plugin.detachFromEngine()
+
+        // Then
+        // RUMS-6227: without clearing this, a background RUM writer thread invoking the mapper
+        // after this (now detached) engine's Dart isolate is gone crashes with a JNI SIGSEGV.
+        assertThat(DatadogRumPlugin.eventMapper.eventMapper).isNull()
     }
 
     @Test


### PR DESCRIPTION
## What & why

Fixes a native crash reported in RUMS-6227: Android SIGSEGV inside JNI
`CallObjectMethod`, at a consistent/deterministic offset.

The RUM/Logs event mapper (`DatadogRumEventMapper`/`DatadogLogEventMapper`)
is held in a static, process-wide singleton in `DatadogRumPlugin` /
`DatadogLogsPlugin`. It's only ever *overwritten* when a mapper is
attached — never cleared. When a Flutter engine detaches (app
backgrounded and killed, hot restart, or Activity recreation on a
config change), that static field keeps pointing at a jnigen-generated
JNI proxy tied to the now-destroyed engine's Dart isolate.

`dd-sdk-android`'s RUM/Logs core is itself a process-wide singleton with
background writer/upload threads that outlive any single Flutter
engine. When one of those threads serializes a queued event and calls
into the stale mapper, it crashes inside `CallObjectMethod` — a
use-after-detach JNI reference, invoked from a background thread. The
deterministic crash offset is the fingerprint of this exact failure
mode (a fixed-layout call into freed memory), rather than random heap
corruption.

## Change

- `detachFromEngine()` in both `DatadogRumPlugin` and `DatadogLogsPlugin`
  now clears the static mapper's `eventMapper` field.
- `DatadogRumEventMapper.eventMapper` / `DatadogLogEventMapper.eventMapper`
  marked `@Volatile`, so the clear is guaranteed visible to whatever
  background thread might be racing to read it.
- Added a regression test (`DatadogRumPluginTest`) asserting the mapper
  is null after `detachFromEngine()`.
- CHANGELOG entry under `Unreleased`.

## Testing

⚠️ I wasn't able to run the existing/new unit tests in my environment
due to a Flutter/Gradle toolchain version mismatch unrelated to this
change (fails identically on unmodified `develop`). Needs a real CI run
before merge.

Refs: RUMS-6227

🤖 Generated with [Claude Code](https://claude.com/claude-code)