### PR TITLE
feat(flags): send the split serial id on exposure events

### DIFF
--- a/packages/datadog_flags/lib/src/assignment.dart
+++ b/packages/datadog_flags/lib/src/assignment.dart
@@ -73,6 +73,7 @@ final class FlagAssignment {
   final Object variationValue;
   final String reason;
   final bool doLog;
+  final int? serialId;
 
   const FlagAssignment._({
     required this.allocationKey,
@@ -81,6 +82,7 @@ final class FlagAssignment {
     required this.variationValue,
     required this.reason,
     required this.doLog,
+    this.serialId,
   });
 
   factory FlagAssignment.fromJson(Map<String, Object?> json) {
@@ -96,6 +98,7 @@ final class FlagAssignment {
       variationValue: variationValue,
       reason: assignment.reason,
       doLog: assignment.doLog,
+      serialId: assignment.serialId,
     );
   }
 

--- a/packages/datadog_flags/lib/src/assignment.g.dart
+++ b/packages/datadog_flags/lib/src/assignment.g.dart
@@ -15,6 +15,7 @@ FlagAssignment _$FlagAssignmentFromJson(Map<String, dynamic> json) =>
       variationValue: json['variationValue'] as Object,
       reason: json['reason'] as String,
       doLog: json['doLog'] as bool,
+      serialId: (json['serialId'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$FlagAssignmentToJson(FlagAssignment instance) =>
@@ -25,4 +26,5 @@ Map<String, dynamic> _$FlagAssignmentToJson(FlagAssignment instance) =>
       'variationValue': sanitizeJsonValue(instance.variationValue),
       'reason': instance.reason,
       'doLog': instance.doLog,
+      'serialId': instance.serialId,
     };

--- a/packages/datadog_flags/lib/src/exposure_logger.dart
+++ b/packages/datadog_flags/lib/src/exposure_logger.dart
@@ -47,6 +47,7 @@ class ExposureLogger {
     final cacheValue = _ExposureCacheValue(
       allocationKey: assignment.allocationKey,
       variationKey: assignment.variationKey,
+      serialId: assignment.serialId,
     );
     if (_loggedAssignments[cacheKey] == cacheValue) {
       return;
@@ -183,11 +184,13 @@ class ExposureLogger {
       'id': evaluationContext.targetingKey,
       'attributes': sanitizeJsonValue(evaluationContext.attributes),
     });
+    final serialId = assignment.serialId;
     return {
       'timestamp': runtime.configuration.dateProvider().millisecondsSinceEpoch,
       'allocation': {'key': assignment.allocationKey},
       'flag': {'key': flagKey},
       'variant': {'key': assignment.variationKey},
+      if (serialId != null) 'serial_id': serialId,
       'subject': subject,
     };
   }
@@ -257,22 +260,25 @@ final class _ExposureCacheKey {
 final class _ExposureCacheValue {
   final String allocationKey;
   final String variationKey;
+  final int? serialId;
 
   const _ExposureCacheValue({
     required this.allocationKey,
     required this.variationKey,
+    required this.serialId,
   });
 
   @override
   bool operator ==(Object other) {
     return other is _ExposureCacheValue &&
         other.allocationKey == allocationKey &&
-        other.variationKey == variationKey;
+        other.variationKey == variationKey &&
+        other.serialId == serialId;
   }
 
   @override
   int get hashCode {
-    return Object.hash(allocationKey, variationKey);
+    return Object.hash(allocationKey, variationKey, serialId);
   }
 }
 

--- a/packages/datadog_flags/test/datadog_flags_test.dart
+++ b/packages/datadog_flags/test/datadog_flags_test.dart
@@ -723,6 +723,132 @@ void main() {
     );
   });
 
+  test('sends the serial id only for assignments that carry one', () async {
+    final requests = <http.Request>[];
+    final client = await _createClient(
+      requests: requests,
+      response: _assignmentsResponse(
+        additionalFlags: {
+          'first-allocation': {
+            ..._assignment(
+              allocationKey: 'allocation-g',
+              variationKey: 'treatment',
+              variationType: 'boolean',
+              variationValue: true,
+            ),
+            'serialId': 0,
+          },
+          'later-allocation': {
+            ..._assignment(
+              allocationKey: 'allocation-h',
+              variationKey: 'treatment',
+              variationType: 'boolean',
+              variationValue: true,
+            ),
+            'serialId': 340132,
+          },
+        },
+      ),
+      trackExposures: true,
+    );
+    await client.initialize(
+      const FlagsEvaluationContext(targetingKey: 'user-123'),
+    );
+
+    client.getBooleanDetails(key: 'first-allocation', defaultValue: false);
+    client.getBooleanDetails(key: 'later-allocation', defaultValue: false);
+    client.getBooleanDetails(key: 'show-paywall', defaultValue: false);
+    await client.shutdown();
+
+    final events = _exposureEvents(_exposureRequests(requests).single);
+    expect(events, hasLength(3));
+    expect(events[0]['serial_id'], 0);
+    expect(events[1]['serial_id'], 340132);
+    expect(events[2].containsKey('serial_id'), isFalse);
+  });
+
+  test('omits the serial id when the server sends an explicit null', () async {
+    final requests = <http.Request>[];
+    final client = await _createClient(
+      requests: requests,
+      response: _assignmentsResponse(
+        additionalFlags: {
+          'null-serial': {
+            ..._assignment(
+              allocationKey: 'allocation-g',
+              variationKey: 'treatment',
+              variationType: 'boolean',
+              variationValue: true,
+            ),
+            'serialId': null,
+          },
+        },
+      ),
+      trackExposures: true,
+    );
+    await client.initialize(
+      const FlagsEvaluationContext(targetingKey: 'user-123'),
+    );
+
+    final details = client.getBooleanDetails(
+      key: 'null-serial',
+      defaultValue: false,
+    );
+    await client.shutdown();
+
+    expect(details.value, isTrue);
+    final event = _exposureEvents(_exposureRequests(requests).single).single;
+    expect(event.containsKey('serial_id'), isFalse);
+  });
+
+  test('logs another exposure when only the serial id changes', () async {
+    final requests = <http.Request>[];
+    var precomputeRequestCount = 0;
+    final client = await _createClient(
+      requests: requests,
+      trackExposures: true,
+      httpClient: MockClient((request) async {
+        requests.add(request);
+        if (request.url.path == '/precompute-assignments') {
+          precomputeRequestCount += 1;
+          return http.Response(
+            jsonEncode(
+              _assignmentsResponse(
+                additionalFlags: {
+                  'serial-cycle': {
+                    ..._assignment(
+                      allocationKey: 'allocation-g',
+                      variationKey: 'treatment',
+                      variationType: 'boolean',
+                      variationValue: true,
+                    ),
+                    if (precomputeRequestCount > 1) 'serialId': 0,
+                  },
+                },
+              ),
+            ),
+            200,
+          );
+        }
+        return http.Response('{"ok":true}', 200);
+      }),
+    );
+
+    for (var attempt = 0; attempt < 3; attempt += 1) {
+      await client.initialize(
+        const FlagsEvaluationContext(targetingKey: 'user-123'),
+      );
+      client.getBooleanDetails(key: 'serial-cycle', defaultValue: false);
+    }
+    await client.shutdown();
+
+    expect(precomputeRequestCount, 3);
+    final events = _exposureEvents(_exposureRequests(requests).single);
+    expect(events, hasLength(2));
+    expect(events[0].containsKey('serial_id'), isFalse);
+    expect(events[1]['serial_id'], 0);
+  });
+
   test(
     'emits flag evaluation batches for typed details at the HTTP boundary',
     () async {


### PR DESCRIPTION
### What and why?

EX-3420. This change adds a `serial_id` field to the exposure event.

The serial id identifies the split that the subject was assigned to. The intake uses it to find the holdout that the allocation comes from. A holdout becomes a usual allocation before the SDK receives it, so the exposure event does not record the holdout in another way.

The precompute response already sends the value in the `serialId` field of each flag. The SDK discarded it.

### How?

| File | Change |
|---|---|
| `lib/src/assignment.dart` | Add an optional `serialId` to `FlagAssignment`. |
| `lib/src/assignment.g.dart` | Generated again. |
| `lib/src/exposure_logger.dart` | Set `serial_id` on the event, and add the value to the exposure cache. |

The server sends an absent key or an explicit null when a flag has no serial id. Both give a null `serialId`, and the SDK then sends no field.

The SDK does not validate the value. The flag configuration layer validates it.

Three new tests. They pin a serial id of `0`, which is a usual value because serial ids start at zero for each organization, a serial id of `340132`, an explicit null, and an absent key.

### Risks

Low. The field is optional. An exposure event without a serial id does not change.

The exposure cache now compares the serial id in addition to the allocation key and the variation key. A subject therefore reports one more exposure when its serial id appears or changes. This is intended: a configuration refresh can add a serial id while both keys stay the same, and the intake must receive that value.

### Review checklist

- [x] This pull request has appropriate unit and / or integration tests
- [x] This pull request references a Github or JIRA issue

*This description was generated by Claude.*
