### PR TITLE
fix: Attempt to avoid crashes caused by forced app termination

### DIFF
--- a/packages/datadog_flutter_plugin/.swiftlint.yml
+++ b/packages/datadog_flutter_plugin/.swiftlint.yml
@@ -9,3 +9,4 @@ excluded:
   - example/ios/Pods
   - example/ios/.symlinks
   - example/ios/Flutter
+  - ios/datadog_flutter_plugin/.build

--- a/packages/datadog_flutter_plugin/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_flutter_plugin/example/ios/Runner.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		496AAFBA27B4496400236887 /* ffi_crash_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 496AAFB927B4496400236887 /* ffi_crash_test.cpp */; };
 		49939D582C65038900F1D95E /* FoundationMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49939D572C65038900F1D95E /* FoundationMocks.swift */; };
 		49D7C98927834F7600A03589 /* DatadogRumPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D7C98827834F7600A03589 /* DatadogRumPluginTests.swift */; };
+		58EC399E23D26709BDCED55B /* NotificationCenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26867B7B46842D6DC4DC7D95 /* NotificationCenterMock.swift */; };
 		72372305D7FBA4CF1A7B797B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 36CD9E6991F0A4392113DBF7 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
@@ -55,6 +56,7 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		265F3872DA5BFB339330883E /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		26867B7B46842D6DC4DC7D95 /* NotificationCenterMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationCenterMock.swift; sourceTree = "<group>"; };
 		36CD9E6991F0A4392113DBF7 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		495118EE27C596AB00F206FE /* DatadogLogsPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatadogLogsPluginTests.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				4956E9562785DA5500E0E3B3 /* EquatableInTests.swift */,
 				495118F227C7C96700F206FE /* ContractHelpers.swift */,
 				49939D572C65038900F1D95E /* FoundationMocks.swift */,
+				26867B7B46842D6DC4DC7D95 /* NotificationCenterMock.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				495118EF27C596AB00F206FE /* DatadogLogsPluginTests.swift in Sources */,
 				49939D582C65038900F1D95E /* FoundationMocks.swift in Sources */,
 				4956E9572785DA5500E0E3B3 /* EquatableInTests.swift in Sources */,
