### PR TITLE
chore: Add chainguard file

### DIFF
--- a/.github/chainguard/self.prepare-release.sts.yaml
+++ b/.github/chainguard/self.prepare-release.sts.yaml
@@ -1,0 +1,21 @@
+# Trust policy allowing dd-octo-sts to grant our prepare-release CI job a GitHub token.
+# This covers mainline (develop), patch (release/*/vX.Y.x), and pre-release (v4) 
+# trigger branches.
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-flutter:ref_type:branch:ref:(develop|release/.+|v4)"
+
+claim_pattern:
+  project_path: "DataDog/dd-sdk-flutter"
+  ref: "^(develop|release/.+|v4)$"
+  ref_type: "branch"
+  ref_path: "^refs/heads/(develop|release/.+|v4)$"
+  ci_config_ref_uri: 'gitlab\.ddbuild\.io/DataDog/dd-sdk-flutter//\.gitlab-ci\.yml@refs/heads/(develop|release/.+|v4)'
+  # Pipeline is created by a branch push; prepare-release itself is just a `when: manual`
+  # job inside that pipeline, so pipeline_source is still "push" (matches dd-sdk-cpp).
+  pipeline_source: "push"
+
+# We need to push commits/branches and open pull requests
+permissions:
+  contents: write
+  pull_requests: write


### PR DESCRIPTION
### What and why?

Chainguard allows us to create secure tokens to work with Github in our CI. A new release process coming in v4 will hopefully make the full release process much easier, but will require chainguard to open PRs as part of the release.

refs: RUM-18022

### How?

If needed, a description of how this PR accomplishes what it does.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
