### PR TITLE
feat: Add reportAppFullyDisplayed to RUM for app launch time to full display (TTFD)

### DIFF
--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -380,7 +380,8 @@ class RumVitalAppLaunchEventDecoder extends RumEventDecoder {
 
   RumViewInfoDecoder get view => RumViewInfoDecoder(rumEvent['view']);
 
-  String get appLaunchMetric => rumEvent['vital']['app_launch_metric'] as String;
+  String get appLaunchMetric =>
+      rumEvent['vital']['app_launch_metric'] as String;
 
   /// Duration of the app launch metric, in nanoseconds.
   int get duration => (rumEvent['vital']['duration'] as num).toInt();

--- a/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
+++ b/packages/datadog_common_test/lib/src/decoders/rum_decoder.dart
@@ -82,9 +82,14 @@ class RumSessionDecoder {
           visit.longTaskEvents.add(longTaskEvent);
           break;
         case 'vital':
-          final operationStepEvent =
-              RumVitalOperationStepEventDecoder(e.rumEvent);
-          visit.vitalStepEvents.add(operationStepEvent);
+          if (RumVitalAppLaunchEventDecoder.isAppLaunchVital(e.rumEvent)) {
+            final appLaunchEvent = RumVitalAppLaunchEventDecoder(e.rumEvent);
+            visit.appLaunchVitalEvents.add(appLaunchEvent);
+          } else {
+            final operationStepEvent =
+                RumVitalOperationStepEventDecoder(e.rumEvent);
+            visit.vitalStepEvents.add(operationStepEvent);
+          }
           break;
       }
     }
@@ -109,6 +114,7 @@ class RumViewVisit {
   final List<RumErrorEventDecoder> errorEvents = [];
   final List<RumLongTaskEventDecoder> longTaskEvents = [];
   final List<RumVitalOperationStepEventDecoder> vitalStepEvents = [];
+  final List<RumVitalAppLaunchEventDecoder> appLaunchVitalEvents = [];
 
   RumViewVisit(this.id, this.name, this.path);
 }
@@ -360,4 +366,24 @@ class RumVitalOperationStepEventDecoder extends RumEventDecoder {
   String? get vitalFailureReason =>
       rumEvent['vital']['failure_reason'] as String?;
   String get stepType => rumEvent['vital']['step_type'] as String;
+}
+
+/// Decodes app launch vitals, which carry the app launch metrics (`ttid` and
+/// `ttfd`) rather than the operation step properties.
+class RumVitalAppLaunchEventDecoder extends RumEventDecoder {
+  RumVitalAppLaunchEventDecoder(super.rumEvent);
+
+  static bool isAppLaunchVital(Map<String, dynamic> rumEvent) {
+    final vital = rumEvent['vital'];
+    return vital is Map && vital['type'] == 'app_launch';
+  }
+
+  RumViewInfoDecoder get view => RumViewInfoDecoder(rumEvent['view']);
+
+  String get appLaunchMetric => rumEvent['vital']['app_launch_metric'] as String;
+
+  /// Duration of the app launch metric, in nanoseconds.
+  int get duration => (rumEvent['vital']['duration'] as num).toInt();
+
+  String? get startupType => rumEvent['vital']['startup_type'] as String?;
 }

--- a/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
+++ b/packages/datadog_flutter_plugin/android/src/main/kotlin/com/datadoghq/flutter/DatadogRumPlugin.kt
@@ -118,6 +118,7 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
                 "stopView" -> stopView(call, result)
                 "addTiming" -> addTiming(call, result)
                 "addViewLoadingTime" -> addViewLoadingTime(call, result)
+                "reportAppFullyDisplayed" -> reportAppFullyDisplayed(call, result)
                 "startResource" -> startResource(call, result)
                 "stopResource" -> stopResource(call, result)
                 "stopResourceWithError" -> stopResourceWithError(call, result)
@@ -289,6 +290,11 @@ class DatadogRumPlugin : MethodChannel.MethodCallHandler {
         } else {
             result.missingParameter(call.method)
         }
+    }
+
+    private fun reportAppFullyDisplayed(call: MethodCall, result: Result) {
+        rum?.reportAppFullyDisplayed()
+        result.success(null)
     }
 
     private fun startResource(call: MethodCall, result: Result) {

--- a/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
+++ b/packages/datadog_flutter_plugin/android/src/test/kotlin/com/datadoghq/flutter/DatadogRumPluginTest.kt
@@ -594,6 +594,21 @@ class DatadogRumPluginTest {
     }
 
     @Test
+    fun `M call monitor reportAppFullyDisplayed W reportAppFullyDisplayed is called`() {
+        // GIVEN
+        val call = MethodCall("reportAppFullyDisplayed", mapOf<String, Any?>())
+        val mockResult = mockk<MethodChannel.Result>()
+        every { mockResult.success(any()) } returns Unit
+
+        // WHEN
+        plugin.onMethodCall(call, mockResult)
+
+        // THEN
+        verify { monitorProxy.mockMonitor.reportAppFullyDisplayed() }
+        verify { mockResult.success(null) }
+    }
+
+    @Test
     fun `M call monitor startResource W startResource is called`(
         @StringForgery resourceKey: String,
         @StringForgery url: String,
@@ -1066,7 +1081,8 @@ class DatadogRumPluginTest {
             "failureReason" to ContractParameter.Type(SupportedContractType.STRING),
             "attributes" to ContractParameter.Type(SupportedContractType.MAP)
         )),
-        Contract("stopSession", mapOf())
+        Contract("stopSession", mapOf()),
+        Contract("reportAppFullyDisplayed", mapOf())
     )
 
     @Test

