### PR TITLE
chore: pin iOS SDK to 3.16.0

### DIFF
--- a/packages/datadog_flutter_plugin/example/ios/Podfile
+++ b/packages/datadog_flutter_plugin/example/ios/Podfile
@@ -36,11 +36,11 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
+++ b/packages/datadog_flutter_plugin/ios/datadog_flutter_plugin/Package.swift
@@ -12,10 +12,7 @@ let package = Package(
         .library(name: "datadog-flutter-plugin", targets: ["datadog_flutter_plugin"])
     ],
     dependencies: [
-        .package(
-            url: "https://github.com/Datadog/dd-sdk-ios.git",
-            .upToNextMinor(from: "3.16.0")
-        ),
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "3.16.0"),
         .package(url: "https://github.com/almazrafi/DictionaryCoder.git", exact: "1.2.0")
     ],
     targets: [

--- a/packages/datadog_session_replay/example/ios/Podfile
+++ b/packages/datadog_session_replay/example/ios/Podfile
@@ -36,11 +36,11 @@ target 'Runner' do
   end
 
   # Datadog Pod Overrides
-  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
-  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :branch => 'develop'
+  pod 'DatadogCore', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogLogs', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogRUM', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogInternal', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
+  pod 'DatadogCrashReporting', :git => 'https://github.com/DataDog/dd-sdk-ios', :tag => '3.16.0'
   # End Datadog Pod Overrides
 end
 

--- a/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
+++ b/packages/datadog_session_replay/ios/datadog_session_replay/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "datadog-session-replay", targets: ["datadog_session_replay", "datadog_session_replay_objc"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", from: "3.0.0")
+        .package(url: "https://github.com/Datadog/dd-sdk-ios.git", exact: "3.16.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
### What and why?

The example apps currently fetch `dd-sdk-ios` from `develop`, so unrelated native changes can break Flutter CI.
This PR pins the iOS SDK to the released version `3.16.0`.

### How?

Updates the CocoaPods overrides and Swift Package Manager manifests for the core and Session Replay packages.
The integration packages remain unchanged.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