+				58EC399E23D26709BDCED55B /* NotificationCenterMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogLogsPluginTests.swift
@@ -102,7 +102,7 @@ class DatadogLogsPluginTests: XCTestCase {
     var mockV2Logger: MockLogger?
 
     override func setUp() {
-        plugin = DatadogLogsPlugin.instance
+        plugin = DatadogLogsPlugin()
         mockV2Logger = MockLogger()
         // "fake string" is the string that the contract tests will send
         plugin.addLogger(logger: mockV2Logger!, withHandle: "fake string")

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -11,7 +11,7 @@ import Flutter
 import DatadogInternal
 @testable import DatadogCore
 @testable import DatadogRUM
-import datadog_flutter_plugin
+@testable import datadog_flutter_plugin
 
 enum ResultStatus: EquatableInTests {
     case notCalled
@@ -117,7 +117,7 @@ class DatadogRumPluginTests: XCTestCase {
 
     override func setUp() {
         mock = MockRUMMonitor()
-        plugin = DatadogRumPlugin.instance
+        plugin = DatadogRumPlugin()
         plugin.inject(rum: mock)
     }
 

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -589,11 +589,14 @@ private class NoOpBinaryMessenger: NSObject, FlutterBinaryMessenger {
 class DatadogPluginDetachTests: XCTestCase {
     private let messenger = NoOpBinaryMessenger()
 
-    private func makePlugin() -> DatadogSdkPlugin {
-        let plugin = DatadogSdkPlugin(channel: FlutterMethodChannel(
-            name: "datadog_sdk_flutter",
-            binaryMessenger: messenger
-        ))
+    private func makePlugin(notificationCenter: NotificationCenterProtocol = NotificationCenter.default) -> DatadogSdkPlugin {
+        let plugin = DatadogSdkPlugin(
+            channel: FlutterMethodChannel(
+                name: "datadog_sdk_flutter",
+                binaryMessenger: messenger
+            ),
+            notificationCenter: notificationCenter
+        )
         plugin.rum.methodChannel = FlutterMethodChannel(
             name: "datadog_sdk_flutter.rum",
             binaryMessenger: messenger
@@ -606,10 +609,14 @@ class DatadogPluginDetachTests: XCTestCase {
     }
 
     func testApplicationWillTerminate_releasesEveryMethodChannel() {
-        let plugin = makePlugin()
+        // Posts to an injected `NotificationCenterMock` instead of the real, process-wide center:
+        // a real post would tear down every other live `DatadogSdkPlugin` in the process too,
+        // including the Runner's own registered plugin and other suites' engines.
+        let notificationCenter = NotificationCenterMock()
+        let plugin = makePlugin(notificationCenter: notificationCenter)
 
         // Termination arrives as a notification, not as a plugin callback
-        NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
+        notificationCenter.post(name: UIApplication.willTerminateNotification)
 
         XCTAssertNil(plugin.rum.methodChannel)
         XCTAssertNil(plugin.logs.methodChannel)

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -565,3 +565,97 @@ class FlutterSdkTests: XCTestCase {
 //        }
 //    }
 }
+
+/// A messenger that does nothing. `FlutterMethodChannel` needs one to exist, but these tests only
+/// care about whether the channel is still held, never about messages crossing it.
+private class NoOpBinaryMessenger: NSObject, FlutterBinaryMessenger {
+    func send(onChannel channel: String, message: Data?) { }
+
+    func send(onChannel channel: String, message: Data?, binaryReply callback: FlutterBinaryReply? = nil) { }
+
+    func setMessageHandlerOnChannel(
+        _ channel: String,
+        binaryMessageHandler handler: FlutterBinaryMessageHandler? = nil
+    ) -> FlutterBinaryMessengerConnection {
+        return 0
+    }
+
+    func cleanUpConnection(_ connection: FlutterBinaryMessengerConnection) { }
+}
+
+/// Teardown has to drop every channel the SDK can call Dart on. Flutter resets the engine's shell on
+/// termination without notifying plugins (flutter/flutter#126671), and anything sent afterwards
+/// asserts inside `-[FlutterEngine sendOnChannel:message:binaryReply:]` — see #1062.
+class DatadogPluginDetachTests: XCTestCase {
+    private let messenger = NoOpBinaryMessenger()
+
+    /// The test host is the Runner app, so the real plugins already registered at launch and these
+    /// channels are live. Saved and restored rather than nil'd, so clearing them here cannot leak into
+    /// whatever test class runs next.
+    private var originalRumChannel: FlutterMethodChannel?
+    private var originalLogsChannel: FlutterMethodChannel?
+
+    override func setUp() {
+        originalRumChannel = DatadogRumPlugin.instance.methodChannel
+        originalLogsChannel = DatadogLogsPlugin.instance?.methodChannel
+
+        DatadogRumPlugin.instance.methodChannel = FlutterMethodChannel(
+            name: "datadog_sdk_flutter.rum",
+            binaryMessenger: messenger
+        )
+        DatadogLogsPlugin.instance?.methodChannel = FlutterMethodChannel(
+            name: "datadog_sdk_flutter.logs",
+            binaryMessenger: messenger
+        )
+    }
+
+    override func tearDown() {
+        DatadogRumPlugin.instance.methodChannel = originalRumChannel
+        DatadogLogsPlugin.instance?.methodChannel = originalLogsChannel
+    }
+
+    private func makePlugin() -> DatadogSdkPlugin {
+        DatadogSdkPlugin(channel: FlutterMethodChannel(
+            name: "datadog_sdk_flutter",
+            binaryMessenger: messenger
+        ))
+    }
+
+    func testApplicationWillTerminate_releasesEveryMethodChannel() {
+        let plugin = makePlugin()
+
+        // Termination arrives as a notification, not as a plugin callback
+        NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
+
+        XCTAssertNil(DatadogRumPlugin.instance.methodChannel)
+        XCTAssertNil(DatadogLogsPlugin.instance?.methodChannel)
+        XCTAssertNotNil(plugin)  // kept alive: NotificationCenter does not retain observers
+    }
+
+    func testDetach_isIdempotent() {
+        // Both teardown paths can run for the same engine: termination fires the notification, and a
+        // host releasing the engine afterwards still calls `detachFromEngine(for:)`.
+        DatadogRumPlugin.instance.onDetach()
+        DatadogLogsPlugin.instance?.onDetach()
+        DatadogRumPlugin.instance.onDetach()
+        DatadogLogsPlugin.instance?.onDetach()
+
+        XCTAssertNil(DatadogRumPlugin.instance.methodChannel)
+        XCTAssertNil(DatadogLogsPlugin.instance?.methodChannel)
+    }
+
+    func testWithoutAChannel_eventMappersReturnTheEventUnmapped() {
+        DatadogRumPlugin.instance.onDetach()
+
+        // Would otherwise hop to the main queue and block on a semaphore until it times out
+        let event = DatadogRumPlugin.instance.callEventMapper(
+            mapperName: "mapViewEvent",
+            event: "unmapped",
+            encodedEvent: [:],
+            completion: { _ in "mapped" }
+        )
+
+        XCTAssertEqual(event, "unmapped")
+        XCTAssertEqual(DatadogRumPlugin.instance.mapperTimeouts, 0)
+    }
+}

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogSdkPluginTests.swift
@@ -589,36 +589,20 @@ private class NoOpBinaryMessenger: NSObject, FlutterBinaryMessenger {
 class DatadogPluginDetachTests: XCTestCase {
     private let messenger = NoOpBinaryMessenger()
 
-    /// The test host is the Runner app, so the real plugins already registered at launch and these
-    /// channels are live. Saved and restored rather than nil'd, so clearing them here cannot leak into
-    /// whatever test class runs next.
-    private var originalRumChannel: FlutterMethodChannel?
-    private var originalLogsChannel: FlutterMethodChannel?
-
-    override func setUp() {
-        originalRumChannel = DatadogRumPlugin.instance.methodChannel
-        originalLogsChannel = DatadogLogsPlugin.instance?.methodChannel
-
-        DatadogRumPlugin.instance.methodChannel = FlutterMethodChannel(
-            name: "datadog_sdk_flutter.rum",
-            binaryMessenger: messenger
-        )
-        DatadogLogsPlugin.instance?.methodChannel = FlutterMethodChannel(
-            name: "datadog_sdk_flutter.logs",
-            binaryMessenger: messenger
-        )
-    }
-
-    override func tearDown() {
-        DatadogRumPlugin.instance.methodChannel = originalRumChannel
-        DatadogLogsPlugin.instance?.methodChannel = originalLogsChannel
-    }
-
     private func makePlugin() -> DatadogSdkPlugin {
-        DatadogSdkPlugin(channel: FlutterMethodChannel(
+        let plugin = DatadogSdkPlugin(channel: FlutterMethodChannel(
             name: "datadog_sdk_flutter",
             binaryMessenger: messenger
         ))
+        plugin.rum.methodChannel = FlutterMethodChannel(
+            name: "datadog_sdk_flutter.rum",
+            binaryMessenger: messenger
+        )
+        plugin.logs.methodChannel = FlutterMethodChannel(
+            name: "datadog_sdk_flutter.logs",
+            binaryMessenger: messenger
+        )
+        return plugin
     }
 
     func testApplicationWillTerminate_releasesEveryMethodChannel() {
@@ -627,28 +611,29 @@ class DatadogPluginDetachTests: XCTestCase {
         // Termination arrives as a notification, not as a plugin callback
         NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
 
-        XCTAssertNil(DatadogRumPlugin.instance.methodChannel)
-        XCTAssertNil(DatadogLogsPlugin.instance?.methodChannel)
-        XCTAssertNotNil(plugin)  // kept alive: NotificationCenter does not retain observers
+        XCTAssertNil(plugin.rum.methodChannel)
+        XCTAssertNil(plugin.logs.methodChannel)
     }
 
     func testDetach_isIdempotent() {
         // Both teardown paths can run for the same engine: termination fires the notification, and a
         // host releasing the engine afterwards still calls `detachFromEngine(for:)`.
-        DatadogRumPlugin.instance.onDetach()
-        DatadogLogsPlugin.instance?.onDetach()
-        DatadogRumPlugin.instance.onDetach()
-        DatadogLogsPlugin.instance?.onDetach()
+        let plugin = makePlugin()
+        plugin.rum.onDetach()
+        plugin.logs.onDetach()
+        plugin.rum.onDetach()
+        plugin.logs.onDetach()
 
-        XCTAssertNil(DatadogRumPlugin.instance.methodChannel)
-        XCTAssertNil(DatadogLogsPlugin.instance?.methodChannel)
+        XCTAssertNil(plugin.rum.methodChannel)
+        XCTAssertNil(plugin.logs.methodChannel)
     }
 
     func testWithoutAChannel_eventMappersReturnTheEventUnmapped() {
-        DatadogRumPlugin.instance.onDetach()
+        let plugin = makePlugin()
+        plugin.rum.onDetach()
 
         // Would otherwise hop to the main queue and block on a semaphore until it times out
-        let event = DatadogRumPlugin.instance.callEventMapper(
+        let event = plugin.rum.callEventMapper(
             mapperName: "mapViewEvent",
             event: "unmapped",
             encodedEvent: [:],
@@ -656,6 +641,21 @@ class DatadogPluginDetachTests: XCTestCase {
         )
 
         XCTAssertEqual(event, "unmapped")
-        XCTAssertEqual(DatadogRumPlugin.instance.mapperTimeouts, 0)
+        XCTAssertEqual(plugin.rum.mapperTimeouts, 0)
+    }
+
+    func testEngineATeardown_doesNotAffectEngineB() {
+        // Regression test for the original multi-engine bug: engine A detaching must not clear
+        // engine B's still-live channel (they used to share one process-wide singleton).
+        let pluginA = makePlugin()
+        let pluginB = makePlugin()
+
+        pluginA.rum.onDetach()
+        pluginA.logs.onDetach()
+
+        XCTAssertNil(pluginA.rum.methodChannel)
+        XCTAssertNil(pluginA.logs.methodChannel)
+        XCTAssertNotNil(pluginB.rum.methodChannel)
+        XCTAssertNotNil(pluginB.logs.methodChannel)
     }
 }

--- a/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/NotificationCenterMock.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/Helpers/NotificationCenterMock.swift
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-2022 Datadog, Inc.
+
+import Foundation
+@testable import datadog_flutter_plugin
+
+/// A `NotificationCenter` stand-in that never broadcasts process-wide: `post(name:)` only invokes
+/// observers registered on this instance, so driving termination in a test cannot tear down another
+/// suite's engine or the Runner's own registered plugin.
+class NotificationCenterMock: NotificationCenterProtocol {
+    private var observers: [(observer: NSObject, selector: Selector, name: NSNotification.Name?)] = []
+
+    func addObserver(_ observer: Any, selector: Selector, name: NSNotification.Name?, object: Any?) {
+        guard let observer = observer as? NSObject else { return }
+        observers.append((observer, selector, name))
+    }
+
+    func removeObserver(_ observer: Any) {
+        guard let observer = observer as? NSObject else { return }
+        observers.removeAll { $0.observer === observer }
+    }
+
+    func post(name: NSNotification.Name) {
+        for entry in observers where entry.name == name {
+            entry.observer.perform(entry.selector)
+        }
+    }
+}

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogLogsPlugin.swift
@@ -35,6 +35,7 @@ extension Logger.Configuration {
 
 public class DatadogLogsPlugin: NSObject, FlutterPlugin {
     public static var instance: DatadogLogsPlugin?
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.logs", binaryMessenger: registrar.messenger())
         instance = DatadogLogsPlugin(channel: channel)
@@ -42,17 +43,27 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
 
     }
 
-    private let channel: FlutterMethodChannel
+    /// Cleared on teardown, so `FlutterLogEventMapper` — which lives inside the SDK for the rest of the
+    /// process — can re-read it per event rather than holding a channel that outlives its engine.
+    internal var methodChannel: FlutterMethodChannel?
     private var currentConfiguration: [AnyHashable: Any]?
     private var loggerRegistry: [String: LoggerProtocol] = [:]
 
     private init(channel: FlutterMethodChannel) {
-        self.channel = channel
+        self.methodChannel = channel
         super.init()
     }
 
+    /// Drops the channel so a log mapper cannot reach an engine that can no longer receive it.
+    ///
+    /// `FlutterLogEventMapper` is handed to `Logs.enable` and lives inside the SDK for the rest of the
+    /// process, mapping events on Datadog worker threads. Once the engine resets its shell,
+    /// `-[FlutterEngine sendOnChannel:message:binaryReply:]` asserts and the app dies — the same crash
+    /// as #1062 in RUM.
+    ///
+    /// Called by `DatadogSdkPlugin`, which owns this plugin's registration.
     public func onDetach() {
-
+        methodChannel = nil
     }
 
     func addLogger(logger: LoggerProtocol, withHandle handle: String) {
@@ -248,7 +259,7 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
                 let attachLogMapper = (configArg["attachLogMapper"] as? NSNumber)?.boolValue ?? false
                 if attachLogMapper {
                     config._internal_mutation {
-                        $0.setLogEventMapper(FlutterLogEventMapper(channel: channel))
+                        $0.setLogEventMapper(FlutterLogEventMapper())
                     }
                 }
                 Logs.enable(with: config)
@@ -283,12 +294,6 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
         "application_id", "session_id", "view.id", "user_action.id"
     ]
 
-    let channel: FlutterMethodChannel
-
-    public init(channel: FlutterMethodChannel) {
-        self.channel = channel
-    }
-
     func map(event: LogEvent, callback: @escaping (LogEvent) -> Void) {
         guard let encoded = logEventToFlutterDictionary(event: event) else {
             // TELEMETRY
@@ -297,6 +302,13 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
         }
 
         DispatchQueue.main.async {
+            // Re-read the channel instead of holding it: this mapper lives inside the SDK for the rest
+            // of the process, so the engine can tear down — and `onDetach` clear the channel — between
+            // `Logs.enable` and this block being drained. Sending after that asserts on a reset shell.
+            guard let channel = DatadogLogsPlugin.instance?.methodChannel else {
+                callback(event)
+                return
+            }
             channel.invokeMethod("mapLogEvent", arguments: ["event": encoded]) { result in
                 guard let result = result as? [String: Any] else {
                     // Don't call the callback, this event was discarded

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogLogsPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogLogsPlugin.swift
@@ -34,23 +34,41 @@ extension Logger.Configuration {
 }
 
 public class DatadogLogsPlugin: NSObject, FlutterPlugin {
-    public static var instance: DatadogLogsPlugin?
+    /// No-op: registration now happens per-instance via `attachToEngine(registrar:)`, called by
+    /// `DatadogSdkPlugin`, which owns one `DatadogLogsPlugin` instance per engine. This static method
+    /// only exists to satisfy `FlutterPlugin` conformance and is never actually invoked, since this
+    /// type is not listed in `GeneratedPluginRegistrant` (only `DatadogSdkPlugin` is).
+    public static func register(with registrar: FlutterPluginRegistrar) {}
 
-    public static func register(with registrar: FlutterPluginRegistrar) {
+    func attachToEngine(registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.logs", binaryMessenger: registrar.messenger())
-        instance = DatadogLogsPlugin(channel: channel)
-        registrar.addMethodCallDelegate(instance!, channel: channel)
-
+        methodChannel = channel
+        registrar.addMethodCallDelegate(self, channel: channel)
     }
 
+    private let methodChannelLock = NSLock()
+    private var _methodChannel: FlutterMethodChannel?
     /// Cleared on teardown, so `FlutterLogEventMapper` — which lives inside the SDK for the rest of the
     /// process — can re-read it per event rather than holding a channel that outlives its engine.
-    internal var methodChannel: FlutterMethodChannel?
-    private var currentConfiguration: [AnyHashable: Any]?
+    /// Lock-backed because it's read on Datadog worker threads while `onDetach()` clears it on the
+    /// main thread.
+    internal var methodChannel: FlutterMethodChannel? {
+        get {
+            methodChannelLock.lock()
+            defer { methodChannelLock.unlock() }
+            return _methodChannel
+        }
+        set {
+            methodChannelLock.lock()
+            defer { methodChannelLock.unlock() }
+            _methodChannel = newValue
+        }
+    }
+
+    private static var previousConfiguration: [AnyHashable: Any]?
     private var loggerRegistry: [String: LoggerProtocol] = [:]
 
-    private init(channel: FlutterMethodChannel) {
-        self.methodChannel = channel
+    override init() {
         super.init()
     }
 
@@ -253,36 +271,39 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
     }
 
     private func enable(arguments: [String: Any?], result: @escaping FlutterResult) {
-        if let configArg = arguments["configuration"] as? [String: Any?] {
-            if currentConfiguration == nil {
+        guard let configArg = arguments["configuration"] as? [String: Any?] else {
+            result(FlutterError.missingParameter(methodName: "enable"))
+            return
+        }
+
+        if Self.previousConfiguration == nil {
+            if Logs._internal.isEnabled() {
+                // Another engine's instance already configured Logs; nothing more to configure.
+                Self.previousConfiguration = configArg as [AnyHashable: Any]
+            } else {
                 var config = Logs.Configuration(fromEncoded: configArg)
                 let attachLogMapper = (configArg["attachLogMapper"] as? NSNumber)?.boolValue ?? false
                 if attachLogMapper {
                     config._internal_mutation {
-                        $0.setLogEventMapper(FlutterLogEventMapper())
+                        $0.setLogEventMapper(FlutterLogEventMapper(owner: self))
                     }
                 }
                 Logs.enable(with: config)
-                currentConfiguration = configArg as [AnyHashable: Any]
-            } else {
-                let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
-                if !dict.isEqual(to: currentConfiguration!) {
-                    consolePrint(
-                        "🔥 Calling Logging `enable` with different options, even after a hot restart," +
-                        " is not supported. Cold restart your application to change your current configuation.",
-                        .error)
-                }
+                Self.previousConfiguration = configArg as [AnyHashable: Any]
             }
-            result(nil)
         } else {
-            result(
-                FlutterError.missingParameter(methodName: "enable")
-            )
+            let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
+            if !dict.isEqual(to: Self.previousConfiguration!) {
+                consolePrint(
+                    "🔥 Calling Logging `enable` with different options, even after a hot restart," +
+                    " is not supported. Cold restart your application to change your current configuation.",
+                    .error)
+            }
         }
+        result(nil)
     }
 
     private func deinitialize(arguments: [String: Any?], result: @escaping FlutterResult) {
-        currentConfiguration = nil
         result(nil)
     }
 }
@@ -293,6 +314,10 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
         "dd.trace_id", "dd.span_id",
         "application_id", "session_id", "view.id", "user_action.id"
     ]
+
+    /// Weak because the native SDK retains this mapper for the life of the process — a strong
+    /// reference here would keep a torn-down engine's plugin (and its channel) alive indefinitely.
+    weak var owner: DatadogLogsPlugin?
 
     func map(event: LogEvent, callback: @escaping (LogEvent) -> Void) {
         guard let encoded = logEventToFlutterDictionary(event: event) else {
@@ -305,7 +330,7 @@ public class DatadogLogsPlugin: NSObject, FlutterPlugin {
             // Re-read the channel instead of holding it: this mapper lives inside the SDK for the rest
             // of the process, so the engine can tear down — and `onDetach` clear the channel — between
             // `Logs.enable` and this block being drained. Sending after that asserts on a reset shell.
-            guard let channel = DatadogLogsPlugin.instance?.methodChannel else {
+            guard let channel = owner?.methodChannel else {
                 callback(event)
                 return
             }

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
@@ -58,15 +58,16 @@ public extension RUM.Configuration {
 
 // swiftlint:disable:next type_body_length
 public class DatadogRumPlugin: NSObject, FlutterPlugin {
-    /// Assigned by `register(with:)` rather than by `init`, because `instance` is created before any
-    /// registrar exists. Internal so tests can seed and inspect it.
-    internal var methodChannel: FlutterMethodChannel?
+    /// No-op: registration now happens per-instance via `attachToEngine(registrar:)`, called by
+    /// `DatadogSdkPlugin`, which owns one `DatadogRumPlugin` instance per engine. This static method
+    /// only exists to satisfy `FlutterPlugin` conformance and is never actually invoked, since this
+    /// type is not listed in `GeneratedPluginRegistrant` (only `DatadogSdkPlugin` is).
+    public static func register(with registrar: FlutterPluginRegistrar) {}
 
-    public static let instance =  DatadogRumPlugin()
-    public static func register(with registrar: FlutterPluginRegistrar) {
+    func attachToEngine(registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.rum", binaryMessenger: registrar.messenger())
-        instance.methodChannel = channel
-        registrar.addMethodCallDelegate(instance, channel: channel)
+        methodChannel = channel
+        registrar.addMethodCallDelegate(self, channel: channel)
     }
 
     internal var rum: RUMMonitorProtocol?
@@ -75,9 +76,27 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
     internal var mainThreadMapperPerf = PerformanceTracker()
     internal var mapperTimeouts = 0
 
-    private var currentConfiguration: [AnyHashable: Any]?
+    private static var previousConfiguration: [AnyHashable: Any]?
 
-    private override init() {
+    private let methodChannelLock = NSLock()
+    private var _methodChannel: FlutterMethodChannel?
+    /// Cleared on teardown so nothing is sent to an engine that can no longer receive it. Internal so
+    /// tests can seed and inspect it. Lock-backed because it's read on Datadog worker threads
+    /// (`callEventMapper`, `onSessionStart`) while `onDetach()` clears it on the main thread.
+    internal var methodChannel: FlutterMethodChannel? {
+        get {
+            methodChannelLock.lock()
+            defer { methodChannelLock.unlock() }
+            return _methodChannel
+        }
+        set {
+            methodChannelLock.lock()
+            defer { methodChannelLock.unlock() }
+            _methodChannel = newValue
+        }
+    }
+
+    override init() {
         super.init()
     }
 
@@ -412,8 +431,11 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
     private func enable(arguments: [String: Any?], call: FlutterMethodCall) {
         let configArg = arguments["configuration"] as? [String: Any?]
         if rum == nil {
-            if let configArg = configArg,
-               var config = RUM.Configuration(fromEncoded: configArg) {
+            if RUM._internal.isEnabled() {
+                // Another engine's instance already configured RUM; just attach to it.
+                rum = RUMMonitor.shared()
+                warnIfConfigMismatch(configArg)
+            } else if let configArg = configArg, var config = RUM.Configuration(fromEncoded: configArg) {
                 attachEventMappers(configArg: configArg, config: &config)
                 // Disable INV as the Flutter calculations for it are different
                 config.nextViewActionPredicate = nil
@@ -433,26 +455,27 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                 RUM.enable(with: config)
                 rum = RUMMonitor.shared()
 
-                currentConfiguration = configArg as [AnyHashable: Any]
+                Self.previousConfiguration = configArg as [AnyHashable: Any]
             }
-        } else if currentConfiguration != nil,
-                    let configArg = configArg {
-            let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
-            if !dict.isEqual(to: currentConfiguration!) {
-                consolePrint(
-                    "🔥 Calling RUM `enable` with different options, even after a hot restart," +
-                    " is not supported. Cold restart your application to change your current configuation.",
-                    .error
-                )
-            }
+        } else {
+            warnIfConfigMismatch(configArg)
+        }
+    }
+
+    private func warnIfConfigMismatch(_ configArg: [String: Any?]?) {
+        guard let previous = Self.previousConfiguration, let configArg = configArg else { return }
+        let dict = NSDictionary(dictionary: configArg as [AnyHashable: Any])
+        if !dict.isEqual(to: previous) {
+            consolePrint(
+                "🔥 Calling RUM `enable` with different options, even after a hot restart," +
+                " is not supported. Cold restart your application to change your current configuation.",
+                .error
+            )
         }
     }
 
     private func deinitialize(arguments: [String: Any?], call: FlutterMethodCall) {
-        if rum != nil {
-            currentConfiguration = nil
-            rum = nil
-        }
+        rum = nil
     }
 
     private func getCurrentSessionId(result: @escaping FlutterResult) {

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
@@ -58,12 +58,15 @@ public extension RUM.Configuration {
 
 // swiftlint:disable:next type_body_length
 public class DatadogRumPlugin: NSObject, FlutterPlugin {
-    private static var methodChannel: FlutterMethodChannel?
+    /// Assigned by `register(with:)` rather than by `init`, because `instance` is created before any
+    /// registrar exists. Internal so tests can seed and inspect it.
+    internal var methodChannel: FlutterMethodChannel?
 
     public static let instance =  DatadogRumPlugin()
     public static func register(with registrar: FlutterPluginRegistrar) {
-        methodChannel = FlutterMethodChannel(name: "datadog_sdk_flutter.rum", binaryMessenger: registrar.messenger())
-        registrar.addMethodCallDelegate(instance, channel: methodChannel!)
+        let channel = FlutterMethodChannel(name: "datadog_sdk_flutter.rum", binaryMessenger: registrar.messenger())
+        instance.methodChannel = channel
+        registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
     internal var rum: RUMMonitorProtocol?
@@ -83,8 +86,19 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         self.rum = rum
     }
 
+    /// Drops the channel so nothing is sent to an engine that can no longer receive it.
+    ///
+    /// `onSessionStart` and the event mappers both hop to the main queue to call Dart, and both fire
+    /// from Datadog worker threads long after a view controller is gone. Once the engine resets its
+    /// shell, `-[FlutterEngine sendOnChannel:message:binaryReply:]` asserts and the app dies with an
+    /// `NSInternalInconsistencyException` — see #1062.
+    ///
+    /// Called by `DatadogSdkPlugin`, which owns this plugin's registration: `register(with:)` here is
+    /// handed that plugin's registrar, so this type has no `FlutterPlugin` teardown callback of its
+    /// own to hook, and must not `publish:` itself — that would overwrite `DatadogSdkPlugin`'s own
+    /// publication under the shared plugin key and break *its* detach.
     public func onDetach() {
-
+        methodChannel = nil
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
@@ -403,9 +417,9 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                 attachEventMappers(configArg: configArg, config: &config)
                 // Disable INV as the Flutter calculations for it are different
                 config.nextViewActionPredicate = nil
-                config.onSessionStart = { sessionId, discarded in
+                config.onSessionStart = { [weak self] sessionId, discarded in
                     DispatchQueue.main.async {
-                        guard let methodChannel = DatadogRumPlugin.methodChannel else { return }
+                        guard let methodChannel = self?.methodChannel else { return }
                         methodChannel.invokeMethod(
                             "onSessionChanged",
                             arguments: [
@@ -541,7 +555,7 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         event: T,
         encodedEvent: [String: Any?],
         completion: ([String: Any?]?) -> T?) -> T? {
-        guard let methodChannel = DatadogRumPlugin.methodChannel else {
+        guard methodChannel != nil else {
             return event
         }
 
@@ -549,7 +563,15 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
         let semaphore = DispatchSemaphore(value: 0)
 
         mainThreadMapperPerf.start()
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            // Re-read the channel instead of capturing it: mappers run on a Datadog worker thread,
+            // so the engine can tear down — and `onDetach()` clear the channel — between the check
+            // above and this block being drained. Sending after that asserts on a reset shell.
+            // Signalling leaves `encodedResult` as the unmapped event, which is what we want.
+            guard let methodChannel = self?.methodChannel else {
+                semaphore.signal()
+                return
+            }
             methodChannel.invokeMethod(mapperName, arguments: ["event": encodedEvent]) { result in
                 if result == nil {
                     encodedResult = nil

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogSdkPlugin.swift
@@ -116,13 +116,17 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
     public init(channel: FlutterMethodChannel) {
         self.channel = channel
         super.init()
+        observeEngineTeardown()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "datadog_sdk_flutter", binaryMessenger: registrar.messenger())
         let instance = DatadogSdkPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
-        registrar.addApplicationDelegate(instance)
         registrar.publish(instance)
 
         DatadogLogsPlugin.register(with: registrar)
@@ -396,7 +400,27 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
         }
     }
 
-    public func applicationWillTerminate(_ application: UIApplication) {
+    /// Covers the teardown `detachFromEngine(for:)` cannot see: app termination.
+    ///
+    /// `-[FlutterEngine dealloc]` is the only caller of `detachFromEngineForRegistrar:`, so every
+    /// teardown that releases the engine is already handled. Termination is not: the view controller
+    /// resets the engine's shell from `-applicationWillTerminate:` while the engine object lives on,
+    /// and no plugin is told (flutter/flutter#126671).
+    ///
+    /// Observed directly rather than via `registrar.addApplicationDelegate(self)`, which forwards app
+    /// lifecycle events only when `UIApplication`'s delegate conforms to `FlutterAppLifeCycleProvider`
+    /// — true for `FlutterAppDelegate`, often false for a native host embedding Flutter.
+    private func observeEngineTeardown() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(engineWillTearDown),
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+
+    @objc
+    private func engineWillTearDown() {
         _onDetach()
     }
 
@@ -412,6 +436,11 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
             consolePrint = oldConsolePrint
         }
         oldConsolePrint = nil
+
+        // RUM and Logs register on this plugin's registrar, so neither has a teardown callback of its
+        // own. Both hold channels that Datadog worker threads call Dart through.
+        DatadogRumPlugin.instance.onDetach()
+        DatadogLogsPlugin.instance?.onDetach()
     }
 
     private func attachToExisting() -> [String: Any?] {

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogSdkPlugin.swift
@@ -113,6 +113,9 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
     var core: DatadogCoreProtocol?
     var oldConsolePrint: ((String, CoreLoggerLevel) -> Void)?
 
+    internal let rum = DatadogRumPlugin()
+    internal let logs = DatadogLogsPlugin()
+
     public init(channel: FlutterMethodChannel) {
         self.channel = channel
         super.init()
@@ -129,8 +132,8 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
         registrar.addMethodCallDelegate(instance, channel: channel)
         registrar.publish(instance)
 
-        DatadogLogsPlugin.register(with: registrar)
-        DatadogRumPlugin.register(with: registrar)
+        instance.logs.attachToEngine(registrar: registrar)
+        instance.rum.attachToEngine(registrar: registrar)
     }
 
     // swiftlint:disable:next cyclomatic_complexity function_body_length
@@ -383,16 +386,16 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
             // TODO:
             let value: [String: Any?] = [
                 "total": [
-                    "minMs": DatadogRumPlugin.instance.mapperPerf.minInMs,
-                    "maxMs": DatadogRumPlugin.instance.mapperPerf.maxInMs,
-                    "avgMs": DatadogRumPlugin.instance.mapperPerf.avgInMs
+                    "minMs": self.rum.mapperPerf.minInMs,
+                    "maxMs": self.rum.mapperPerf.maxInMs,
+                    "avgMs": self.rum.mapperPerf.avgInMs
                 ],
                 "mainThread": [
-                    "minMs": DatadogRumPlugin.instance.mainThreadMapperPerf.minInMs,
-                    "maxMs": DatadogRumPlugin.instance.mainThreadMapperPerf.maxInMs,
-                    "avgMs": DatadogRumPlugin.instance.mainThreadMapperPerf.avgInMs
+                    "minMs": self.rum.mainThreadMapperPerf.minInMs,
+                    "maxMs": self.rum.mainThreadMapperPerf.maxInMs,
+                    "avgMs": self.rum.mainThreadMapperPerf.avgInMs
                 ],
-                "mapperTimeouts": DatadogRumPlugin.instance.mapperTimeouts
+                "mapperTimeouts": self.rum.mapperTimeouts
             ]
             return value
         default:
@@ -437,10 +440,11 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
         }
         oldConsolePrint = nil
 
-        // RUM and Logs register on this plugin's registrar, so neither has a teardown callback of its
-        // own. Both hold channels that Datadog worker threads call Dart through.
-        DatadogRumPlugin.instance.onDetach()
-        DatadogLogsPlugin.instance?.onDetach()
+        // RUM and Logs are owned instances (one per engine, see `rum`/`logs` above), not singletons,
+        // so neither has a teardown callback of its own to hook. Both hold channels that Datadog
+        // worker threads call Dart through.
+        rum.onDetach()
+        logs.onDetach()
     }
 
     private func attachToExisting() -> [String: Any?] {

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogSdkPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogSdkPlugin.swift
@@ -101,6 +101,16 @@ public class ContextMessageReceiver: FeatureMessageReceiver {
     }
 }
 
+/// Thin abstraction over `NotificationCenter` so tests can inject a fake that never broadcasts
+/// process-wide, instead of every test posting the real `UIApplication.willTerminateNotification`
+/// (which every live plugin instance in the process would observe, including other suites' engines).
+public protocol NotificationCenterProtocol {
+    func addObserver(_ observer: Any, selector: Selector, name: NSNotification.Name?, object: Any?)
+    func removeObserver(_ observer: Any)
+}
+
+extension NotificationCenter: NotificationCenterProtocol {}
+
 // swiftlint:disable:next type_body_length
 public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
     public static var name: String = "flutter_plugin"
@@ -116,14 +126,19 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
     internal let rum = DatadogRumPlugin()
     internal let logs = DatadogLogsPlugin()
 
-    public init(channel: FlutterMethodChannel) {
+    /// Injected so tests can drive termination through a fake center instead of posting the real,
+    /// process-wide notification.
+    private let notificationCenter: NotificationCenterProtocol
+
+    public init(channel: FlutterMethodChannel, notificationCenter: NotificationCenterProtocol = NotificationCenter.default) {
         self.channel = channel
+        self.notificationCenter = notificationCenter
         super.init()
         observeEngineTeardown()
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        notificationCenter.removeObserver(self)
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -414,7 +429,7 @@ public class DatadogSdkPlugin: NSObject, FlutterPlugin, DatadogFeature {
     /// lifecycle events only when `UIApplication`'s delegate conforms to `FlutterAppLifeCycleProvider`
     /// — true for `FlutterAppDelegate`, often false for a native host embedding Flutter.
     private func observeEngineTeardown() {
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self,
             selector: #selector(engineWillTearDown),
             name: UIApplication.willTerminateNotification,

--- a/packages/datadog_session_replay/example/ios/Podfile.lock
+++ b/packages/datadog_session_replay/example/ios/Podfile.lock
@@ -1,15 +1,4 @@
 PODS:
-  - datadog_flutter_plugin (0.0.1):
-    - DatadogCore (~> 3)
-    - DatadogCrashReporting (~> 3)
-    - DatadogInternal (~> 3)
-    - DatadogLogs (~> 3)
-    - DatadogRUM (~> 3)
-    - DictionaryCoder (= 1.2.0)
-    - Flutter
-  - datadog_session_replay (0.0.1):
-    - DatadogCore (~> 3)
-    - Flutter
   - DatadogCore (3.14.0):
     - DatadogInternal (= 3.14.0)
   - DatadogCrashReporting (3.14.0):
@@ -21,10 +10,7 @@ PODS:
     - DatadogInternal (= 3.14.0)
   - DatadogRUM (3.14.0):
     - DatadogInternal (= 3.14.0)
-  - DictionaryCoder (1.2.0)
   - Flutter (1.0.0)
-  - integration_test (0.0.1):
-    - Flutter
   - KSCrash/Core (2.5.1)
   - KSCrash/Filters (2.5.1):
     - KSCrash/Recording
@@ -40,27 +26,19 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - datadog_flutter_plugin (from `.symlinks/plugins/datadog_flutter_plugin/ios`)
-  - datadog_session_replay (from `.symlinks/plugins/datadog_session_replay/ios`)
   - DatadogCore (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - DatadogCrashReporting (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - DatadogInternal (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - DatadogLogs (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - DatadogRUM (from `https://github.com/DataDog/dd-sdk-ios`, branch `develop`)
   - Flutter (from `Flutter`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - objective_c (from `.symlinks/plugins/objective_c/ios`)
 
 SPEC REPOS:
   trunk:
-    - DictionaryCoder
     - KSCrash
 
 EXTERNAL SOURCES:
-  datadog_flutter_plugin:
-    :path: ".symlinks/plugins/datadog_flutter_plugin/ios"
-  datadog_session_replay:
-    :path: ".symlinks/plugins/datadog_session_replay/ios"
   DatadogCore:
     :branch: develop
     :git: https://github.com/DataDog/dd-sdk-ios
@@ -78,8 +56,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/DataDog/dd-sdk-ios
   Flutter:
     :path: Flutter
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
   objective_c:
     :path: ".symlinks/plugins/objective_c/ios"
 
@@ -101,16 +77,12 @@ CHECKOUT OPTIONS:
     :git: https://github.com/DataDog/dd-sdk-ios
 
 SPEC CHECKSUMS:
-  datadog_flutter_plugin: 64adc7ef089a1328c78fd4fab24e49afa09d95a5
-  datadog_session_replay: 8e4f4a520f20feb2916c623c011a53ba63f8d77f
   DatadogCore: bcc686c9e21e86ab3206c3f7da03019d0c3696c0
   DatadogCrashReporting: ce89b6cb9772383d27eb6660fa47c53eb1804fe6
   DatadogInternal: 5317b8fcd6f21de6b89785d0e44418c8e42fe7c3
   DatadogLogs: 4218289212980fd3462d9a34b91c57b75a2c2f13
   DatadogRUM: e7887cf89018945fb46d2bd546396e4cdf2f77c2
-  DictionaryCoder: f7115fcd074c8301e91f2eb862da1ea7d0385e61
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   KSCrash: 8c4464fd5da7de520f2ce4a00fdf63f169a80f18
   objective_c: 77e887b5ba1827970907e10e832eec1683f3431d
 

--- a/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/datadog_session_replay/example/ios/Runner.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		BC0DEB13FDD8056873023575 /* NotificationCenterMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CBB840D216545E3DE18D5B /* NotificationCenterMock.swift */; };
 		E1E091C69AD74808BE3733231FC76E98 /* DatadogSessionReplayPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35542C60C09A47729F76E13B6A659C63 /* DatadogSessionReplayPluginTests.swift */; };
 		E7162BD14BF84CACB6B101E947BD07D1 /* SessionReplayTestContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */; };
 /* End PBXBuildFile section */
@@ -93,6 +94,8 @@
 		6A0117D673D82B937FDFE484 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* datadog_session_replay */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = datadog_session_replay; path = ../../ios/datadog_session_replay; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		79BD53055738C1114E4457B5 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -107,6 +110,7 @@
 		BE0C0F8D524DC14EF6F6CFB0 /* DataStoreMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataStoreMock.swift; sourceTree = "<group>"; };
 		CB6E419C80EE782C5F5B2C8E /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		CDF9F7F84B03E7F780D7C869 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D9CBB840D216545E3DE18D5B /* NotificationCenterMock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationCenterMock.swift; sourceTree = "<group>"; };
 		E3A52EA2C191523119AFBBD1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		F2038B61D19548C0AF36B8B3C6603AE1 /* SessionReplayTestContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionReplayTestContainer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -202,6 +206,7 @@
 				495A027F2DCE433B00869BEA /* FoundationMocks.swift */,
 				495A02802DCE433B00869BEA /* MultipartBuilderSpy.swift */,
 				BE0C0F8D524DC14EF6F6CFB0 /* DataStoreMock.swift */,
+				D9CBB840D216545E3DE18D5B /* NotificationCenterMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -209,6 +214,8 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* datadog_session_replay */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
@@ -297,7 +304,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				856D27D165E93DCA04A44742 /* [CP] Embed Pods Frameworks */,
-				F6722193A3C2B1911D5FE9DF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -468,23 +474,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		F6722193A3C2B1911D5FE9DF /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -514,6 +503,7 @@
 				4944008D2E58F71300AC46CC /* ResourcesWriterTest.swift in Sources */,
 				495642A52E5E2512000FF536 /* ResourceResolverTest.swift in Sources */,
 				1F0B9721A43A6A63DCC17933 /* DataStoreMock.swift in Sources */,
