### PR TITLE
chore: Fix issues from Dart 3.13 upgrade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,7 @@ Next, at the root of the repository, bootstrap melos:
 melos bootstrap
 ```
 
-Next, we need to generate some necessary files with `flutter pub run build_runner build`, 
-and generate `.env` files for the various apps in order to use them with
+Next, we need to generate necessary `.env` files for the various apps in order to use them with
 Datadog. We use Melos for this as well. Run:
 
 ```bash

--- a/melos.yaml
+++ b/melos.yaml
@@ -266,10 +266,9 @@ scripts:
       dirExists: 'example/ios'
 
   prepare:
-    run: melos pub:get && melos build_runner && melos generate_env && melos generate_env:e2e
+    run: melos pub:get && melos generate_env && melos generate_env:e2e
     description: |
-      Run `flutter pub run build_runner build` on all packages and
-      generate `.env` files for all package examples
+      Run `flutter pub get` on all packages and generate `.env` files for all package examples
 
   pub:get:
     exec:
@@ -286,7 +285,7 @@ scripts:
   build_runner:
     exec:
       concurrency: 1
-    run: flutter pub run build_runner build --delete-conflicting-outputs
+    run: dart run build_runner build --delete-conflicting-outputs
     packageFilters:
       dependsOn: build_runner
   

--- a/packages/datadog_common_test/build.yaml
+++ b/packages/datadog_common_test/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        generate_for:
+          - lib/src/request_log.dart

--- a/packages/datadog_dio/example/android/settings.gradle.kts
+++ b/packages/datadog_dio/example/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.0.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/packages/datadog_flutter_plugin/build.yaml
+++ b/packages/datadog_flutter_plugin/build.yaml
@@ -5,3 +5,8 @@ targets:
         - example/**
         - integration_test_app/**
         - e2e_test_app/**
+    builders:
+      json_serializable:
+        generate_for:
+          - lib/src/logs/ddlog_event.dart
+          - lib/src/rum/ddrum_events.dart

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -18,62 +18,11 @@ import 'ddrum_platform_interface.dart';
 import 'inv_metric_provider.dart';
 import 'rum_long_task_observer.dart';
 
-/// HTTP method of the resource
-enum RumHttpMethod { post, get, head, put, delete, patch }
-
 RumHttpMethod rumMethodFromMethodString(String value) {
   var lowerValue = value.toLowerCase();
   return RumHttpMethod.values.firstWhere(
     (e) => e.toString() == 'RumHttpMethod.$lowerValue',
   );
-}
-
-/// Describes the type of a RUM Action.
-enum RumActionType { click, tap, scroll, swipe, custom }
-
-/// Describe the source of a RUM Error.
-enum RumErrorSource {
-  /// Error originated in the source code.
-  source,
-
-  /// Error originated in the network layer.
-  network,
-
-  /// Error originated in a webview.
-  webview,
-
-  /// Error originated in a web console (used by bridges).
-  console,
-
-  /// Custom error source.
-  custom,
-}
-
-/// Describe the type of resource loaded.
-enum RumResourceType {
-  document,
-  image,
-  xhr,
-  beacon,
-  css,
-  fetch,
-  font,
-  js,
-  media,
-  other,
-  native,
-}
-
-/// Represents the possible reasons for a failed feature operation.
-enum RumFeatureOperationFailureReason {
-  /// Represents a failure caused by an error during execution.
-  error,
-
-  /// Represents a failure caused by user or process abandonment.
-  abandoned,
-
-  /// Represents a failure due to other unspecified reasons.
-  other
 }
 
 RumResourceType resourceTypeFromContentType(ContentType? type) {

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_enums.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_enums.dart
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-Present Datadog, Inc.
+
+/// HTTP method of the resource
+enum RumHttpMethod { post, get, head, put, delete, patch }
+
+/// Describes the type of a RUM Action.
+enum RumActionType { click, tap, scroll, swipe, custom }
+
+/// Describe the source of a RUM Error.
+enum RumErrorSource {
+  /// Error originated in the source code.
+  source,
+
+  /// Error originated in the network layer.
+  network,
+
+  /// Error originated in a webview.
+  webview,
+
+  /// Error originated in a web console (used by bridges).
+  console,
+
+  /// Custom error source.
+  custom,
+}
+
+/// Describe the type of resource loaded.
+enum RumResourceType {
+  document,
+  image,
+  xhr,
+  beacon,
+  css,
+  fetch,
+  font,
+  js,
+  media,
+  other,
+  native,
+}
+
+/// Represents the possible reasons for a failed feature operation.
+enum RumFeatureOperationFailureReason {
+  /// Represents a failure caused by an error during execution.
+  error,
+
+  /// Represents a failure caused by user or process abandonment.
+  abandoned,
+
+  /// Represents a failure due to other unspecified reasons.
+  other
+}

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_events.dart
@@ -4,8 +4,8 @@
 
 import 'package:json_annotation/json_annotation.dart';
 
-import '../../datadog_flutter_plugin.dart';
 import '../json_helpers.dart';
+import 'ddrum_enums.dart';
 
 part 'ddrum_events.g.dart';
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/rum.dart
@@ -3,6 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 export 'ddrum.dart';
+export 'ddrum_enums.dart';
 export 'ddrum_events.dart';
 export 'navigation_observer.dart';
 export 'resource_headers_extractor.dart';

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -7,8 +7,8 @@ import 'dart:math';
 
 import 'package:datadog_common_test/datadog_common_test.dart';
 import 'package:datadog_flutter_plugin/datadog_internal.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/ddrum_method_channel.dart';
+import 'package:datadog_flutter_plugin/src/rum/rum.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/datadog_flutter_plugin/test/rum/inv_metric_provider_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/inv_metric_provider_test.dart
@@ -3,8 +3,8 @@
 // Copyright 2025-Present Datadog, Inc.
 
 import 'package:datadog_common_test/datadog_common_test.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
 import 'package:datadog_flutter_plugin/src/rum/inv_metric_provider.dart';
+import 'package:datadog_flutter_plugin/src/rum/rum.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 const defaultFirstBuildTime = Duration(milliseconds: 38);

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -3,8 +3,7 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import 'package:datadog_common_test/datadog_common_test.dart';
-import 'package:datadog_flutter_plugin/src/rum/ddrum.dart';
-import 'package:datadog_flutter_plugin/src/rum/rum_user_action_detector.dart';
+import 'package:datadog_flutter_plugin/src/rum/rum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/datadog_session_replay/build.yaml
+++ b/packages/datadog_session_replay/build.yaml
@@ -3,3 +3,7 @@ targets:
     sources:
       exclude:
         - example/**
+    builders:
+      json_serializable:
+        generate_for:
+          - lib/src/sr_data_models.dart


### PR DESCRIPTION
### What and why?

Dart 3.13 added dot shorthand, which Flutter 3.47 uses extensively. But, because we're using older versions of `json_serializable` (which include older versions of `analyzer`), running json generation on files that include that doc shorthand causes the generation to crash.

Fix by only running the json_serializable on files that need it, and moving RUM enums out of a file that includes `flutter` libraries so that `ddrum_events.dart` can import them cleanly.

Thankfully, this doesn't affect consumers of the library as we ship pre-generated files, and they do not have to run the generation themselves.

Remove JSON generation from our build as well. This was done when we didn't commit the generated files and is no longer necessary.

Also fix datadog_dio build issues with Flutter 3.47.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