--- a/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
+++ b/packages/datadog_flutter_plugin/example/ios/Tests/DatadogRumPluginTests.swift
@@ -196,7 +196,8 @@ class DatadogRumPluginTests: XCTestCase {
             "failureReason": .string,
             "attributes": .map
         ]),
-        Contract(methodName: "stopSession", requiredParameters: [:])
+        Contract(methodName: "stopSession", requiredParameters: [:]),
+        Contract(methodName: "reportAppFullyDisplayed", requiredParameters: [:])
     ]
 
     func testRumPlugin_ContractViolationsThrowErrors() {
@@ -379,6 +380,18 @@ class DatadogRumPluginTests: XCTestCase {
         }
 
         XCTAssertEqual(mock.callLog, [ .addViewLoadingTime(overwrite: true) ])
+        XCTAssertEqual(resultStatus, .called(value: nil))
+    }
+
+    func testReportAppFullyDisplayed_CallsRumMonitor() {
+        let call = FlutterMethodCall(methodName: "reportAppFullyDisplayed", arguments: [:] as [String: Any?])
+
+        var resultStatus = ResultStatus.notCalled
+        plugin.handle(call) { result in
+            resultStatus = .called(value: result)
+        }
+
+        XCTAssertEqual(mock.callLog, [ .reportAppFullyDisplayed ])
         XCTAssertEqual(resultStatus, .called(value: nil))
     }
 

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -187,6 +187,28 @@ void main() {
     expect(view1.vitalStepEvents[2].vitalOperationKey, isNull);
     expect(view1.vitalStepEvents[2].vitalFailureReason, 'error');
 
+    // `reportAppFullyDisplayed` reports TTFD as an app launch vital rather than
+    // as a property of the view it was called from, so look for it across the
+    // whole session. It is not supported by the Browser SDK.
+    if (!kIsWeb) {
+      final ttfdVitals = rumLog
+          .where((e) =>
+              e.eventType == 'vital' &&
+              RumVitalAppLaunchEventDecoder.isAppLaunchVital(e.rumEvent))
+          .map((e) => RumVitalAppLaunchEventDecoder(e.rumEvent))
+          .where((e) => e.appLaunchMetric == 'ttfd')
+          .toList();
+
+      // Only the first call to `reportAppFullyDisplayed` is reported.
+      expect(ttfdVitals.length, 1);
+      // TTFD is measured from the launch of the app, so it should be at least
+      // as long as the fake loading the scenario performs before reporting it.
+      expect(ttfdVitals[0].duration,
+          greaterThanOrEqualTo(const Duration(milliseconds: 50).inNanoseconds));
+      expect(ttfdVitals[0].duration,
+          lessThan(const Duration(seconds: 60).inNanoseconds));
+    }
+
     // Verify user in all events, except for the first view event
     for (final viewEvent in view1.viewEvents.sublist(1)) {
       verifyUser(viewEvent);

--- a/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/integration_test/rum_manual_test.dart
@@ -189,8 +189,13 @@ void main() {
 
     // `reportAppFullyDisplayed` reports TTFD as an app launch vital rather than
     // as a property of the view it was called from, so look for it across the
-    // whole session. It is not supported by the Browser SDK.
-    if (!kIsWeb) {
+    // whole session.
+    //
+    // This is only checked on iOS. The Browser SDK has no equivalent API, and
+    // the Android SDK only sends TTFD once it has computed TTID for the startup
+    // scenario, which does not happen in this app -- it sends no app launch
+    // vitals at all, so there is nothing to assert on there yet.
+    if (!kIsWeb && Platform.isIOS) {
       final ttfdVitals = rumLog
           .where((e) =>
               e.eventType == 'vital' &&

--- a/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
+++ b/packages/datadog_flutter_plugin/integration_test_app/lib/integration_scenarios/rum_manual_instrumentation_scenario.dart
@@ -105,6 +105,7 @@ class _RumManualInstrumentationScenarioState
     await Future<void>.delayed(const Duration(milliseconds: 50));
     DatadogSdk.instance.rum?.addTiming('content-ready');
     DatadogSdk.instance.rum?.addViewLoadingTime();
+    DatadogSdk.instance.rum?.reportAppFullyDisplayed();
 
     DatadogSdk.instance.setUserInfo(
         id: 'fake-id',

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Sources/datadog_flutter_plugin/DatadogRumPlugin.swift
@@ -194,6 +194,9 @@ public class DatadogRumPlugin: NSObject, FlutterPlugin {
                     FlutterError.missingParameter(methodName: call.method)
                 )
             }
+        case "reportAppFullyDisplayed":
+            rum?.reportAppFullyDisplayed()
+            result(nil)
         case "startResource":
             if let key = arguments["key"] as? String,
                let methodString = arguments["httpMethod"] as? String,

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum.dart
@@ -271,6 +271,20 @@ class DatadogRum {
     });
   }
 
+  /// Marks the moment when the UI of the app is considered fully displayed.
+  /// The duration between the launch of the app and this call is reported as
+  /// the time to full display (TTFD) of the app launch.
+  ///
+  /// Only the first call to this method has any effect for a given RUM
+  /// session.
+  ///
+  /// *Note*: This API is experimental and may change in the future.
+  void reportAppFullyDisplayed() {
+    wrap('rum.reportAppFullyDisplayed', logger, null, () {
+      return _platform.reportAppFullyDisplayed();
+    });
+  }
+
   /// Notifies that the Exception or Error [error] occurred in currently
   /// presented View, with an origin of [source]. You can optionally set
   /// additional [attributes] for this error, an [errorType] and a

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_method_channel.dart
@@ -203,6 +203,14 @@ class DdRumMethodChannel extends DdRumPlatform {
   }
 
   @override
+  Future<void> reportAppFullyDisplayed() {
+    return methodChannel.invokeMethod(
+      'reportAppFullyDisplayed',
+      <String, Object?>{},
+    );
+  }
+
+  @override
   Future<void> addErrorInfo(
     DateTime timestamp,
     String message,

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_noop_platform.dart
@@ -58,6 +58,11 @@ class DdNoOpRumPlatform extends DdRumPlatform {
   }
 
   @override
+  Future<void> reportAppFullyDisplayed() {
+    return Future.value();
+  }
+
+  @override
   Future<void> addAction(
     DateTime timestamp,
     RumActionType type,

--- a/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/ddrum_platform_interface.dart
@@ -41,6 +41,7 @@ abstract class DdRumPlatform extends PlatformInterface {
   );
   Future<void> addTiming(DateTime timestamp, String name);
   Future<void> addViewLoadingTime(bool overwrite);
+  Future<void> reportAppFullyDisplayed();
 
   Future<void> startResource(
     DateTime timestamp,

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -211,6 +211,11 @@ class DdRumWeb extends DdRumPlatform {
   }
 
   @override
+  Future<void> reportAppFullyDisplayed() async {
+    // NOOP - Not supported by the Browser SDK
+  }
+
+  @override
   Future<void> addAction(
     DateTime timestamp,
     RumActionType type,

--- a/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/ddrum_method_channel_test.dart
@@ -150,6 +150,14 @@ void main() {
     ]);
   });
 
+  test('reportAppFullyDisplayed calls to platform', () async {
+    await ddRumPlatform.reportAppFullyDisplayed();
+
+    expect(log, [
+      isMethodCall('reportAppFullyDisplayed', arguments: <String, Object?>{}),
+    ]);
+  });
+
   test('startResource calls to platform', () async {
     final timestamp = randomTimestamp();
     await ddRumPlatform.startResource(


### PR DESCRIPTION
### What and why?

Bridges `reportAppFullyDisplayed()` from the native SDKs to Dart.

Both native SDKs have shipped this API for a while — `RUMMonitorProtocol.reportAppFullyDisplayed()` on iOS and `RumMonitor.reportAppFullyDisplayed()` on Android — but it was never exposed through the Flutter plugin. `addViewLoadingTime` was bridged in #655; the app-launch equivalent was not. Without this method there is no way for a Flutter app to mark the moment its UI is fully displayed, so `rum.measure.app.startup_to_full_display` never populates for Flutter apps at all.

#944 is the standing request for TTFD support on Flutter.

### How?

Purely additive: one new no-argument method threaded through the existing layers — `DatadogRum` → `DdRumPlatform` → method channel → `DatadogRumPlugin` on iOS and Android. Web is a no-op, as the Browser SDK has no equivalent (same treatment as `addViewLoadingTime`).

No existing behaviour changes. `addViewLoadingTime` is deliberately untouched — that is per-view loading time, a different metric.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests
- [x] This pull request references a Github or JIRA issue

Tests mirror the `addViewLoadingTime` ones: a method-channel test in `ddrum_method_channel_test.dart`, plugin tests plus contract entries on both `DatadogRumPluginTest.kt` and `DatadogRumPluginTests.swift`, and the call is exercised in the manual RUM integration scenario. The existing native mocks already implemented `reportAppFullyDisplayed`, so they needed no changes.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
