### PR TITLE
Pin `dd-sdk-ios` SPM dependency to 3.16.x

### DIFF
--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
@@ -12,7 +12,10 @@ let package = Package(
         .library(name: "datadog-flutter-plugin", targets: ["datadog_flutter_plugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", branch: "develop"),
+        .package(
+            url: "https://github.com/Datadog/dd-sdk-ios.git",
+            .upToNextMinor(from: "3.16.0")
+        ),
         .package(url: "https://github.com/almazrafi/DictionaryCoder.git", exact: "1.2.0")
     ],
     targets: [


### PR DESCRIPTION
### What and why?

This pins the core plugin’s Swift Package Manager dependency to `dd-sdk-ios` 3.16.x.  
Using `develop` can pull unreleased changes into CI, including the upcoming iOS 15 minimum.

### How?

Replace the `develop` branch with `.upToNextMinor(from: "3.16.0")`

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