+				BC0DEB13FDD8056873023575 /* NotificationCenterMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -86,6 +86,56 @@ class DatadogSessionReplayPluginTests {
         #expect(callsToEngine == 1)  // primed on enable, nothing after
     }
 
+    /// Flutter never calls `detachFromEngine(for:)` on termination — it resets the engine's shell and
+    /// leaves the engine object, and therefore the plugin registry, alone
+    /// (flutter/flutter#126671) — so the plugin has to notice termination itself, or the Dart context
+    /// callback outlives the isolate that shell owned.
+    @Test
+    func applicationWillTerminate_releasesThisEnginesDartCallback() throws {
+        // Given — an engine paired with this plugin's messenger
+        var callsToEngine = 0
+        let core = PassthroughCoreMock()
+        let engine = FlutterSessionReplay(manager: manager)
+        try engine.enableOrThrow(with: .init(onContextChanged: { _ in callsToEngine += 1 }), in: core)
+        let plugin = DatadogSessionReplayPlugin(messenger: messenger, manager: manager)
+        _ = handle(plugin, method: "registerEngine", arguments: engine.engineToken)
+
+        // When — the app terminates without ever detaching the plugin. The plugin is kept alive
+        // across the post because `NotificationCenter` does not retain its observers.
+        withExtendedLifetime(plugin) {
+            NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
+            manager.broadcastContext(.mockRandom())
+        }
+
+        // Then
+        #expect(callsToEngine == 1)  // primed on enable, nothing after
+    }
+
+    /// Flutter never calls `detachFromEngine(for:)` on termination — it resets the engine's shell and
+    /// leaves the engine object, and therefore the plugin registry, alone (flutter/flutter#126671) —
+    /// so the plugin observes `UIApplication.willTerminateNotification` itself. Otherwise the Dart
+    /// context callback outlives the isolate that shell owned.
+    ///
+    /// Drives the handler directly instead of posting that notification: every plugin instance in the
+    /// process observes it, so a real post tears down engines belonging to suites running in parallel.
+    @Test
+    func engineWillTearDown_releasesThisEnginesDartCallback() throws {
+        // Given — an engine paired with this plugin's messenger
+        var callsToEngine = 0
+        let core = PassthroughCoreMock()
+        let engine = FlutterSessionReplay(manager: manager)
+        try engine.enableOrThrow(with: .init(onContextChanged: { _ in callsToEngine += 1 }), in: core)
+        let plugin = DatadogSessionReplayPlugin(messenger: messenger, manager: manager)
+        _ = handle(plugin, method: "registerEngine", arguments: engine.engineToken)
+
+        // When — the app terminates without ever detaching the plugin
+        plugin.engineWillTearDown()
+        manager.broadcastContext(.mockRandom())
+
+        // Then
+        #expect(callsToEngine == 1)  // primed on enable, nothing after
+    }
+
     @Test
     func registerEngine_withoutAToken_returnsAnError() {
         // Given

--- a/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/DatadogSessionReplayPluginTests.swift
@@ -87,37 +87,13 @@ class DatadogSessionReplayPluginTests {
     }
 
     /// Flutter never calls `detachFromEngine(for:)` on termination — it resets the engine's shell and
-    /// leaves the engine object, and therefore the plugin registry, alone
-    /// (flutter/flutter#126671) — so the plugin has to notice termination itself, or the Dart context
-    /// callback outlives the isolate that shell owned.
-    @Test
-    func applicationWillTerminate_releasesThisEnginesDartCallback() throws {
-        // Given — an engine paired with this plugin's messenger
-        var callsToEngine = 0
-        let core = PassthroughCoreMock()
-        let engine = FlutterSessionReplay(manager: manager)
-        try engine.enableOrThrow(with: .init(onContextChanged: { _ in callsToEngine += 1 }), in: core)
-        let plugin = DatadogSessionReplayPlugin(messenger: messenger, manager: manager)
-        _ = handle(plugin, method: "registerEngine", arguments: engine.engineToken)
-
-        // When — the app terminates without ever detaching the plugin. The plugin is kept alive
-        // across the post because `NotificationCenter` does not retain its observers.
-        withExtendedLifetime(plugin) {
-            NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
-            manager.broadcastContext(.mockRandom())
-        }
-
-        // Then
-        #expect(callsToEngine == 1)  // primed on enable, nothing after
-    }
-
-    /// Flutter never calls `detachFromEngine(for:)` on termination — it resets the engine's shell and
     /// leaves the engine object, and therefore the plugin registry, alone (flutter/flutter#126671) —
     /// so the plugin observes `UIApplication.willTerminateNotification` itself. Otherwise the Dart
     /// context callback outlives the isolate that shell owned.
     ///
-    /// Drives the handler directly instead of posting that notification: every plugin instance in the
-    /// process observes it, so a real post tears down engines belonging to suites running in parallel.
+    /// Posts to an injected `NotificationCenterMock` instead of the real, process-wide center: this
+    /// exercises the actual observer registration (name, selector) rather than calling a test-only
+    /// escape hatch, without the risk of tearing down another suite's engine.
     @Test
     func engineWillTearDown_releasesThisEnginesDartCallback() throws {
         // Given — an engine paired with this plugin's messenger
@@ -125,11 +101,16 @@ class DatadogSessionReplayPluginTests {
         let core = PassthroughCoreMock()
         let engine = FlutterSessionReplay(manager: manager)
         try engine.enableOrThrow(with: .init(onContextChanged: { _ in callsToEngine += 1 }), in: core)
-        let plugin = DatadogSessionReplayPlugin(messenger: messenger, manager: manager)
+        let notificationCenter = NotificationCenterMock()
+        let plugin = DatadogSessionReplayPlugin(
+            messenger: messenger,
+            manager: manager,
+            notificationCenter: notificationCenter
+        )
         _ = handle(plugin, method: "registerEngine", arguments: engine.engineToken)
 
         // When — the app terminates without ever detaching the plugin
-        plugin.engineWillTearDown()
+        notificationCenter.post(name: UIApplication.willTerminateNotification)
         manager.broadcastContext(.mockRandom())
 
         // Then

--- a/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/NotificationCenterMock.swift
+++ b/packages/datadog_session_replay/example/ios/RunnerTests/Mocks/NotificationCenterMock.swift
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-Present Datadog, Inc.
+
+import Foundation
+@testable import datadog_session_replay
+
+/// A `NotificationCenter` stand-in that never broadcasts process-wide: `post(name:)` only invokes
+/// observers registered on this instance, so driving termination in a test cannot tear down another
+/// suite's engine or the Runner's own registered plugin.
+class NotificationCenterMock: NotificationCenterProtocol {
+    private var observers: [(observer: NSObject, selector: Selector, name: NSNotification.Name?)] = []
+
+    func addObserver(_ observer: Any, selector: Selector, name: NSNotification.Name?, object: Any?) {
+        guard let observer = observer as? NSObject else { return }
+        observers.append((observer, selector, name))
+    }
+
+    func removeObserver(_ observer: Any) {
+        guard let observer = observer as? NSObject else { return }
+        observers.removeAll { $0.observer === observer }
+    }
+
+    func post(name: NSNotification.Name) {
+        for entry in observers where entry.name == name {
+            entry.observer.perform(entry.selector)
+        }
+    }
+}

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/DatadogSessionReplayPlugin.swift
@@ -5,6 +5,16 @@ import Foundation
 import Flutter
 import UIKit
 
+/// Thin abstraction over `NotificationCenter` so tests can inject a fake that never broadcasts
+/// process-wide, instead of every test posting the real `UIApplication.willTerminateNotification`
+/// (which every live plugin instance in the process would observe, including other suites' engines).
+protocol NotificationCenterProtocol {
+    func addObserver(_ observer: Any, selector: Selector, name: NSNotification.Name?, object: Any?)
+    func removeObserver(_ observer: Any)
+}
+
+extension NotificationCenter: NotificationCenterProtocol {}
+
 @objc(DatadogSessionReplayPlugin)
 public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
     private let messenger: AnyObject
@@ -13,15 +23,24 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
     /// substitute it.
     private let manager: FlutterSessionReplayManager
 
-    internal init(messenger: AnyObject, manager: FlutterSessionReplayManager = .shared) {
+    /// Injected so tests can drive termination through a fake center instead of posting the real,
+    /// process-wide notification.
+    private let notificationCenter: NotificationCenterProtocol
+
+    internal init(
+        messenger: AnyObject,
+        manager: FlutterSessionReplayManager = .shared,
+        notificationCenter: NotificationCenterProtocol = NotificationCenter.default
+    ) {
         self.messenger = messenger
         self.manager = manager
+        self.notificationCenter = notificationCenter
         super.init()
         observeEngineTeardown()
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        notificationCenter.removeObserver(self)
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -72,7 +91,7 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
     /// context callback would then outlive the isolate that shell owned and trap in
     /// `DLRT_GetFfiCallbackMetadata`.
     private func observeEngineTeardown() {
-        NotificationCenter.default.addObserver(
+        notificationCenter.addObserver(
             self,
             selector: #selector(engineWillTearDown),
             name: UIApplication.willTerminateNotification,
@@ -80,11 +99,8 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
         )
     }
 
-    /// Internal rather than private so tests can drive it without posting the real notification,
-    /// which every plugin instance in the process observes — including those of suites running in
-    /// parallel.
     @objc
-    internal func engineWillTearDown() {
+    private func engineWillTearDown() {
         _onDetach()
     }
 

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/DatadogSessionReplayPlugin.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Sources/Swift/DatadogSessionReplayPlugin.swift
@@ -16,6 +16,12 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
     internal init(messenger: AnyObject, manager: FlutterSessionReplayManager = .shared) {
         self.messenger = messenger
         self.manager = manager
+        super.init()
+        observeEngineTeardown()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -30,6 +36,7 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
             binaryMessenger: registrar.messenger()
         )
         registrar.addMethodCallDelegate(instance, channel: channel)
+        registrar.publish(instance)
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -55,7 +62,37 @@ public class DatadogSessionReplayPlugin: NSObject, FlutterPlugin {
         }
     }
 
+    /// Covers teardown path `detachFromEngine(for:)` cannot see: app termination.
+    ///
+    /// Every other way an engine goes away ends in `-[FlutterEngine dealloc]`, which is the sole
+    /// caller of `detachFromEngineForRegistrar:` — closing a scene, or a host releasing an engine,
+    /// both land there. Termination does not: `-[FlutterViewController applicationWillTerminate:]`
+    /// resets the engine's shell via `-appOrSceneWillTerminate` → `-destroyContext` while the engine
+    /// object itself stays alive, so no plugin is ever notified (flutter/flutter#126671). Our Dart
+    /// context callback would then outlive the isolate that shell owned and trap in
+    /// `DLRT_GetFfiCallbackMetadata`.
+    private func observeEngineTeardown() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(engineWillTearDown),
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+    }
+
+    /// Internal rather than private so tests can drive it without posting the real notification,
+    /// which every plugin instance in the process observes — including those of suites running in
+    /// parallel.
+    @objc
+    internal func engineWillTearDown() {
+        _onDetach()
+    }
+
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        _onDetach()
+    }
+
+    private func _onDetach() {
         // Release this engine's Dart context callback before its isolate goes away —
         // invoking it afterwards traps in `DLRT_GetFfiCallbackMetadata` on force close.
         // Keyed by messenger, so a detaching secondary engine cannot clear a live one's.


### PR DESCRIPTION
### What and why?

When Flutter is shutting down due to a force close (willTerminateNotification), it doesn't inform plugins that they need to detach from the engine. If a background thread is in the middle of calling a mapper or performing onContextChange, this can cause a crash.

To avoid this, we listen to `willTerminate` directly, and ensure we've torn down these functions so they can't be called accidentally. Since the whole application is going away, we don't have to worry about Flutter attempting to reattach an engine.

As part of this, refactor some the plugins to prevent similar issues, and make the setup for this detach more consistent.

This crash is incredibly difficult to reproduce, so we are guessing that this is a complete solution for preventing it.

refs: #1062

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
