### PR TITLE
Serve integration test images locally

### DIFF
--- a/packages/datadog_common_test/lib/src/mock_http_sever.dart
+++ b/packages/datadog_common_test/lib/src/mock_http_sever.dart
@@ -20,6 +20,9 @@ const uuid = Uuid();
 
 const int _bindingPort = 2228;
 String get _endpoint => 'http://localhost:$_bindingPort';
+const _imagePaths = ['/test-image-1.png', '/test-image-2.png'];
+const _transparentPng =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
 class RecordingHttpServer {
   late HttpServer server;
@@ -38,13 +41,27 @@ class RecordingHttpServer {
         ..add(HttpHeaders.accessControlAllowOriginHeader, '*')
         ..add(HttpHeaders.accessControlAllowHeadersHeader, '*')
         ..add(HttpHeaders.accessControlAllowMethodsHeader, 'GET, POST');
-      if (request.requestedUri.path.endsWith('session')) {
+      if (_imagePaths.contains(request.requestedUri.path)) {
+        return _respondToImageRequest(request);
+      } else if (request.requestedUri.path.endsWith('session')) {
         return _respondToSessionRequest(request);
       } else {
         return _logRequest(request);
       }
     }));
     print('Server started, listening on port $_bindingPort');
+  }
+
+  Future<void> _respondToImageRequest(HttpRequest request) async {
+    if (request.method == 'GET') {
+      request.response.headers.contentType = ContentType('image', 'png');
+      request.response.add(base64Decode(_transparentPng));
+    } else if (request.method == 'OPTIONS') {
+      request.response.statusCode = HttpStatus.noContent;
+    } else {
+      request.response.statusCode = HttpStatus.methodNotAllowed;
+    }
+    return request.response.close();
   }
 
   Future<dynamic> _logRequest(HttpRequest request) async {
@@ -116,6 +133,8 @@ abstract class RecordingServerClient {
   var currentSession = '';
 
   String get sessionEndpoint => '$_endpoint/$currentSession/';
+  List<String> get imageUrls =>
+      _imagePaths.map((path) => '$_endpoint$path').toList();
 
   Future<String> startNewSession();
   Future<List<RequestLog>> fetchRequests(String sessionId);

--- a/packages/datadog_dio/example/integration_test/dio_interceptor_headers_test.dart
+++ b/packages/datadog_dio/example/integration_test/dio_interceptor_headers_test.dart
@@ -48,6 +48,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',

--- a/packages/datadog_dio/example/integration_test/dio_interceptor_test.dart
+++ b/packages/datadog_dio/example/integration_test/dio_interceptor_test.dart
@@ -49,6 +49,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',

--- a/packages/datadog_dio/example/lib/scenario_config.dart
+++ b/packages/datadog_dio/example/lib/scenario_config.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-Present Datadog, Inc.
 class RumAutoInstrumentationScenarioConfig {
+  final List<String> imageUrls;
   final List<String> firstPartyHosts;
   final String firstPartyGetUrl;
   final String? firstPartyPostUrl;
@@ -11,6 +12,10 @@ class RumAutoInstrumentationScenarioConfig {
   final String thirdPartyMissingUrl;
 
   RumAutoInstrumentationScenarioConfig({
+    this.imageUrls = const [
+      'https://picsum.photos/200',
+      'https://placehold.co/200x200.png',
+    ],
     this.firstPartyHosts = const ['foo.bar'],
     this.firstPartyGetUrl = 'https://status.datadoghq.com',
     this.firstPartyPostUrl,

--- a/packages/datadog_dio/example/lib/screens/instrumentation_scenario.dart
+++ b/packages/datadog_dio/example/lib/screens/instrumentation_scenario.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import '../custom_card.dart';
+import '../scenario_config.dart';
 import 'instrumentation_second_screen.dart';
 
 class InstrumentationScenario extends StatefulWidget {
@@ -21,11 +22,6 @@ class InstrumentationScenario extends StatefulWidget {
 }
 
 class _InstrumentationScenarioState extends State<InstrumentationScenario> {
-  final images = [
-    'https://picsum.photos/200',
-    'https://placehold.co/200x200.png'
-  ];
-
   bool _doneWait = false;
 
   @override
@@ -81,6 +77,7 @@ class _InstrumentationScenarioState extends State<InstrumentationScenario> {
 
   @override
   Widget build(BuildContext context) {
+    final imageUrls = RumAutoInstrumentationScenarioConfig.instance.imageUrls;
     return _doneWait
         ? Scaffold(
             appBar: AppBar(
@@ -89,9 +86,9 @@ class _InstrumentationScenarioState extends State<InstrumentationScenario> {
             body: SingleChildScrollView(
               child: Column(
                 children: [
-                  for (int i = 0; i < images.length; ++i)
+                  for (int i = 0; i < imageUrls.length; ++i)
                     CustomCard(
-                      image: images[i],
+                      image: imageUrls[i],
                       text: 'Item $i',
                       onTap: () => _onTap(i),
                     ),

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_dio_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_dio_test.dart
@@ -45,6 +45,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',
@@ -104,18 +105,12 @@ void main() {
     expect(
         view1.viewEvents.last.view.resourceCount, view1.resourceEvents.length);
 
-    // After redirects, we don't end up with a picsum.photos url.
-    final picsumResource = view1.resourceEvents
-        .firstWhereOrNull((e) => e.url.contains('picsum.photos'));
-    expect(picsumResource, isNotNull);
-
-    final placeholdResource = view1.resourceEvents
-        .firstWhereOrNull((e) => e.url.contains('placehold.co'));
-    expect(placeholdResource, isNotNull);
-    expect(placeholdResource!.url, 'https://placehold.co/200x200.png');
-    // Allow this to fail since we don't have as much control over them
-    if (placeholdResource.statusCode == 200) {
-      expect(view1.resourceEvents[1].resourceType, kIsWeb ? 'xhr' : 'image');
+    for (final imageUrl in scenarioConfig.imageUrls) {
+      final imageResource = view1.resourceEvents
+          .firstWhereOrNull((resource) => resource.url == imageUrl);
+      expect(imageResource, isNotNull);
+      expect(imageResource!.statusCode, 200);
+      expect(imageResource.resourceType, kIsWeb ? 'xhr' : 'image');
     }
 
     final view2 = session.visits[2];

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_headers_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_headers_test.dart
@@ -44,6 +44,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_client_test.dart
@@ -45,6 +45,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',
@@ -96,12 +97,12 @@ void main() {
 
     final view1 = session.visits[1];
     expect(view1.viewEvents.last.view.resourceCount, 2);
-    // After redirects, we don't end up with a picsum.photos url.
-    expect(view1.resourceEvents[0].url.contains('picsum.photos'), isTrue);
-    expect(view1.resourceEvents[1].url, 'https://placehold.co/200x200.png');
-    // Allow this to fail since we don't have as much control over them
-    if (view1.resourceEvents[1].statusCode == 200) {
-      expect(view1.resourceEvents[1].resourceType, 'image');
+    for (final imageUrl in scenarioConfig.imageUrls) {
+      final imageResource = view1.resourceEvents
+          .firstWhereOrNull((resource) => resource.url == imageUrl);
+      expect(imageResource, isNotNull);
+      expect(imageResource!.statusCode, 200);
+      expect(imageResource.resourceType, 'image');
     }
 
     final view2 = session.visits[2];

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_headers_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_headers_test.dart
@@ -45,6 +45,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',

--- a/packages/datadog_tracking_http_client/example/integration_test/tracking_http_test.dart
+++ b/packages/datadog_tracking_http_client/example/integration_test/tracking_http_test.dart
@@ -46,6 +46,7 @@ void main() {
         : null;
 
     final scenarioConfig = RumAutoInstrumentationScenarioConfig(
+      imageUrls: sessionRecorder.imageUrls,
       firstPartyHosts: [(sessionRecorder.sessionEndpoint)],
       firstPartyGetUrl: '${sessionRecorder.sessionEndpoint}/integration_get',
       firstPartyPostUrl: '${sessionRecorder.sessionEndpoint}/integration_post',

--- a/packages/datadog_tracking_http_client/example/lib/scenario_config.dart
+++ b/packages/datadog_tracking_http_client/example/lib/scenario_config.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 
 @immutable
 class RumAutoInstrumentationScenarioConfig {
+  final List<String> imageUrls;
   final List<String> firstPartyHosts;
   final String firstPartyGetUrl;
   final String? firstPartyPostUrl;
@@ -15,6 +16,10 @@ class RumAutoInstrumentationScenarioConfig {
   final bool enableIoHttpTracking;
 
   const RumAutoInstrumentationScenarioConfig({
+    this.imageUrls = const [
+      'https://picsum.photos/200',
+      'https://placehold.co/200x200.png',
+    ],
     this.firstPartyHosts = const ['foo.bar'],
     this.firstPartyGetUrl = 'https://status.datadoghq.com',
     this.firstPartyPostUrl,

--- a/packages/datadog_tracking_http_client/example/lib/screens/instrumentation_scenario.dart
+++ b/packages/datadog_tracking_http_client/example/lib/screens/instrumentation_scenario.dart
@@ -9,6 +9,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import '../clients/abstract_client.dart';
 import '../custom_card.dart';
+import '../scenario_config.dart';
 import 'instrumentation_second_screen.dart';
 
 class InstrumentationScenario extends StatefulWidget {
@@ -23,11 +24,6 @@ class InstrumentationScenario extends StatefulWidget {
 }
 
 class _InstrumentationScenarioState extends State<InstrumentationScenario> {
-  final images = [
-    'https://picsum.photos/200',
-    'https://placehold.co/200x200.png'
-  ];
-
   bool _doneWait = false;
 
   @override
@@ -83,6 +79,7 @@ class _InstrumentationScenarioState extends State<InstrumentationScenario> {
 
   @override
   Widget build(BuildContext context) {
+    final imageUrls = RumAutoInstrumentationScenarioConfig.instance.imageUrls;
     return _doneWait
         ? Scaffold(
             appBar: AppBar(
@@ -91,9 +88,9 @@ class _InstrumentationScenarioState extends State<InstrumentationScenario> {
             body: SingleChildScrollView(
               child: Column(
                 children: [
-                  for (int i = 0; i < images.length; ++i)
+                  for (int i = 0; i < imageUrls.length; ++i)
                     CustomCard(
-                      image: images[i],
+                      image: imageUrls[i],
                       text: 'Item $i',
                       onTap: () => _onTap(i),
                     ),


### PR DESCRIPTION
### What and why?

The Dio and HTTP client integration tests depend on public image services, which can make CI fail when those services are unavailable.

This change serves deterministic PNGs from the existing `RecordingHttpServer`, preserving image resource tracking without external dependencies.

### How?

The test scenarios use local image URLs and verify the exact URLs, successful responses, and expected resource types.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue