### PR TITLE
fix(web): Use JS types in TracingUrl closure

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -121,8 +121,8 @@ scripts:
   unit_test:web:
     run:
       mkdir -p $MELOS_ROOT_PATH/.build/test-results &&
-      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"'"
-      # melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"'" 
+      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web.xml\"'" &&
+      melos exec -c 1 -- "bash -c 'set -euxo pipefail; flutter test --machine --platform chrome --wasm | tojunit \"--output\" \"$MELOS_ROOT_PATH/.build/test-results/\$MELOS_PACKAGE_NAME_unit_web_wasm.xml\"'" 
     packageFilters:
       scope: 'datadog_flutter_plugin'
 
@@ -219,6 +219,7 @@ scripts:
     exec: |
       cd integration_test_app
       dart $MELOS_ROOT_PATH/tools/ci/bin/web_integration_tests.dart
+      dart $MELOS_ROOT_PATH/tools/ci/bin/web_integration_tests.dart --wasm
     packageFilters:
       scope: 'datadog_flutter_plugin'
 
@@ -228,6 +229,7 @@ scripts:
     run: |
       cd example      
       dart $MELOS_ROOT_PATH/tools/ci/bin/web_integration_tests.dart
+      dart $MELOS_ROOT_PATH/tools/ci/bin/web_integration_tests.dart --wasm
     packageFilters:
       scope: 'datadog_tracking_http_client'
 

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -59,9 +59,9 @@ class DdRumWeb extends DdRumPlatform {
         allowedTracingUrls: [
           for (final host in sanitizedFirstPartyHosts)
             _TracingUrl(
-              match: ((String check) {
-                final uri = Uri.parse(check);
-                return host.regExp.hasMatch(uri.host);
+              match: ((JSString check) {
+                final uri = Uri.parse(check.toDart);
+                return host.regExp.hasMatch(uri.host).toJS;
               }).toJS,
               propagatorTypes: host.headerTypes
                   .map(_headerTypeToPropagatorType)

--- a/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
+++ b/packages/datadog_flutter_plugin/test/rum/rum_user_action_detector_test.dart
@@ -3,7 +3,10 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import 'package:datadog_common_test/datadog_common_test.dart';
+import 'package:datadog_flutter_plugin/datadog_internal.dart';
+import 'package:datadog_flutter_plugin/src/datadog_noop_platform.dart';
 import 'package:datadog_flutter_plugin/src/rum/rum.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -79,6 +82,10 @@ Widget _buildSimpleApp(DatadogRum rum, Widget innerWidget) {
 void main() {
   setUpAll(() {
     registerFallbackValue(RumActionType.custom);
+    if (kIsWeb) {
+      // This doesn't happen automatically in wasm testing for some reason
+      DatadogSdkPlatform.instance = DatadogSdkNoOpPlatform();
+    }
   });
 
   testWidgets('tap button reports tap to RUM', (tester) async {

--- a/tools/ci/bin/web_integration_tests.dart
+++ b/tools/ci/bin/web_integration_tests.dart
@@ -32,7 +32,7 @@ const fileExclude = [
 
 const testDriver = 'test_driver/integration_test.dart';
 
-void main() async {
+void main(List<String> args) async {
   // Check path
   var testDirectory = Directory('integration_test');
   if (!testDirectory.existsSync()) {
@@ -40,6 +40,8 @@ void main() async {
         'Could not find the "integration_test" directory. Make sure you are running this from the integration_test_app root');
     exit(1);
   }
+
+  bool wasm = args.contains('--wasm');
 
   for (final file in testDirectory.listSync()) {
     if (file is File) {
@@ -50,6 +52,7 @@ void main() async {
 
       final args = [
         'drive',
+        if (wasm) '--wasm',
         '--driver=$testDriver',
         '--target=integration_test/$baseName',
         '-d',


### PR DESCRIPTION
### What and why?

Not using JS types was breaking WASM builds.

Re-enable WASM unit and integration tests now that they don't stall on macOS.

refs: #1127

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
