### PR TITLE
chore: Fix multiple warnings that were language version dependent

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -140,7 +140,7 @@ scripts:
   unit_test:windows:
     exec:
       concurrency: 1
-    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/$MELOS_PACKAGE_NAME_unit.xml -- flutter test --machine
+    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/${MELOS_PACKAGE_NAME}_unit.xml -- flutter test --machine
     packageFilters:
       dirExists: 'test'
       ignore:
@@ -149,7 +149,7 @@ scripts:
   unit_test:linux:
     exec:
       concurrency: 1
-    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/$MELOS_PACKAGE_NAME_unit.xml -- flutter test --machine
+    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/${MELOS_PACKAGE_NAME}_unit.xml -- flutter test --machine
     packageFilters:
       dirExists: 'test'
       ignore:

--- a/melos.yaml
+++ b/melos.yaml
@@ -298,9 +298,9 @@ scripts:
       concurrency: 1
     run: |
       cd example
-      dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results
+      dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results --verbose
     packageFilters:
-      dirExists: 
+      dirExists:
         - 'example/integration_test'
         - 'example/linux'
       ignore:
@@ -311,7 +311,7 @@ scripts:
   integration_test:linux:main:
     exec: |
       cd integration_test_app
-      dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results
+      dart $MELOS_ROOT_PATH/tools/ci/bin/desktop_integration_tests.dart --output $MELOS_ROOT_PATH/.build/test-results --verbose
     packageFilters:
       scope: 'datadog_flutter_plugin'
 

--- a/melos.yaml
+++ b/melos.yaml
@@ -138,18 +138,14 @@ scripts:
         - 'datadog_flutter_plugin_web'
 
   unit_test:windows:
-    exec:
-      concurrency: 1
-    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/${MELOS_PACKAGE_NAME}_unit.xml -- flutter test --machine
+    run: melos exec -c 1 -- "dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit.xml -- flutter test --machine"
     packageFilters:
       dirExists: 'test'
       ignore:
         - 'datadog_flutter_plugin_web'
 
   unit_test:linux:
-    exec:
-      concurrency: 1
-    run: dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/${MELOS_PACKAGE_NAME}_unit.xml -- flutter test --machine
+    run: melos exec -c 1 -- "dart $MELOS_ROOT_PATH/tools/ci/bin/run_with_junit.dart --output $MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit.xml -- flutter test --machine"
     packageFilters:
       dirExists: 'test'
       ignore:
@@ -264,6 +260,21 @@ scripts:
       scope: 'datadog_flutter_plugin'
 
   integration_test:windows:
+    run: melos integration_test:windows:build && melos verify:ffi_bindings && melos integration_test:windows:tests
+
+  # Only exists to populate the CMake FetchContent headers that
+  # verify:ffi_bindings regenerates against. Scoped to the desktop plugin's
+  # example because that is the tree ffigen.yaml points at, and built debug
+  # rather than release: `melos build:windows` would build four examples into a
+  # separate release tree, none of which the integration tests below reuse.
+  integration_test:windows:build:
+    exec:
+      concurrency: 1
+    run: cd example && flutter build windows --debug
+    packageFilters:
+      scope: 'datadog_flutter_plugin_desktop'
+
+  integration_test:windows:tests:
     run: melos integration_test:windows:main && melos integration_test:windows:other
 
   # Desktop platforms can't run the whole integration_test directory in one `flutter test`
@@ -287,7 +298,29 @@ scripts:
     packageFilters:
       scope: 'datadog_flutter_plugin'
 
+  # Regenerates datadog_flutter_plugin_desktop's ffigen bindings and fails if the
+  # result differs from what is committed. dd-sdk-cpp is pulled by CMake
+  # FetchContent, so its C API can move without anything in this repo changing.
+  # Drift is not a compile error: Dart allocates sizeOf<T>() bytes and the C SDK
+  # writes sizeof(struct T) into them, so a struct that grew upstream shows up as
+  # heap corruption in an unrelated test instead. Desktop-only, and requires a
+  # desktop build to have populated the FetchContent headers first.
+  verify:ffi_bindings:
+    run: dart $MELOS_ROOT_PATH/tools/ci/bin/verify_ffi_bindings.dart
+
   integration_test:linux:
