### PR TITLE
chore: Add package discovery + release plan foundation

### DIFF
--- a/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
+++ b/packages/datadog_grpc_interceptor/test/datadog_grpc_interceptor_test.dart
@@ -31,7 +31,10 @@ class LoggingGreeterService extends GreeterServiceBase {
 }
 
 void main() {
-  const int port = 50192;
+  // Bound by the OS at serve() time rather than hardcoded: any fixed port here
+  // lands inside Linux's ephemeral range (32768-60999) and intermittently
+  // collides with an in-use port on CI, erroring every test in the file.
+  late int port;
   late LoggingGreeterService loggingService;
 
   late DatadogPlatformMock mockPlatform;
@@ -149,6 +152,11 @@ void main() {
     late Server server;
 
     setUp(() async {
+      loggingService = LoggingGreeterService();
+      server = Server.create(services: [loggingService]);
+      await server.serve(port: 0);
+      port = server.port!;
+
       channel = ClientChannel(
         'localhost',
         port: port,
@@ -156,9 +164,6 @@ void main() {
           credentials: ChannelCredentials.insecure(),
         ),
       );
-      loggingService = LoggingGreeterService();
-      server = Server.create(services: [loggingService]);
-      await server.serve(port: port);
 
       mockPlatform = DatadogPlatformMock();
 
@@ -415,14 +420,16 @@ void main() {
   });
 
   test('secure channel adds https scheme', () async {
+    loggingService = LoggingGreeterService();
+    final server = Server.create(services: [loggingService]);
+    await server.serve(port: 0);
+    port = server.port!;
+
     final channel = ClientChannel(
       'localhost',
       port: port,
       options: const ChannelOptions(credentials: ChannelCredentials.secure()),
     );
-    loggingService = LoggingGreeterService();
-    final server = Server.create(services: [loggingService]);
-    await server.serve(port: port);
 
     mockPlatform = DatadogPlatformMock();
     mockDatadog = DatadogSdkMock();
@@ -471,14 +478,16 @@ void main() {
   });
 
   test('internet address channel adds scheme', () async {
+    loggingService = LoggingGreeterService();
+    final server = Server.create(services: [loggingService]);
+    await server.serve(port: 0);
+    port = server.port!;
+
     final channel = ClientChannel(
       InternetAddress.loopbackIPv4,
       port: port,
       options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
     );
-    loggingService = LoggingGreeterService();
-    final server = Server.create(services: [loggingService]);
-    await server.serve(port: port);
 
     mockPlatform = DatadogPlatformMock();
     mockDatadog = DatadogSdkMock();
@@ -521,14 +530,16 @@ void main() {
   });
 
   test('secure internet address channel adds scheme', () async {
+    loggingService = LoggingGreeterService();
+    final server = Server.create(services: [loggingService]);
+    await server.serve(port: 0);
+    port = server.port!;
+
     final channel = ClientChannel(
       InternetAddress.loopbackIPv4,
       port: port,
       options: const ChannelOptions(credentials: ChannelCredentials.secure()),
     );
-    loggingService = LoggingGreeterService();
-    final server = Server.create(services: [loggingService]);
-    await server.serve(port: port);
 
     mockPlatform = DatadogPlatformMock();
     mockDatadog = DatadogSdkMock();

--- a/tools/releaser/lib/package_discovery.dart
+++ b/tools/releaser/lib/package_discovery.dart
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
+import 'package:path/path.dart' as p;
+import 'package:pubspec_parse/pubspec_parse.dart';
+
+/// Suffix a federated package's platform-interface uses. Within a group,
+/// this one always releases first.
+const platformInterfaceSuffix = '_platform_interface';
+
+/// Suffixes of federated per-platform implementation packages. Within a
+/// group these are independent of each other -- any relative order among
+/// them is fine.
+const implementationSuffixes = ['_android', '_ios', '_web', '_desktop'];
+
+enum PackageRole {
+  platformInterface(publishOrder: 0),
+  implementation(publishOrder: 1),
+  // The terminal node in a group's publish order -- the package everything
+  // else in its group (if any) is a dependency of. A standalone package is
+  // trivially its own terminal node, so this covers both a federated
+  // group's app-facing package and any singleton.
+  appFacing(publishOrder: 2);
+
+  /// Where this role publishes relative to its siblings within the same
+  /// group (lower publishes first). Platform interface before
+  /// implementations before the app-facing package, since each depends on
+  /// the one(s) before it.
+  final int publishOrder;
+
+  const PackageRole({required this.publishOrder});
+}
+
+class DiscoveredPackage {
+  final String name;
+  final String version;
+
+  /// Path to the package's directory, relative to the repo root -- e.g.
+  /// `packages/datadog_flutter_plugin/datadog_flutter_plugin_ios`. Resolved
+  /// from where its pubspec.yaml actually lives, not assumed from its name.
+  final String relativePath;
+  final PackageRole role;
+
+  DiscoveredPackage({
+    required this.name,
+    required this.version,
+    required this.relativePath,
+    required this.role,
+  });
+
+  String absolutePath(String repoRoot) => p.join(repoRoot, relativePath);
+
+  @override
+  String toString() => '$name@$version ($relativePath, $role)';
+}
+
+/// A set of packages that release together. Federated groups (platform
+/// interface + per-platform impls + app-facing package) have more than one
+/// member, listed in topological order (interface, then impls, then
+/// app-facing). Everything else is a singleton group of exactly one.
+class PackageGroup {
+  final String key;
+  final List<DiscoveredPackage> members;
+
+  PackageGroup({required this.key, required this.members});
+
+  bool get isFederated => members.length > 1;
+}
+
+/// Discovers every releasable package under `[repoRoot]/packages`, grouping
+/// federated siblings together in topological order. Resolves each
+/// package's actual directory by walking the tree, since federated
+/// sub-packages don't live at a flat `packages/{name}` path.
+///
+/// Packages with `publish_to: none` (example apps, integration/e2e test
+/// harnesses, and deliberately-unpublished support packages like
+/// `datadog_common_test`) are excluded; they're never part of a release.
+Future<List<PackageGroup>> discoverPackages(String repoRoot) async {
+  final pubspecGlob = Glob('packages/**/pubspec.yaml');
+  final packages = <DiscoveredPackage>[];
+
+  for (final entity in pubspecGlob.listSync(
+    root: repoRoot,
+    followLinks: false,
+  )) {
+    if (entity is! File) continue;
+    final pubspecFile = entity as File;
+
+    final pubspec = Pubspec.parse(
+      await pubspecFile.readAsString(),
+      sourceUrl: pubspecFile.uri,
+    );
+
+    if (pubspec.publishTo == 'none') continue;
+
+    final relativePath = p.dirname(
+      p.relative(pubspecFile.path, from: repoRoot),
+    );
+    packages.add(
+      DiscoveredPackage(
+        name: pubspec.name,
+        version: pubspec.version?.toString() ?? '0.0.0',
+        relativePath: relativePath,
+        // Corrected below once every package's group is known.
+        role: PackageRole.appFacing,
+      ),
+    );
+  }
+
+  return _groupPackages(packages);
+}
+
+/// Groups packages by their shared parent directory -- packages nested
+/// under a common container dir (e.g. everything under
+/// `packages/datadog_flutter_plugin/`) are a federated group; packages
+/// sitting directly under `packages/` are standalone.
+List<PackageGroup> _groupPackages(List<DiscoveredPackage> packages) {
+  final byContainerDir = <String, List<DiscoveredPackage>>{};
+  for (final pkg in packages) {
+    final containerDir = p.dirname(pkg.relativePath);
+    // Two packages both living directly under packages/ aren't siblings
+    // just because they share that top-level directory -- key each of
+    // them by their own path so they don't get grouped together.
+    final key = containerDir == 'packages' ? pkg.relativePath : containerDir;
+    byContainerDir.putIfAbsent(key, () => []).add(pkg);
+  }
+
+  final groups = <PackageGroup>[];
+  byContainerDir.forEach((containerDir, members) {
+    if (members.length == 1) {
+      // Deliberately not run through `_roleFor` -- a standalone package's
+      // name might coincidentally end in a federation suffix (see
+      // `lonely_ios` in the tests), but with no siblings it's still just
+      // the terminal node of its own one-package group.
+      final pkg = members.single;
+      groups.add(
+        PackageGroup(
+          key: pkg.name,
+          members: [_withRole(pkg, PackageRole.appFacing)],
+        ),
+      );
+      return;
+    }
+
+    final roled =
+        members.map((pkg) => _withRole(pkg, _roleFor(pkg.name))).toList()
+          ..sort((a, b) {
+            final byOrder = a.role.publishOrder.compareTo(b.role.publishOrder);
+            return byOrder != 0 ? byOrder : a.name.compareTo(b.name);
+          });
+
+    groups.add(PackageGroup(key: p.basename(containerDir), members: roled));
+  });
+
+  return groups;
+}
+
+/// Classifies a package's role *within* a group already formed by shared
+/// directory -- this is ordering info only, not what decides grouping.
+PackageRole _roleFor(String name) {
+  if (name.endsWith(platformInterfaceSuffix)) {
+    return PackageRole.platformInterface;
+  }
+  if (implementationSuffixes.any(name.endsWith)) {
+    return PackageRole.implementation;
+  }
+  return PackageRole.appFacing;
+}
+
+DiscoveredPackage _withRole(DiscoveredPackage pkg, PackageRole role) =>
+    DiscoveredPackage(
+      name: pkg.name,
+      version: pkg.version,
+      relativePath: pkg.relativePath,
+      role: role,
+    );

--- a/tools/releaser/lib/package_discovery.dart
+++ b/tools/releaser/lib/package_discovery.dart
@@ -98,13 +98,20 @@ Future<List<PackageGroup>> discoverPackages(String repoRoot) async {
 
     if (pubspec.publishTo == 'none') continue;
 
+    if (pubspec.version == null) {
+      throw StateError(
+        'Package "${pubspec.name}" (${pubspecFile.path}) has no version in '
+        'its pubspec.yaml -- every releasable package must declare one.',
+      );
+    }
+
     final relativePath = p.dirname(
       p.relative(pubspecFile.path, from: repoRoot),
     );
     packages.add(
       DiscoveredPackage(
         name: pubspec.name,
-        version: pubspec.version?.toString() ?? '0.0.0',
+        version: pubspec.version.toString(),
         relativePath: relativePath,
         // Corrected below once every package's group is known.
         role: PackageRole.appFacing,

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -142,6 +142,19 @@ List<DiscoveredPackage> _selectPackages(
 
   if (ctx.requestedPackages.isEmpty) return all;
 
+  if (ctx.trigger == TriggerContext.patch) {
+    // A patch run's single package is already implied by currentBranch (see
+    // _resolveGroups) -- an inherited --packages/PACKAGES filter shouldn't
+    // be able to narrow or wipe that out, so it doesn't apply here.
+    return all;
+  }
+
   final requested = ctx.requestedPackages.toSet();
+  final discovered = all.map((pkg) => pkg.name).toSet();
+  final unknown = requested.difference(discovered);
+  if (unknown.isNotEmpty) {
+    throw StateError('Requested package(s) not found: ${unknown.join(', ')}.');
+  }
+
   return all.where((pkg) => requested.contains(pkg.name)).toList();
 }

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:collection/collection.dart';
+
+import 'package_discovery.dart';
+
+/// Which of the three GitLab trigger contexts a run is happening under:
+/// mainline (`develop`), patch (a standing `release/{package}/vX.Y.x`
+/// branch), or pre-release (a whitelisted long-lived branch like `v4`).
+enum TriggerContext { mainline, patch, preRelease }
+
+final _patchBranchPattern = RegExp(r'^release/([^/]+)/v\d+\.\d+\.x$');
+
+/// Extracts the package name from a `release/{package}/v{major}.{minor}.x`
+/// patch-branch name, or null if [branch] doesn't match that convention.
+String? packageNameFromPatchBranch(String branch) =>
+    _patchBranchPattern.firstMatch(branch)?.group(1);
+
+/// Everything about how a `prepare-release`/`preview-release` run was
+/// invoked -- shared by both entry points so they can't compute different
+/// plans from the same inputs.
+class RunContext {
+  final String repoRoot;
+  final TriggerContext trigger;
+  final String currentBranch;
+
+  /// Explicit package names from `--packages`/`PACKAGES`; empty means
+  /// `--all` (every package with pending commits). Not applicable on a
+  /// patch branch, where the package is implied by [currentBranch].
+  final List<String> requestedPackages;
+
+  final String? bumpTypeOverride;
+  final String? prereleaseLabel;
+  final String? iosSdkVersionOverride;
+  final String? androidSdkVersionOverride;
+  final String? cppVersionOverride;
+
+  RunContext({
+    required this.repoRoot,
+    required this.trigger,
+    required this.currentBranch,
+    this.requestedPackages = const [],
+    this.bumpTypeOverride,
+    this.prereleaseLabel,
+    this.iosSdkVersionOverride,
+    this.androidSdkVersionOverride,
+    this.cppVersionOverride,
+  });
+}
+
+/// The computed plan for a single releasing package.
+class PackagePlan {
+  final DiscoveredPackage package;
+  final String currentVersion;
+
+  // TODO: compute from conventional-commit bump detection / overrides.
+  final String? newVersion;
+  // TODO: compute alongside newVersion.
+  final String? bumpLevel;
+  // TODO: resolve from the commits contributing to this release.
+  final List<String> contributingPrs;
+
+  PackagePlan({
+    required this.package,
+    required this.currentVersion,
+    this.newVersion,
+    this.bumpLevel,
+    this.contributingPrs = const [],
+  });
+}
+
+class ReleasePlan {
+  final TriggerContext trigger;
+  final List<PackagePlan> packages;
+
+  ReleasePlan({required this.trigger, required this.packages});
+}
+
+/// Computes what a release run would do, without writing anything. Shared
+/// by `prepare_release.dart` (which acts on the result) and
+/// `preview_release.dart` (which only prints it) so the two can't drift
+/// apart.
+///
+/// TODO: conventional-commit bump detection, native SDK version checks, and
+/// PR resolution -- `newVersion`/`bumpLevel`/`contributingPrs` are null or
+/// empty on every returned plan until those land.
+Future<ReleasePlan> computeReleasePlan(RunContext ctx) async {
+  final groups = await _resolveGroups(ctx);
+  final selected = _selectPackages(groups, ctx);
+
+  final plans = selected
+      .map((pkg) => PackagePlan(package: pkg, currentVersion: pkg.version))
+      .toList();
+
+  return ReleasePlan(trigger: ctx.trigger, packages: plans);
+}
+
+Future<List<PackageGroup>> _resolveGroups(RunContext ctx) async {
+  final allGroups = await discoverPackages(ctx.repoRoot);
+
+  if (ctx.trigger != TriggerContext.patch) {
+    return allGroups;
+  }
+
+  // Patch branches never use topology -- a caret constraint already
+  // tolerates a sibling staying behind, so only the one named package
+  // moves, with no grouping applied to it.
+  final packageName = packageNameFromPatchBranch(ctx.currentBranch);
+  if (packageName == null) {
+    throw StateError(
+      'Branch "${ctx.currentBranch}" does not match the '
+      'release/{package}/v{major}.{minor}.x patch-branch convention.',
+    );
+  }
+
+  final pkg = allGroups
+      .expand((group) => group.members)
+      .where((pkg) => pkg.name == packageName)
+      .firstOrNull;
+  if (pkg == null) {
+    throw StateError(
+      'No discovered package named "$packageName" (from patch branch '
+      '"${ctx.currentBranch}").',
+    );
+  }
+
+  return [
+    PackageGroup(key: pkg.name, members: [pkg]),
+  ];
+}
+
+List<DiscoveredPackage> _selectPackages(
+  List<PackageGroup> groups,
+  RunContext ctx,
+) {
+  // Groups are already topologically ordered internally; flattening in
+  // discovery order preserves that, and cross-group order doesn't matter
+  // since independent groups/singletons publish in parallel.
+  final all = groups.expand((group) => group.members).toList();
+
+  if (ctx.requestedPackages.isEmpty) return all;
+
+  final requested = ctx.requestedPackages.toSet();
+  return all.where((pkg) => requested.contains(pkg.name)).toList();
+}

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -178,7 +178,7 @@ packages:
     source: hosted
     version: "2.3.1"
   glob:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
@@ -314,7 +314,7 @@ packages:
     source: hosted
     version: "2.2.0"
   pubspec_parse:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   version: ^2.0.0
   json_annotation: ^4.12.0
   collection: ^1.19.1
+  glob: ^2.1.3
+  pubspec_parse: ^1.5.0
 
 dev_dependencies:
   build_runner: ^2.15.0

--- a/tools/releaser/test/package_discovery_test.dart
+++ b/tools/releaser/test/package_discovery_test.dart
@@ -2,6 +2,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:releaser/package_discovery.dart';
@@ -33,11 +36,15 @@ void main() {
     expect(group.members.map((pkg) => pkg.name), [
       'datadog_flutter_plugin_platform_interface',
       'datadog_flutter_plugin_android',
+      'datadog_flutter_plugin_desktop',
       'datadog_flutter_plugin_ios',
+      'datadog_flutter_plugin_web',
       'datadog_flutter_plugin',
     ]);
     expect(group.members.map((pkg) => pkg.role), [
       PackageRole.platformInterface,
+      PackageRole.implementation,
+      PackageRole.implementation,
       PackageRole.implementation,
       PackageRole.implementation,
       PackageRole.appFacing,
@@ -76,6 +83,22 @@ void main() {
         ios.relativePath,
         'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios',
       );
+    },
+  );
+
+  test(
+    'a publishable package with no version in its pubspec is an error, not a silent 0.0.0',
+    () async {
+      final root = await Directory.systemTemp.createTemp('releaser_test_');
+      addTearDown(() => root.delete(recursive: true));
+
+      final packageDir = Directory(p.join(root.path, 'packages', 'no_version'))
+        ..createSync(recursive: true);
+      File(
+        p.join(packageDir.path, 'pubspec.yaml'),
+      ).writeAsStringSync('name: no_version\nenvironment:\n  sdk: ^3.0.0\n');
+
+      await expectLater(discoverPackages(root.path), throwsStateError);
     },
   );
 }

--- a/tools/releaser/test/package_discovery_test.dart
+++ b/tools/releaser/test/package_discovery_test.dart
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:test/test.dart';
+
+import 'package:releaser/package_discovery.dart';
+import 'support/fixture_repo.dart';
+
+void main() {
+  late FixtureRepo fixture;
+
+  setUp(() async {
+    fixture = await FixtureRepo.create();
+  });
+
+  tearDown(() => fixture.delete());
+
+  test('excludes packages with publish_to: none', () async {
+    final groups = await discoverPackages(fixture.root.path);
+    final names = groups.expand((g) => g.members).map((pkg) => pkg.name);
+
+    expect(names, isNot(contains('datadog_dio_example')));
+    expect(names, isNot(contains('datadog_common_test')));
+    expect(names, isNot(contains('datadog_flutter_plugin_ios_example')));
+  });
+
+  test('groups federated siblings in topological order', () async {
+    final groups = await discoverPackages(fixture.root.path);
+    final group = groups.firstWhere((g) => g.key == 'datadog_flutter_plugin');
+
+    expect(group.isFederated, isTrue);
+    expect(group.members.map((pkg) => pkg.name), [
+      'datadog_flutter_plugin_platform_interface',
+      'datadog_flutter_plugin_android',
+      'datadog_flutter_plugin_ios',
+      'datadog_flutter_plugin',
+    ]);
+    expect(group.members.map((pkg) => pkg.role), [
+      PackageRole.platformInterface,
+      PackageRole.implementation,
+      PackageRole.implementation,
+      PackageRole.appFacing,
+    ]);
+  });
+
+  test('treats non-federated packages as singleton groups', () async {
+    final groups = await discoverPackages(fixture.root.path);
+    final group = groups.firstWhere((g) => g.key == 'datadog_dio');
+
+    expect(group.isFederated, isFalse);
+    expect(group.members.single.role, PackageRole.appFacing);
+  });
+
+  test(
+    'a lone package with a federation-looking suffix is not misclassified as an implementation',
+    () async {
+      final groups = await discoverPackages(fixture.root.path);
+      final group = groups.firstWhere((g) => g.key == 'lonely_ios');
+
+      expect(group.isFederated, isFalse);
+      expect(group.members.single.name, 'lonely_ios');
+      expect(group.members.single.role, PackageRole.appFacing);
+    },
+  );
+
+  test(
+    'resolves each package to its real directory, not an assumed flat path',
+    () async {
+      final groups = await discoverPackages(fixture.root.path);
+      final ios = groups
+          .expand((g) => g.members)
+          .firstWhere((pkg) => pkg.name == 'datadog_flutter_plugin_ios');
+
+      expect(
+        ios.relativePath,
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios',
+      );
+    },
+  );
+}

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:test/test.dart';
+
+import 'package:releaser/release_plan.dart';
+import 'support/fixture_repo.dart';
+
+void main() {
+  late FixtureRepo fixture;
+
+  setUp(() async {
+    fixture = await FixtureRepo.create();
+  });
+
+  tearDown(() => fixture.delete());
+
+  test(
+    'mainline with no requestedPackages returns every discovered package',
+    () async {
+      final plan = await computeReleasePlan(
+        RunContext(
+          repoRoot: fixture.root.path,
+          trigger: TriggerContext.mainline,
+          currentBranch: 'develop',
+        ),
+      );
+
+      final names = plan.packages.map((p) => p.package.name);
+      expect(
+        names,
+        containsAll([
+          'datadog_dio',
+          'datadog_flutter_plugin',
+          'datadog_flutter_plugin_ios',
+          'lonely_ios',
+        ]),
+      );
+      expect(names, isNot(contains('datadog_common_test')));
+    },
+  );
+
+  test('mainline with requestedPackages filters to just those', () async {
+    final plan = await computeReleasePlan(
+      RunContext(
+        repoRoot: fixture.root.path,
+        trigger: TriggerContext.mainline,
+        currentBranch: 'develop',
+        requestedPackages: ['datadog_dio', 'datadog_flutter_plugin_ios'],
+      ),
+    );
+
+    expect(
+      plan.packages.map((p) => p.package.name),
+      unorderedEquals(['datadog_dio', 'datadog_flutter_plugin_ios']),
+    );
+  });
+
+  test(
+    'patch branch resolves the single named package with no grouping',
+    () async {
+      final plan = await computeReleasePlan(
+        RunContext(
+          repoRoot: fixture.root.path,
+          trigger: TriggerContext.patch,
+          currentBranch: 'release/datadog_dio/v1.1.x',
+        ),
+      );
+
+      expect(plan.packages, hasLength(1));
+      expect(plan.packages.single.package.name, 'datadog_dio');
+    },
+  );
+
+  test(
+    'patch branch on a federated member still selects only that one package',
+    () async {
+      final plan = await computeReleasePlan(
+        RunContext(
+          repoRoot: fixture.root.path,
+          trigger: TriggerContext.patch,
+          currentBranch: 'release/datadog_flutter_plugin_ios/v1.0.x',
+        ),
+      );
+
+      expect(plan.packages, hasLength(1));
+      expect(plan.packages.single.package.name, 'datadog_flutter_plugin_ios');
+    },
+  );
+
+  test('patch branch with a malformed name throws', () async {
+    await expectLater(
+      computeReleasePlan(
+        RunContext(
+          repoRoot: fixture.root.path,
+          trigger: TriggerContext.patch,
+          currentBranch: 'not-a-patch-branch',
+        ),
+      ),
+      throwsStateError,
+    );
+  });
+
+  test('patch branch naming an unknown package throws', () async {
+    await expectLater(
+      computeReleasePlan(
+        RunContext(
+          repoRoot: fixture.root.path,
+          trigger: TriggerContext.patch,
+          currentBranch: 'release/does_not_exist/v1.0.x',
+        ),
+      ),
+      throwsStateError,
+    );
+  });
+}

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -57,6 +57,20 @@ void main() {
     );
   });
 
+  test('mainline with an unknown requested package throws', () async {
+    await expectLater(
+      computeReleasePlan(
+        RunContext(
+          repoRoot: fixture.root.path,
+          trigger: TriggerContext.mainline,
+          currentBranch: 'develop',
+          requestedPackages: ['datadog_dio', 'does_not_exist'],
+        ),
+      ),
+      throwsStateError,
+    );
+  });
+
   test(
     'patch branch resolves the single named package with no grouping',
     () async {
@@ -113,5 +127,21 @@ void main() {
       ),
       throwsStateError,
     );
+  });
+
+  test('patch branch ignores an inherited requestedPackages filter', () async {
+    final plan = await computeReleasePlan(
+      RunContext(
+        repoRoot: fixture.root.path,
+        trigger: TriggerContext.patch,
+        currentBranch: 'release/datadog_dio/v1.1.x',
+        // Simulates a stale/inherited PACKAGES env var that doesn't name
+        // this branch's package -- it must not empty out the plan.
+        requestedPackages: ['some_other_package'],
+      ),
+    );
+
+    expect(plan.packages, hasLength(1));
+    expect(plan.packages.single.package.name, 'datadog_dio');
   });
 }

--- a/tools/releaser/test/support/fixture_repo.dart
+++ b/tools/releaser/test/support/fixture_repo.dart
@@ -7,11 +7,12 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 
 /// A throwaway pubspec.yaml tree, mirroring the shapes that matter in
-/// dd-sdk-flutter's real `packages/` layout (a federated group, several
-/// singletons, an intentionally-unpublished support package, an example
-/// app, and a package whose name merely *looks* federated). Discovery
-/// tests run against this instead of the real tree so they don't depend
-/// on -- or get broken by -- packages/ changing over time.
+/// dd-sdk-flutter's real `packages/` layout (a federated group with all
+/// four real platform implementations, several singletons, an
+/// intentionally-unpublished support package, an example app, and a
+/// package whose name merely *looks* federated). Discovery tests run
+/// against this instead of the real tree so they don't depend on -- or
+/// get broken by -- packages/ changing over time.
 class FixtureRepo {
   final Directory root;
 
@@ -67,6 +68,16 @@ class FixtureRepo {
       '$flutterPluginBase/datadog_flutter_plugin_ios/example',
       name: 'datadog_flutter_plugin_ios_example',
       publishTo: 'none',
+    );
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin_web',
+      name: 'datadog_flutter_plugin_web',
+      version: '1.0.0',
+    );
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin_desktop',
+      name: 'datadog_flutter_plugin_desktop',
+      version: '1.0.0',
     );
     repo._writePubspec(
       '$flutterPluginBase/datadog_flutter_plugin',

--- a/tools/releaser/test/support/fixture_repo.dart
+++ b/tools/releaser/test/support/fixture_repo.dart
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// A throwaway pubspec.yaml tree, mirroring the shapes that matter in
+/// dd-sdk-flutter's real `packages/` layout (a federated group, several
+/// singletons, an intentionally-unpublished support package, an example
+/// app, and a package whose name merely *looks* federated). Discovery
+/// tests run against this instead of the real tree so they don't depend
+/// on -- or get broken by -- packages/ changing over time.
+class FixtureRepo {
+  final Directory root;
+
+  FixtureRepo._(this.root);
+
+  static Future<FixtureRepo> create() async {
+    final root = await Directory.systemTemp.createTemp('releaser_test_');
+    final repo = FixtureRepo._(root);
+
+    repo._writePubspec(
+      'packages/datadog_dio',
+      name: 'datadog_dio',
+      version: '2.3.0',
+    );
+    repo._writePubspec(
+      'packages/datadog_dio/example',
+      name: 'datadog_dio_example',
+      publishTo: 'none',
+    );
+
+    repo._writePubspec(
+      'packages/datadog_common_test',
+      name: 'datadog_common_test',
+      publishTo: 'none',
+    );
+
+    // Ends in a federation suffix but has no siblings -- must stay a
+    // singleton under its own name, not get collapsed into a "lonely"
+    // group of one.
+    repo._writePubspec(
+      'packages/lonely_ios',
+      name: 'lonely_ios',
+      version: '1.0.0',
+    );
+
+    const flutterPluginBase = 'packages/datadog_flutter_plugin';
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin_platform_interface',
+      name: 'datadog_flutter_plugin_platform_interface',
+      version: '1.0.0',
+    );
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin_android',
+      name: 'datadog_flutter_plugin_android',
+      version: '1.0.0',
+    );
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin_ios',
+      name: 'datadog_flutter_plugin_ios',
+      version: '1.0.0',
+    );
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin_ios/example',
+      name: 'datadog_flutter_plugin_ios_example',
+      publishTo: 'none',
+    );
+    repo._writePubspec(
+      '$flutterPluginBase/datadog_flutter_plugin',
+      name: 'datadog_flutter_plugin',
+      version: '4.0.0',
+    );
+
+    return repo;
+  }
+
+  void _writePubspec(
+    String relativeDir, {
+    required String name,
+    String? version,
+    String? publishTo,
+  }) {
+    final dir = Directory(p.join(root.path, relativeDir));
+    dir.createSync(recursive: true);
+
+    final buffer = StringBuffer('name: $name\n');
+    if (version != null) buffer.writeln('version: $version');
+    if (publishTo != null) buffer.writeln("publish_to: '$publishTo'");
+    buffer.writeln('environment:\n  sdk: ^3.0.0');
+
+    File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync(buffer.toString());
+  }
+
+  Future<void> delete() => root.delete(recursive: true);
+}


### PR DESCRIPTION
### What and why?

We're working on a new / simpler release process for all of the Flutter libraries, which will be necessary when we're close to 15+ with the new federation system. This is the first step to provide tooling that will be able to determine what changes occurred in each package and the nature of those changes are.

This portion replaces the hardcoded, federation-unaware package_list.dart approach with dynamic discovery (packages grouped by shared parent directory, ordered by publish dependency: platform interface -> impls -> app-facing) and a shared release_plan.dart that will let preview/prepare release tooling compute the same plan without duplicating logic.

Also started adding unit tests to better check our release tooling.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
