### PR TITLE
fix(android): Prevent retaining a potentially GC'd Companion object

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/android/android_log_event_mapper.dart
+++ b/packages/datadog_flutter_plugin/lib/src/android/android_log_event_mapper.dart
@@ -28,6 +28,9 @@ class AndroidLogEventMapper extends LogMapperProxy {
       ),
     );
 
-    DatadogLogsPlugin.Companion.setLogsEventMapper(listener);
+    // Deliberately calling the static overload, not
+    // `DatadogLogsPlugin.Companion.setLogsEventMapper(listener)` to avoid
+    // potentially retaining a GC'd Companion object
+    DatadogLogsPlugin.setLogsEventMapper(listener);
   }
 }

--- a/packages/datadog_flutter_plugin/lib/src/android/android_rum_event_mapper.dart
+++ b/packages/datadog_flutter_plugin/lib/src/android/android_rum_event_mapper.dart
@@ -49,7 +49,10 @@ class AndroidRumEventMapper extends RumMapperProxy {
       ),
     );
 
-    DatadogRumPlugin.Companion.setRumEventMapper(listener);
+    // Deliberately calling the static overload, not
+    // `DatadogLogsPlugin.Companion.setLogsEventMapper(listener)` to avoid
+    // potentially retaining a GC'd Companion object
+    DatadogRumPlugin.setRumEventMapper(listener);
   }
 
   JString? _callMapper(JString encoded, _MapperFunction mapper) {


### PR DESCRIPTION
### What and why?

Using `Companion` in `setLogsEventMapper` could potentially hold on to the Companion object in Dart in such a way that it could be GC'd, which would cause a SIGSEV crash.

Use the `@JvmStatic` call instead, which won't retain the Companion object, preventing the crash.

refs: #1133

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
