### PR TITLE
tools(releaser): Add version computation and native SDK pinning to releaser

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,6 +121,7 @@ build-flutter:
     - specific:true
   script:
     - !reference [.pre, script]
+    - pushd tools/releaser && dart pub get && dart test && popd
     - melos dartfmt_check
     - melos run analyze:dart
     - melos run unit_test:flutter

--- a/tools/releaser/lib/cmake_util.dart
+++ b/tools/releaser/lib/cmake_util.dart
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+import 'helpers.dart';
+
+/// Matches the `GIT_TAG <ref>` argument anywhere on a line -- not anchored to
+/// the line start, since `FetchContent_Declare(dd-sdk-cpp ... GIT_TAG develop)`
+/// is valid CMake written on a single line.
+final _gitTagPattern = RegExp(r'(?<prefix>GIT_TAG\s+)(?<ref>[\w./-]+)');
+
+/// A trailing `# ...` comment, stripped before [_gitTagPattern] is applied so
+/// a previous run's `# <tag>` annotation is replaced rather than duplicated --
+/// and so a `#`-commented mention of `GIT_TAG` can't be mistaken for the pin.
+final _trailingCommentPattern = RegExp(r'\s*#.*$');
+
+final _ddSdkCppDeclareStartPattern = RegExp(
+  r'FetchContent_Declare\(\s*dd-sdk-cpp\b',
+);
+
+/// Tracks whether a line belongs to the `FetchContent_Declare(dd-sdk-cpp ...)`
+/// call, which can span several lines -- a `CMakeLists.txt` is free to declare
+/// other `FetchContent` dependencies, and only dd-sdk-cpp's `GIT_TAG` is this
+/// tooling's to read or rewrite.
+///
+/// Shared by [hasDdSdkCppGitTag] (which decides whether a file counts as a
+/// dd-sdk-cpp dependency file at all) and [pinCppVersion] (which rewrites it),
+/// so the two can't disagree about where the block starts and ends.
+class _DdSdkCppBlockScanner {
+  var _inBlock = false;
+  var _parenDepth = 0;
+
+  static int _parenBalance(String line) =>
+      '('.allMatches(line).length - ')'.allMatches(line).length;
+
+  /// Advances the scanner over [line] and returns whether that line is inside
+  /// the block -- the opening `FetchContent_Declare(dd-sdk-cpp` line included,
+  /// since a single-line declaration carries its `GIT_TAG` there.
+  bool accept(String line) {
+    if (_ddSdkCppDeclareStartPattern.hasMatch(line)) {
+      _inBlock = true;
+      _parenDepth = _parenBalance(line);
+    } else if (_inBlock) {
+      _parenDepth += _parenBalance(line);
+    }
+
+    final result = _inBlock;
+    if (_inBlock && _parenDepth <= 0) _inBlock = false;
+    return result;
+  }
+}
+
+/// Whether [cmakeListsContent] pins dd-sdk-cpp -- a `GIT_TAG` line inside a
+/// `FetchContent_Declare(dd-sdk-cpp ...)` call. This is what makes a
+/// `windows/`/`linux/` `CMakeLists.txt` a native-dependency file as far as
+/// `native_sdk.dart`'s discovery is concerned; a file whose only `GIT_TAG`
+/// belongs to some other vendored dependency isn't one.
+bool hasDdSdkCppGitTag(String cmakeListsContent) {
+  final scanner = _DdSdkCppBlockScanner();
+  for (final line in cmakeListsContent.split('\n')) {
+    if (scanner.accept(line) &&
+        _gitTagPattern.hasMatch(
+          line.replaceFirst(_trailingCommentPattern, ''),
+        )) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Rewrites [line]'s `GIT_TAG` ref to [targetSha], re-annotated with
+/// `# [targetTag]`, leaving everything else on the line as-is -- a trailing
+/// `)` closing the `FetchContent_Declare(...` call, a `GIT_REPOSITORY` sharing
+/// the line in a single-line declaration, the original indentation. The
+/// comment goes at end of line, since a `#` placed before the closing paren
+/// would comment it out and break the call.
+String _pinGitTagLine(String line, String targetTag, String targetSha) {
+  final bare = line.replaceFirst(_trailingCommentPattern, '');
+  final match = _gitTagPattern.firstMatch(bare);
+  if (match == null) return line;
+
+  final pinned = bare.replaceRange(
+    match.start,
+    match.end,
+    '${match.namedGroup('prefix')}$targetSha',
+  );
+  return '${pinned.trimRight()}  # $targetTag';
+}
+
+/// Rewrites a CMakeLists.txt's dd-sdk-cpp `GIT_TAG` line to pin at
+/// [targetSha] -- the resolved commit SHA for [targetTag] (e.g. `v1.4.0`),
+/// kept as a trailing `# <tag>` comment since CMake's `FetchContent_Declare`
+/// has no field of its own for pairing a tag with a verified commit. A
+/// full commit SHA is used as the actual pin (not the tag) because it's
+/// immutable, unlike a tag, which can be moved to point elsewhere later.
+///
+/// Preserves the line's existing whitespace and everything around the ref --
+/// see [_pinGitTagLine].
+///
+/// Only ever called against a release-prep/patch/pre-release branch's copy
+/// of the file -- `develop`'s own floating `GIT_TAG develop` is never
+/// touched by release tooling.
+Future<void> pinCppVersion(
+  File cmakeListsFile,
+  String targetTag,
+  String targetSha,
+  Logger logger,
+  bool dryRun,
+) async {
+  logger.info(
+    'ℹ️ Pinning dd-sdk-cpp GIT_TAG to $targetSha ($targetTag) in '
+    '${cmakeListsFile.path}',
+  );
+
+  final scanner = _DdSdkCppBlockScanner();
+
+  await transformFile(
+    cmakeListsFile,
+    logger,
+    dryRun,
+    (line) => scanner.accept(line)
+        ? _pinGitTagLine(line, targetTag, targetSha)
+        : line,
+  );
+}

--- a/tools/releaser/lib/conventional_commits.dart
+++ b/tools/releaser/lib/conventional_commits.dart
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'version_bump.dart';
+
+/// A parsed conventional commit: header (`type(scope)!: description`) plus
+/// the footers other tooling in this package cares about (a `BREAKING
+/// CHANGE:` footer, and `refs:` lines referencing GitHub issues).
+class ConventionalCommit {
+  final String type;
+  final String? scope;
+
+  /// Whether the header itself carries a `!` breaking marker, on either side
+  /// of the scope -- see [_headerPattern].
+  final bool hasBreakingMarker;
+  final String description;
+
+  /// Whether a `BREAKING CHANGE:`/`BREAKING-CHANGE:` footer is present,
+  /// independent of [hasBreakingMarker] -- either one marks the commit
+  /// breaking, see [isBreaking].
+  final bool hasBreakingFooter;
+
+  /// Raw reference tokens from `refs:` footer lines (e.g. `refs: #123,
+  /// RUM-456` -> `['#123', 'RUM-456']`) -- a GitHub issue number, a JIRA
+  /// ticket, or anything else a `refs:` footer might carry. Not filtered
+  /// or interpreted here; a consumer that only wants GitHub issue links
+  /// (like `generate_changelog.dart`) picks those out itself.
+  final List<String> refs;
+
+  ConventionalCommit({
+    required this.type,
+    required this.scope,
+    required this.hasBreakingMarker,
+    required this.description,
+    required this.hasBreakingFooter,
+    required this.refs,
+  });
+
+  bool get isBreaking => hasBreakingMarker || hasBreakingFooter;
+
+  /// The semver bump this commit implies on its own: major if breaking
+  /// (marker or footer), minor for `feat`, patch for `fix`/`perf`, or null
+  /// for a type that doesn't carry semver weight by itself (`chore:`,
+  /// `docs:`, `test:`, etc.) and isn't marked breaking.
+  VersionBumpType? get bumpType {
+    if (isBreaking) return VersionBumpType.major;
+
+    switch (type) {
+      case 'feat':
+        return VersionBumpType.minor;
+      case 'fix':
+      case 'perf':
+        return VersionBumpType.patch;
+      default:
+        return null;
+    }
+  }
+
+  /// `type(scope)!: description`, with the `!` accepted on either side of the
+  /// scope.
+  ///
+  /// The convention puts it after -- `feat(web)!:` -- but `feat!(web):` gets
+  /// written in practice, and this repo's history already contains one. The
+  /// cost of not accepting it is badly asymmetric: an unparsed header is
+  /// dropped entirely, so the one shape most likely to be typo'd is also the
+  /// one whose loss matters most. A commit that means "breaking" would
+  /// silently contribute nothing, and a release that should be major comes
+  /// out minor.
+  static final _headerPattern = RegExp(
+    r'^(?<type>\w+)(?<earlyBreaking>!)?(\((?<scope>[^)]*)\))?'
+    r'(?<breaking>!)?:\s*(?<rest>.*)',
+  );
+  static final _breakingFooterPattern = RegExp(
+    r'^BREAKING[ -]CHANGE:',
+    multiLine: true,
+  );
+
+  /// Parses a full commit message (subject line plus body/footers) into
+  /// its conventional-commit parts, or returns null if the subject line
+  /// doesn't match the convention at all.
+  static ConventionalCommit? parse(String commitMessage) {
+    final lines = commitMessage.split('\n');
+    final match = _headerPattern.firstMatch(lines.first);
+    if (match == null) return null;
+
+    final refs = [
+      for (final refLine in lines.where((l) => l.startsWith('refs:')))
+        for (final token
+            in refLine.substring('refs:'.length).split(RegExp(r'[,\s]+')))
+          if (token.isNotEmpty) token,
+    ];
+
+    return ConventionalCommit(
+      type: match.namedGroup('type')!,
+      scope: match.namedGroup('scope'),
+      hasBreakingMarker:
+          match.namedGroup('breaking') == '!' ||
+          match.namedGroup('earlyBreaking') == '!',
+      description: match.namedGroup('rest')!,
+      hasBreakingFooter: _breakingFooterPattern.hasMatch(commitMessage),
+      refs: refs,
+    );
+  }
+}
+
+/// The highest-severity bump implied by [commits] (major > minor > patch),
+/// or null if none of them carry semver weight.
+VersionBumpType? aggregateBumpLevel(Iterable<ConventionalCommit> commits) {
+  VersionBumpType? highest;
+  for (final commit in commits) {
+    final bump = commit.bumpType;
+    if (bump == null) continue;
+    if (highest == null || bump.severity > highest.severity) {
+      highest = bump;
+    }
+  }
+  return highest;
+}

--- a/tools/releaser/lib/git_history.dart
+++ b/tools/releaser/lib/git_history.dart
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:git/git.dart';
+
+/// The commit a release tag points at, or null if the tag doesn't exist.
+///
+/// Deliberately a **lookup by exact name**, not a search. Which versions
+/// exist is pub.dev's question (see `published_versions.dart`); git is only
+/// asked where a version already known to exist actually landed.
+///
+/// That split is what keeps this file free of heuristics. Searching tags for
+/// "what did we last ship on this line" means guessing from tag names --
+/// scoping by major/minor, filtering to stable versions, ordering candidates,
+/// testing ancestry -- and none of those guesses can be made reliable here,
+/// because release tags live on `release/...` branches that are never merged
+/// back. An ancestry test, for instance, rejects every real release: none of
+/// them is reachable from `develop`.
+///
+/// Returns null rather than throwing: pub.dev can legitimately know a version
+/// git can't locate (a release published before its tag was pushed, or whose
+/// tag was never pushed at all -- two of `datadog_flutter_plugin`'s 65
+/// published versions are in that state). The caller reports the fallback it
+/// took; see `release_plan.dart`.
+Future<String?> tagSha(GitDir gitDir, String tagName) async {
+  final result = await gitDir.runCommand([
+    'rev-list',
+    '-n',
+    '1',
+    tagName,
+  ], throwOnError: false);
+
+  if (result.exitCode != 0) return null;
+  final sha = (result.stdout as String).trim();
+  return sha.isEmpty ? null : sha;
+}
+
+/// Full commit messages (subject + body/footers) touching [pathspec], from
+/// just after [sinceSha] through HEAD. A null [sinceSha] walks the entire
+/// history of [pathspec] -- the "since inception" case for a package that has
+/// never been published.
+Future<List<String>> commitMessagesSince(
+  GitDir gitDir, {
+  required String pathspec,
+  String? sinceSha,
+}) async {
+  final range = sinceSha != null ? '$sinceSha..HEAD' : 'HEAD';
+  final result = await gitDir.runCommand([
+    '--no-pager',
+    'log',
+    range,
+    '--pretty=format:%B|||END|||',
+    '--',
+    pathspec,
+  ]);
+
+  return (result.stdout as String)
+      .split('|||END|||')
+      .map((m) => m.trim())
+      .where((m) => m.isNotEmpty)
+      .toList();
+}

--- a/tools/releaser/lib/github_cmd_wrapper.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.dart
@@ -57,7 +57,7 @@ class GithubCommandWrapper {
         '--repo',
         repoSlug,
         '--json',
-        'name,isLatest,tagName'
+        'name,isLatest,tagName',
       ],
       workingDirectory: cwd,
       stdout: (line) => buffer.write(line),
@@ -79,13 +79,46 @@ class GithubCommandWrapper {
   }
 
   Future<GHRelease?> getReleaseByTagName(
-      Logger logger, String repoSlug, String tagName) async {
+    Logger logger,
+    String repoSlug,
+    String tagName,
+  ) async {
     final releases = await fetchReleases(logger, repoSlug);
     return releases.firstWhereOrNull((e) => e.tagName == tagName);
   }
 
-  Future<void> createRelease(Logger logger, String tag, String name,
-      String changelog, bool isPrerelease) async {
+  /// Resolves [ref] (a tag or branch name) to the full commit SHA it
+  /// currently points to, for pinning native SDKs whose config has no
+  /// dedicated "verify this tag against this commit" field (CMake's
+  /// `FetchContent_Declare`, notably) -- the SHA is what's actually pinned.
+  Future<String> getCommitSha(
+    Logger logger,
+    String repoSlug,
+    String ref,
+  ) async {
+    final buffer = StringBuffer();
+    final exitCode = await runProcess(
+      'gh',
+      ['api', 'repos/$repoSlug/commits/$ref', '--jq', '.sha'],
+      workingDirectory: cwd,
+      stdout: (line) => buffer.write(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    if (exitCode != 0) {
+      throw Exception('gh returned exit code $exitCode.');
+    }
+
+    return buffer.toString().trim();
+  }
+
+  Future<void> createRelease(
+    Logger logger,
+    String tag,
+    String name,
+    String changelog,
+    bool isPrerelease,
+  ) async {
     final buffer = StringBuffer();
     final exitCode = await runProcess(
       'gh',
@@ -98,7 +131,7 @@ class GithubCommandWrapper {
         '--notes',
         changelog,
         '--draft',
-        if (isPrerelease) '--prerelease'
+        if (isPrerelease) '--prerelease',
       ],
       workingDirectory: cwd,
       stdout: (line) => buffer.write(line),

--- a/tools/releaser/lib/native_sdk.dart
+++ b/tools/releaser/lib/native_sdk.dart
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'cmake_util.dart';
+import 'trigger_context.dart';
+
+/// A native SDK a Flutter package can depend on.
+enum NativeSdk {
+  ios(repoSlug: 'DataDog/dd-sdk-ios'),
+  android(repoSlug: 'DataDog/dd-sdk-android'),
+  cpp(repoSlug: 'DataDog/dd-sdk-cpp');
+
+  final String repoSlug;
+
+  const NativeSdk({required this.repoSlug});
+}
+
+/// Matches a podspec's `s.dependency 'Datadog...', '<constraint>'` lines.
+///
+/// Private, like every pattern in this file. Nothing in this module rewrites
+/// these files -- discovery only needs to recognise one -- and sharing a
+/// pattern with the legacy CLI's pin-rewriting commands would couple a
+/// *matcher* to a *rewriter*, which want different things from it: a matcher
+/// wants to be permissive, a rewriter has to reproduce exactly what it
+/// matched.
+final _iosPodspecDependencyPattern = RegExp(
+  r"s\.dependency\s+'Datadog\w*'\s*,\s*'[^']+'",
+);
+
+/// Matches a `build.gradle`'s `ext.datadog_version = "..."` assignment.
+final _androidGradleVersionPattern = RegExp(
+  r'ext\.datadog_version\s*=\s*"[^"]+"',
+);
+
+/// Matches a `Package.swift`'s dd-sdk-ios dependency line, e.g.
+/// `.package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0")`.
+/// Matched case-insensitively on the URL: both `Datadog` and `DataDog`
+/// spellings appear across this repo's manifests.
+final _iosSpmDependencyPattern = RegExp(
+  r'\.package\(url:\s*"[^"]*dd-sdk-ios[^"]*",\s*[^)]+\)',
+  caseSensitive: false,
+);
+
+/// The native-dependency files found in a package's own directory --
+/// resolved by checking what's actually there, not assumed from the
+/// package's name or role.
+class NativeDependencyFiles {
+  final File? iosPodspec;
+
+  /// A `Package.swift` pinning dd-sdk-ios via SPM -- independent of
+  /// [iosPodspec] since a package can ship both, each pinning the same
+  /// dependency in its own file format.
+  final File? iosSpmManifest;
+  final File? androidGradle;
+  final List<File> cppCMakeLists;
+
+  NativeDependencyFiles({
+    this.iosPodspec,
+    this.iosSpmManifest,
+    this.androidGradle,
+    this.cppCMakeLists = const [],
+  });
+
+  bool get isEmpty =>
+      iosPodspec == null &&
+      iosSpmManifest == null &&
+      androidGradle == null &&
+      cppCMakeLists.isEmpty;
+}
+
+/// Walks [packageRoot] (a package's own directory, not its example/test
+/// apps) for the native-dependency files this tooling knows how to read and
+/// pin: an iOS podspec with a Datadog pod dependency, a `Package.swift`
+/// pinning dd-sdk-ios via SPM, an Android `build.gradle` with a
+/// `datadog_version`, and/or a `windows/`/`linux/` `CMakeLists.txt` with a
+/// dd-sdk-cpp `GIT_TAG` inside its `FetchContent_Declare(dd-sdk-cpp ...)`
+/// block (a `CMakeLists.txt` whose only `GIT_TAG` belongs to some other
+/// vendored dependency doesn't count).
+NativeDependencyFiles resolveNativeDependencyFiles(String packageRoot) {
+  File? iosPodspec;
+  File? iosSpmManifest;
+  final iosDir = Directory(p.join(packageRoot, 'ios'));
+  if (iosDir.existsSync()) {
+    for (final entity in iosDir.listSync()) {
+      if (entity is File &&
+          entity.path.endsWith('.podspec') &&
+          _iosPodspecDependencyPattern.hasMatch(entity.readAsStringSync())) {
+        iosPodspec = entity;
+      } else if (entity is Directory) {
+        // The real layout is `ios/<package_name>/Package.swift` -- a
+        // manifest for building the plugin's iOS code via SPM instead of
+        // CocoaPods.
+        final packageSwift = File(p.join(entity.path, 'Package.swift'));
+        if (packageSwift.existsSync() &&
+            _iosSpmDependencyPattern.hasMatch(
+              packageSwift.readAsStringSync(),
+            )) {
+          iosSpmManifest = packageSwift;
+        }
+      }
+    }
+  }
+
+  File? androidGradle;
+  final gradleFile = File(p.join(packageRoot, 'android', 'build.gradle'));
+  if (gradleFile.existsSync() &&
+      _androidGradleVersionPattern.hasMatch(gradleFile.readAsStringSync())) {
+    androidGradle = gradleFile;
+  }
+
+  final cppCMakeLists = <File>[];
+  for (final platformDir in ['windows', 'linux']) {
+    final cmakeFile = File(p.join(packageRoot, platformDir, 'CMakeLists.txt'));
+    if (cmakeFile.existsSync() &&
+        hasDdSdkCppGitTag(cmakeFile.readAsStringSync())) {
+      cppCMakeLists.add(cmakeFile);
+    }
+  }
+
+  return NativeDependencyFiles(
+    iosPodspec: iosPodspec,
+    iosSpmManifest: iosSpmManifest,
+    androidGradle: androidGradle,
+    cppCMakeLists: cppCMakeLists,
+  );
+}
+
+/// What one native SDK dependency of a package resolves to this run.
+///
+/// This is a *target*, not a diff: `develop` (and a long-lived pre-release
+/// branch) deliberately keeps its manifests on floating constraints (`~> 3`,
+/// `branch: "develop"`, `GIT_TAG develop`), and only the release-prep branch's
+/// copy is ever pinned. So there's no meaningful "current pin" to subtract
+/// from -- the plan just says what to pin to, and `prepare_release.dart`
+/// rewrites [files] to match.
+///
+/// [targetVersion] is null when nothing should change -- the patch-branch
+/// default, absent an explicit override.
+///
+/// [targetSha] is only meaningful for [NativeSdk.cpp]: CMake's
+/// `FetchContent_Declare` has no field for pinning a tag *and* verifying
+/// its commit, so the resolved SHA is what actually gets written to
+/// `GIT_TAG` (see cmake_util.dart's `pinCppVersion`) -- a full commit SHA
+/// is immutable, unlike a tag, which can be moved.
+class NativeSdkDelta {
+  final NativeSdk sdk;
+  final String? targetVersion;
+  final String? targetSha;
+
+  /// Every file of this package that pins this dependency and therefore needs
+  /// rewriting -- one for [NativeSdk.android] (`build.gradle`), up to two for
+  /// [NativeSdk.ios] (podspec and/or `Package.swift`), and one per platform
+  /// for [NativeSdk.cpp] (`windows/CMakeLists.txt`, `linux/CMakeLists.txt`).
+  /// Carried on the plan so the apply step rewrites exactly what discovery
+  /// found, rather than resolving the file set a second time.
+  final List<File> files;
+
+  NativeSdkDelta({
+    required this.sdk,
+    required this.targetVersion,
+    this.targetSha,
+    this.files = const [],
+  });
+
+  @override
+  String toString() => targetVersion == null
+      ? '${sdk.name}: no change'
+      : '${sdk.name}: -> $targetVersion';
+}
+
+/// The network calls native SDK resolution needs -- bundled so callers
+/// (`release_plan.dart`) don't thread three separate function parameters
+/// through every layer between `computeReleasePlan` and
+/// [resolveNativeSdkTarget]. All three are keyed by a GitHub repo slug
+/// (e.g. `DataDog/dd-sdk-ios`) so one instance covers all three SDKs.
+class NativeSdkGateways {
+  final Future<String> Function(String repoSlug) fetchLatest;
+  final Future<String> Function(String repoSlug, String ref) resolveCommitSha;
+  final Future<bool> Function(String repoSlug, String version) releaseExists;
+
+  const NativeSdkGateways({
+    required this.fetchLatest,
+    required this.resolveCommitSha,
+    required this.releaseExists,
+  });
+}
+
+/// Resolves what a native SDK's pin should become this run:
+/// - an explicit [override] wins, but only once [releaseExists] confirms
+///   it's a real release -- this is the check `release_validator.dart`'s
+///   `_validateReleaseVersion` already did for iOS/Android before this file
+///   existed; skipping it would let a typo'd `IOS_SDK_VERSION`/
+///   `ANDROID_SDK_VERSION` sail through undetected until a much later,
+///   harder-to-diagnose build failure;
+/// - on a patch branch (default: no change) the pin is left alone, since
+///   auto-jumping to the latest native SDK defeats the point of an
+///   isolated patch;
+/// - otherwise (mainline or pre-release), it defaults to the latest
+///   published release, resolved via [fetchLatest].
+Future<String?> resolveNativeSdkTarget({
+  required TriggerContext trigger,
+  required String? override,
+  required Future<String> Function() fetchLatest,
+  required Future<bool> Function(String version) releaseExists,
+}) async {
+  if (override != null) {
+    if (!await releaseExists(override)) {
+      throw StateError('Release "$override" was not found.');
+    }
+    return override;
+  }
+  if (trigger == TriggerContext.patch) return null;
+  return await fetchLatest();
+}

--- a/tools/releaser/lib/published_versions.dart
+++ b/tools/releaser/lib/published_versions.dart
@@ -1,0 +1,149 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:version/version.dart';
+
+/// Every version of one package that has actually been published, newest
+/// last.
+///
+/// pub.dev is the source of truth for release history here, in preference to
+/// git tags or GitHub Releases, because publishing *is* the event. A tag or a
+/// GitHub Release is created after the fact and can therefore be skipped --
+/// measured against this repo, GitHub Releases are missing 5 of
+/// `datadog_flutter_plugin`'s 65 published versions and tags are missing 2,
+/// while pub.dev by definition cannot be missing any. Drift is entirely
+/// one-directional.
+///
+/// It also has no topology. Release commits land on `release/...` branches
+/// that never merge back, so "which versions exist" cannot be answered from
+/// the commit graph of the branch being planned.
+class PublishedVersions {
+  /// Ascending semver order. Empty when the package has never been published.
+  final List<Version> versions;
+
+  PublishedVersions(List<Version> versions)
+    : versions = List.unmodifiable(versions.toList()..sort());
+
+  /// A package pub.dev has never heard of -- its first release. Distinct from
+  /// a lookup failure, which throws.
+  static final never = PublishedVersions(const []);
+
+  bool get isEmpty => versions.isEmpty;
+
+  /// The newest release of any kind, pre-release included.
+  ///
+  /// This is "when did we last ship anything", which is what a commit range
+  /// and an eligibility check want -- as opposed to [latestStable], which is
+  /// what a *version* is computed from. On a pre-release line those differ,
+  /// and conflating them is what made an untouched package pick up its entire
+  /// history and qualify for a spurious beta.
+  Version? get latest => versions.lastOrNull;
+
+  /// The newest non-pre-release version. Mainline's baseline, and the base a
+  /// pre-release target is computed from.
+  Version? get latestStable =>
+      versions.where((v) => !v.isPreRelease).lastOrNull;
+
+  /// The newest release on a `{major}.{minor}.x` line -- a patch branch's own
+  /// line, so a newer major/minor mainline has since cut can't be picked up.
+  Version? latestOn(int major, int minor) =>
+      versions.where((v) => v.major == major && v.minor == minor).lastOrNull;
+
+  /// Pre-releases already published against [target]'s exact
+  /// major.minor.patch, ascending -- the counter a new pre-release continues.
+  /// [target]'s own pre-release suffix, if any, is ignored: a pubspec sitting
+  /// at `4.0.0-beta.1` is still working towards `4.0.0`.
+  List<Version> prereleasesAt(Version target) => versions
+      .where(
+        (v) =>
+            v.isPreRelease &&
+            v.major == target.major &&
+            v.minor == target.minor &&
+            v.patch == target.patch,
+      )
+      .toList();
+
+  /// Whether [target]'s exact major.minor.patch has already shipped stably --
+  /// a new pre-release against it would sort below an existing release.
+  bool hasStableAt(Version target) => versions.any(
+    (v) =>
+        !v.isPreRelease &&
+        v.major == target.major &&
+        v.minor == target.minor &&
+        v.patch == target.patch,
+  );
+}
+
+/// Fetches a package's published versions. Injected so tests -- and
+/// `preview_release.dart`'s unit tests -- don't reach the network.
+typedef PublishedVersionsGateway =
+    Future<PublishedVersions> Function(String packageName);
+
+/// Reads release history from pub.dev's public API.
+///
+/// A 404 means the package has never been published ([PublishedVersions.never])
+/// -- the first-release path, and the expected state of the federated
+/// sub-packages that have yet to ship. Any other failure throws rather than
+/// degrading to a guess: an under-reported history silently recomputes a
+/// version that already exists, and there is deliberately no fallback to tag
+/// scanning, since that is the archaeology this module exists to replace.
+Future<PublishedVersions> fetchPublishedVersions(String packageName) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(
+      Uri.https('pub.dev', '/api/packages/$packageName'),
+    );
+    final response = await request.close();
+
+    if (response.statusCode == HttpStatus.notFound) {
+      await response.drain<void>();
+      return PublishedVersions.never;
+    }
+    if (response.statusCode != HttpStatus.ok) {
+      await response.drain<void>();
+      throw StateError(
+        'pub.dev returned ${response.statusCode} for "$packageName". Release '
+        'history is read from pub.dev, so planning cannot continue without '
+        'it.',
+      );
+    }
+
+    final body =
+        jsonDecode(await response.transform(utf8.decoder).join())
+            as Map<String, dynamic>;
+    return PublishedVersions(parsePubDevVersions(body));
+  } on SocketException catch (e) {
+    throw StateError(
+      'Could not reach pub.dev to read release history for "$packageName" '
+      '(${e.message}). Planning reads published versions from pub.dev and has '
+      'no offline fallback.',
+    );
+  } finally {
+    client.close();
+  }
+}
+
+/// Pulls the version list out of a pub.dev `/api/packages/{name}` payload.
+///
+/// Split out from [fetchPublishedVersions] so the parsing is testable against
+/// a captured payload without a network round-trip. Entries that don't parse
+/// as semver are skipped rather than failing the run -- pub.dev won't serve
+/// one, but a malformed entry shouldn't be able to block a release.
+List<Version> parsePubDevVersions(Map<String, dynamic> body) {
+  final entries = (body['versions'] as List?) ?? const [];
+  final versions = <Version>[];
+  for (final entry in entries) {
+    final raw = (entry as Map<String, dynamic>)['version'];
+    if (raw is! String) continue;
+    try {
+      versions.add(Version.parse(raw));
+    } catch (_) {
+      continue;
+    }
+  }
+  return versions;
+}

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -3,20 +3,25 @@
 // Copyright 2019-Present Datadog, Inc.
 
 import 'package:collection/collection.dart';
+import 'package:git/git.dart';
+import 'package:logging/logging.dart';
+import 'package:version/version.dart';
 
+import 'conventional_commits.dart';
+import 'git_history.dart';
+import 'github_cmd_wrapper.dart';
+import 'native_sdk.dart';
 import 'package_discovery.dart';
+import 'published_versions.dart';
+import 'trigger_context.dart';
+import 'version_bump.dart';
 
-/// Which of the three GitLab trigger contexts a run is happening under:
-/// mainline (`develop`), patch (a standing `release/{package}/vX.Y.x`
-/// branch), or pre-release (a whitelisted long-lived branch like `v4`).
-enum TriggerContext { mainline, patch, preRelease }
+export 'published_versions.dart'
+    show PublishedVersions, PublishedVersionsGateway;
+export 'trigger_context.dart';
+export 'version_bump.dart';
 
-final _patchBranchPattern = RegExp(r'^release/([^/]+)/v\d+\.\d+\.x$');
-
-/// Extracts the package name from a `release/{package}/v{major}.{minor}.x`
-/// patch-branch name, or null if [branch] doesn't match that convention.
-String? packageNameFromPatchBranch(String branch) =>
-    _patchBranchPattern.firstMatch(branch)?.group(1);
+final _log = Logger('release_plan');
 
 /// Everything about how a `prepare-release`/`preview-release` run was
 /// invoked -- shared by both entry points so they can't compute different
@@ -53,21 +58,38 @@ class RunContext {
 /// The computed plan for a single releasing package.
 class PackagePlan {
   final DiscoveredPackage package;
+
+  /// What is currently published, or `pubspec.yaml`'s version for a package
+  /// that has never been published.
+  ///
+  /// Read from pub.dev rather than `pubspec.yaml` for anything published:
+  /// every release ends by bumping pubspec to a "next potential" version that
+  /// doesn't exist, so pubspec routinely names something never shipped
+  /// (`3.6.0` while `3.5.0` is the newest release).
   final String currentVersion;
 
-  // TODO: compute from conventional-commit bump detection / overrides.
-  final String? newVersion;
-  // TODO: compute alongside newVersion.
-  final String? bumpLevel;
-  // TODO: resolve from the commits contributing to this release.
-  final List<String> contributingPrs;
+  final String newVersion;
+
+  /// Null for a promotion or a first release -- nothing was "bumped".
+  final VersionBumpType? bumpLevel;
+
+  /// The commits that justified this release.
+  final List<ConventionalCommit> contributingCommits;
+
+  final List<NativeSdkDelta> nativeSdkDeltas;
+
+  /// Anything a human should see about how this plan was derived -- notably
+  /// a published version whose tag is missing, which widens the commit range.
+  final List<String> warnings;
 
   PackagePlan({
     required this.package,
     required this.currentVersion,
-    this.newVersion,
+    required this.newVersion,
     this.bumpLevel,
-    this.contributingPrs = const [],
+    this.contributingCommits = const [],
+    this.nativeSdkDeltas = const [],
+    this.warnings = const [],
   });
 }
 
@@ -83,18 +105,599 @@ class ReleasePlan {
 /// `preview_release.dart` (which only prints it) so the two can't drift
 /// apart.
 ///
-/// TODO: conventional-commit bump detection, native SDK version checks, and
-/// PR resolution -- `newVersion`/`bumpLevel`/`contributingPrs` are null or
-/// empty on every returned plan until those land.
-Future<ReleasePlan> computeReleasePlan(RunContext ctx) async {
+/// The gateways are injectable so tests need neither network nor a real git
+/// history; all default to real implementations rooted at
+/// [RunContext.repoRoot].
+Future<ReleasePlan> computeReleasePlan(
+  RunContext ctx, {
+  GitDir? gitDir,
+  NativeSdkGateways? nativeSdkGateways,
+  PublishedVersionsGateway? publishedVersions,
+}) async {
+  _validateTriggerInputs(ctx);
+
+  final resolvedGitDir =
+      gitDir ??
+      await GitDir.fromExisting(ctx.repoRoot, allowSubdirectory: true);
+  final published = publishedVersions ?? fetchPublishedVersions;
+  final gateways = nativeSdkGateways ?? _githubGateways(ctx.repoRoot);
+
   final groups = await _resolveGroups(ctx);
   final selected = _selectPackages(groups, ctx);
 
-  final plans = selected
-      .map((pkg) => PackagePlan(package: pkg, currentVersion: pkg.version))
-      .toList();
+  final plans = <PackagePlan>[];
+  for (final pkg in selected) {
+    final plan = await _computePackagePlan(
+      pkg,
+      ctx,
+      resolvedGitDir,
+      gateways,
+      await published(pkg.name),
+      isExplicitlyRequested: ctx.requestedPackages.contains(pkg.name),
+    );
+    if (plan != null) plans.add(plan);
+  }
 
   return ReleasePlan(trigger: ctx.trigger, packages: plans);
+}
+
+NativeSdkGateways _githubGateways(String repoRoot) {
+  final github = GithubCommandWrapper(repoRoot);
+  return NativeSdkGateways(
+    fetchLatest: (repoSlug) async =>
+        (await github.getLatestRelease(_log, repoSlug)).tagName,
+    resolveCommitSha: (repoSlug, ref) =>
+        github.getCommitSha(_log, repoSlug, ref),
+    releaseExists: (repoSlug, version) async =>
+        await github.getReleaseByTagName(_log, repoSlug, version) != null,
+  );
+}
+
+/// Rejects per-run overrides the run has no coherent way to honour, rather
+/// than accepting and silently reinterpreting them.
+///
+/// Only the mainline path derives a bump level at all: a patch branch forces
+/// `patch` by definition, and a pre-release branch's version comes from the
+/// prerelease counter. A `BUMP_TYPE` on either would read as "this release is
+/// a major" and quietly not be.
+///
+/// Even on mainline it requires an explicit `PACKAGES`. "Override the computed
+/// bump" is only meaningful about packages the caller named: combined with
+/// `--all` it re-levels whatever happened to qualify, so a single `fix:` typo
+/// ships as a major.
+void _validateTriggerInputs(RunContext ctx) {
+  final bumpType = ctx.bumpTypeOverride;
+  if (bumpType == null || bumpType.isEmpty) return;
+
+  switch (ctx.trigger) {
+    case TriggerContext.mainline:
+      if (ctx.requestedPackages.isEmpty) {
+        throw StateError(
+          'BUMP_TYPE="$bumpType" requires an explicit PACKAGES list -- it '
+          'applies uniformly to every package in the run, so on an --all run '
+          'it would re-level whichever packages happened to qualify, turning '
+          'an unrelated fix into a $bumpType release. Name the packages this '
+          'bump is for, or clear BUMP_TYPE and let the commits decide.',
+        );
+      }
+      // Otherwise parsed (and rejected if unrecognized) where it's applied.
+      return;
+    case TriggerContext.patch:
+      throw StateError(
+        'BUMP_TYPE="$bumpType" does not apply on a patch branch -- a patch '
+        'release always increments the patch level of its release line, and '
+        'a commit that would justify anything more is rejected outright. '
+        'Clear BUMP_TYPE, or release from develop instead.',
+      );
+    case TriggerContext.preRelease:
+      throw StateError(
+        'BUMP_TYPE="$bumpType" does not apply on a pre-release branch -- the '
+        'version comes from the prerelease counter against a target computed '
+        'from the last stable release. Use PRERELEASE_LABEL to start a new '
+        'label.',
+      );
+  }
+}
+
+Future<PackagePlan?> _computePackagePlan(
+  DiscoveredPackage pkg,
+  RunContext ctx,
+  GitDir gitDir,
+  NativeSdkGateways gateways,
+  PublishedVersions published, {
+  required bool isExplicitlyRequested,
+}) async {
+  // Two questions, answered separately because on a pre-release line they
+  // have different answers:
+  //
+  //   versionBase -- what the new version is derived from.
+  //   commitBase  -- what "since we last shipped" means, for the changelog
+  //                  range and for whether this package ships at all.
+  //
+  // They coincide on mainline (a stable release supersedes the whole line)
+  // and on a patch branch (confined to its own line). A pre-release run has
+  // to resolve its target first, because both its baselines are scoped to
+  // that target's line -- see [_prereleaseTarget].
+  final Version? versionBase;
+  final Version? commitBase;
+  final warnings = <String>[];
+
+  switch (ctx.trigger) {
+    case TriggerContext.mainline:
+      versionBase = commitBase = published.latestStable;
+    case TriggerContext.patch:
+      final (major, minor) = _releaseLineFromPatchBranch(ctx.currentBranch);
+      versionBase = commitBase = published.latestOn(major, minor);
+      if (versionBase == null) {
+        throw StateError(
+          'Branch "${ctx.currentBranch}" patches the $major.$minor.x line of '
+          '"${pkg.name}", but no $major.$minor release of it has been '
+          'published. A patch branch builds on an existing release; there is '
+          'nothing here to patch. Check the branch name, or release '
+          '$major.$minor.0 from develop first.',
+        );
+      }
+    case TriggerContext.preRelease:
+      final target = await _prereleaseTarget(pkg, published, gitDir, warnings);
+      versionBase = target;
+      // Scoped to the target's own line. The global newest release is the
+      // wrong answer here: a concurrent pre-release effort (a `v5` branch
+      // publishing `5.0.0-alpha.1` while `v4` is still shipping betas) is
+      // unrelated to this line, and taking its tag as the range start would
+      // both mis-measure "what's new" and reject this line's next beta for
+      // sorting below it.
+      commitBase =
+          published.prereleasesAt(target).lastOrNull ?? published.latestStable;
+  }
+
+  final (sinceSha, rangeWarnings) = await _commitRangeStart(
+    gitDir,
+    pkg.name,
+    published,
+    commitBase,
+  );
+  for (final warning in rangeWarnings) {
+    if (!warnings.contains(warning)) warnings.add(warning);
+  }
+  final commits = await _conventionalCommitsSince(
+    gitDir,
+    pathspec: pkg.relativePath,
+    sinceSha: sinceSha,
+  );
+
+  final files = resolveNativeDependencyFiles(pkg.absolutePath(ctx.repoRoot));
+
+  // Whether this package releases at all is decided before anything touches
+  // the network -- resolving native SDK targets for a package with nothing to
+  // ship is pure waste.
+  //
+  // A patch run is exempt: its single package comes from the branch name, and
+  // a patch branch exists precisely because something needs shipping from it.
+  if (ctx.trigger != TriggerContext.patch &&
+      aggregateBumpLevel(commits) == null &&
+      !isExplicitlyRequested &&
+      !_hasForcedNativeUpdate(files, ctx)) {
+    return null;
+  }
+
+  final nativeSdkDeltas = await _computeNativeSdkDeltas(files, ctx, gateways);
+  final currentVersion = published.latest?.toString() ?? pkg.version;
+
+  return switch (ctx.trigger) {
+    TriggerContext.patch => _computePatchPlan(
+      pkg,
+      currentVersion,
+      commits,
+      versionBase,
+      nativeSdkDeltas,
+      warnings,
+    ),
+    TriggerContext.preRelease => _computePrereleasePlan(
+      pkg,
+      ctx,
+      currentVersion,
+      commits,
+      versionBase,
+      published,
+      nativeSdkDeltas,
+      warnings,
+    ),
+    TriggerContext.mainline => _computeMainlinePlan(
+      pkg,
+      ctx,
+      currentVersion,
+      commits,
+      versionBase,
+      nativeSdkDeltas,
+      warnings,
+    ),
+  };
+}
+
+/// The version a pre-release run is working towards.
+///
+/// Computed, not declared: the last stable release plus the bump aggregated
+/// from every commit since it (`3.5.0` + a `feat!` on `v4` -> `4.0.0`). This
+/// is the same derivation a stable release would use, which is what makes a
+/// pre-release "mainline plus a suffix" and makes the path self-correcting --
+/// once `4.0.0` ships stably the base moves on and the target becomes
+/// `4.1.0`.
+///
+/// Note this aggregates from the last **stable** release, not the last
+/// pre-release. Measuring from the previous beta would make the target
+/// collapse as the line progresses: after `4.0.0-beta.1`, a lone `fix:` would
+/// compute `3.5.1` instead of `4.0.0`.
+///
+/// A package with no stable release takes `pubspec.yaml`'s version, which for
+/// something never published is the only declaration of what it's aiming at.
+Future<Version> _prereleaseTarget(
+  DiscoveredPackage pkg,
+  PublishedVersions published,
+  GitDir gitDir,
+  List<String> warnings,
+) async {
+  final stableBase = published.latestStable;
+  if (stableBase == null) return Version.parse(pkg.version);
+
+  final (sinceSha, stableWarnings) = await _commitRangeStart(
+    gitDir,
+    pkg.name,
+    published,
+    stableBase,
+  );
+  for (final warning in stableWarnings) {
+    if (!warnings.contains(warning)) warnings.add(warning);
+  }
+
+  final bump = aggregateBumpLevel(
+    await _conventionalCommitsSince(
+      gitDir,
+      pathspec: pkg.relativePath,
+      sinceSha: sinceSha,
+    ),
+  );
+
+  // Nothing since the last stable carries semver weight -- this package is
+  // only here because it was named or a native SDK override is driving it, so
+  // the next patch is what it's aiming at.
+  return _applyBump(stableBase, bump ?? VersionBumpType.patch);
+}
+
+/// The sha a commit range starts from, plus anything a human should know
+/// about how it was chosen.
+///
+/// pub.dev can legitimately know a version git can't locate -- a release
+/// published before its tag was pushed, or whose tag never was. Two of
+/// `datadog_flutter_plugin`'s 65 published versions are in that state today.
+/// Rather than reconciling the two sources up front (which would report the
+/// same historical gaps on every run until people stopped reading them), this
+/// walks back to the newest version that does resolve and says so. A stale
+/// entry is only ever consulted when it's the newest on the line being
+/// released, so the noise is bounded to the case that actually matters.
+Future<(String?, List<String>)> _commitRangeStart(
+  GitDir gitDir,
+  String packageName,
+  PublishedVersions published,
+  Version? from,
+) async {
+  if (from == null) return (null, <String>[]);
+
+  final candidates = published.versions
+      .where((v) => v <= from)
+      .toList()
+      .reversed;
+
+  for (final version in candidates) {
+    final sha = await tagSha(gitDir, '$packageName/v$version');
+    if (sha == null) continue;
+    if (version == from) return (sha, <String>[]);
+    return (
+      sha,
+      [
+        '$from is published but has no tag -- the commit range falls back to '
+            'v$version, so this changelog may repeat entries already shipped '
+            'in $from.',
+      ],
+    );
+  }
+
+  return (
+    null,
+    [
+      'No tag could be found for any published version of $packageName up to '
+          '$from -- the commit range covers the package\'s entire history and '
+          'this changelog will almost certainly repeat released entries.',
+    ],
+  );
+}
+
+PackagePlan _computePatchPlan(
+  DiscoveredPackage pkg,
+  String currentVersion,
+  List<ConventionalCommit> commits,
+  Version? versionBase,
+  List<NativeSdkDelta> nativeSdkDeltas,
+  List<String> warnings,
+) {
+  for (final commit in commits) {
+    final bump = commit.bumpType;
+    if (bump == VersionBumpType.major || bump == VersionBumpType.minor) {
+      throw StateError(
+        'Commit looks like a ${bump!.name} change, which does not belong on '
+        'a patch branch (only fixes are allowed here):\n'
+        '${commit.type}: ${commit.description}',
+      );
+    }
+  }
+
+  return PackagePlan(
+    package: pkg,
+    currentVersion: currentVersion,
+    newVersion: versionBase == null
+        ? pkg.version
+        : versionBase.incrementPatch().toString(),
+    // Nothing to increment from means nothing was bumped -- see the same
+    // reasoning in _computeMainlinePlan.
+    bumpLevel: versionBase == null ? null : VersionBumpType.patch,
+    contributingCommits: commits,
+    nativeSdkDeltas: nativeSdkDeltas,
+    warnings: warnings,
+  );
+}
+
+PackagePlan _computeMainlinePlan(
+  DiscoveredPackage pkg,
+  RunContext ctx,
+  String currentVersion,
+  List<ConventionalCommit> commits,
+  Version? versionBase,
+  List<NativeSdkDelta> nativeSdkDeltas,
+  List<String> warnings,
+) {
+  // Never released stably: pubspec.yaml states the intended first version and
+  // is the only source for it, so nothing is bumped and bumpLevel stays null.
+  // Reporting a level here would misdescribe the plan -- datadog_session_replay
+  // has only ever published previews, and its commits aggregate to `major`
+  // while the version comes from pubspec untouched.
+  if (versionBase == null) {
+    return PackagePlan(
+      package: pkg,
+      currentVersion: currentVersion,
+      newVersion: pkg.version,
+      contributingCommits: commits,
+      nativeSdkDeltas: nativeSdkDeltas,
+      warnings: warnings,
+    );
+  }
+
+  // With nothing auto-detected, this package is here because it was asked for
+  // by name or a forced native SDK update is driving it -- still worth a
+  // release, treated as a maintenance patch.
+  final bump =
+      VersionBumpType.parseOverride(ctx.bumpTypeOverride) ??
+      aggregateBumpLevel(commits) ??
+      VersionBumpType.patch;
+
+  return PackagePlan(
+    package: pkg,
+    currentVersion: currentVersion,
+    newVersion: _applyBump(versionBase, bump).toString(),
+    bumpLevel: bump,
+    contributingCommits: commits,
+    nativeSdkDeltas: nativeSdkDeltas,
+    warnings: warnings,
+  );
+}
+
+/// A pre-release is mainline plus a suffix: the target is computed the same
+/// way a stable release would be, then a counter is appended.
+///
+/// The target is deliberately *not* read from `pubspec.yaml`, which would be
+/// a second source of truth free to disagree with what has actually shipped.
+/// Computing it also makes the path self-correcting: once `4.0.0` ships
+/// stably the base moves on, the target becomes `4.1.0` or `5.0.0`, and no
+/// state is left claiming otherwise.
+PackagePlan _computePrereleasePlan(
+  DiscoveredPackage pkg,
+  RunContext ctx,
+  String currentVersion,
+  List<ConventionalCommit> commits,
+  Version? target,
+  PublishedVersions published,
+  List<NativeSdkDelta> nativeSdkDeltas,
+  List<String> warnings,
+) {
+  target!;
+  final counter = published.prereleasesAt(target).lastOrNull;
+  final label = ctx.prereleaseLabel;
+
+  final Version newVersion;
+  if (counter != null && (label == null || counter.preRelease.first == label)) {
+    newVersion = counter.incrementPreRelease();
+  } else if (published.hasStableAt(target)) {
+    // Can only happen when the target was reached by a path that doesn't
+    // consult the commits (a never-published package taking its version from
+    // pubspec, say) -- a new pre-release here would sort below a release
+    // that already exists.
+    throw StateError(
+      'Package "${pkg.name}" target $target has already been released stably '
+      '-- a pre-release against it would sort below the published version.',
+    );
+  } else if (label != null) {
+    newVersion = Version(
+      target.major,
+      target.minor,
+      target.patch,
+      preRelease: [label, '1'],
+    );
+  } else {
+    throw StateError(
+      'No prior pre-release for "${pkg.name}" at target $target -- '
+      'PRERELEASE_LABEL is required the first time a label is used against a '
+      'given target version.',
+    );
+  }
+
+  // Whatever the branches above decided, a release has to move forward.
+  //
+  // Asserted as an invariant rather than enumerated as another case, because
+  // the ways to go backwards outnumber the ways to go forwards: labels are
+  // compared lexically by semver, so `beta` after `rc.1` restarts at
+  // `beta.1` -- already published, and below the latest release. It doesn't
+  // self-correct either: `rc.1` stays the highest at this target, so every
+  // subsequent run proposes that same `beta.1` again.
+  //
+  // Scoped to this target's own line, not to the newest release anywhere: a
+  // concurrent effort publishing `5.0.0-alpha.1` says nothing about whether
+  // `4.0.0-beta.2` moves this line forward, and comparing against it would
+  // block the `v4` line entirely.
+  final highestAtTarget = published.prereleasesAt(target).lastOrNull;
+  if (highestAtTarget != null && newVersion <= highestAtTarget) {
+    throw StateError(
+      'Pre-release $newVersion for "${pkg.name}" would not move forward from '
+      'the published $highestAtTarget. Pre-release labels are ordered '
+      'lexically (alpha < beta < rc), so a label earlier than the one already '
+      'shipped restarts below it. Continue with a label that sorts after '
+      '"${highestAtTarget.preRelease.first}".',
+    );
+  }
+
+  return PackagePlan(
+    package: pkg,
+    currentVersion: currentVersion,
+    newVersion: newVersion.toString(),
+    bumpLevel: VersionBumpType.prerelease,
+    // The version is counter-based rather than commit-derived, but the
+    // commits are still what the changelog is written from.
+    contributingCommits: commits,
+    nativeSdkDeltas: nativeSdkDeltas,
+    warnings: warnings,
+  );
+}
+
+Version _applyBump(Version base, VersionBumpType bump) {
+  switch (bump) {
+    case VersionBumpType.major:
+      return base.incrementMajor();
+    case VersionBumpType.minor:
+      return base.incrementMinor();
+    case VersionBumpType.patch:
+      return base.incrementPatch();
+    case VersionBumpType.prerelease:
+      throw ArgumentError(
+        '_applyBump does not handle prerelease bumps -- see '
+        '_computePrereleasePlan for that path.',
+      );
+  }
+}
+
+/// Whether this run carries an explicit native SDK version override for an SDK
+/// [files] shows the package actually depends on.
+///
+/// Scoped that way deliberately: an `IOS_SDK_VERSION` on an `--all` run should
+/// make the iOS packages eligible, not sweep every pure-Dart package in the
+/// repo into the release alongside them.
+bool _hasForcedNativeUpdate(NativeDependencyFiles files, RunContext ctx) =>
+    ((files.iosPodspec != null || files.iosSpmManifest != null) &&
+        ctx.iosSdkVersionOverride != null) ||
+    (files.androidGradle != null && ctx.androidSdkVersionOverride != null) ||
+    (files.cppCMakeLists.isNotEmpty && ctx.cppVersionOverride != null);
+
+/// Resolves what each native SDK this package depends on should be pinned to
+/// this run, one [NativeSdkDelta] per SDK it actually ships a manifest for.
+///
+/// Purely a *target* resolution -- see [NativeSdkDelta] for why there's no
+/// "current pin" to compare against.
+Future<List<NativeSdkDelta>> _computeNativeSdkDeltas(
+  NativeDependencyFiles files,
+  RunContext ctx,
+  NativeSdkGateways gateways,
+) async {
+  final perSdkFiles = {
+    NativeSdk.ios: (
+      files: [?files.iosPodspec, ?files.iosSpmManifest],
+      override: ctx.iosSdkVersionOverride,
+    ),
+    NativeSdk.android: (
+      files: [?files.androidGradle],
+      override: ctx.androidSdkVersionOverride,
+    ),
+    NativeSdk.cpp: (
+      files: files.cppCMakeLists,
+      override: ctx.cppVersionOverride,
+    ),
+  };
+
+  final deltas = <NativeSdkDelta>[];
+  for (final MapEntry(key: sdk, value: (:files, :override))
+      in perSdkFiles.entries) {
+    if (files.isEmpty) continue;
+
+    final target = await resolveNativeSdkTarget(
+      trigger: ctx.trigger,
+      override: override,
+      fetchLatest: () => gateways.fetchLatest(sdk.repoSlug),
+      releaseExists: (version) => gateways.releaseExists(sdk.repoSlug, version),
+    );
+
+    deltas.add(
+      NativeSdkDelta(
+        sdk: sdk,
+        targetVersion: target,
+        // CMake's FetchContent_Declare has no field for pinning a tag and
+        // verifying its commit -- the resolved SHA is what actually gets
+        // written to GIT_TAG (see cmake_util.dart's pinCppVersion).
+        targetSha: sdk == NativeSdk.cpp && target != null
+            ? await gateways.resolveCommitSha(sdk.repoSlug, target)
+            : null,
+        files: files,
+      ),
+    );
+  }
+
+  return deltas;
+}
+
+/// [commitMessagesSince]'s raw messages, parsed into [ConventionalCommit]s
+/// and narrowed to the ones that carry semver weight -- commits that fail
+/// to parse, or parse but don't bump anything (`chore:`, `docs:`, etc.),
+/// are dropped since nothing here cares about them either as bump input or
+/// as a [PackagePlan.contributingCommits] entry.
+Future<List<ConventionalCommit>> _conventionalCommitsSince(
+  GitDir gitDir, {
+  required String pathspec,
+  String? sinceSha,
+}) async {
+  final messages = await commitMessagesSince(
+    gitDir,
+    pathspec: pathspec,
+    sinceSha: sinceSha,
+  );
+  return messages
+      .map(ConventionalCommit.parse)
+      .nonNulls
+      .where((c) => c.bumpType != null)
+      .toList();
+}
+
+final _patchBranchPattern = RegExp(
+  r'^release/(?<package>[^/]+)/v(?<major>\d+)\.(?<minor>\d+)\.x$',
+);
+
+/// Extracts the package name from a `release/{package}/v{major}.{minor}.x`
+/// patch-branch name, or null if [branch] doesn't match that convention.
+String? packageNameFromPatchBranch(String branch) =>
+    _patchBranchPattern.firstMatch(branch)?.namedGroup('package');
+
+/// The `{major}.{minor}` release line a patch branch is confined to. Only
+/// called once [_resolveGroups] has validated the branch matches the
+/// convention, so a non-match here would be a bug in that validation.
+(int major, int minor) _releaseLineFromPatchBranch(String branch) {
+  final match = _patchBranchPattern.firstMatch(branch)!;
+  return (
+    int.parse(match.namedGroup('major')!),
+    int.parse(match.namedGroup('minor')!),
+  );
 }
 
 Future<List<PackageGroup>> _resolveGroups(RunContext ctx) async {

--- a/tools/releaser/lib/trigger_context.dart
+++ b/tools/releaser/lib/trigger_context.dart
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+/// Which of the three GitLab trigger contexts a run is happening under:
+/// mainline (`develop`), patch (a standing `release/{package}/vX.Y.x`
+/// branch), or pre-release (a whitelisted long-lived branch like `v4`).
+///
+/// Lives in its own file (rather than alongside `release_plan.dart`, its
+/// only real "owner") because `native_sdk.dart` also needs it, and
+/// `release_plan.dart` in turn needs types from `native_sdk.dart` --
+/// putting the enum in either file would create a cyclic import between
+/// the two.
+enum TriggerContext { mainline, patch, preRelease }

--- a/tools/releaser/lib/version_bump.dart
+++ b/tools/releaser/lib/version_bump.dart
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+/// The semver bump a release applies.
+///
+/// Deliberately separate from the identically-named enum in
+/// `version_updater.dart`. That one belongs to the legacy `releaser` CLI,
+/// still carries a `rev` variant, and is scheduled for deletion once
+/// `prepare_release.dart` replaces that pipeline. Sharing it would couple the
+/// release-plan module to code on its way out; a duplicated enum until then
+/// is the cheaper side of that trade.
+enum VersionBumpType {
+  patch(severity: 0),
+  minor(severity: 1),
+  major(severity: 2),
+  // Not part of the major/minor/patch severity ordering below -- assigned
+  // directly from a prerelease label/counter, never derived by comparing
+  // against another bump level.
+  prerelease(severity: -1);
+
+  /// Where this bump ranks against another major/minor/patch bump (higher
+  /// wins). Meaningless for [prerelease], which is never compared this way.
+  final int severity;
+
+  const VersionBumpType({required this.severity});
+
+  /// Parses a `BUMP_TYPE` per-run override -- major/minor/patch only, or
+  /// null for "no override given" (a null or empty [raw]). `prerelease`
+  /// isn't a valid override; that path is driven by `PRERELEASE_LABEL` on
+  /// a pre-release branch instead. Throws rather than silently falling
+  /// back on anything unrecognized, so a typo'd `BUMP_TYPE` fails the run
+  /// rather than quietly becoming a patch bump.
+  static VersionBumpType? parseOverride(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+
+    switch (raw) {
+      case 'major':
+        return VersionBumpType.major;
+      case 'minor':
+        return VersionBumpType.minor;
+      case 'patch':
+        return VersionBumpType.patch;
+      default:
+        throw StateError('BUMP_TYPE "$raw" is not one of major, minor, patch.');
+    }
+  }
+}

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "105.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "14.1.0"
   args:
     dependency: "direct main"
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,34 +45,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.12.7"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,18 +133,18 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
+      sha256: "82ade9fc4273f29ed673e33166944465225b4f7fc5d4aaef48605cc751c18fc1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.7"
+    version: "3.1.13"
   file:
     dependency: transitive
     description:
@@ -173,10 +173,10 @@ packages:
     dependency: "direct main"
     description:
       name: git
-      sha256: de678c6f0d5e2761c2c3643d31b1010883cc4d3e352949ef7c15f98f27d676ea
+      sha256: "46556ed28a3b25b1be9bcde0291d84a57b206a899f8b37bf7ab335d8fb640e84"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   glob:
     dependency: "direct main"
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
+      sha256: e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d
       url: "https://pub.dev"
     source: hosted
-    version: "6.14.0"
+    version: "6.14.1"
   lints:
     dependency: "direct dev"
     description:
@@ -253,18 +253,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.20"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   path:
     dependency: "direct main"
     description:
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -357,18 +357,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
+      sha256: "11b6047da8e4eb6c643ccac3d0fda3f9c9e11651695f7da24a85ade8aff15a44"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.3.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
+      sha256: "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.12"
+    version: "1.3.13"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -381,18 +381,18 @@ packages:
     dependency: transitive
     description:
       name: source_maps
-      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      sha256: "14c2945847669b44089bb1222f66873d7ff7103c58911917f2a63c5a62327898"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.13"
+    version: "0.10.14"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -437,26 +437,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
+      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.1"
+    version: "1.31.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.13"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
+      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18"
+    version: "0.6.19"
   typed_data:
     dependency: transitive
     description:
@@ -477,18 +477,18 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   web:
     dependency: transitive
     description:
@@ -530,4 +530,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/tools/releaser/test/cmake_util_test.dart
+++ b/tools/releaser/test/cmake_util_test.dart
@@ -1,0 +1,161 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:releaser/cmake_util.dart';
+
+const _sha = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+void main() {
+  late Directory root;
+  final logger = Logger('cmake_util_test');
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('cmake_util_test_');
+  });
+
+  tearDown(() => root.delete(recursive: true));
+
+  test('pins GIT_TAG to the SHA, keeping the tag as a trailing comment, '
+      'preserving a trailing GIT_CONFIG line', () async {
+    final file = File(p.join(root.path, 'CMakeLists.txt'));
+    await file.writeAsString('''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop
+  GIT_CONFIG     core.longpaths=true)
+''');
+
+    await pinCppVersion(file, 'v1.4.0', _sha, logger, false);
+
+    final contents = await file.readAsString();
+    expect(contents, contains('GIT_TAG        $_sha  # v1.4.0'));
+    expect(contents, contains('GIT_CONFIG     core.longpaths=true)'));
+    expect(contents, isNot(contains('develop')));
+  });
+
+  test(
+    'keeps the closing paren before the comment when it is on the same line',
+    () async {
+      final file = File(p.join(root.path, 'CMakeLists.txt'));
+      await file.writeAsString('''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop)
+''');
+
+      await pinCppVersion(file, 'v1.4.0', _sha, logger, false);
+
+      final contents = await file.readAsString();
+      // The `)` must stay *before* the comment -- moving it after would
+      // comment out the closing paren and break FetchContent_Declare(...).
+      expect(contents, contains('GIT_TAG        $_sha)  # v1.4.0'));
+    },
+  );
+
+  test(
+    're-pinning replaces both the old SHA and the old comment cleanly',
+    () async {
+      final file = File(p.join(root.path, 'CMakeLists.txt'));
+      await file.writeAsString(
+        'FetchContent_Declare(dd-sdk-cpp\n'
+        '  GIT_TAG        oldsha1234567890oldsha1234567890oldsha1)  # v1.3.0\n',
+      );
+
+      await pinCppVersion(file, 'v1.4.0', _sha, logger, false);
+
+      final contents = await file.readAsString();
+      expect(contents, contains('  GIT_TAG        $_sha)  # v1.4.0'));
+    },
+  );
+
+  test('dry run leaves the file untouched', () async {
+    final file = File(p.join(root.path, 'CMakeLists.txt'));
+    const original =
+        'FetchContent_Declare(dd-sdk-cpp\n  GIT_TAG        develop)\n';
+    await file.writeAsString(original);
+
+    await pinCppVersion(file, 'v1.4.0', _sha, logger, true);
+
+    expect(await file.readAsString(), original);
+  });
+
+  test('a second FetchContent_Declare for a different dependency keeps its '
+      'own GIT_TAG untouched', () async {
+    final file = File(p.join(root.path, 'CMakeLists.txt'));
+    await file.writeAsString('''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop)
+FetchContent_MakeAvailable(dd-sdk-cpp)
+
+FetchContent_Declare(some_other_dep
+  GIT_REPOSITORY https://github.com/example/some_other_dep.git
+  GIT_TAG        v9.9.9)
+FetchContent_MakeAvailable(some_other_dep)
+''');
+
+    await pinCppVersion(file, 'v1.4.0', _sha, logger, false);
+
+    final contents = await file.readAsString();
+    expect(contents, contains('GIT_TAG        $_sha)  # v1.4.0'));
+    expect(contents, contains('GIT_TAG        v9.9.9)'));
+  });
+
+  test('handles a declaration written on a single line', () async {
+    final file = File(p.join(root.path, 'CMakeLists.txt'));
+    await file.writeAsString(
+      'FetchContent_Declare(dd-sdk-cpp '
+      'GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git '
+      'GIT_TAG develop)\n',
+    );
+
+    await pinCppVersion(file, 'v1.4.0', _sha, logger, false);
+
+    expect(
+      (await file.readAsString()).trim(),
+      'FetchContent_Declare(dd-sdk-cpp '
+      'GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git '
+      'GIT_TAG $_sha)  # v1.4.0',
+    );
+  });
+
+  test('re-pinning replaces the previous annotation rather than stacking '
+      'another one', () async {
+    final file = File(p.join(root.path, 'CMakeLists.txt'));
+    await file.writeAsString(
+      'FetchContent_Declare(dd-sdk-cpp\n  GIT_TAG        $_sha)  # v1.4.0\n',
+    );
+
+    await pinCppVersion(file, 'v1.5.0', _sha, logger, false);
+
+    final contents = await file.readAsString();
+    expect(contents, contains('GIT_TAG        $_sha)  # v1.5.0'));
+    expect(contents, isNot(contains('v1.4.0')));
+  });
+
+  test('leaves everything else in the file untouched', () async {
+    final file = File(p.join(root.path, 'CMakeLists.txt'));
+    await file.writeAsString('''
+cmake_minimum_required(VERSION 3.14)
+set(PROJECT_NAME "datadog_flutter_plugin_desktop")
+
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop)
+FetchContent_MakeAvailable(dd-sdk-cpp)
+''');
+
+    await pinCppVersion(file, 'v1.4.0', _sha, logger, false);
+
+    final contents = await file.readAsString();
+    expect(contents, contains('cmake_minimum_required(VERSION 3.14)'));
+    expect(contents, contains('FetchContent_MakeAvailable(dd-sdk-cpp)'));
+  });
+}

--- a/tools/releaser/test/conventional_commits_test.dart
+++ b/tools/releaser/test/conventional_commits_test.dart
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:test/test.dart';
+
+import 'package:releaser/conventional_commits.dart';
+import 'package:releaser/version_bump.dart';
+
+/// Shorthand matching the old `classifyCommitBump` free function's
+/// behavior, for tests that just want a message's bump type.
+VersionBumpType? _bumpOf(String commitMessage) =>
+    ConventionalCommit.parse(commitMessage)?.bumpType;
+
+/// Parses each message, dropping any that don't parse -- for feeding
+/// [aggregateBumpLevel], which now operates on [ConventionalCommit]s.
+List<ConventionalCommit> _parseAll(List<String> messages) =>
+    messages.map(ConventionalCommit.parse).nonNulls.toList();
+
+void main() {
+  group('ConventionalCommit.parse -- bumpType', () {
+    test('feat: is a minor bump', () {
+      expect(
+        _bumpOf('feat: add frustration signal tracking'),
+        VersionBumpType.minor,
+      );
+    });
+
+    test('fix: and perf: are patch bumps', () {
+      expect(
+        _bumpOf('fix: correct crash on session init'),
+        VersionBumpType.patch,
+      );
+      expect(_bumpOf('perf: reduce startup overhead'), VersionBumpType.patch);
+    });
+
+    test('a ! misplaced before the scope is still a major bump', () {
+      // The convention puts it after the scope, but `feat!(web):` gets
+      // written -- this repo's own v4 history contains one. An unparsed
+      // header is dropped entirely, so refusing this shape silently loses a
+      // breaking change and turns a major release into a minor one.
+      expect(
+        _bumpOf('feat!(web): Update to v7 of the Browser SDK'),
+        VersionBumpType.major,
+      );
+      final commit = ConventionalCommit.parse('feat!(web): Update to v7')!;
+      expect(commit.type, 'feat');
+      expect(commit.scope, 'web');
+      expect(commit.hasBreakingMarker, isTrue);
+      expect(commit.description, 'Update to v7');
+    });
+
+    test('a ! after the type/scope is a major bump regardless of type', () {
+      expect(
+        _bumpOf('feat!: remove deprecated trackEvent API'),
+        VersionBumpType.major,
+      );
+      expect(
+        _bumpOf('fix(ios)!: change method signature'),
+        VersionBumpType.major,
+      );
+    });
+
+    test('a BREAKING CHANGE footer is a major bump', () {
+      final message =
+          'feat: add new config option\n\n'
+          'BREAKING CHANGE: the old option is removed';
+      expect(_bumpOf(message), VersionBumpType.major);
+    });
+
+    test('chore/docs/test do not carry semver weight on their own', () {
+      expect(_bumpOf('chore: bump dependencies'), isNull);
+      expect(_bumpOf('docs: fix typo in README'), isNull);
+      expect(_bumpOf('test: add missing coverage'), isNull);
+    });
+
+    test('a non-conventional-commit message fails to parse entirely', () {
+      expect(
+        ConventionalCommit.parse('Merge pull request #123 from foo/bar'),
+        isNull,
+      );
+    });
+  });
+
+  group('aggregateBumpLevel', () {
+    test('picks the highest severity across all commits', () {
+      final bump = aggregateBumpLevel(
+        _parseAll([
+          'fix: correct crash',
+          'chore: cleanup',
+          'feat: add a thing',
+        ]),
+      );
+      expect(bump, VersionBumpType.minor);
+    });
+
+    test('a single breaking commit outranks everything else', () {
+      final bump = aggregateBumpLevel(
+        _parseAll([
+          'fix: correct crash',
+          'feat!: remove old API',
+          'feat: add a thing',
+        ]),
+      );
+      expect(bump, VersionBumpType.major);
+    });
+
+    test('returns null when nothing carries semver weight', () {
+      final bump = aggregateBumpLevel(
+        _parseAll(['chore: cleanup', 'docs: fix typo']),
+      );
+      expect(bump, isNull);
+    });
+
+    test('returns null for an empty list', () {
+      expect(aggregateBumpLevel(<ConventionalCommit>[]), isNull);
+    });
+  });
+}

--- a/tools/releaser/test/native_sdk_test.dart
+++ b/tools/releaser/test/native_sdk_test.dart
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:releaser/native_sdk.dart';
+import 'package:releaser/trigger_context.dart';
+
+const _iosPodspec = '''
+Pod::Spec.new do |s|
+  s.name             = 'datadog_flutter_plugin_ios'
+  s.dependency 'Flutter'
+  s.dependency 'DatadogCore', '~> 3'
+  s.dependency 'DatadogLogs', '~> 3'
+end
+''';
+
+const _androidGradle = '''
+buildscript {
+    ext.kotlin_version = "2.2.20"
+    ext.datadog_version = "3.11.0"
+}
+''';
+
+const _windowsCMakeLists = '''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop
+  GIT_CONFIG     core.longpaths=true)
+''';
+
+const _linuxCMakeLists = '''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop)
+''';
+
+const _packageSwift = '''
+let package = Package(
+    name: "datadog_session_replay",
+    dependencies: [
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0")
+    ]
+)
+''';
+
+void main() {
+  group('resolveNativeDependencyFiles', () {
+    late Directory root;
+
+    setUp(() async {
+      root = await Directory.systemTemp.createTemp('native_sdk_test_');
+    });
+
+    tearDown(() => root.delete(recursive: true));
+
+    void write(String relativePath, String contents) {
+      final file = File(p.join(root.path, relativePath));
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync(contents);
+    }
+
+    test('finds all native dependency files when present', () {
+      write('ios/datadog_flutter_plugin_ios.podspec', _iosPodspec);
+      write('ios/datadog_flutter_plugin_ios/Package.swift', _packageSwift);
+      write('android/build.gradle', _androidGradle);
+      write('windows/CMakeLists.txt', _windowsCMakeLists);
+      write('linux/CMakeLists.txt', _linuxCMakeLists);
+
+      final files = resolveNativeDependencyFiles(root.path);
+
+      expect(files.iosPodspec, isNotNull);
+      expect(files.iosSpmManifest, isNotNull);
+      expect(files.androidGradle, isNotNull);
+      expect(files.cppCMakeLists, hasLength(2));
+      expect(files.isEmpty, isFalse);
+    });
+
+    test(
+      'finds a Package.swift even when there is no podspec alongside it',
+      () {
+        write('ios/datadog_flutter_plugin_ios/Package.swift', _packageSwift);
+
+        final files = resolveNativeDependencyFiles(root.path);
+
+        expect(files.iosPodspec, isNull);
+        expect(files.iosSpmManifest, isNotNull);
+      },
+    );
+
+    test('ignores a Package.swift with no dd-sdk-ios dependency', () {
+      write(
+        'ios/some_other_plugin/Package.swift',
+        '.package(url: "https://github.com/other/pkg.git", from: "1.0.0")',
+      );
+
+      final files = resolveNativeDependencyFiles(root.path);
+
+      expect(files.iosSpmManifest, isNull);
+    });
+
+    test('ignores a build.gradle with no Datadog dependency', () {
+      write('android/build.gradle', 'ext.kotlin_version = "2.2.20"');
+
+      final files = resolveNativeDependencyFiles(root.path);
+
+      expect(files.androidGradle, isNull);
+      expect(files.isEmpty, isTrue);
+    });
+
+    test('ignores a CMakeLists.txt whose only GIT_TAG belongs to a different '
+        'FetchContent_Declare', () {
+      write('windows/CMakeLists.txt', '''
+FetchContent_Declare(some_other_dep
+  GIT_REPOSITORY https://github.com/example/some_other_dep.git
+  GIT_TAG        v9.9.9)
+''');
+
+      final files = resolveNativeDependencyFiles(root.path);
+
+      expect(files.cppCMakeLists, isEmpty);
+      expect(files.isEmpty, isTrue);
+    });
+
+    test('ignores a podspec with no Datadog dependency', () {
+      write('ios/some_other_plugin.podspec', "s.dependency 'Flutter'");
+
+      final files = resolveNativeDependencyFiles(root.path);
+
+      expect(files.iosPodspec, isNull);
+    });
+
+    test(
+      'a pure-Dart package with no ios/android/windows/linux dirs is empty',
+      () {
+        final files = resolveNativeDependencyFiles(root.path);
+        expect(files.isEmpty, isTrue);
+      },
+    );
+  });
+
+  group('resolveNativeSdkTarget', () {
+    test(
+      'an explicit override wins once confirmed to be a real release',
+      () async {
+        final target = await resolveNativeSdkTarget(
+          trigger: TriggerContext.mainline,
+          override: '3.12.0',
+          fetchLatest: () => Future.value('9.9.9'),
+          releaseExists: (version) async => version == '3.12.0',
+        );
+        expect(target, '3.12.0');
+      },
+    );
+
+    test('an override that is not a real release fails loudly', () async {
+      await expectLater(
+        resolveNativeSdkTarget(
+          trigger: TriggerContext.mainline,
+          override: 'not-a-real-version',
+          fetchLatest: () => Future.value('9.9.9'),
+          releaseExists: (version) async => false,
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('on a patch branch, no override means no change (and no '
+        'releaseExists call)', () async {
+      final target = await resolveNativeSdkTarget(
+        trigger: TriggerContext.patch,
+        override: null,
+        fetchLatest: () => Future.value('9.9.9'),
+        releaseExists: (version) =>
+            throw StateError('should not be called with no override'),
+      );
+      expect(target, isNull);
+    });
+
+    test('a patch-branch override still applies', () async {
+      final target = await resolveNativeSdkTarget(
+        trigger: TriggerContext.patch,
+        override: '3.12.1',
+        fetchLatest: () => Future.value('9.9.9'),
+        releaseExists: (version) async => true,
+      );
+      expect(target, '3.12.1');
+    });
+
+    test(
+      'on develop, no override means latest (and no releaseExists call)',
+      () async {
+        final target = await resolveNativeSdkTarget(
+          trigger: TriggerContext.mainline,
+          override: null,
+          fetchLatest: () => Future.value('3.13.0'),
+          releaseExists: (version) =>
+              throw StateError('should not be called with no override'),
+        );
+        expect(target, '3.13.0');
+      },
+    );
+
+    test('on a pre-release branch, no override also means latest', () async {
+      final target = await resolveNativeSdkTarget(
+        trigger: TriggerContext.preRelease,
+        override: null,
+        fetchLatest: () => Future.value('3.13.0'),
+        releaseExists: (version) =>
+            throw StateError('should not be called with no override'),
+      );
+      expect(target, '3.13.0');
+    });
+  });
+}

--- a/tools/releaser/test/published_versions_test.dart
+++ b/tools/releaser/test/published_versions_test.dart
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:releaser/published_versions.dart';
+import 'package:test/test.dart';
+import 'package:version/version.dart';
+
+PublishedVersions of(List<String> versions) =>
+    PublishedVersions(versions.map(Version.parse).toList());
+
+void main() {
+  group('queries', () {
+    // Shaped like datadog_flutter_plugin's real history: an old pre-release
+    // line, several stable lines, and a live pre-release line on top.
+    final history = of([
+      '1.0.0-rc.1',
+      '1.0.0',
+      '3.1.2',
+      '3.1.3',
+      '3.5.0',
+      '4.0.0-beta.1',
+      '4.0.0-beta.2',
+    ]);
+
+    test('latest is the newest release of any kind', () {
+      // What a commit range and an eligibility check want -- "when did we
+      // last ship anything" -- so an untouched package on a pre-release line
+      // doesn't re-walk its whole history.
+      expect(history.latest, Version.parse('4.0.0-beta.2'));
+    });
+
+    test('latestStable skips the live pre-release line', () {
+      expect(history.latestStable, Version.parse('3.5.0'));
+    });
+
+    test('latestOn restricts to one release line', () {
+      expect(history.latestOn(3, 1), Version.parse('3.1.3'));
+      expect(history.latestOn(9, 9), isNull);
+    });
+
+    test('prereleasesAt finds the counter for a target', () {
+      expect(history.prereleasesAt(Version.parse('4.0.0')), [
+        Version.parse('4.0.0-beta.1'),
+        Version.parse('4.0.0-beta.2'),
+      ]);
+    });
+
+    test("prereleasesAt ignores the target's own pre-release suffix", () {
+      // A pubspec sitting at 4.0.0-beta.1 mid-line still targets 4.0.0.
+      expect(
+        history.prereleasesAt(Version.parse('4.0.0-beta.1')),
+        hasLength(2),
+      );
+    });
+
+    test('hasStableAt detects an already-shipped target', () {
+      expect(history.hasStableAt(Version.parse('1.0.0')), isTrue);
+      expect(history.hasStableAt(Version.parse('4.0.0')), isFalse);
+    });
+
+    test('an unpublished package answers everything with null/empty', () {
+      expect(PublishedVersions.never.isEmpty, isTrue);
+      expect(PublishedVersions.never.latest, isNull);
+      expect(PublishedVersions.never.latestStable, isNull);
+      expect(PublishedVersions.never.latestOn(1, 0), isNull);
+    });
+
+    test('input order does not matter', () {
+      expect(of(['3.5.0', '1.0.0', '3.1.3']).latest, Version.parse('3.5.0'));
+    });
+  });
+
+  group('parsePubDevVersions', () {
+    test('reads the version list from a pub.dev payload', () {
+      final body =
+          jsonDecode('''
+{"name":"datadog_dio","latest":{"version":"2.3.0"},
+ "versions":[{"version":"2.2.0"},{"version":"2.3.0-beta.1"},{"version":"2.3.0"}]}
+''')
+              as Map<String, dynamic>;
+
+      expect(
+        PublishedVersions(parsePubDevVersions(body)).latest,
+        Version.parse('2.3.0'),
+      );
+      expect(parsePubDevVersions(body), hasLength(3));
+    });
+
+    test('skips an entry that is not valid semver rather than failing', () {
+      // pub.dev won't serve one, but a malformed entry must not be able to
+      // block a release.
+      final body =
+          jsonDecode(
+                '{"versions":[{"version":"1.0.0"},{"version":"not-a-version"}]}',
+              )
+              as Map<String, dynamic>;
+
+      expect(parsePubDevVersions(body), [Version.parse('1.0.0')]);
+    });
+
+    test('a payload with no versions yields an empty history', () {
+      expect(parsePubDevVersions(<String, dynamic>{}), isEmpty);
+    });
+  });
+}

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -2,10 +2,33 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
-import 'package:test/test.dart';
-
+import 'package:path/path.dart' as p;
+import 'package:releaser/native_sdk.dart';
 import 'package:releaser/release_plan.dart';
+import 'package:test/test.dart';
+import 'package:version/version.dart';
+
 import 'support/fixture_repo.dart';
+
+const _iosPodspecWithDatadogDependency = '''
+Pod::Spec.new do |s|
+  s.dependency 'DatadogCore', '~> 3'
+end
+''';
+
+const _windowsCMakeListsWithGitTag = '''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop)
+''';
+
+const _packageSwiftWithDatadogDependency = '''
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0")
+    ]
+)
+''';
 
 void main() {
   late FixtureRepo fixture;
@@ -16,132 +39,600 @@ void main() {
 
   tearDown(() => fixture.delete());
 
-  test(
-    'mainline with no requestedPackages returns every discovered package',
-    () async {
-      final plan = await computeReleasePlan(
-        RunContext(
-          repoRoot: fixture.root.path,
-          trigger: TriggerContext.mainline,
-          currentBranch: 'develop',
-        ),
+  /// Stands in for pub.dev. Anything not named here has never been published,
+  /// which is the fixture's default and the federated sub-packages' real
+  /// state.
+  PublishedVersionsGateway publishedAs(Map<String, List<String>> byPackage) =>
+      (name) async => PublishedVersions(
+        (byPackage[name] ?? const []).map(Version.parse).toList(),
       );
 
-      final names = plan.packages.map((p) => p.package.name);
+  Future<ReleasePlan> plan(
+    RunContext ctx, {
+    Map<String, List<String>> published = const {},
+    Future<String> Function(String repoSlug)? fetchLatestNativeSdkVersion,
+    Future<String> Function(String repoSlug, String ref)? resolveCommitSha,
+    Future<bool> Function(String repoSlug, String version)? releaseExists,
+  }) async => computeReleasePlan(
+    ctx,
+    gitDir: await fixture.gitDir,
+    publishedVersions: publishedAs(published),
+    nativeSdkGateways: NativeSdkGateways(
+      fetchLatest:
+          fetchLatestNativeSdkVersion ??
+          (repoSlug) => throw StateError('fetchLatest not stubbed'),
+      resolveCommitSha:
+          resolveCommitSha ??
+          (repoSlug, ref) => throw StateError('resolveCommitSha not stubbed'),
+      releaseExists: releaseExists ?? (repoSlug, version) async => true,
+    ),
+  );
+
+  RunContext mainlineCtx({
+    List<String> requestedPackages = const [],
+    String? bumpTypeOverride,
+    String? iosSdkVersionOverride,
+    String? cppVersionOverride,
+  }) => RunContext(
+    repoRoot: fixture.root.path,
+    trigger: TriggerContext.mainline,
+    currentBranch: 'develop',
+    requestedPackages: requestedPackages,
+    bumpTypeOverride: bumpTypeOverride,
+    iosSdkVersionOverride: iosSdkVersionOverride,
+    cppVersionOverride: cppVersionOverride,
+  );
+
+  group('mainline, version computation', () {
+    test('bumps from the published version, not from pubspec', () async {
+      // The heart of the rework. pubspec says 2.3.0; every release ends by
+      // bumping pubspec to a "next potential" version, so it routinely names
+      // something that was never shipped. pub.dev says 2.2.0 shipped last.
+      await fixture.tag('datadog_dio/v2.2.0');
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+      await fixture.commit('feat: something new');
+
+      final result = await plan(
+        mainlineCtx(),
+        published: {
+          'datadog_dio': ['2.1.0', '2.2.0'],
+        },
+      );
+
+      final dio = result.packages.singleWhere(
+        (e) => e.package.name == 'datadog_dio',
+      );
+      expect(dio.currentVersion, '2.2.0');
+      expect(dio.newVersion, '2.3.0');
+      expect(dio.bumpLevel, VersionBumpType.minor);
+    });
+
+    test('a never-published package takes its version from pubspec', () async {
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+      await fixture.commit('feat: the first release');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_dio']),
+      );
+
+      expect(result.packages.single.newVersion, '2.3.0');
+      expect(result.packages.single.currentVersion, '2.3.0');
+    });
+
+    test(
+      'a package with only pre-releases published reports no bump level',
+      () async {
+        // datadog_session_replay's real shape: 14 previews, never a stable
+        // release. The version comes from pubspec untouched, so reporting the
+        // commits' `major` aggregate would misdescribe what happened.
+        fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+        await fixture.commit('feat!: breaking work');
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_dio']),
+          published: {
+            'datadog_dio': ['1.0.0-preview.1', '1.0.0-preview.2'],
+          },
+        );
+
+        expect(result.packages.single.newVersion, '2.3.0'); // pubspec
+        expect(result.packages.single.currentVersion, '1.0.0-preview.2');
+        expect(result.packages.single.bumpLevel, isNull);
+      },
+    );
+
+    test('a published pre-release is not mainline\'s baseline', () async {
+      // A v4 line published betas, then merged back. Mainline computes from
+      // the last stable release; the line's own breaking commits carry it to
+      // the major it was leading up to. No promotion special case needed.
+      await fixture.tag('datadog_flutter_plugin/v3.5.0');
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+        'the v4 work',
+      );
+      await fixture.commit('feat!: the federation rework');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_flutter_plugin']),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0', '4.0.0-beta.1', '4.0.0-beta.2'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '4.0.0');
+      expect(result.packages.single.bumpLevel, VersionBumpType.major);
+    });
+  });
+
+  group('mainline, package selection', () {
+    test('--all excludes packages with no qualifying commits', () async {
+      await fixture.tag('datadog_dio/v2.2.0');
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'a real feature');
+      await fixture.commit('feat: add a real feature to dio');
+
+      final result = await plan(
+        mainlineCtx(),
+        published: {
+          'datadog_dio': ['2.2.0'],
+        },
+      );
+      final names = result.packages.map((e) => e.package.name);
+
+      expect(names, contains('datadog_dio'));
+      expect(names, isNot(contains('lonely_ios')));
+    });
+
+    test('BUMP_TYPE without an explicit PACKAGES list is rejected', () async {
+      await expectLater(
+        plan(mainlineCtx(bumpTypeOverride: 'major')),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('requires an explicit PACKAGES list'),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'a native SDK override includes only packages shipping that SDK',
+      () async {
+        fixture.writeFile(
+          'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+          'datadog_flutter_plugin_ios.podspec',
+          _iosPodspecWithDatadogDependency,
+        );
+        await fixture.commit('chore: add podspec fixture');
+
+        final result = await plan(mainlineCtx(iosSdkVersionOverride: '3.12.0'));
+        final names = result.packages.map((e) => e.package.name);
+
+        expect(names, contains('datadog_flutter_plugin_ios'));
+        expect(names, isNot(contains('lonely_ios')));
+        expect(names, isNot(contains('datadog_dio')));
+      },
+    );
+  });
+
+  group('mainline, native SDK deltas', () {
+    setUp(() async {
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+        'datadog_flutter_plugin_ios.podspec',
+        _iosPodspecWithDatadogDependency,
+      );
+      await fixture.commit('chore: add podspec fixture');
+    });
+
+    test(
+      'resolves a target, with no comparison against the current pin',
+      () async {
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
+          fetchLatestNativeSdkVersion: (repoSlug) async {
+            expect(repoSlug, 'DataDog/dd-sdk-ios');
+            return '3.13.0';
+          },
+        );
+
+        final delta = result.packages.single.nativeSdkDeltas.single;
+        expect(delta.sdk, NativeSdk.ios);
+        expect(delta.targetVersion, '3.13.0');
+      },
+    );
+
+    test(
+      'a Package.swift alongside the podspec is carried for rewriting',
+      () async {
+        fixture.writeFile(
+          'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+          'datadog_flutter_plugin_ios/Package.swift',
+          _packageSwiftWithDatadogDependency,
+        );
+        await fixture.commit('chore: add Package.swift fixture');
+
+        final result = await plan(
+          mainlineCtx(
+            requestedPackages: ['datadog_flutter_plugin_ios'],
+            iosSdkVersionOverride: '3.12.0',
+          ),
+        );
+
+        expect(
+          result.packages.single.nativeSdkDeltas.single.files.map(
+            (f) => p.basename(f.path),
+          ),
+          ['datadog_flutter_plugin_ios.podspec', 'Package.swift'],
+        );
+      },
+    );
+
+    test('C++ resolves the target tag to a commit SHA', () async {
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_desktop/'
+        'windows/CMakeLists.txt',
+        _windowsCMakeListsWithGitTag,
+      );
+      await fixture.commit('chore: add CMakeLists fixture');
+
+      final result = await plan(
+        mainlineCtx(
+          requestedPackages: ['datadog_flutter_plugin_desktop'],
+          cppVersionOverride: 'v1.4.0',
+        ),
+        resolveCommitSha: (repoSlug, ref) async {
+          expect(repoSlug, 'DataDog/dd-sdk-cpp');
+          expect(ref, 'v1.4.0');
+          return 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+        },
+      );
+
+      final delta = result.packages.single.nativeSdkDeltas.single;
+      expect(delta.targetVersion, 'v1.4.0');
+      expect(delta.targetSha, 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2');
+    });
+  });
+
+  group('missing tag for a published version', () {
+    test(
+      'falls back to the newest version that is tagged, and says so',
+      () async {
+        // pub.dev knows 2.2.0 but no tag was ever pushed for it -- two of
+        // datadog_flutter_plugin's 65 published versions are in that state.
+        await fixture.tag('datadog_dio/v2.1.0');
+        fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+        await fixture.commit('fix: something');
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_dio']),
+          published: {
+            'datadog_dio': ['2.1.0', '2.2.0'],
+          },
+        );
+
+        expect(result.packages.single.newVersion, '2.2.1');
+        expect(
+          result.packages.single.warnings.single,
+          allOf(
+            contains('2.2.0 is published but has no tag'),
+            contains('falls back to v2.1.0'),
+          ),
+        );
+      },
+    );
+
+    test('no warning when the baseline resolves cleanly', () async {
+      await fixture.tag('datadog_dio/v2.2.0');
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+      await fixture.commit('fix: something');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_dio']),
+        published: {
+          'datadog_dio': ['2.2.0'],
+        },
+      );
+
+      expect(result.packages.single.warnings, isEmpty);
+    });
+  });
+
+  group('patch branch', () {
+    RunContext patchCtx(String branch) => RunContext(
+      repoRoot: fixture.root.path,
+      trigger: TriggerContext.patch,
+      currentBranch: branch,
+    );
+
+    test('increments the patch level of its own release line', () async {
+      await fixture.tag('datadog_dio/v2.1.2');
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'a fix');
+      await fixture.commit('fix: a cherry-picked fix');
+
+      final result = await plan(
+        patchCtx('release/datadog_dio/v2.1.x'),
+        // Mainline has since cut 2.2.0 and a 3.0 line; neither may be picked.
+        published: {
+          'datadog_dio': ['2.1.0', '2.1.2', '2.2.0', '3.0.0'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '2.1.3');
+      expect(result.packages.single.bumpLevel, VersionBumpType.patch);
+    });
+
+    test(
+      'fails when nothing has been published on the branch\'s line',
+      () async {
+        // release/datadog_dio/v2.1.x with only 2.2.0 published. Falling back to
+        // pubspec here produced a version outside the branch's own line.
+        await expectLater(
+          plan(
+            patchCtx('release/datadog_dio/v2.1.x'),
+            published: {
+              'datadog_dio': ['2.2.0'],
+            },
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('no 2.1 release'),
+                contains('nothing here to patch'),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+
+    test('fails loudly if a feat commit snuck onto the patch branch', () async {
+      await fixture.tag('datadog_dio/v2.1.2');
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'a feature');
+      await fixture.commit('feat: does not belong here');
+
+      await expectLater(
+        plan(
+          patchCtx('release/datadog_dio/v2.1.x'),
+          published: {
+            'datadog_dio': ['2.1.2'],
+          },
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('BUMP_TYPE is rejected rather than silently ignored', () async {
+      await expectLater(
+        plan(
+          RunContext(
+            repoRoot: fixture.root.path,
+            trigger: TriggerContext.patch,
+            currentBranch: 'release/datadog_dio/v2.1.x',
+            bumpTypeOverride: 'major',
+          ),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('does not apply on a patch branch'),
+          ),
+        ),
+      );
+    });
+
+    test('a malformed branch name throws', () async {
+      await expectLater(plan(patchCtx('release/whatever')), throwsStateError);
+    });
+  });
+
+  group('pre-release branch', () {
+    RunContext preReleaseCtx({
+      String? prereleaseLabel,
+      List<String> requestedPackages = const ['datadog_flutter_plugin'],
+    }) => RunContext(
+      repoRoot: fixture.root.path,
+      trigger: TriggerContext.preRelease,
+      currentBranch: 'v4',
+      requestedPackages: requestedPackages,
+      prereleaseLabel: prereleaseLabel,
+    );
+
+    /// The v4 shape: a stable 3.5.0 behind us, breaking work on the branch.
+    Future<void> breakingWorkSince3_5_0() async {
+      await fixture.tag('datadog_flutter_plugin/v3.5.0');
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+        'the v4 work',
+      );
+      await fixture.commit('feat!: the federation rework');
+    }
+
+    test('computes the target from the last stable release', () async {
+      // 3.5.0 + a breaking commit -> 4.0.0, then the label starts the counter.
+      // pubspec is never consulted for the target.
+      await breakingWorkSince3_5_0();
+
+      final result = await plan(
+        preReleaseCtx(prereleaseLabel: 'beta'),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '4.0.0-beta.1');
+      expect(result.packages.single.bumpLevel, VersionBumpType.prerelease);
+    });
+
+    test('continues an existing counter', () async {
+      await breakingWorkSince3_5_0();
+      await fixture.tag('datadog_flutter_plugin/v4.0.0-beta.1');
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+        'more',
+      );
+      await fixture.commit('fix: more v4 work');
+
+      final result = await plan(
+        preReleaseCtx(),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0', '4.0.0-beta.1'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '4.0.0-beta.2');
+    });
+
+    test('a concurrent pre-release line does not derail this one', () async {
+      // A `v5` effort publishing 5.0.0-alpha.1 while `v4` is still shipping
+      // betas. It is the newest release overall, but says nothing about
+      // whether 4.0.0-beta.2 moves *this* line forward -- scoping the
+      // monotonicity check globally rejected it and blocked v4 entirely.
+      await breakingWorkSince3_5_0();
+      await fixture.tag('datadog_flutter_plugin/v4.0.0-beta.1');
+
+      final result = await plan(
+        preReleaseCtx(prereleaseLabel: 'beta'),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0', '4.0.0-beta.1', '5.0.0-alpha.1'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '4.0.0-beta.2');
+    });
+
+    test(
+      'a concurrent line is not used as the commit-range baseline',
+      () async {
+        // Same shape, but the v5 tag exists and this line has new work since
+        // its own last beta. Measuring "what's new" from the v5 tag would
+        // report the wrong commits into the changelog.
+        await breakingWorkSince3_5_0();
+        await fixture.tag('datadog_flutter_plugin/v4.0.0-beta.1');
+        await fixture.tag('datadog_flutter_plugin/v5.0.0-alpha.1');
+        fixture.writeFile(
+          'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+          'more v4 work',
+        );
+        await fixture.commit('fix: one more v4 fix');
+
+        final result = await plan(
+          preReleaseCtx(),
+          published: {
+            'datadog_flutter_plugin': [
+              '3.5.0',
+              '4.0.0-beta.1',
+              '5.0.0-alpha.1',
+            ],
+          },
+        );
+
+        expect(result.packages.single.newVersion, '4.0.0-beta.2');
+        // Only the work since this line's own beta, not since the v5 tag.
+        expect(result.packages.single.contributingCommits, hasLength(1));
+      },
+    );
+
+    test('a label that would move the version backward is rejected', () async {
+      await breakingWorkSince3_5_0();
+
+      await expectLater(
+        plan(
+          preReleaseCtx(prereleaseLabel: 'beta'),
+          published: {
+            'datadog_flutter_plugin': ['3.5.0', '4.0.0-beta.1', '4.0.0-rc.1'],
+          },
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('would not move forward'),
+          ),
+        ),
+      );
+    });
+
+    test('the first pre-release against a target requires a label', () async {
+      await breakingWorkSince3_5_0();
+
+      await expectLater(
+        plan(
+          preReleaseCtx(),
+          published: {
+            'datadog_flutter_plugin': ['3.5.0'],
+          },
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('PRERELEASE_LABEL is required'),
+          ),
+        ),
+      );
+    });
+
+    test('--all excludes packages with nothing to ship', () async {
+      await breakingWorkSince3_5_0();
+
+      final result = await plan(
+        preReleaseCtx(prereleaseLabel: 'beta', requestedPackages: const []),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0'],
+        },
+      );
+      final names = result.packages.map((e) => e.package.name);
+
+      expect(names, contains('datadog_flutter_plugin'));
+      // Untouched -- handing it a beta would publish a release nobody asked
+      // for, and without a label it would abort the whole plan.
+      expect(names, isNot(contains('lonely_ios')));
+    });
+
+    test("--all without a label doesn't abort on a package that was never part "
+        'of the pre-release line', () async {
+      // Omitting the label to continue an existing counter is a documented
+      // workflow, so an untouched package with no tag at the target must not
+      // abort the whole plan.
+      await breakingWorkSince3_5_0();
+      await fixture.tag('datadog_flutter_plugin/v4.0.0-beta.1');
+
+      final result = await plan(
+        preReleaseCtx(requestedPackages: const []),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0', '4.0.0-beta.1'],
+        },
+      );
+
       expect(
-        names,
-        containsAll([
-          'datadog_dio',
-          'datadog_flutter_plugin',
-          'datadog_flutter_plugin_ios',
-          'lonely_ios',
-        ]),
+        result.packages.map((e) => e.package.name),
+        isNot(contains('lonely_ios')),
       );
-      expect(names, isNot(contains('datadog_common_test')));
-    },
-  );
+    });
 
-  test('mainline with requestedPackages filters to just those', () async {
-    final plan = await computeReleasePlan(
-      RunContext(
-        repoRoot: fixture.root.path,
-        trigger: TriggerContext.mainline,
-        currentBranch: 'develop',
-        requestedPackages: ['datadog_dio', 'datadog_flutter_plugin_ios'],
-      ),
-    );
-
-    expect(
-      plan.packages.map((p) => p.package.name),
-      unorderedEquals(['datadog_dio', 'datadog_flutter_plugin_ios']),
-    );
-  });
-
-  test('mainline with an unknown requested package throws', () async {
-    await expectLater(
-      computeReleasePlan(
-        RunContext(
-          repoRoot: fixture.root.path,
-          trigger: TriggerContext.mainline,
-          currentBranch: 'develop',
-          requestedPackages: ['datadog_dio', 'does_not_exist'],
+    test('BUMP_TYPE is rejected rather than silently ignored', () async {
+      await expectLater(
+        plan(
+          RunContext(
+            repoRoot: fixture.root.path,
+            trigger: TriggerContext.preRelease,
+            currentBranch: 'v4',
+            prereleaseLabel: 'beta',
+            bumpTypeOverride: 'minor',
+          ),
         ),
-      ),
-      throwsStateError,
-    );
-  });
-
-  test(
-    'patch branch resolves the single named package with no grouping',
-    () async {
-      final plan = await computeReleasePlan(
-        RunContext(
-          repoRoot: fixture.root.path,
-          trigger: TriggerContext.patch,
-          currentBranch: 'release/datadog_dio/v1.1.x',
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('does not apply on a pre-release branch'),
+          ),
         ),
       );
-
-      expect(plan.packages, hasLength(1));
-      expect(plan.packages.single.package.name, 'datadog_dio');
-    },
-  );
-
-  test(
-    'patch branch on a federated member still selects only that one package',
-    () async {
-      final plan = await computeReleasePlan(
-        RunContext(
-          repoRoot: fixture.root.path,
-          trigger: TriggerContext.patch,
-          currentBranch: 'release/datadog_flutter_plugin_ios/v1.0.x',
-        ),
-      );
-
-      expect(plan.packages, hasLength(1));
-      expect(plan.packages.single.package.name, 'datadog_flutter_plugin_ios');
-    },
-  );
-
-  test('patch branch with a malformed name throws', () async {
-    await expectLater(
-      computeReleasePlan(
-        RunContext(
-          repoRoot: fixture.root.path,
-          trigger: TriggerContext.patch,
-          currentBranch: 'not-a-patch-branch',
-        ),
-      ),
-      throwsStateError,
-    );
-  });
-
-  test('patch branch naming an unknown package throws', () async {
-    await expectLater(
-      computeReleasePlan(
-        RunContext(
-          repoRoot: fixture.root.path,
-          trigger: TriggerContext.patch,
-          currentBranch: 'release/does_not_exist/v1.0.x',
-        ),
-      ),
-      throwsStateError,
-    );
-  });
-
-  test('patch branch ignores an inherited requestedPackages filter', () async {
-    final plan = await computeReleasePlan(
-      RunContext(
-        repoRoot: fixture.root.path,
-        trigger: TriggerContext.patch,
-        currentBranch: 'release/datadog_dio/v1.1.x',
-        // Simulates a stale/inherited PACKAGES env var that doesn't name
-        // this branch's package -- it must not empty out the plan.
-        requestedPackages: ['some_other_package'],
-      ),
-    );
-
-    expect(plan.packages, hasLength(1));
-    expect(plan.packages.single.package.name, 'datadog_dio');
+    });
   });
 }

--- a/tools/releaser/test/support/fixture_repo.dart
+++ b/tools/releaser/test/support/fixture_repo.dart
@@ -4,21 +4,26 @@
 
 import 'dart:io';
 
+import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
 
 /// A throwaway pubspec.yaml tree, mirroring the shapes that matter in
-/// dd-sdk-flutter's real `packages/` layout (a federated group with all
-/// four real platform implementations, several singletons, an
-/// intentionally-unpublished support package, an example app, and a
-/// package whose name merely *looks* federated). Discovery tests run
-/// against this instead of the real tree so they don't depend on -- or
-/// get broken by -- packages/ changing over time.
+/// dd-sdk-flutter's real `packages/` layout (a federated group, several
+/// singletons, an intentionally-unpublished support package, an example
+/// app, and a package whose name merely *looks* federated). Discovery
+/// tests run against this instead of the real tree so they don't depend
+/// on -- or get broken by -- packages/ changing over time.
+///
+/// Also a real git repo (unless [withGit] is false) with an initial commit,
+/// so release-plan tests can layer real commits/tags on top of this same
+/// layout instead of needing a second, separately-maintained fixture.
 class FixtureRepo {
   final Directory root;
+  GitDir? _gitDir;
 
   FixtureRepo._(this.root);
 
-  static Future<FixtureRepo> create() async {
+  static Future<FixtureRepo> create({bool withGit = true}) async {
     final root = await Directory.systemTemp.createTemp('releaser_test_');
     final repo = FixtureRepo._(root);
 
@@ -85,8 +90,51 @@ class FixtureRepo {
       version: '4.0.0',
     );
 
+    if (withGit) {
+      await repo._run(['init', '-q', '-b', 'main']);
+      await repo._run(['config', 'user.email', 'releaser-test@example.com']);
+      await repo._run(['config', 'user.name', 'Releaser Test']);
+      await repo.commit('chore: Initial fixture layout');
+    }
+
     return repo;
   }
+
+  /// Writes (or overwrites) a file at [relativePath], creating parent
+  /// directories as needed. Does not commit -- call [commit] separately.
+  void writeFile(String relativePath, String contents) {
+    final file = File(p.join(root.path, relativePath));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(contents);
+  }
+
+  /// Stages everything and commits. [body] lines (e.g. a `BREAKING CHANGE:`
+  /// footer) are appended after a blank line, matching real commit shape.
+  Future<void> commit(String subject, {List<String> body = const []}) async {
+    await _run(['add', '.']);
+    final message = body.isEmpty ? subject : '$subject\n\n${body.join('\n')}';
+    await _run(['commit', '-q', '--allow-empty', '-m', message]);
+  }
+
+  // Annotated, not lightweight -- this machine's git config signs tags,
+  // which requires a message (`git tag <name>` alone fails with
+  // "no tag message?").
+  Future<void> tag(String name) => _run(['tag', '-a', '-m', name, name]);
+
+  /// Creates and switches to a new branch off the current commit -- used
+  /// to simulate a tag cut on a line that never merged back (a long-lived
+  /// prerelease branch), so it exists in the repo but isn't an ancestor of
+  /// `main` once [checkout] switches back.
+  Future<void> checkoutNewBranch(String name) =>
+      _run(['checkout', '-q', '-b', name]);
+
+  Future<void> checkout(String name) => _run(['checkout', '-q', name]);
+
+  Future<GitDir> get gitDir async =>
+      _gitDir ??= await GitDir.fromExisting(root.path);
+
+  Future<ProcessResult> _run(List<String> args) =>
+      Process.run('git', args, workingDirectory: root.path);
 
   void _writePubspec(
     String relativeDir, {


### PR DESCRIPTION
### What and why?

Perform per-package version computation from conventional commits, and native SDK target resolution for iOS/Android/C++.

Release history comes from pub.dev, not from git tags because release commits in this repo land on `release/...` branches that are never merged back, so no release tag is an ancestor of `develop` or of a pre-release branch like `v4`. Using pub.dev as the source of truth helps prevent numerous issues attempting to determine the last published version from Tags or Github Releases.

To determine change history, we split the question in two: pub.dev answers "which versions exist" and git answers "where is version X" by exact ref name.

`pubspec.yaml` is not consulted for a published package because currently every release ends by bumping it to a "next potential" version, so it routinely names something that hasn't shipped yet. This step will likely go away in the future.

Per trigger:

- mainline    -- last stable release + the bump aggregated from commits since
- patch       -- last release on the branch's own line, patch-incremented;
                 a `feat` or breaking commit in range is rejected outright
- pre-release -- mainline plus a suffix. The target is computed the same way a
                 stable release would be (3.5.0 + a `feat!` on v4 -> 4.0.0),
                 then a counter is appended. Not declared in pubspec, which
                 would be a second source of truth free to disagree with what
                 shipped -- and computing it self-corrects, since once 4.0.0
                 ships stably the base moves on.

Updating the Native SDK deltas are targets, not diffs. Nothing compares against a manifest's current pin, because `develop` keeps those on floating constraints by design and only the release-prep branch is ever pinned -- there is no current pin to subtract from. A package is eligible when it has qualifying commits, was named explicitly, or carries a native SDK override for an SDK it actually ships a manifest for.

Inputs the run can't honor are rejected rather than reinterpreted. For example:

- BUMP_TYPE requires an explicit PACKAGES (with `--all` it re-levels whatever qualified, shipping an unrelated `fix:` as a major) and is invalid on patch and pre-release
- a pre-release must move forward, since labels sort lexically and `beta` after `rc.1` restarts below it without self-correcting; a patch branch whose line has no published release fails instead of falling back outside its own line.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