+    run: melos integration_test:linux:build && melos verify:ffi_bindings && melos integration_test:linux:tests
+
+  # See integration_test:windows:build -- populates the FetchContent headers for
+  # verify:ffi_bindings, nothing more.
+  integration_test:linux:build:
+    exec:
+      concurrency: 1
+    run: cd example && flutter build linux --debug
+    packageFilters:
+      scope: 'datadog_flutter_plugin_desktop'
+
+  integration_test:linux:tests:
     run: melos integration_test:linux:main && melos integration_test:linux:other
 
   # Desktop platforms can't run the whole integration_test directory in one `flutter test`

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/example/lib/example_app.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/example/lib/example_app.dart
@@ -41,19 +41,19 @@ class _ExampleAppState extends State<ExampleApp> {
 
     router.define(
       '/logging',
-      handler: Handler(handlerFunc: (_, __) => const LoggingScreen()),
+      handler: Handler(handlerFunc: (_, _) => const LoggingScreen()),
     );
     router.define(
       '/rum',
-      handler: Handler(handlerFunc: (_, __) => const RumScreen()),
+      handler: Handler(handlerFunc: (_, _) => const RumScreen()),
     );
     router.define(
       '/rum_user_actions',
-      handler: Handler(handlerFunc: (_, __) => const RumUserActionsScreen()),
+      handler: Handler(handlerFunc: (_, _) => const RumUserActionsScreen()),
     );
     router.define(
       '/rum_crash_reporting',
-      handler: Handler(handlerFunc: (_, __) => const CrashReportingScreen()),
+      handler: Handler(handlerFunc: (_, _) => const CrashReportingScreen()),
     );
   }
 

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/example/lib/rum_screen.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/example/lib/rum_screen.dart
@@ -254,7 +254,7 @@ class _RumScreenState extends State<RumScreen> {
                         padding: const EdgeInsets.all(8),
                         margin: const EdgeInsets.symmetric(vertical: 4),
                         decoration: BoxDecoration(
-                          color: Colors.green.withOpacity(0.2),
+                          color: Colors.green.withValues(alpha: 0.2),
                           borderRadius: BorderRadius.circular(4),
                         ),
                         child: const Text(

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/test/logs/ddlogs_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/test/logs/ddlogs_test.dart
@@ -405,7 +405,7 @@ void main() {
       var printLog = <String>[];
       void Function() overridePrint(void Function() testFn) => () {
         var spec = ZoneSpecification(
-          print: (_, __, ___, String msg) {
+          print: (_, _, _, String msg) {
             // Add to log instead of printing to stdout
             printLog.add(msg);
           },

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -1165,7 +1165,10 @@ void main() {
     await tester.pumpWidget(
       _buildSimpleApp(
         mockRum,
-        Radio(groupValue: 0, onChanged: (value) {}, value: 1),
+        RadioGroup(
+          onChanged: (value) {},
+          child: Column(children: [Radio(value: 1)]),
+        ),
       ),
     );
 
@@ -1185,7 +1188,10 @@ void main() {
         mockRum,
         RumUserActionAnnotation(
           description: annotation,
-          child: Radio(groupValue: 0, onChanged: (value) {}, value: 1),
+          child: RadioGroup(
+            onChanged: (value) {},
+            child: Column(children: [Radio(value: 1)]),
+          ),
         ),
       ),
     );

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/ffigen.yaml
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/ffigen.yaml
@@ -1,8 +1,18 @@
-# Run: dart run ffigen --config ffigen.yaml
+# Prefer: dart tools/ci/bin/verify_ffi_bindings.dart --write
 #
-# Before running, build the example app for Windows to populate the FetchContent cache:
+# That regenerates using this config but retargets the header paths below at
+# whichever FetchContent tree actually exists, so it works on Linux as well as
+# Windows. `melos run verify:ffi_bindings` runs the same thing in check mode.
+#
+# To run ffigen directly instead, build the example app for Windows first, to
+# populate the FetchContent cache:
 #   cd example && flutter build windows
 # Headers land at: example/build/windows/x64/_deps/dd-sdk-cpp-src/include-c/
+#
+# include-directives is deliberately a loose glob rather than the entry-point
+# path: an exact prefix silently dropped every declaration from timestamp.h and
+# uuid.h (they are reached via attribute.h, not directly from datadog.h), which
+# removed 12 functions from the generated bindings.
 name: DdSdkFfi
 description: 'Auto-generated FFI bindings for the dd-sdk-cpp C API.'
 output: 'lib/src/ffi_bindings.dart'
@@ -11,7 +21,7 @@ headers:
   entry-points:
     - 'example/build/windows/x64/_deps/dd-sdk-cpp-src/include-c/datadog.h'
   include-directives:
-    - 'example/build/windows/x64/_deps/dd-sdk-cpp-src/include-c/**'
+    - '**/dd-sdk-cpp-src/include-c/**'
 
 functions:
   # Only pure value/struct functions are safe to mark as leaf calls. Anything that

--- a/packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/lib/src/ffi_bindings.dart
+++ b/packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/lib/src/ffi_bindings.dart
@@ -1746,6 +1746,16 @@ class DdSdkFfi {
       _dd_logger_config_set_enrich_with_rum_contextPtr
           .asFunction<void Function(ffi.Pointer<dd_logger_config_t>, bool)>();
 
+  /// Attribute key that, when included in the `attributes` passed to a log call, sets
+  /// a custom Error Tracking grouping fingerprint on the resulting log event.
+  late final ffi.Pointer<ffi.Pointer<ffi.Char>>
+  _DD_LOG_ERROR_FINGERPRINT_ATTRIBUTE_KEY = _lookup<ffi.Pointer<ffi.Char>>(
+    'DD_LOG_ERROR_FINGERPRINT_ATTRIBUTE_KEY',
+  );
+
+  ffi.Pointer<ffi.Char> get DD_LOG_ERROR_FINGERPRINT_ATTRIBUTE_KEY =>
+      _DD_LOG_ERROR_FINGERPRINT_ATTRIBUTE_KEY.value;
+
   /// Registers the logging feature with the core of the Datadog SDK. MUST be matched with
   /// a call to dd_logging_destroy().
   ffi.Pointer<dd_logging_t> dd_logging_init(ffi.Pointer<dd_core_t> core) {
@@ -2323,6 +2333,39 @@ class DdSdkFfi {
   late final _dd_rum_config_set_session_sample_rate =
       _dd_rum_config_set_session_sample_ratePtr
           .asFunction<void Function(ffi.Pointer<dd_rum_config_t>, double)>();
+
+  /// Sets whether an anonymous user id should be generated and tracked for the current
+  /// device, persisted across app launches. If true (the default), a randomly-generated
+  /// id is written to a file in the SDK's configured storage directory and is included as
+  /// `usr.anonymous_id` on RUM and Log events.
+  void dd_rum_config_set_track_anonymous_user(
+    ffi.Pointer<dd_rum_config_t> config,
+    bool value,
+  ) {
+    return _dd_rum_config_set_track_anonymous_user(config, value);
+  }
+
+  late final _dd_rum_config_set_track_anonymous_userPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<dd_rum_config_t>, ffi.Bool)
+        >
+      >('dd_rum_config_set_track_anonymous_user');
+  late final _dd_rum_config_set_track_anonymous_user =
+      _dd_rum_config_set_track_anonymous_userPtr
+          .asFunction<void Function(ffi.Pointer<dd_rum_config_t>, bool)>();
+
+  /// Attribute key that, when included in the `attributes` passed to
+  /// dd_rum_add_error(), sets a custom Error Tracking grouping fingerprint on the
+  /// resulting RUM error event.
+  late final ffi.Pointer<ffi.Pointer<ffi.Char>>
+  _DD_RUM_ERROR_CUSTOM_FINGERPRINT_ATTRIBUTE_KEY =
+      _lookup<ffi.Pointer<ffi.Char>>(
+        'DD_RUM_ERROR_CUSTOM_FINGERPRINT_ATTRIBUTE_KEY',
+      );
+
+  ffi.Pointer<ffi.Char> get DD_RUM_ERROR_CUSTOM_FINGERPRINT_ATTRIBUTE_KEY =>
+      _DD_RUM_ERROR_CUSTOM_FINGERPRINT_ATTRIBUTE_KEY.value;
 
   /// Registers the RUM feature with the core of the Datadog SDK. MUST be matched with
   /// a call to dd_rum_destroy().
@@ -3464,6 +3507,9 @@ final class dd_rum_config extends ffi.Struct {
 
   @ffi.Float()
   external double session_sample_rate;
+
+  @ffi.Bool()
+  external bool track_anonymous_user;
 }
 
 /// RUM configuration struct: initialize with dd_rum_config_init(), then call

--- a/packages/datadog_grpc_interceptor/lib/datadog_grpc_interceptor.dart
+++ b/packages/datadog_grpc_interceptor/lib/datadog_grpc_interceptor.dart
@@ -2,6 +2,4 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-library datadog_grpc_interceptor;
-
 export 'src/datadog_grpc_interceptor.dart';

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -1,7 +1,7 @@
 name: datadog_grpc_interceptor
 description: A plugin for use with the DatadogSdk, used to track performance of gRPC and enable Datadog Distributed Tracing.
 version: 2.1.0
-homepage: http://datadoghq.com
+homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:

--- a/packages/datadog_session_replay/example/lib/screens/material_widgets_screen.dart
+++ b/packages/datadog_session_replay/example/lib/screens/material_widgets_screen.dart
@@ -101,29 +101,25 @@ class _MaterialWidgetsScreenState extends State<MaterialWidgetsScreen> {
               ),
               _WidgetDisplay(
                 name: 'Radio',
-                builder: (_) => Column(
-                  children: [
-                    Row(
-                      children: [
-                        Radio<String>(
-                          value: 'a',
-                          groupValue: _radioValue,
-                          onChanged: _onRadioChanged,
-                        ),
-                        Text('A'),
-                      ],
-                    ),
-                    Row(
-                      children: [
-                        Radio<String>(
-                          value: 'b',
-                          groupValue: _radioValue,
-                          onChanged: _onRadioChanged,
-                        ),
-                        Text('B'),
-                      ],
-                    ),
-                  ],
+                builder: (_) => RadioGroup(
+                  onChanged: _onRadioChanged,
+                  groupValue: _radioValue,
+                  child: Column(
+                    children: [
+                      Row(
+                        children: [
+                          Radio<String>(value: 'a'),
+                          Text('A'),
+                        ],
+                      ),
+                      Row(
+                        children: [
+                          Radio<String>(value: 'b'),
+                          Text('B'),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
               _WidgetDisplay(

--- a/packages/datadog_session_replay/test/capture/image_recorder_test.dart
+++ b/packages/datadog_session_replay/test/capture/image_recorder_test.dart
@@ -826,7 +826,7 @@ void main() {
           ImageRecorder(
             kg,
             imageDownscaling: ImageDownscaling.enabled,
-            downscaleOverride: (_, __, ___) async =>
+            downscaleOverride: (_, _, _) async =>
                 throw StateError('simulated raster failure'),
           ),
         ],
@@ -1270,7 +1270,7 @@ void main() {
             kg6,
             imageDownscaling: ImageDownscaling.enabled,
             circuitBreaker: circuitBreaker,
-            downscaleOverride: (_, __, ___) async {
+            downscaleOverride: (_, _, _) async {
               downscaleCalled = true;
               return smallImage!;
             },

--- a/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
+++ b/packages/datadog_tracking_http_client/lib/src/tracking_http_client_plugin.dart
@@ -15,7 +15,7 @@ import '../datadog_tracking_http_client.dart';
 ///
 /// DatadogTrackingHttpClient allows you to receive a callback when an
 /// HttpClientRequest starts and when an HttpClientResponse finishes. They
-/// provide a resource key and a mutable Map<String, Object?> of attributes that
+/// provide a resource key and a mutable Map&lt;String, Object?&gt; of attributes that
 /// you can modify to add attributes to the resulting Datadog RUM resource.
 ///
 /// The userAttributes parameter supplied in [requestStarted] and

--- a/packages/datadog_webview_tracking/pubspec.yaml
+++ b/packages/datadog_webview_tracking/pubspec.yaml
@@ -1,7 +1,7 @@
 name: datadog_webview_tracking
 description: A package for tracking Datadog sessions in a webview
 version: 3.2.0
-homepage: http://datadoghq.com
+homepage: https://datadoghq.com
 repository: https://github.com/DataDog/dd-sdk-flutter
 
 environment:

--- a/tools/ci/bin/desktop_integration_tests.dart
+++ b/tools/ci/bin/desktop_integration_tests.dart
@@ -31,7 +31,7 @@ String currentDevice() {
 // lib/integration_scenarios/scenario_runner.dart.
 const _dataStorageService = 'com.datadoghq.flutter.integration';
 
-const _appExecutableName = 'datadog_integration_test_app';
+final packageName = Platform.environment['MELOS_PACKAGE_NAME'] ?? 'desktop';
 
 // Mirrors DesktopPlatform._storagePath in datadog_flutter_plugin_desktop.
 Directory _dataStorageDirectory() {
@@ -108,54 +108,44 @@ void main(List<String> arguments) async {
       }
       final testName = path.basenameWithoutExtension(baseName);
 
-      // Desktop `flutter test` occasionally fails with a "did not complete"
-      // / "No tests were found" combo caused by a Flutter/Dart test-harness
-      // race (the local package:test harness channel closing while the app
-      // is still alive and healthy, so retry once before treating it as a
-      // real failure.
-      const maxAttempts = 2;
-      var exitCode = 1;
-      for (var attempt = 1; attempt <= maxAttempts; attempt++) {
-        if (attempt > 1) {
-          await Future.delayed(Duration(seconds: 2));
-          print(
-            '[${_timestamp()}] retrying $testName in 2 seconds (attempt $attempt/$maxAttempts) '
-            'after a possible test-harness flake',
-          );
-        }
+      _deleteStaleDatadogData();
 
-        _deleteStaleDatadogData();
-
-        final args = ['test', 'integration_test/$baseName', '-d', device];
-        // Opt-in: captures the flutter tool's own VM-service/test-harness
-        // logs, which is what we need to confirm whether "did not complete"
-        // failures are a lost connection to a still-alive app versus a real
-        // app-side failure. Off by default since it's very noisy.
-        if (results['verbose'] == true) {
-          args.add('--verbose');
-        }
-        final clientToken = Platform.environment['DD_CLIENT_TOKEN'];
-        if (clientToken != null) {
-          args.addAll(['--dart-define', 'DD_CLIENT_TOKEN=$clientToken']);
-        }
-        final applicationId = Platform.environment['DD_APPLICATION_ID'];
-        if (applicationId != null) {
-          args.addAll(['--dart-define', 'DD_APPLICATION_ID=$applicationId']);
-        }
-
-        final startTime = DateTime.now();
-        // TODO: tojunit was swallowing flutter test's stdout (including
-        // --verbose trace output), so junit reporting is disabled for now
-        // while we diagnose the isolate_tracking_test CI failure.
-        exitCode = await _runTest(args, testName);
-        final elapsed = DateTime.now().difference(startTime);
-        print(
-          '[${_timestamp()}] $testName attempt $attempt finished with exit '
-          'code $exitCode after ${elapsed.inMilliseconds}ms',
-        );
-
-        if (exitCode == 0) break;
+      final args = ['test', 'integration_test/$baseName', '-d', device];
+      // Opt-in: captures the flutter tool's own VM-service/test-harness
+      // logs, which is what we need to confirm whether "did not complete"
+      // failures are a lost connection to a still-alive app versus a real
+      // app-side failure. Off by default since it's very noisy.
+      if (results['verbose'] == true) {
+        args.add('--verbose');
       }
+      final clientToken = Platform.environment['DD_CLIENT_TOKEN'];
+      if (clientToken != null) {
+        args.addAll(['--dart-define', 'DD_CLIENT_TOKEN=$clientToken']);
+      }
+      final applicationId = Platform.environment['DD_APPLICATION_ID'];
+      if (applicationId != null) {
+        args.addAll(['--dart-define', 'DD_APPLICATION_ID=$applicationId']);
+      }
+
+      final startTime = DateTime.now();
+
+      if (outputDir != null) {
+        final outputFile = path.join(
+          outputDir,
+          '${packageName}_${device}_integration_$testName.xml',
+        );
+        exitCode = await _runTestWithJunit(
+          [...args, '--machine'],
+          outputFile,
+          testName,
+        );
+      } else {
+        exitCode = await _runTest(args, testName);
+      }
+      final elapsed = DateTime.now().difference(startTime);
+      print(
+        '[${_timestamp()}] $testName attempt finished with exit code $exitCode after ${elapsed.inMilliseconds}ms',
+      );
 
       if (exitCode != 0) {
         print('Command failed');

--- a/tools/ci/bin/desktop_integration_tests.dart
+++ b/tools/ci/bin/desktop_integration_tests.dart
@@ -31,6 +31,8 @@ String currentDevice() {
 // lib/integration_scenarios/scenario_runner.dart.
 const _dataStorageService = 'com.datadoghq.flutter.integration';
 
+const _appExecutableName = 'datadog_integration_test_app';
+
 // Mirrors DesktopPlatform._storagePath in datadog_flutter_plugin_desktop.
 Directory _dataStorageDirectory() {
   if (Platform.isWindows) {
@@ -46,10 +48,22 @@ Directory _dataStorageDirectory() {
 // data can otherwise leak into the next test file's run.
 void _deleteStaleDatadogData() {
   final dir = _dataStorageDirectory();
-  if (dir.existsSync()) {
+  if (!dir.existsSync()) {
+    return;
+  }
+  try {
     dir.deleteSync(recursive: true);
+  } catch (e) {
+    // If a previous test's process hasn't fully released its file handles
+    // yet, this delete can fail. It could mean the previous process outlived
+    // `flutter test`, so surface it loudly instead of silently retrying or
+    // swallowing it.
+    print('[${_timestamp()}] WARNING: failed to delete $dir: $e');
+    rethrow;
   }
 }
+
+String _timestamp() => DateTime.now().toIso8601String();
 
 void main(List<String> arguments) async {
   final parser = ArgParser()
@@ -59,6 +73,11 @@ void main(List<String> arguments) async {
       help:
           'Directory to write a junit XML report per test file to. If '
           'omitted, test output is streamed to the console instead.',
+    )
+    ..addFlag(
+      'verbose',
+      abbr: 'v',
+      help: 'Enable verbose output from flutter test',
     );
   final results = parser.parse(arguments);
   final outputDir = results['output'] as String?;
@@ -90,27 +109,62 @@ void main(List<String> arguments) async {
       }
       final testName = path.basenameWithoutExtension(baseName);
 
-      _deleteStaleDatadogData();
+      // Desktop `flutter test` occasionally fails with a "did not complete"
+      // / "No tests were found" combo caused by a Flutter/Dart test-harness
+      // race (the local package:test harness channel closing while the app
+      // is still alive and healthy, so retry once before treating it as a
+      // real failure.
+      const maxAttempts = 2;
+      var exitCode = 1;
+      for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+        if (attempt > 1) {
+          await Future.delayed(Duration(seconds: 2));
+          print(
+            '[${_timestamp()}] retrying $testName in 2 seconds (attempt $attempt/$maxAttempts) '
+            'after a possible test-harness flake',
+          );
+        }
 
-      final args = ['test', 'integration_test/$baseName', '-d', device];
-      final clientToken = Platform.environment['DD_CLIENT_TOKEN'];
-      if (clientToken != null) {
-        args.addAll(['--dart-define', 'DD_CLIENT_TOKEN=$clientToken']);
-      }
-      final applicationId = Platform.environment['DD_APPLICATION_ID'];
-      if (applicationId != null) {
-        args.addAll(['--dart-define', 'DD_APPLICATION_ID=$applicationId']);
-      }
+        _deleteStaleDatadogData();
 
-      int exitCode;
-      if (outputDir != null) {
-        final outputFile = path.join(
-          outputDir,
-          '${packageName}_${device}_integration_$testName.xml',
+        final args = ['test', 'integration_test/$baseName', '-d', device];
+        // Opt-in: captures the flutter tool's own VM-service/test-harness
+        // logs, which is what we need to confirm whether "did not complete"
+        // failures are a lost connection to a still-alive app versus a real
+        // app-side failure. Off by default since it's very noisy.
+        if (results['verbose'] == true) {
+          args.add('--verbose');
+        }
+        final clientToken = Platform.environment['DD_CLIENT_TOKEN'];
+        if (clientToken != null) {
+          args.addAll(['--dart-define', 'DD_CLIENT_TOKEN=$clientToken']);
+        }
+        final applicationId = Platform.environment['DD_APPLICATION_ID'];
+        if (applicationId != null) {
+          args.addAll(['--dart-define', 'DD_APPLICATION_ID=$applicationId']);
+        }
+
+        final startTime = DateTime.now();
+        if (outputDir != null) {
+          final outputFile = path.join(
+            outputDir,
+            '${packageName}_${device}_integration_$testName.xml',
+          );
+          exitCode = await _runTestWithJunit(
+            [...args, '--machine'],
+            outputFile,
+            testName,
+          );
+        } else {
+          exitCode = await _runTest(args, testName);
+        }
+        final elapsed = DateTime.now().difference(startTime);
+        print(
+          '[${_timestamp()}] $testName attempt $attempt finished with exit '
+          'code $exitCode after ${elapsed.inMilliseconds}ms',
         );
-        exitCode = await _runTestWithJunit([...args, '--machine'], outputFile);
-      } else {
-        exitCode = await _runTest(args);
+
+        if (exitCode == 0) break;
       }
 
       if (exitCode != 0) {
@@ -121,8 +175,8 @@ void main(List<String> arguments) async {
   }
 }
 
-Future<int> _runTest(List<String> args) async {
-  print('flutter ${args.join(' ')}');
+Future<int> _runTest(List<String> args, String testName) async {
+  print('[${_timestamp()}] flutter ${args.join(' ')}');
   final process = await Process.start(
     'flutter',
     args,
@@ -131,17 +185,25 @@ Future<int> _runTest(List<String> args) async {
   process.stdout
       .transform(utf8.decoder)
       .transform(const LineSplitter())
-      .listen(print);
+      .listen((line) => print('[${_timestamp()}] $line'));
   process.stderr
       .transform(utf8.decoder)
       .transform(const LineSplitter())
-      .listen(print);
+      .listen((line) => print('[${_timestamp()}] $line'));
 
-  return process.exitCode;
+  final exitCode = await process.exitCode;
+
+  return exitCode;
 }
 
-Future<int> _runTestWithJunit(List<String> args, String outputFile) async {
-  print('flutter ${args.join(' ')} | tojunit --output $outputFile');
+Future<int> _runTestWithJunit(
+  List<String> args,
+  String outputFile,
+  String testName,
+) async {
+  print(
+    '[${_timestamp()}] flutter ${args.join(' ')} | tojunit --output $outputFile',
+  );
   final testProcess = await Process.start(
     'flutter',
     args,
@@ -155,7 +217,7 @@ Future<int> _runTestWithJunit(List<String> args, String outputFile) async {
   testProcess.stderr
       .transform(utf8.decoder)
       .transform(const LineSplitter())
-      .listen(print);
+      .listen((line) => print('[${_timestamp()}] $line'));
 
   // If tojunit exits early (e.g. it can't parse the test output) it closes its
   // stdin, and writing to it after that throws - swallow that here so a tojunit
@@ -167,7 +229,9 @@ Future<int> _runTestWithJunit(List<String> args, String outputFile) async {
   await pipeDone;
   final tojunitExitCode = await tojunitProcess.exitCode;
   if (tojunitExitCode != 0) {
-    print('tojunit failed with exit code $tojunitExitCode for $outputFile');
+    print(
+      '[${_timestamp()}] tojunit failed with exit code $tojunitExitCode for $outputFile',
+    );
   }
 
   return testExitCode;

--- a/tools/ci/bin/desktop_integration_tests.dart
+++ b/tools/ci/bin/desktop_integration_tests.dart
@@ -92,7 +92,6 @@ void main(List<String> arguments) async {
   }
 
   final device = currentDevice();
-  final packageName = Platform.environment['MELOS_PACKAGE_NAME'] ?? 'desktop';
 
   if (outputDir != null) {
     Directory(outputDir).createSync(recursive: true);
@@ -145,19 +144,10 @@ void main(List<String> arguments) async {
         }
 
         final startTime = DateTime.now();
-        if (outputDir != null) {
-          final outputFile = path.join(
-            outputDir,
-            '${packageName}_${device}_integration_$testName.xml',
-          );
-          exitCode = await _runTestWithJunit(
-            [...args, '--machine'],
-            outputFile,
-            testName,
-          );
-        } else {
-          exitCode = await _runTest(args, testName);
-        }
+        // TODO: tojunit was swallowing flutter test's stdout (including
+        // --verbose trace output), so junit reporting is disabled for now
+        // while we diagnose the isolate_tracking_test CI failure.
+        exitCode = await _runTest(args, testName);
         final elapsed = DateTime.now().difference(startTime);
         print(
           '[${_timestamp()}] $testName attempt $attempt finished with exit '

--- a/tools/ci/bin/verify_ffi_bindings.dart
+++ b/tools/ci/bin/verify_ffi_bindings.dart
@@ -1,0 +1,209 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-Present Datadog, Inc.
+// ignore_for_file: avoid_print
+
+// Regenerates datadog_flutter_plugin_desktop's ffigen bindings and fails if the
+// result differs from the checked-in file on disk.
+//
+// The bindings mirror C structs from dd-sdk-cpp, which CMake FetchContent pulls
+// at build time, so the C API can move without anything in this repo changing.
+// Drift is not a compile error: Dart allocates sizeOf<T>() bytes from the arena
+// and the C SDK writes sizeof(struct T) bytes into that allocation. When
+// dd_rum_config gained a field upstream, Dart kept allocating 24 bytes while
+// dd_rum_config_init() wrote 28. glibc does not notice the 4-byte overflow until
+// some later, unrelated free(), so the symptom was an abort() ("free(): invalid
+// next size") partway through SDK init that read as a test-harness or background
+// isolate problem rather than a bindings problem.
+//
+// Requires a desktop build to have run first, so the FetchContent headers exist.
+// ffigen.yaml's header paths point at the Windows build tree; this retargets them
+// at whichever tree is actually present, so the same check runs on Linux too.
+//
+// Usage:
+//   dart tools/ci/bin/verify_ffi_bindings.dart [--headers <dir>] [--write]
+//
+//     --headers <dir>   Path to dd-sdk-cpp include-c. When omitted, the most
+//                       recently built FetchContent tree is used.
+//     --write           Leave the regenerated file in place instead of restoring
+//                       it (i.e. accept the new output).
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+const _desktopPkgRelPath =
+    'packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop';
+const _bindingsRelPath = 'lib/src/ffi_bindings.dart';
+
+String? _option(List<String> args, String name) {
+  final i = args.indexOf(name);
+  return (i >= 0 && i + 1 < args.length) ? args[i + 1] : null;
+}
+
+/// Walks up from this script to find the repository root.
+String _repoRoot() {
+  final fromEnv = Platform.environment['MELOS_ROOT_PATH'];
+  if (fromEnv != null && File(path.join(fromEnv, 'melos.yaml')).existsSync()) {
+    return fromEnv;
+  }
+  var dir = path.dirname(Platform.script.toFilePath());
+  for (var i = 0; i < 8; i++) {
+    if (File(path.join(dir, 'melos.yaml')).existsSync()) return dir;
+    dir = path.dirname(dir);
+  }
+  print('Could not locate the repository root (no melos.yaml found).');
+  exit(2);
+}
+
+/// Where the FetchContent headers land once `integration_test:<platform>:build`
+/// has run. That step always builds the same example, so the path is fixed
+/// rather than something we have to go looking for.
+///
+/// The two platforms differ in shape: Ninja is a single-config generator, so on
+/// Linux the build config is part of the path, while MSVC is multi-config and
+/// puts _deps directly under x64. The Windows layout is the one ffigen.yaml has
+/// always referenced.
+List<Directory> _candidateHeaderDirs(String root) {
+  final exampleBuild = path.join(root, _desktopPkgRelPath, 'example', 'build');
+  Directory dir(List<String> parts) => Directory(
+    path.joinAll([
+      exampleBuild,
+      ...parts,
+      '_deps',
+      'dd-sdk-cpp-src',
+      'include-c',
+    ]),
+  );
+  if (Platform.isWindows) {
+    return [
+      dir(['windows', 'x64']),
+    ];
+  }
+  // The build step uses --debug; accept a release tree too, for local runs.
+  return [
+    dir(['linux', 'x64', 'debug']),
+    dir(['linux', 'x64', 'release']),
+  ];
+}
+
+Directory _resolveHeaders(String root, List<String> args) {
+  final headersArg = _option(args, '--headers');
+  if (headersArg != null) {
+    return Directory(path.normalize(path.absolute(headersArg)));
+  }
+  final candidates = _candidateHeaderDirs(root);
+  for (final candidate in candidates) {
+    if (File(path.join(candidate.path, 'datadog.h')).existsSync()) {
+      return candidate;
+    }
+  }
+  final platform = Platform.isWindows ? 'windows' : 'linux';
+  print(
+    'ERROR: could not find the dd-sdk-cpp headers. Looked in:\n'
+    '${candidates.map((c) => '  ${c.path}').join('\n')}\n\n'
+    'Run the build step first so CMake FetchContent populates them:\n'
+    '  melos run integration_test:$platform:build\n'
+    'or pass --headers <dir>.',
+  );
+  exit(2);
+}
+
+/// Writes a copy of ffigen.yaml whose header paths point at [headers].
+///
+/// ffigen.yaml is checked in with the Windows build tree's path, which does not
+/// exist on Linux. Everything else about the config is preserved, so this stays
+/// a faithful regeneration rather than a differently-configured one.
+File _tempConfig(Directory pkg, Directory headers) {
+  final original = File(path.join(pkg.path, 'ffigen.yaml'));
+  final target = headers.path.replaceAll(r'\', '/');
+  // Keep any leading -I: the path also appears inside a compiler-opt, and
+  // swallowing the flag would turn the include dir into a linker input.
+  final rewritten = original.readAsStringSync().replaceAllMapped(
+    RegExp(r"""(-I)?[^\s'"]*dd-sdk-cpp-src[/\\]include-c"""),
+    (m) => '${m[1] ?? ''}$target',
+  );
+  final temp = File(path.join(pkg.path, '.ffigen_verify.yaml'))
+    ..writeAsStringSync(rewritten);
+  return temp;
+}
+
+void main(List<String> args) {
+  final root = _repoRoot();
+  final pkg = Directory(path.join(root, _desktopPkgRelPath));
+  final bindings = File(path.join(pkg.path, _bindingsRelPath));
+  if (!bindings.existsSync()) {
+    print('Generated bindings not found at ${bindings.path}');
+    exit(2);
+  }
+
+  final headers = _resolveHeaders(root, args);
+  if (!File(path.join(headers.path, 'datadog.h')).existsSync()) {
+    print('No datadog.h under ${headers.path}');
+    exit(2);
+  }
+
+  final before = bindings.readAsStringSync();
+  final backup = File('${bindings.path}.verify-backup')
+    ..writeAsStringSync(before);
+  final config = _tempConfig(pkg, headers);
+
+  print('Headers:  ${headers.path}');
+  print('Bindings: ${bindings.path}');
+  print('Regenerating...\n');
+
+  ProcessResult result;
+  try {
+    result = Process.runSync(Platform.resolvedExecutable, [
+      'run',
+      'ffigen',
+      '--config',
+      path.basename(config.path),
+    ], workingDirectory: pkg.path);
+  } finally {
+    config.deleteSync();
+  }
+
+  if (result.exitCode != 0) {
+    backup.deleteSync();
+    print('ffigen failed:\n${result.stdout}\n${result.stderr}');
+    exit(2);
+  }
+
+  final after = bindings.readAsStringSync();
+  if (after == before) {
+    backup.deleteSync();
+    print('Bindings are up to date.');
+    exit(0);
+  }
+
+  // Render a real diff rather than just announcing a mismatch.
+  final diff = Process.runSync('git', [
+    '--no-pager',
+    'diff',
+    '--no-index',
+    '--',
+    backup.path,
+    bindings.path,
+  ], workingDirectory: root);
+  print(diff.stdout);
+
+  if (args.contains('--write')) {
+    backup.deleteSync();
+    print('\nRegenerated bindings left in place (--write).');
+  } else {
+    bindings.writeAsStringSync(before);
+    backup.deleteSync();
+  }
+
+  print(
+    '\nERROR: ffi_bindings.dart is out of date with the dd-sdk-cpp headers.\n\n'
+    'The committed bindings no longer match the C API being built against. '
+    'This is not a cosmetic diff: a struct that changed size means Dart and '
+    'the C SDK disagree about how many bytes to allocate, which corrupts the '
+    'heap at runtime instead of failing to compile.\n\n'
+    'Regenerate and commit:\n'
+    '  dart tools/ci/bin/verify_ffi_bindings.dart --write',
+  );
+  exit(1);
+}


### PR DESCRIPTION
### What and why?

Fixed multiple analysis infos that required an update to Dart 3.8+. Some of these were older but we're getting to them now with the Dart 3.10 upgrade.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
