### PR TITLE
tools(releaser): Add a "Preview Release" tool

### DIFF
--- a/tools/releaser/bin/deployer.dart
+++ b/tools/releaser/bin/deployer.dart
@@ -17,12 +17,7 @@ class ReleaseInfo {
   final String version;
   final String changeLog;
 
-  ReleaseInfo(
-    this.commitSha,
-    this.package,
-    this.version,
-    this.changeLog,
-  );
+  ReleaseInfo(this.commitSha, this.package, this.version, this.changeLog);
 }
 
 void main(List<String> arguments) async {
@@ -74,8 +69,9 @@ void main(List<String> arguments) async {
 
   final github = GithubCommandWrapper(gitDir.path);
   if (!await github.checkAuth(Logger.root)) {
-    Logger.root
-        .shout('❌ Could not auth with `gh` command. Run `gh auth login`.');
+    Logger.root.shout(
+      '❌ Could not auth with `gh` command. Run `gh auth login`.',
+    );
     exit(1);
   }
 
@@ -94,11 +90,18 @@ void main(List<String> arguments) async {
 }
 
 Future<bool> _performGitHubRelease(
-    GitDir gitDir, ReleaseInfo releaseInfo) async {
+  GitDir gitDir,
+  ReleaseInfo releaseInfo,
+) async {
   final tag = '${releaseInfo.package}/v${releaseInfo.version}';
   Logger.root.fine('ℹ️ Creating tag $tag');
-  await gitDir.runCommand(
-      ['tag', '-a', tag, '-m', '🏷 Tag created by deploy.dart for $tag']);
+  await gitDir.runCommand([
+    'tag',
+    '-a',
+    tag,
+    '-m',
+    '🏷 Tag created by deploy.dart for $tag',
+  ]);
   Logger.root.fine('ℹ️ Pushing to origin');
   await gitDir.runCommand(['push', 'origin', tag]);
 
@@ -132,8 +135,9 @@ Future<bool> _validateBranchState(GitDir gitDir) async {
   final currentBranch = await gitDir.currentBranch();
   if (!(currentBranch.branchName == 'main' ||
       currentBranch.branchName.startsWith('release'))) {
-    Logger.root
-        .shout('❌ Only deploy releases from `main` or a `release` branch.');
+    Logger.root.shout(
+      '❌ Only deploy releases from `main` or a `release` branch.',
+    );
     return false;
   }
 
@@ -159,11 +163,11 @@ Future<ReleaseInfo?> _getReleaseInfo(GitDir gitDir, String packageName) async {
       .transform(utf8.decoder)
       .transform(LineSplitter())
       .forEach((element) {
-    final match = pubspecVersionRegex.firstMatch(element);
-    if (match != null) {
-      pubspecVersion = match.namedGroup('version');
-    }
-  });
+        final match = pubspecVersionRegex.firstMatch(element);
+        if (match != null) {
+          pubspecVersion = match.namedGroup('version');
+        }
+      });
 
   if (pubspecVersion == null) {
     Logger.root.shout('Version in pubspec is missing!');
@@ -183,17 +187,17 @@ Future<ReleaseInfo?> _getReleaseInfo(GitDir gitDir, String packageName) async {
       .transform(utf8.decoder)
       .transform(LineSplitter())
       .forEach((line) {
-    if (foundVersion) {
-      if (line.startsWith('##')) {
-        // Reached the end of the version
-        foundVersion = false;
-      } else if (line.trim().isNotEmpty) {
-        changeLog.writeln(line);
-      }
-    } else if (line == '## $pubspecVersion') {
-      foundVersion = true;
-    }
-  });
+        if (foundVersion) {
+          if (line.startsWith('##')) {
+            // Reached the end of the version
+            foundVersion = false;
+          } else if (line.trim().isNotEmpty) {
+            changeLog.writeln(line);
+          }
+        } else if (line == '## $pubspecVersion') {
+          foundVersion = true;
+        }
+      });
 
   return ReleaseInfo(
     currentBranch.sha,

--- a/tools/releaser/bin/pinner.dart
+++ b/tools/releaser/bin/pinner.dart
@@ -22,22 +22,21 @@ Future<int> main(List<String> arguments) async {
     print(event.message);
   });
 
-  final argParser =
-      ArgParser()
-        ..addOption('version', abbr: 'v')
-        ..addOption(
-          'platform',
-          abbr: 'p',
-          allowed: ['ios', 'android'],
-          mandatory: true,
-        )
-        ..addOption('package', mandatory: true)
-        ..addFlag(
-          'remove',
-          abbr: 'r',
-          help: 'Remove the version pin and set back to develop / snapshots',
-          negatable: false,
-        );
+  final argParser = ArgParser()
+    ..addOption('version', abbr: 'v')
+    ..addOption(
+      'platform',
+      abbr: 'p',
+      allowed: ['ios', 'android'],
+      mandatory: true,
+    )
+    ..addOption('package', mandatory: true)
+    ..addFlag(
+      'remove',
+      abbr: 'r',
+      help: 'Remove the version pin and set back to develop / snapshots',
+      negatable: false,
+    );
 
   ArgResults argResults;
   try {
@@ -82,8 +81,9 @@ Future<int> _pinIOS(GitDir gitDir, String package, String? version) async {
     r"(?<ws>\s+)pod '(?<dependency>.+)', :git => '(?<git>[^']*?)', :(?<overrideType>\w+) => '(?<override>[^']*?)'",
   );
 
-  final podVersionString =
-      version != null ? ":tag => '$version'" : ":branch => 'develop'";
+  final podVersionString = version != null
+      ? ":tag => '$version'"
+      : ":branch => 'develop'";
   final podFile = 'packages/$package/example/ios/Podfile';
 
   final file = File(path.join(gitDir.path, podFile));
@@ -111,8 +111,9 @@ Future<int> _pinIOS(GitDir gitDir, String package, String? version) async {
     return line;
   });
 
-  final spmVersionString =
-      version != null ? 'exact: "$version"' : 'branch: "develop"';
+  final spmVersionString = version != null
+      ? 'exact: "$version"'
+      : 'branch: "develop"';
   await PinSwiftPackageVersion.pinSpmVersion(
     gitDir.path,
     package,

--- a/tools/releaser/bin/preview_release.dart
+++ b/tools/releaser/bin/preview_release.dart
@@ -1,0 +1,238 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:logging/logging.dart';
+import 'package:releaser/helpers.dart';
+import 'package:releaser/release_plan.dart';
+
+final _log = Logger('preview_release');
+
+Future<void> main(List<String> arguments) async {
+  Logger.root.onRecord.listen((record) {
+    if (record.level >= Level.WARNING) {
+      stderr.writeln(record.message);
+    } else {
+      print(record.message);
+    }
+  });
+
+  final argParser = ArgParser()
+    ..addOption(
+      'packages',
+      help:
+          'Comma-separated package names. Omit for --all behaviour: every '
+          'package with pending commits.',
+    )
+    ..addFlag(
+      'include-federated',
+      help:
+          'Naming a member of a federated group in --packages widens '
+          'selection to every member of that group. Each extra sibling '
+          'still only ships if independently eligible (qualifying '
+          'commits, or a forced native SDK update) -- this does not force '
+          'them in the way --packages itself does.',
+      defaultsTo: false,
+    )
+    ..addOption(
+      'bump-type',
+      help:
+          'Override the computed bump (major/minor/patch). Requires '
+          '--packages; invalid on a patch or pre-release branch.',
+    )
+    ..addOption(
+      'ios-sdk-version',
+      help: 'Pin dd-sdk-ios to this version instead of the default.',
+    )
+    ..addOption(
+      'android-sdk-version',
+      help: 'Pin dd-sdk-android to this version instead of the default.',
+    )
+    ..addOption(
+      'cpp-version',
+      help: 'Pin dd-sdk-cpp to this version instead of the default.',
+    )
+    ..addOption(
+      'prerelease-label',
+      help:
+          'Required the first time a label (e.g. "beta") is used against '
+          'a given target version on a pre-release branch.',
+    )
+    ..addOption(
+      'trigger',
+      allowed: ['auto', 'mainline', 'patch', 'prerelease'],
+      defaultsTo: 'auto',
+      help:
+          'Which trigger context to plan for. "auto" detects patch from '
+          'the current branch name, defaulting to mainline otherwise.',
+    )
+    ..addOption(
+      'repo-root',
+      help: 'Repo root to plan from. Defaults to the current directory.',
+    )
+    ..addFlag(
+      'verbose',
+      help: 'Also list each package\'s contributing commits.',
+      defaultsTo: false,
+    )
+    ..addFlag('help', abbr: 'h', negatable: false, help: 'Print this help.');
+
+  final ArgResults args;
+  try {
+    args = argParser.parse(arguments);
+  } on FormatException catch (e) {
+    _log.shout('❌ ${e.message}\n\n${argParser.usage}');
+    exitCode = 1;
+    return;
+  }
+
+  if (args['help'] as bool) {
+    print(argParser.usage);
+    return;
+  }
+
+  Logger.root.level = (args['verbose'] as bool) ? Level.FINEST : Level.INFO;
+
+  final gitDir = await getGitDir(args['repo-root'] as String?);
+  if (gitDir == null) {
+    exitCode = 1;
+    return;
+  }
+
+  final currentBranch = (await gitDir.currentBranch()).branchName;
+  final trigger =
+      TriggerContext.parse(args['trigger'] as String) ??
+      resolveTriggerContext(currentBranch);
+
+  final requestedPackages =
+      (args['packages'] as String?)
+          ?.split(',')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty)
+          .toList() ??
+      const <String>[];
+
+  final ctx = RunContext(
+    repoRoot: gitDir.path,
+    trigger: trigger,
+    currentBranch: currentBranch,
+    requestedPackages: requestedPackages,
+    includeFederated: args['include-federated'] as bool,
+    bumpTypeOverride: args['bump-type'] as String?,
+    prereleaseLabel: args['prerelease-label'] as String?,
+    iosSdkVersionOverride: args['ios-sdk-version'] as String?,
+    androidSdkVersionOverride: args['android-sdk-version'] as String?,
+    cppVersionOverride: args['cpp-version'] as String?,
+  );
+
+  final ReleasePlan plan;
+  try {
+    plan = await computeReleasePlan(ctx);
+  } on StateError catch (e) {
+    _log.shout('❌ ${e.message}');
+    exitCode = 1;
+    return;
+  }
+
+  _printPlan(plan);
+}
+
+void _printPlan(ReleasePlan plan) {
+  if (plan.packages.isEmpty) {
+    _log.info('No packages would release from this run.');
+    return;
+  }
+
+  final rows = plan.packages.map(_PlanRow.from).toList();
+
+  final nameWidth = [
+    'Package'.length,
+    ...rows.map((r) => r.name.length),
+  ].reduce((a, b) => a > b ? a : b);
+  final versionsWidth = [
+    'Current → New'.length,
+    ...rows.map((r) => r.versions.length),
+  ].reduce((a, b) => a > b ? a : b);
+
+  _log.info(
+    '${'Package'.padRight(nameWidth + 2)}'
+    '${'Current → New'.padRight(versionsWidth + 2)}'
+    'Bump',
+  );
+
+  for (final row in rows) {
+    final bumpLabel = row.isMajor ? '${row.bump} ⚠' : row.bump;
+    final nativeSuffix = row.nativeSdkSummary.isEmpty
+        ? ''
+        : '  ${row.nativeSdkSummary}';
+    _log.info(
+      '${row.name.padRight(nameWidth + 2)}'
+      '${row.versions.padRight(versionsWidth + 2)}'
+      '$bumpLabel$nativeSuffix',
+    );
+
+    for (final commit in row.plan.contributingCommits) {
+      final flag = commit.isBreaking ? '  [BREAKING]' : '';
+      _log.fine('    ${commit.type}: ${commit.description}$flag');
+    }
+
+    for (final warning in row.plan.warnings) {
+      _log.warning('  ⚠️ $warning');
+    }
+  }
+
+  final majorPackages = rows
+      .where((r) => r.isMajor)
+      .map((r) => r.name)
+      .toList();
+  if (majorPackages.isNotEmpty) {
+    _log.info(
+      '\n⚠ ${majorPackages.length} package${majorPackages.length == 1 ? '' : 's'} '
+      'with a MAJOR version bump: ${majorPackages.join(', ')}',
+    );
+  }
+}
+
+class _PlanRow {
+  final PackagePlan plan;
+  final String name;
+  final String versions;
+  final String bump;
+  final bool isMajor;
+  final String nativeSdkSummary;
+
+  _PlanRow({
+    required this.plan,
+    required this.name,
+    required this.versions,
+    required this.bump,
+    required this.isMajor,
+    required this.nativeSdkSummary,
+  });
+
+  factory _PlanRow.from(PackagePlan plan) {
+    final level = plan.bumpLevel;
+    // Null only ever means "never stably released" here -- computePackagePlan
+    // excludes anything else with nothing to report before a plan is built.
+    final bumpLabel = level == null ? 'first release' : level.name;
+
+    final nativeSdkSummary = [
+      ...plan.nativeSdkDeltas
+          .where((d) => d.targetVersion != null)
+          .map((d) => d.toString()),
+      ...plan.nativeDependencyChanges.map((c) => c.toString()),
+    ].join(', ');
+
+    return _PlanRow(
+      plan: plan,
+      name: plan.package.name,
+      versions: '${plan.currentVersion} → ${plan.newVersion}',
+      bump: bumpLabel,
+      isMajor: level?.name == 'major',
+      nativeSdkSummary: nativeSdkSummary.isEmpty ? '' : '($nativeSdkSummary)',
+    );
+  }
+}

--- a/tools/releaser/bin/releaser.dart
+++ b/tools/releaser/bin/releaser.dart
@@ -23,8 +23,10 @@ void main(List<String> arguments) async {
   });
 
   final argParser = ArgParser()
-    ..addOption('packages',
-        help: 'A comma separated list of package:version pairs to release.')
+    ..addOption(
+      'packages',
+      help: 'A comma separated list of package:version pairs to release.',
+    )
     ..addOption('version', abbr: 'v')
     ..addOption('repo-root', help: 'The root of the repo to release from')
     ..addFlag(
@@ -116,8 +118,9 @@ void main(List<String> arguments) async {
   // }
 
   // If there are any initial releases, having no changes on the chore branch is okay (though unlikely)
-  final isInitialRelease =
-      commandArgs.packages.where((e) => e.version == '1.0.0').isNotEmpty;
+  final isInitialRelease = commandArgs.packages
+      .where((e) => e.version == '1.0.0')
+      .isNotEmpty;
 
   final commitPackageName = commandArgs.packages.length == 1
       ? '${commandArgs.packages.first.name} ${commandArgs.packages.first.version}'
@@ -128,7 +131,7 @@ void main(List<String> arguments) async {
     commitBody = 'Releasing the following packages:\n';
     commitBody += [
       for (final package in commandArgs.packages)
-        ' - ${package.name} ${package.version}'
+        ' - ${package.name} ${package.version}',
     ].join('\n');
   }
 
@@ -173,7 +176,9 @@ void main(List<String> arguments) async {
 }
 
 Future<CommandArguments?> _validateArguments(
-    ArgResults argResults, Logger logger) async {
+  ArgResults argResults,
+  Logger logger,
+) async {
   var packages = _parsePackages(argResults['packages'], logger);
   if (packages == null) {
     if (argResults.rest.isEmpty) {
@@ -228,7 +233,8 @@ List<PackageRelease>? _parsePackages(String? packages, Logger logger) {
     final colonIndex = e.indexOf(':');
     if (colonIndex < 0) {
       logger.shout(
-          '❌ Invalid package specification $e. Missing : to specify version.');
+        '❌ Invalid package specification $e. Missing : to specify version.',
+      );
       throw Error();
     }
 

--- a/tools/releaser/lib/cmake_util.dart
+++ b/tools/releaser/lib/cmake_util.dart
@@ -72,6 +72,23 @@ bool hasDdSdkCppGitTag(String cmakeListsContent) {
   return false;
 }
 
+/// The `GIT_TAG` ref currently declared in [cmakeListsContent]'s
+/// `FetchContent_Declare(dd-sdk-cpp ...)` block (e.g. `develop`, or a
+/// previously-pinned tag/SHA), or null if there isn't one. Purely
+/// informational -- a display string for "what this currently says", never
+/// compared against anything; see `NativeSdkDelta.currentDeclaration`.
+String? currentGitTag(String cmakeListsContent) {
+  final scanner = _DdSdkCppBlockScanner();
+  for (final line in cmakeListsContent.split('\n')) {
+    if (!scanner.accept(line)) continue;
+    final match = _gitTagPattern.firstMatch(
+      line.replaceFirst(_trailingCommentPattern, ''),
+    );
+    if (match != null) return match.namedGroup('ref');
+  }
+  return null;
+}
+
 /// Rewrites [line]'s `GIT_TAG` ref to [targetSha], re-annotated with
 /// `# [targetTag]`, leaving everything else on the line as-is -- a trailing
 /// `)` closing the `FetchContent_Declare(...` call, a `GIT_REPOSITORY` sharing

--- a/tools/releaser/lib/cocoapod_util.dart
+++ b/tools/releaser/lib/cocoapod_util.dart
@@ -22,8 +22,9 @@ class PinCocoapodsVersionCommand extends Command {
     }
 
     // Other packages can keep looser version constraints
-    final pinedPackage = args.packages
-        .firstWhereOrNull((e) => e.name == 'datadog_flutter_plugin');
+    final pinedPackage = args.packages.firstWhereOrNull(
+      (e) => e.name == 'datadog_flutter_plugin',
+    );
     if (pinedPackage != null) {
       if (!await _pinPodspecVersion(args, pinedPackage, logger)) {
         return false;
@@ -64,14 +65,14 @@ class PinCocoapodsVersionCommand extends Command {
   }
 
   Future<bool> _pinPodspecVersion(
-      CommandArguments args, PackageRelease package, Logger logger) async {
+    CommandArguments args,
+    PackageRelease package,
+    Logger logger,
+  ) async {
     final podspecLocation = 'ios/${package.name}.podspec';
 
     final file = File(
-      path.join(
-        getPackageRoot(args, package),
-        podspecLocation,
-      ),
+      path.join(getPackageRoot(args, package), podspecLocation),
     );
 
     if (!file.existsSync()) {

--- a/tools/releaser/lib/generate_changelog.dart
+++ b/tools/releaser/lib/generate_changelog.dart
@@ -34,21 +34,28 @@ class GenerateChangelogCommand extends Command {
       final lastReleaseSha = await _findLastReleaseSha(logger, args, package);
       if (lastReleaseSha == null) {
         Logger.root.shout(
-            '⚠️ Could not find last release! Hopefully this is a new package!.');
+          '⚠️ Could not find last release! Hopefully this is a new package!.',
+        );
         Logger.root.shout(
-            '‼️ Changelogs cannot be generated for an initial release! Make sure you have what you need in there.');
+          '‼️ Changelogs cannot be generated for an initial release! Make sure you have what you need in there.',
+        );
       } else {
-        final commits =
-            await _getCommits(args, package, '$lastReleaseSha..HEAD');
+        final commits = await _getCommits(
+          args,
+          package,
+          '$lastReleaseSha..HEAD',
+        );
 
         final changelogItems = _getChangelogItems(commits);
         logger.fine(
-            'Found ${changelogItems.length} changelog items for ${package.name} version ${package.version}');
+          'Found ${changelogItems.length} changelog items for ${package.name} version ${package.version}',
+        );
 
         final versionChangelog = changelogItems.map((e) => '* $e').join('\n');
 
-        final file =
-            File(path.join(getPackageRoot(args, package), 'CHANGELOG.md'));
+        final file = File(
+          path.join(getPackageRoot(args, package), 'CHANGELOG.md'),
+        );
         if (!file.existsSync()) {
           Logger.root.shout('❌ Could not find file CHANGELOG.md for package.');
           return false;
@@ -62,7 +69,8 @@ class GenerateChangelogCommand extends Command {
             String? oldLine = line;
             if (line == '## Unreleased') {
               logger.info(
-                  'ℹ️ ## Unreleased headers are no longer needed. Removing.');
+                'ℹ️ ## Unreleased headers are no longer needed. Removing.',
+              );
               oldLine = null;
             }
 
@@ -78,9 +86,11 @@ class GenerateChangelogCommand extends Command {
     }
 
     print(
-        'Verify the CHANGELOG.md changes for all packages and add changes from iOS and Android Native SDK updates.');
+      'Verify the CHANGELOG.md changes for all packages and add changes from iOS and Android Native SDK updates.',
+    );
     print(
-        'For reference iOS SDK will be updated to ${args.iOSRelease} and Android SDK will be updated to ${args.androidRelease}.');
+      'For reference iOS SDK will be updated to ${args.iOSRelease} and Android SDK will be updated to ${args.androidRelease}.',
+    );
 
     return _waitForConfirmation(logger);
   }
@@ -98,7 +108,8 @@ class GenerateChangelogCommand extends Command {
         return false;
       } else {
         logger.shout(
-            '❓ Not sure what you meant by that... stopping just in case.');
+          '❓ Not sure what you meant by that... stopping just in case.',
+        );
         return false;
       }
     }
@@ -107,7 +118,10 @@ class GenerateChangelogCommand extends Command {
   }
 
   Future<String?> _findLastReleaseSha(
-      Logger logger, CommandArguments args, PackageRelease package) async {
+    Logger logger,
+    CommandArguments args,
+    PackageRelease package,
+  ) async {
     final packageTags = await args.gitDir
         .tags()
         .where((t) => t.tag.startsWith('${package.name}/'))
@@ -143,7 +157,10 @@ class GenerateChangelogCommand extends Command {
   }
 
   Future<List<String>> _getCommits(
-      CommandArguments args, PackageRelease package, String commitRange) async {
+    CommandArguments args,
+    PackageRelease package,
+    String commitRange,
+  ) async {
     final packageRoot = getPackageRoot(args, package);
     final result = await args.gitDir.runCommand([
       '--no-pager',
@@ -151,7 +168,7 @@ class GenerateChangelogCommand extends Command {
       commitRange,
       '--pretty=format:%H|||%an <%aE>|||%ai|||%B||||',
       '--',
-      packageRoot
+      packageRoot,
     ]);
 
     final rawCommits = (result.stdout as String)
@@ -167,8 +184,9 @@ class GenerateChangelogCommand extends Command {
 }
 
 List<String> _getChangelogItems(List<String> commitMessages) {
-  RegExp conventionalCommitPattern =
-      RegExp(r'(?<type>\w*)(\((?<scope>.*)\))?(?<breaking>!)?: (?<rest>.*)');
+  RegExp conventionalCommitPattern = RegExp(
+    r'(?<type>\w*)(\((?<scope>.*)\))?(?<breaking>!)?: (?<rest>.*)',
+  );
   RegExp githubIssueMention = RegExp(r'\#(?<issue_number>\d+)');
 
   final items = <String>[];
@@ -206,8 +224,9 @@ List<String> _getChangelogItems(List<String> commitMessages) {
           }
         }
         if (githubRefs.isNotEmpty) {
-          final seeStrings = githubRefs
-              .map((r) => '[#$r](${GenerateChangelogCommand.issuesLink}$r)');
+          final seeStrings = githubRefs.map(
+            (r) => '[#$r](${GenerateChangelogCommand.issuesLink}$r)',
+          );
           changelogItem += ' See ${seeStrings.join(' ')}';
         }
 

--- a/tools/releaser/lib/git_actions.dart
+++ b/tools/releaser/lib/git_actions.dart
@@ -75,17 +75,15 @@ class CommitChangesCommand extends Command {
         return true;
       } else if (!args.dryRun) {
         logger.shout(
-            '❌ No changes from previous command. This is probably not expected.');
+          '❌ No changes from previous command. This is probably not expected.',
+        );
         return false;
       }
     }
 
     logger.info('ℹ️ Committing changes');
     if (!args.dryRun) {
-      var result = await args.gitDir.runCommand([
-        'add',
-        '.',
-      ]);
+      var result = await args.gitDir.runCommand(['add', '.']);
       if (result.exitCode != 0) {
         logger.shout('❌ Failed to stage: ${result.stderr}');
         return false;
@@ -122,10 +120,7 @@ class SwitchBranchCommand extends Command {
   Future<bool> run(CommandArguments args, Logger logger) async {
     logger.info('ℹ️ Switching to branch $branch');
     if (!args.dryRun) {
-      var result = await args.gitDir.runCommand([
-        'checkout',
-        branch,
-      ]);
+      var result = await args.gitDir.runCommand(['checkout', branch]);
       if (result.exitCode != 0) {
         logger.shout('❌ Failed to checkout branch $branch: ${result.stderr}');
         return false;

--- a/tools/releaser/lib/git_history.dart
+++ b/tools/releaser/lib/git_history.dart
@@ -36,6 +36,25 @@ Future<String?> tagSha(GitDir gitDir, String tagName) async {
   return sha.isEmpty ? null : sha;
 }
 
+/// [relativePath]'s content as it existed at the commit tagged [tagName], or
+/// null if the tag can't be resolved (see [tagSha]) or the file didn't
+/// exist at that commit.
+Future<String?> fileContentAtTag(
+  GitDir gitDir,
+  String tagName,
+  String relativePath,
+) async {
+  final sha = await tagSha(gitDir, tagName);
+  if (sha == null) return null;
+
+  final result = await gitDir.runCommand([
+    'show',
+    '$sha:$relativePath',
+  ], throwOnError: false);
+
+  return result.exitCode == 0 ? result.stdout as String : null;
+}
+
 /// Full commit messages (subject + body/footers) touching [pathspec], from
 /// just after [sinceSha] through HEAD. A null [sinceSha] walks the entire
 /// history of [pathspec] -- the "since inception" case for a package that has

--- a/tools/releaser/lib/helpers.dart
+++ b/tools/releaser/lib/helpers.dart
@@ -25,10 +25,7 @@ Future<GitDir?> getGitDir(String? root) async {
     return null;
   }
 
-  return await GitDir.fromExisting(
-    currentPath,
-    allowSubdirectory: true,
-  );
+  return await GitDir.fromExisting(currentPath, allowSubdirectory: true);
 }
 
 String getPackageRoot(CommandArguments args, PackageRelease package) {
@@ -47,11 +44,11 @@ Future<void> transformFile(
       .transform(utf8.decoder)
       .transform(LineSplitter())
       .forEach((element) {
-    final newValue = transformer(element);
-    if (newValue != null) {
-      newFileBuffer.writeln(newValue);
-    }
-  });
+        final newValue = transformer(element);
+        if (newValue != null) {
+          newFileBuffer.writeln(newValue);
+        }
+      });
 
   final filename = path.basename(file.path);
   logger.finest(' ------- NEW  $filename CONTENTS ------');
@@ -70,7 +67,8 @@ bool validateVersionNumber(String versionNumber, Logger logger) {
     return true;
   } on FormatException {
     logger.shout(
-        '❌ Version $versionNumber does not parse properly as a semantic version');
+      '❌ Version $versionNumber does not parse properly as a semantic version',
+    );
   }
   return false;
 }

--- a/tools/releaser/lib/native_sdk.dart
+++ b/tools/releaser/lib/native_sdk.dart
@@ -29,12 +29,12 @@ enum NativeSdk {
 /// wants to be permissive, a rewriter has to reproduce exactly what it
 /// matched.
 final _iosPodspecDependencyPattern = RegExp(
-  r"s\.dependency\s+'Datadog\w*'\s*,\s*'[^']+'",
+  r"s\.dependency\s+'Datadog\w*'\s*,\s*'(?<constraint>[^']+)'",
 );
 
 /// Matches a `build.gradle`'s `ext.datadog_version = "..."` assignment.
 final _androidGradleVersionPattern = RegExp(
-  r'ext\.datadog_version\s*=\s*"[^"]+"',
+  r'ext\.datadog_version\s*=\s*"(?<version>[^"]+)"',
 );
 
 /// Matches a `Package.swift`'s dd-sdk-ios dependency line, e.g.
@@ -42,7 +42,7 @@ final _androidGradleVersionPattern = RegExp(
 /// Matched case-insensitively on the URL: both `Datadog` and `DataDog`
 /// spellings appear across this repo's manifests.
 final _iosSpmDependencyPattern = RegExp(
-  r'\.package\(url:\s*"[^"]*dd-sdk-ios[^"]*",\s*[^)]+\)',
+  r'\.package\(url:\s*"[^"]*dd-sdk-ios[^"]*",\s*(?<versionArg>[^)]+)\)',
   caseSensitive: false,
 );
 
@@ -130,17 +130,52 @@ NativeDependencyFiles resolveNativeDependencyFiles(String packageRoot) {
   );
 }
 
+/// The dd-sdk-ios constraint declared in [podspecContent] (e.g. `~> 3`), or,
+/// absent that, [spmContent]'s version argument (e.g. `from: "3.0.0"`).
+/// Null if neither matches. Takes content, not a [File] -- see
+/// [NativeSdkDelta.currentDeclaration].
+String? currentIosDeclaration({String? podspecContent, String? spmContent}) {
+  if (podspecContent != null) {
+    return _iosPodspecDependencyPattern
+        .firstMatch(podspecContent)
+        ?.namedGroup('constraint');
+  }
+  if (spmContent == null) return null;
+  return _iosSpmDependencyPattern
+      .firstMatch(spmContent)
+      ?.namedGroup('versionArg')
+      ?.trim();
+}
+
+/// The `ext.datadog_version` declared in [gradleContent], or null.
+String? currentAndroidDeclaration(String? gradleContent) {
+  if (gradleContent == null) return null;
+  return _androidGradleVersionPattern
+      .firstMatch(gradleContent)
+      ?.namedGroup('version');
+}
+
+/// The dd-sdk-cpp `GIT_TAG` declared in [cmakeListsContent], or null.
+String? currentCppDeclaration(String? cmakeListsContent) {
+  if (cmakeListsContent == null) return null;
+  return currentGitTag(cmakeListsContent);
+}
+
 /// What one native SDK dependency of a package resolves to this run.
 ///
-/// This is a *target*, not a diff: `develop` (and a long-lived pre-release
-/// branch) deliberately keeps its manifests on floating constraints (`~> 3`,
-/// `branch: "develop"`, `GIT_TAG develop`), and only the release-prep branch's
-/// copy is ever pinned. So there's no meaningful "current pin" to subtract
-/// from -- the plan just says what to pin to, and `prepare_release.dart`
-/// rewrites [files] to match.
+/// [targetVersion]/[targetSha] are a *target*, not a diff: `develop` (and a
+/// long-lived pre-release branch) deliberately keeps its manifests on
+/// floating constraints (`~> 3`, `branch: "develop"`, `GIT_TAG develop`), and
+/// only the release-prep branch's copy is ever pinned. Planning decisions
+/// (eligibility, bump level) never compare against a "current" value for
+/// exactly that reason -- the plan just says what to pin to, and
+/// `prepare_release.dart` rewrites [files] to match.
 ///
-/// [targetVersion] is null when nothing should change -- the patch-branch
-/// default, absent an explicit override.
+/// [currentDeclaration] is purely informational, shown alongside
+/// [targetVersion]. Must be sourced from the last published version's git
+/// history (`fileContentAtTag` in `git_history.dart`), not from [files] as
+/// they sit in the working tree -- the working tree floats, so it isn't
+/// evidence of what anything previously released with.
 ///
 /// [targetSha] is only meaningful for [NativeSdk.cpp]: CMake's
 /// `FetchContent_Declare` has no field for pinning a tag *and* verifying
@@ -150,6 +185,7 @@ NativeDependencyFiles resolveNativeDependencyFiles(String packageRoot) {
 class NativeSdkDelta {
   final NativeSdk sdk;
   final String? targetVersion;
+  final String? currentDeclaration;
   final String? targetSha;
 
   /// Every file of this package that pins this dependency and therefore needs
@@ -163,14 +199,19 @@ class NativeSdkDelta {
   NativeSdkDelta({
     required this.sdk,
     required this.targetVersion,
+    this.currentDeclaration,
     this.targetSha,
     this.files = const [],
   });
 
   @override
-  String toString() => targetVersion == null
-      ? '${sdk.name}: no change'
-      : '${sdk.name}: -> $targetVersion';
+  String toString() {
+    if (targetVersion == null) return '${sdk.name}: no change';
+    final from = currentDeclaration;
+    return from == null
+        ? '${sdk.name}: -> $targetVersion'
+        : '${sdk.name}: $from -> $targetVersion';
+  }
 }
 
 /// The network calls native SDK resolution needs -- bundled so callers

--- a/tools/releaser/lib/package_discovery.dart
+++ b/tools/releaser/lib/package_discovery.dart
@@ -46,11 +46,15 @@ class DiscoveredPackage {
   final String relativePath;
   final PackageRole role;
 
+  /// The [PackageGroup.key] of the group this package belongs to.
+  final String groupKey;
+
   DiscoveredPackage({
     required this.name,
     required this.version,
     required this.relativePath,
     required this.role,
+    required this.groupKey,
   });
 
   String absolutePath(String repoRoot) => p.join(repoRoot, relativePath);
@@ -113,8 +117,9 @@ Future<List<PackageGroup>> discoverPackages(String repoRoot) async {
         name: pubspec.name,
         version: pubspec.version.toString(),
         relativePath: relativePath,
-        // Corrected below once every package's group is known.
+        // Both corrected below once every package's group is known.
         role: PackageRole.appFacing,
+        groupKey: '',
       ),
     );
   }
@@ -148,20 +153,23 @@ List<PackageGroup> _groupPackages(List<DiscoveredPackage> packages) {
       groups.add(
         PackageGroup(
           key: pkg.name,
-          members: [_withRole(pkg, PackageRole.appFacing)],
+          members: [_withRoleAndGroup(pkg, PackageRole.appFacing, pkg.name)],
         ),
       );
       return;
     }
 
+    final groupKey = p.basename(containerDir);
     final roled =
-        members.map((pkg) => _withRole(pkg, _roleFor(pkg.name))).toList()
+        members
+            .map((pkg) => _withRoleAndGroup(pkg, _roleFor(pkg.name), groupKey))
+            .toList()
           ..sort((a, b) {
             final byOrder = a.role.publishOrder.compareTo(b.role.publishOrder);
             return byOrder != 0 ? byOrder : a.name.compareTo(b.name);
           });
 
-    groups.add(PackageGroup(key: p.basename(containerDir), members: roled));
+    groups.add(PackageGroup(key: groupKey, members: roled));
   });
 
   return groups;
@@ -179,10 +187,14 @@ PackageRole _roleFor(String name) {
   return PackageRole.appFacing;
 }
 
-DiscoveredPackage _withRole(DiscoveredPackage pkg, PackageRole role) =>
-    DiscoveredPackage(
-      name: pkg.name,
-      version: pkg.version,
-      relativePath: pkg.relativePath,
-      role: role,
-    );
+DiscoveredPackage _withRoleAndGroup(
+  DiscoveredPackage pkg,
+  PackageRole role,
+  String groupKey,
+) => DiscoveredPackage(
+  name: pkg.name,
+  version: pkg.version,
+  relativePath: pkg.relativePath,
+  role: role,
+  groupKey: groupKey,
+);

--- a/tools/releaser/lib/process_helper.dart
+++ b/tools/releaser/lib/process_helper.dart
@@ -7,27 +7,33 @@ import 'dart:io';
 
 typedef OutputPipeHandler = void Function(String line);
 
-Future<int> runProcess(String executable, List<String> args,
-    {String? workingDirectory,
-    OutputPipeHandler? stdout,
-    OutputPipeHandler? stderr}) async {
-  var process =
-      await Process.start(executable, args, workingDirectory: workingDirectory);
+Future<int> runProcess(
+  String executable,
+  List<String> args, {
+  String? workingDirectory,
+  OutputPipeHandler? stdout,
+  OutputPipeHandler? stderr,
+}) async {
+  var process = await Process.start(
+    executable,
+    args,
+    workingDirectory: workingDirectory,
+  );
   if (stdout != null) {
     process.stdout
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .listen((event) {
-      stdout(event);
-    });
+          stdout(event);
+        });
   }
   if (stderr != null) {
     process.stderr
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .listen((event) {
-      stderr(event);
-    });
+          stderr(event);
+        });
   }
 
   return await process.exitCode;

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -2,9 +2,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:git/git.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:version/version.dart';
 
 import 'conventional_commits.dart';
@@ -23,6 +26,11 @@ export 'version_bump.dart';
 
 final _log = Logger('release_plan');
 
+/// The only [PackageGroup.key] whose members get native SDK version
+/// resolution. Other packages' podspec/gradle files are never read for
+/// this purpose, even if one declares a Datadog dependency.
+const _nativeSdkEligibleGroupKey = 'datadog_flutter_plugin';
+
 /// Everything about how a `prepare-release`/`preview-release` run was
 /// invoked -- shared by both entry points so they can't compute different
 /// plans from the same inputs.
@@ -36,6 +44,14 @@ class RunContext {
   /// patch branch, where the package is implied by [currentBranch].
   final List<String> requestedPackages;
 
+  /// When true, naming any member of a federated group in
+  /// [requestedPackages] widens selection to every member of that group --
+  /// see `_selectPackages`. Those extra siblings are still not
+  /// "explicitly requested" themselves: each is only included if it's
+  /// independently eligible (qualifying commits, or a forced native SDK
+  /// update). A no-op for a singleton group.
+  final bool includeFederated;
+
   final String? bumpTypeOverride;
   final String? prereleaseLabel;
   final String? iosSdkVersionOverride;
@@ -47,6 +63,7 @@ class RunContext {
     required this.trigger,
     required this.currentBranch,
     this.requestedPackages = const [],
+    this.includeFederated = false,
     this.bumpTypeOverride,
     this.prereleaseLabel,
     this.iosSdkVersionOverride,
@@ -78,6 +95,13 @@ class PackagePlan {
 
   final List<NativeSdkDelta> nativeSdkDeltas;
 
+  /// Native dependency constraints, outside [_nativeSdkEligibleGroupKey],
+  /// that have changed since this package's last published release --
+  /// e.g. a hand-edit to raise the minimum supported dd-sdk-ios version to
+  /// pick up a new feature. Not resolved or pinned by this tooling, just
+  /// reported.
+  final List<NativeDependencyChange> nativeDependencyChanges;
+
   /// Anything a human should see about how this plan was derived -- notably
   /// a published version whose tag is missing, which widens the commit range.
   final List<String> warnings;
@@ -89,8 +113,26 @@ class PackagePlan {
     this.bumpLevel,
     this.contributingCommits = const [],
     this.nativeSdkDeltas = const [],
+    this.nativeDependencyChanges = const [],
     this.warnings = const [],
   });
+}
+
+/// A native dependency's constraint as declared now vs. as declared at
+/// [PackagePlan.currentVersion] -- see [PackagePlan.nativeDependencyChanges].
+class NativeDependencyChange {
+  final NativeSdk sdk;
+  final String? previous;
+  final String? current;
+
+  NativeDependencyChange({
+    required this.sdk,
+    required this.previous,
+    required this.current,
+  });
+
+  @override
+  String toString() => '${sdk.name}: $previous -> $current';
 }
 
 class ReleasePlan {
@@ -224,7 +266,21 @@ Future<PackagePlan?> _computePackagePlan(
 
   switch (ctx.trigger) {
     case TriggerContext.mainline:
-      versionBase = commitBase = published.latestStable;
+      final latestPrerelease = published.latest;
+      if (published.latestStable != null) {
+        versionBase = commitBase = published.latestStable;
+      } else if (latestPrerelease != null) {
+        // Promote to the base version the pre-release already declares
+        // ("1.0.0-preview.14" -> "1.0.0"), not pubspec.yaml.
+        versionBase = Version(
+          latestPrerelease.major,
+          latestPrerelease.minor,
+          latestPrerelease.patch,
+        );
+        commitBase = latestPrerelease;
+      } else {
+        versionBase = commitBase = null;
+      }
     case TriggerContext.patch:
       final (major, minor) = _releaseLineFromPatchBranch(ctx.currentBranch);
       versionBase = commitBase = published.latestOn(major, minor);
@@ -267,6 +323,10 @@ Future<PackagePlan?> _computePackagePlan(
 
   final files = resolveNativeDependencyFiles(pkg.absolutePath(ctx.repoRoot));
 
+  // See [_nativeSdkEligibleGroupKey]. Non-eligible packages' files are
+  // still discovered, for [_nativeDependencyChanges] below.
+  final isNativeSdkEligible = pkg.groupKey == _nativeSdkEligibleGroupKey;
+
   // Whether this package releases at all is decided before anything touches
   // the network -- resolving native SDK targets for a package with nothing to
   // ship is pure waste.
@@ -276,11 +336,25 @@ Future<PackagePlan?> _computePackagePlan(
   if (ctx.trigger != TriggerContext.patch &&
       aggregateBumpLevel(commits) == null &&
       !isExplicitlyRequested &&
-      !_hasForcedNativeUpdate(files, ctx)) {
+      !(isNativeSdkEligible && _hasForcedNativeUpdate(files, ctx))) {
     return null;
   }
 
-  final nativeSdkDeltas = await _computeNativeSdkDeltas(files, ctx, gateways);
+  final nativeSdkDeltas = isNativeSdkEligible
+      ? await _computeNativeSdkDeltas(
+          pkg,
+          files,
+          ctx,
+          gitDir,
+          published,
+          gateways,
+        )
+      : const <NativeSdkDelta>[];
+
+  final nativeDependencyChanges = isNativeSdkEligible
+      ? const <NativeDependencyChange>[]
+      : await _nativeDependencyChanges(pkg, files, ctx, gitDir, published);
+
   final currentVersion = published.latest?.toString() ?? pkg.version;
 
   return switch (ctx.trigger) {
@@ -290,6 +364,7 @@ Future<PackagePlan?> _computePackagePlan(
       commits,
       versionBase,
       nativeSdkDeltas,
+      nativeDependencyChanges,
       warnings,
     ),
     TriggerContext.preRelease => _computePrereleasePlan(
@@ -300,6 +375,7 @@ Future<PackagePlan?> _computePackagePlan(
       versionBase,
       published,
       nativeSdkDeltas,
+      nativeDependencyChanges,
       warnings,
     ),
     TriggerContext.mainline => _computeMainlinePlan(
@@ -308,8 +384,10 @@ Future<PackagePlan?> _computePackagePlan(
       currentVersion,
       commits,
       versionBase,
-      nativeSdkDeltas,
-      warnings,
+      isPromotion: published.latestStable == null && published.latest != null,
+      nativeSdkDeltas: nativeSdkDeltas,
+      nativeDependencyChanges: nativeDependencyChanges,
+      warnings: warnings,
     ),
   };
 }
@@ -417,6 +495,7 @@ PackagePlan _computePatchPlan(
   List<ConventionalCommit> commits,
   Version? versionBase,
   List<NativeSdkDelta> nativeSdkDeltas,
+  List<NativeDependencyChange> nativeDependencyChanges,
   List<String> warnings,
 ) {
   for (final commit in commits) {
@@ -441,6 +520,7 @@ PackagePlan _computePatchPlan(
     bumpLevel: versionBase == null ? null : VersionBumpType.patch,
     contributingCommits: commits,
     nativeSdkDeltas: nativeSdkDeltas,
+    nativeDependencyChanges: nativeDependencyChanges,
     warnings: warnings,
   );
 }
@@ -450,15 +530,13 @@ PackagePlan _computeMainlinePlan(
   RunContext ctx,
   String currentVersion,
   List<ConventionalCommit> commits,
-  Version? versionBase,
-  List<NativeSdkDelta> nativeSdkDeltas,
-  List<String> warnings,
-) {
-  // Never released stably: pubspec.yaml states the intended first version and
-  // is the only source for it, so nothing is bumped and bumpLevel stays null.
-  // Reporting a level here would misdescribe the plan -- datadog_session_replay
-  // has only ever published previews, and its commits aggregate to `major`
-  // while the version comes from pubspec untouched.
+  Version? versionBase, {
+  required bool isPromotion,
+  required List<NativeSdkDelta> nativeSdkDeltas,
+  required List<NativeDependencyChange> nativeDependencyChanges,
+  required List<String> warnings,
+}) {
+  // Never published: pubspec.yaml is the only declaration of the first version.
   if (versionBase == null) {
     return PackagePlan(
       package: pkg,
@@ -466,6 +544,20 @@ PackagePlan _computeMainlinePlan(
       newVersion: pkg.version,
       contributingCommits: commits,
       nativeSdkDeltas: nativeSdkDeltas,
+      nativeDependencyChanges: nativeDependencyChanges,
+      warnings: warnings,
+    );
+  }
+
+  // versionBase is already the promotion target -- not something to bump.
+  if (isPromotion) {
+    return PackagePlan(
+      package: pkg,
+      currentVersion: currentVersion,
+      newVersion: versionBase.toString(),
+      contributingCommits: commits,
+      nativeSdkDeltas: nativeSdkDeltas,
+      nativeDependencyChanges: nativeDependencyChanges,
       warnings: warnings,
     );
   }
@@ -485,6 +577,7 @@ PackagePlan _computeMainlinePlan(
     bumpLevel: bump,
     contributingCommits: commits,
     nativeSdkDeltas: nativeSdkDeltas,
+    nativeDependencyChanges: nativeDependencyChanges,
     warnings: warnings,
   );
 }
@@ -505,6 +598,7 @@ PackagePlan _computePrereleasePlan(
   Version? target,
   PublishedVersions published,
   List<NativeSdkDelta> nativeSdkDeltas,
+  List<NativeDependencyChange> nativeDependencyChanges,
   List<String> warnings,
 ) {
   target!;
@@ -571,6 +665,7 @@ PackagePlan _computePrereleasePlan(
     // commits are still what the changelog is written from.
     contributingCommits: commits,
     nativeSdkDeltas: nativeSdkDeltas,
+    nativeDependencyChanges: nativeDependencyChanges,
     warnings: warnings,
   );
 }
@@ -603,33 +698,65 @@ bool _hasForcedNativeUpdate(NativeDependencyFiles files, RunContext ctx) =>
     (files.androidGradle != null && ctx.androidSdkVersionOverride != null) ||
     (files.cppCMakeLists.isNotEmpty && ctx.cppVersionOverride != null);
 
-/// Resolves what each native SDK this package depends on should be pinned to
-/// this run, one [NativeSdkDelta] per SDK it actually ships a manifest for.
-///
-/// Purely a *target* resolution -- see [NativeSdkDelta] for why there's no
-/// "current pin" to compare against.
+/// [file]'s content as it existed in [pkg]'s last published version's git
+/// history, or null if there's no published version, no tag resolves (see
+/// [tagSha]), or [file] didn't exist at that commit.
+Future<String?> _lastPublishedContent(
+  DiscoveredPackage pkg,
+  PublishedVersions published,
+  RunContext ctx,
+  GitDir gitDir,
+  File? file,
+) async {
+  final latest = published.latest;
+  if (latest == null || file == null) return null;
+  return fileContentAtTag(
+    gitDir,
+    '${pkg.name}/v$latest',
+    p.relative(file.path, from: ctx.repoRoot),
+  );
+}
+
+/// One [NativeSdkDelta] per SDK [pkg] ships a manifest for.
 Future<List<NativeSdkDelta>> _computeNativeSdkDeltas(
+  DiscoveredPackage pkg,
   NativeDependencyFiles files,
   RunContext ctx,
+  GitDir gitDir,
+  PublishedVersions published,
   NativeSdkGateways gateways,
 ) async {
+  Future<String?> historicalContent(File? file) =>
+      _lastPublishedContent(pkg, published, ctx, gitDir, file);
+
+  final iosPodspecContent = await historicalContent(files.iosPodspec);
+  final iosSpmContent = await historicalContent(files.iosSpmManifest);
+  final androidContent = await historicalContent(files.androidGradle);
+  final cppContent = await historicalContent(files.cppCMakeLists.firstOrNull);
+
   final perSdkFiles = {
     NativeSdk.ios: (
       files: [?files.iosPodspec, ?files.iosSpmManifest],
       override: ctx.iosSdkVersionOverride,
+      current: currentIosDeclaration(
+        podspecContent: iosPodspecContent,
+        spmContent: iosSpmContent,
+      ),
     ),
     NativeSdk.android: (
       files: [?files.androidGradle],
       override: ctx.androidSdkVersionOverride,
+      current: currentAndroidDeclaration(androidContent),
     ),
     NativeSdk.cpp: (
       files: files.cppCMakeLists,
       override: ctx.cppVersionOverride,
+      current: currentCppDeclaration(cppContent),
     ),
   };
 
   final deltas = <NativeSdkDelta>[];
-  for (final MapEntry(key: sdk, value: (:files, :override))
+  for (final MapEntry(key: sdk, value: (:files, :override, :current))
       in perSdkFiles.entries) {
     if (files.isEmpty) continue;
 
@@ -644,6 +771,7 @@ Future<List<NativeSdkDelta>> _computeNativeSdkDeltas(
       NativeSdkDelta(
         sdk: sdk,
         targetVersion: target,
+        currentDeclaration: current,
         // CMake's FetchContent_Declare has no field for pinning a tag and
         // verifying its commit -- the resolved SHA is what actually gets
         // written to GIT_TAG (see cmake_util.dart's pinCppVersion).
@@ -656,6 +784,71 @@ Future<List<NativeSdkDelta>> _computeNativeSdkDeltas(
   }
 
   return deltas;
+}
+
+/// Native dependency constraints, for a package outside
+/// [_nativeSdkEligibleGroupKey], that have changed since its own last
+/// published release -- see [PackagePlan.nativeDependencyChanges].
+Future<List<NativeDependencyChange>> _nativeDependencyChanges(
+  DiscoveredPackage pkg,
+  NativeDependencyFiles files,
+  RunContext ctx,
+  GitDir gitDir,
+  PublishedVersions published,
+) async {
+  // Require a resolvable tag, not just published.latest != null -- else a
+  // package whose latest published version has no tag (e.g.
+  // datadog_session_replay's 1.0.0-preview.14) falsely reports every
+  // dependency as newly added.
+  final latest = published.latest;
+  if (latest == null || await tagSha(gitDir, '${pkg.name}/v$latest') == null) {
+    return const [];
+  }
+
+  Future<String?> historicalContent(File? file) =>
+      _lastPublishedContent(pkg, published, ctx, gitDir, file);
+
+  final changes = <NativeDependencyChange>[];
+
+  void checkFor(NativeSdk sdk, String? current, String? previous) {
+    if (current == previous) return;
+    changes.add(
+      NativeDependencyChange(sdk: sdk, previous: previous, current: current),
+    );
+  }
+
+  if (files.iosPodspec != null || files.iosSpmManifest != null) {
+    checkFor(
+      NativeSdk.ios,
+      currentIosDeclaration(
+        podspecContent: files.iosPodspec?.readAsStringSync(),
+        spmContent: files.iosSpmManifest?.readAsStringSync(),
+      ),
+      currentIosDeclaration(
+        podspecContent: await historicalContent(files.iosPodspec),
+        spmContent: await historicalContent(files.iosSpmManifest),
+      ),
+    );
+  }
+
+  if (files.androidGradle != null) {
+    checkFor(
+      NativeSdk.android,
+      currentAndroidDeclaration(files.androidGradle!.readAsStringSync()),
+      currentAndroidDeclaration(await historicalContent(files.androidGradle)),
+    );
+  }
+
+  if (files.cppCMakeLists.isNotEmpty) {
+    final file = files.cppCMakeLists.first;
+    checkFor(
+      NativeSdk.cpp,
+      currentCppDeclaration(file.readAsStringSync()),
+      currentCppDeclaration(await historicalContent(file)),
+    );
+  }
+
+  return changes;
 }
 
 /// [commitMessagesSince]'s raw messages, parsed into [ConventionalCommit]s
@@ -688,6 +881,19 @@ final _patchBranchPattern = RegExp(
 /// patch-branch name, or null if [branch] doesn't match that convention.
 String? packageNameFromPatchBranch(String branch) =>
     _patchBranchPattern.firstMatch(branch)?.namedGroup('package');
+
+/// Auto-detects a run's trigger context from [currentBranch] where that's
+/// unambiguous, and defaults to mainline otherwise.
+///
+/// Patch is recognised unconditionally by branch-name convention. Pre-release
+/// is deliberately *not* guessed here. To preview a pre-release run with an
+/// explicit `--trigger=prerelease` instead.
+TriggerContext resolveTriggerContext(String currentBranch) {
+  if (packageNameFromPatchBranch(currentBranch) != null) {
+    return TriggerContext.patch;
+  }
+  return TriggerContext.mainline;
+}
 
 /// The `{major}.{minor}` release line a patch branch is confined to. Only
 /// called once [_resolveGroups] has validated the branch matches the
@@ -759,5 +965,16 @@ List<DiscoveredPackage> _selectPackages(
     throw StateError('Requested package(s) not found: ${unknown.join(', ')}.');
   }
 
-  return all.where((pkg) => requested.contains(pkg.name)).toList();
+  if (!ctx.includeFederated) {
+    return all.where((pkg) => requested.contains(pkg.name)).toList();
+  }
+
+  final groupKeys = groups
+      .where(
+        (group) => group.members.any((pkg) => requested.contains(pkg.name)),
+      )
+      .map((group) => group.key)
+      .toSet();
+
+  return all.where((pkg) => groupKeys.contains(pkg.groupKey)).toList();
 }

--- a/tools/releaser/lib/release_validator.dart
+++ b/tools/releaser/lib/release_validator.dart
@@ -48,7 +48,8 @@ class ValidateReleaseCommand extends Command {
     // Don't allow unstaged changes
     if (!await gitDir.isWorkingTreeClean()) {
       logger.shout(
-          '❌ Working tree is not clean. Please stage or revert your changes before attempting to release.');
+        '❌ Working tree is not clean. Please stage or revert your changes before attempting to release.',
+      );
       return false;
     }
 
@@ -57,7 +58,8 @@ class ValidateReleaseCommand extends Command {
     if (!(currentBranch.branchName == 'develop' ||
         currentBranch.branchName.startsWith('release'))) {
       logger.shout(
-          '❌ We really should only release from `develop` or another `release` branch.');
+        '❌ We really should only release from `develop` or another `release` branch.',
+      );
       return false;
     }
 
@@ -65,16 +67,32 @@ class ValidateReleaseCommand extends Command {
   }
 
   Future<bool> _validateiOSRelease(
-      String packagePath, CommandArguments args, Logger logger) async {
+    String packagePath,
+    CommandArguments args,
+    Logger logger,
+  ) async {
     args.iOSRelease = await _validateReleaseVersion(
-        args, 'DataDog/dd-sdk-ios', 'iOS', args.iOSRelease, logger);
+      args,
+      'DataDog/dd-sdk-ios',
+      'iOS',
+      args.iOSRelease,
+      logger,
+    );
     return args.iOSRelease != null;
   }
 
   Future<bool> _validateAndroidRelease(
-      String packagePath, CommandArguments args, Logger logger) async {
+    String packagePath,
+    CommandArguments args,
+    Logger logger,
+  ) async {
     args.androidRelease = await _validateReleaseVersion(
-        args, 'DataDog/dd-sdk-android', 'Android', args.androidRelease, logger);
+      args,
+      'DataDog/dd-sdk-android',
+      'Android',
+      args.androidRelease,
+      logger,
+    );
 
     return args.androidRelease != null;
   }
@@ -98,7 +116,8 @@ class ValidateReleaseCommand extends Command {
       final ghRelease = await gh.getReleaseByTagName(logger, repoName, release);
       if (ghRelease == null) {
         logger.shout(
-            '❌ Could not find target $platform release $release. Please check the tag name');
+          '❌ Could not find target $platform release $release. Please check the tag name',
+        );
         return null;
       }
     }

--- a/tools/releaser/lib/spm_util.dart
+++ b/tools/releaser/lib/spm_util.dart
@@ -19,8 +19,9 @@ class PinSwiftPackageVersion extends Command {
   @override
   Future<bool> run(CommandArguments args, Logger logger) async {
     // Other packages can keep looser version constraints
-    final corePacakge = args.packages
-        .firstWhereOrNull((e) => e.name == 'datadog_flutter_plugin');
+    final corePacakge = args.packages.firstWhereOrNull(
+      (e) => e.name == 'datadog_flutter_plugin',
+    );
     if (corePacakge != null) {
       if (!await _pinSpmVersion(args, corePacakge, logger)) {
         return false;
@@ -31,7 +32,10 @@ class PinSwiftPackageVersion extends Command {
   }
 
   Future<bool> _pinSpmVersion(
-      CommandArguments args, PackageRelease package, Logger logger) {
+    CommandArguments args,
+    PackageRelease package,
+    Logger logger,
+  ) {
     return pinSpmVersion(
       args.gitDir.path,
       package.name,

--- a/tools/releaser/lib/trigger_context.dart
+++ b/tools/releaser/lib/trigger_context.dart
@@ -11,4 +11,21 @@
 /// `release_plan.dart` in turn needs types from `native_sdk.dart` --
 /// putting the enum in either file would create a cyclic import between
 /// the two.
-enum TriggerContext { mainline, patch, preRelease }
+enum TriggerContext {
+  mainline,
+  patch,
+  preRelease;
+
+  static TriggerContext? parse(String raw) {
+    switch (raw.toLowerCase()) {
+      case 'mainline':
+        return TriggerContext.mainline;
+      case 'patch':
+        return TriggerContext.patch;
+      case 'prerelease':
+        return TriggerContext.preRelease;
+      default:
+        return null;
+    }
+  }
+}

--- a/tools/releaser/lib/version_updater.dart
+++ b/tools/releaser/lib/version_updater.dart
@@ -20,13 +20,18 @@ class UpdateVersionsCommand extends Command {
     for (final package in args.packages) {
       final packageRoot = getPackageRoot(args, package);
       if (!await updateVersions(
-          packageRoot, package.version, logger, args.dryRun)) {
+        packageRoot,
+        package.version,
+        logger,
+        args.dryRun,
+      )) {
         return false;
       }
     }
 
-    final corePackage = args.packages
-        .firstWhereOrNull((e) => e.name == 'datadog_flutter_plugin');
+    final corePackage = args.packages.firstWhereOrNull(
+      (e) => e.name == 'datadog_flutter_plugin',
+    );
 
     if (corePackage != null) {
       if (!await _updateReadmeVersions(args, corePackage, logger)) {
@@ -68,15 +73,20 @@ class BumpVersionCommand extends Command {
             newVersion = version.incrementPreRelease();
           } catch (e) {
             logger.shout(
-                '❌ Failed to increment the pre-release version of $version. Is it not a pre-release?');
+              '❌ Failed to increment the pre-release version of $version. Is it not a pre-release?',
+            );
             return false;
           }
           break;
       }
 
       logger.info('🔀 Bumping version to $newVersion');
-      success &= await updateVersions(getPackageRoot(args, package),
-          newVersion.toString(), logger, args.dryRun);
+      success &= await updateVersions(
+        getPackageRoot(args, package),
+        newVersion.toString(),
+        logger,
+        args.dryRun,
+      );
     }
     return success;
   }
@@ -85,7 +95,11 @@ class BumpVersionCommand extends Command {
 final _versionCapture = RegExp(r'^version\: (?<version>.*)');
 
 Future<bool> updateVersions(
-    String packageRoot, String version, Logger logger, bool dryRun) async {
+  String packageRoot,
+  String version,
+  Logger logger,
+  bool dryRun,
+) async {
   if (!await _updatePackagePubspec(packageRoot, version, logger, dryRun)) {
     return false;
   }
@@ -96,7 +110,11 @@ Future<bool> updateVersions(
 }
 
 Future<bool> _updatePackagePubspec(
-    String packageRoot, String version, Logger logger, bool dryRun) async {
+  String packageRoot,
+  String version,
+  Logger logger,
+  bool dryRun,
+) async {
   final pubspecFile = File(path.join(packageRoot, 'pubspec.yaml'));
   if (!pubspecFile.existsSync()) {
     logger.shout('⁉️ Could not find pubspec.yaml at ${pubspecFile.path}');
@@ -107,8 +125,9 @@ Future<bool> _updatePackagePubspec(
     final match = _versionCapture.firstMatch(element);
     if (match != null) {
       final oldVersion = match.namedGroup('version');
-      logger
-          .info(' - 🔀 Replacing version $oldVersion with $version in pubspec');
+      logger.info(
+        ' - 🔀 Replacing version $oldVersion with $version in pubspec',
+      );
       element = 'version: $version';
     }
     return element;
@@ -118,7 +137,11 @@ Future<bool> _updatePackagePubspec(
 }
 
 Future<bool> _updateVersionDartFile(
-    String packageRoot, String version, Logger logger, bool dryRun) async {
+  String packageRoot,
+  String version,
+  Logger logger,
+  bool dryRun,
+) async {
   final versionFile = File(path.join(packageRoot, 'lib/src/version.dart'));
   if (!versionFile.existsSync()) {
     logger.shout('⁉️ Could not find version.dart at ${versionFile.path}');
@@ -137,7 +160,10 @@ Future<bool> _updateVersionDartFile(
 }
 
 Future<bool> _updateReadmeVersions(
-    CommandArguments args, PackageRelease package, Logger logger) async {
+  CommandArguments args,
+  PackageRelease package,
+  Logger logger,
+) async {
   final packageRoot = getPackageRoot(args, package);
   final changelogFile = File(path.join(packageRoot, 'README.md'));
   if (!changelogFile.existsSync()) {
@@ -152,7 +178,8 @@ Future<bool> _updateReadmeVersions(
         inVersionTable = false;
 
         // Write the new version table:
-        line = '''[//]: # (SDK Table)
+        line =
+            '''[//]: # (SDK Table)
 
 | iOS SDK | Android SDK | Browser SDK |
 | :-----: | :---------: | :---------: |
@@ -176,20 +203,26 @@ Future<bool> _updateReadmeVersions(
 }
 
 Future<bool> _updateNativeSDKVersions(
-    CommandArguments args, PackageRelease package, Logger logger) async {
+  CommandArguments args,
+  PackageRelease package,
+  Logger logger,
+) async {
   final packageRoot = getPackageRoot(args, package);
-  final nativeSDKVersionsFile =
-      File(path.join(packageRoot, 'NATIVE_SDK_VERSIONS.md'));
+  final nativeSDKVersionsFile = File(
+    path.join(packageRoot, 'NATIVE_SDK_VERSIONS.md'),
+  );
   final newVersionEntry =
       '| ${package.version} | ${args.iOSRelease} | ${args.androidRelease} |';
   final header = '| Flutter | iOS SDK | Android SDK |';
   final separator = '|---------|---------|-------------|';
 
   if (!nativeSDKVersionsFile.existsSync()) {
-    logger
-        .warning('⚠️ NATIVE_SDK_VERSIONS.md does not exist, creating it now.');
-    await nativeSDKVersionsFile
-        .writeAsString('$header\n$separator\n$newVersionEntry');
+    logger.warning(
+      '⚠️ NATIVE_SDK_VERSIONS.md does not exist, creating it now.',
+    );
+    await nativeSDKVersionsFile.writeAsString(
+      '$header\n$separator\n$newVersionEntry',
+    );
     return true;
   }
 
@@ -200,7 +233,8 @@ Future<bool> _updateNativeSDKVersions(
     final parts = line.split('|').map((s) => s.trim()).toList();
     if (parts.length > 1 && parts[1] == package.version) {
       logger.info(
-          '✅ Version ${package.version} already exists in NATIVE_SDK_VERSIONS.md, skipping.');
+        '✅ Version ${package.version} already exists in NATIVE_SDK_VERSIONS.md, skipping.',
+      );
       return true;
     }
   }

--- a/tools/releaser/lib/yaml_util.dart
+++ b/tools/releaser/lib/yaml_util.dart
@@ -22,8 +22,9 @@ class RemoveDependencyOverridesCommand extends Command {
       }
 
       await _removeDependencyOverrides(logger, pubspecFile, args.dryRun);
-      final examplePubspec =
-          File(path.join(packageRoot, 'example', 'pubspec.yaml'));
+      final examplePubspec = File(
+        path.join(packageRoot, 'example', 'pubspec.yaml'),
+      );
       if (await examplePubspec.exists()) {
         await _removeDependencyOverrides(logger, examplePubspec, args.dryRun);
       }

--- a/tools/releaser/test/cmake_util_test.dart
+++ b/tools/releaser/test/cmake_util_test.dart
@@ -158,4 +158,42 @@ FetchContent_MakeAvailable(dd-sdk-cpp)
     expect(contents, contains('cmake_minimum_required(VERSION 3.14)'));
     expect(contents, contains('FetchContent_MakeAvailable(dd-sdk-cpp)'));
   });
+
+  group('currentGitTag', () {
+    test('reads the floating ref as-is', () {
+      expect(
+        currentGitTag('''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        develop)
+'''),
+        'develop',
+      );
+    });
+
+    test('reads a previously-pinned SHA, ignoring its trailing comment', () {
+      expect(
+        currentGitTag('''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  GIT_TAG        $_sha)  # v1.4.0
+'''),
+        _sha,
+      );
+    });
+
+    test('is null with no dd-sdk-cpp declaration at all', () {
+      expect(currentGitTag('cmake_minimum_required(VERSION 3.14)'), isNull);
+    });
+
+    test("ignores another dependency's GIT_TAG outside the block", () {
+      expect(
+        currentGitTag('''
+FetchContent_Declare(some_other_dep
+  GIT_TAG v9.9.9)
+'''),
+        isNull,
+      );
+    });
+  });
 }

--- a/tools/releaser/test/native_sdk_test.dart
+++ b/tools/releaser/test/native_sdk_test.dart
@@ -143,6 +143,47 @@ FetchContent_Declare(some_other_dep
     );
   });
 
+  group('current*Declaration -- display strings, not resolvable versions', () {
+    // Pure content-parsing functions -- no filesystem needed. The caller
+    // (release_plan.dart) is responsible for sourcing that content from a
+    // past release's git history, not the working tree; see
+    // NativeSdkDelta.currentDeclaration.
+
+    test('iOS prefers the podspec constraint over Package.swift', () {
+      expect(
+        currentIosDeclaration(
+          podspecContent: _iosPodspec,
+          spmContent: _packageSwift,
+        ),
+        '~> 3',
+      );
+    });
+
+    test('iOS falls back to the Package.swift version arg with no podspec', () {
+      expect(currentIosDeclaration(spmContent: _packageSwift), 'from: "3.0.0"');
+    });
+
+    test('iOS is null with neither content', () {
+      expect(currentIosDeclaration(), isNull);
+    });
+
+    test('Android reads the current ext.datadog_version verbatim', () {
+      expect(currentAndroidDeclaration(_androidGradle), '3.11.0');
+    });
+
+    test('Android is null with no content', () {
+      expect(currentAndroidDeclaration(null), isNull);
+    });
+
+    test('C++ reads the floating GIT_TAG as-is, not resolved to a version', () {
+      expect(currentCppDeclaration(_windowsCMakeLists), 'develop');
+    });
+
+    test('C++ is null with no content', () {
+      expect(currentCppDeclaration(null), isNull);
+    });
+  });
+
   group('resolveNativeSdkTarget', () {
     test(
       'an explicit override wins once confirmed to be a real release',

--- a/tools/releaser/test/package_discovery_test.dart
+++ b/tools/releaser/test/package_discovery_test.dart
@@ -60,6 +60,22 @@ void main() {
   });
 
   test(
+    'every member carries its own group\'s key, even after flattening',
+    () async {
+      final groups = await discoverPackages(fixture.root.path);
+      final byName = {
+        for (final pkg in groups.expand((g) => g.members)) pkg.name: pkg,
+      };
+
+      expect(
+        byName['datadog_flutter_plugin_ios']?.groupKey,
+        'datadog_flutter_plugin',
+      );
+      expect(byName['datadog_dio']?.groupKey, 'datadog_dio');
+    },
+  );
+
+  test(
     'a lone package with a federation-looking suffix is not misclassified as an implementation',
     () async {
       final groups = await discoverPackages(fixture.root.path);

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -70,6 +70,7 @@ void main() {
 
   RunContext mainlineCtx({
     List<String> requestedPackages = const [],
+    bool includeFederated = false,
     String? bumpTypeOverride,
     String? iosSdkVersionOverride,
     String? cppVersionOverride,
@@ -78,6 +79,7 @@ void main() {
     trigger: TriggerContext.mainline,
     currentBranch: 'develop',
     requestedPackages: requestedPackages,
+    includeFederated: includeFederated,
     bumpTypeOverride: bumpTypeOverride,
     iosSdkVersionOverride: iosSdkVersionOverride,
     cppVersionOverride: cppVersionOverride,
@@ -119,27 +121,55 @@ void main() {
       expect(result.packages.single.currentVersion, '2.3.0');
     });
 
-    test(
-      'a package with only pre-releases published reports no bump level',
-      () async {
-        // datadog_session_replay's real shape: 14 previews, never a stable
-        // release. The version comes from pubspec untouched, so reporting the
-        // commits' `major` aggregate would misdescribe what happened.
-        fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
-        await fixture.commit('feat!: breaking work');
+    test('a package with only pre-releases published promotes to the base '
+        'version its pre-releases already declared, not pubspec', () async {
+      // datadog_session_replay's real shape: 14 previews, never a stable
+      // release, with pubspec left at a stale-looking 2.3.0. A
+      // "1.0.0-preview.2" is already announcing "1.0.0" -- promoting it
+      // takes that triple regardless of how much feature work happened
+      // during the preview, not pubspec, which is exactly the kind of
+      // second source of truth this planner exists to stop trusting once
+      // pub.dev has real history for a package.
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+      await fixture.commit('feat!: breaking work');
 
-        final result = await plan(
-          mainlineCtx(requestedPackages: ['datadog_dio']),
-          published: {
-            'datadog_dio': ['1.0.0-preview.1', '1.0.0-preview.2'],
-          },
-        );
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_dio']),
+        published: {
+          'datadog_dio': ['1.0.0-preview.1', '1.0.0-preview.2'],
+        },
+      );
 
-        expect(result.packages.single.newVersion, '2.3.0'); // pubspec
-        expect(result.packages.single.currentVersion, '1.0.0-preview.2');
-        expect(result.packages.single.bumpLevel, isNull);
-      },
-    );
+      expect(result.packages.single.newVersion, '1.0.0');
+      expect(result.packages.single.currentVersion, '1.0.0-preview.2');
+      expect(result.packages.single.bumpLevel, isNull);
+    });
+
+    test('promotion measures new commits from the last pre-release, not the '
+        'whole package history', () async {
+      // Work already shipped in the preview shouldn't resurface in the
+      // promotion's changelog just because there's no stable tag yet for
+      // the commit range to stop at.
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'preview work');
+      await fixture.commit('fix: work included in the preview');
+      await fixture.tag('datadog_dio/v1.0.0-preview.2');
+
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'more work');
+      await fixture.commit('fix: a fix after the last preview');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_dio']),
+        published: {
+          'datadog_dio': ['1.0.0-preview.1', '1.0.0-preview.2'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '1.0.0');
+      expect(
+        result.packages.single.contributingCommits.map((c) => c.description),
+        ['a fix after the last preview'],
+      );
+    });
 
     test('a published pre-release is not mainline\'s baseline', () async {
       // A v4 line published betas, then merged back. Mainline computes from
@@ -165,6 +195,71 @@ void main() {
   });
 
   group('mainline, package selection', () {
+    test('--include-federated widens selection to the whole group, but '
+        'siblings still need their own eligibility', () async {
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_android/'
+            'CHANGES',
+        'a fix',
+      );
+      await fixture.commit('fix: something in the android impl');
+
+      final result = await plan(
+        mainlineCtx(
+          requestedPackages: ['datadog_flutter_plugin'],
+          includeFederated: true,
+        ),
+      );
+      final names = result.packages.map((e) => e.package.name).toSet();
+
+      expect(names, contains('datadog_flutter_plugin')); // named explicitly
+      expect(names, contains('datadog_flutter_plugin_android')); // has a fix
+      expect(
+        names,
+        isNot(contains('datadog_flutter_plugin_web')),
+      ); // nothing to ship
+      expect(names, isNot(contains('datadog_dio'))); // outside the group
+    });
+
+    test('without --include-federated, a sibling with qualifying commits is '
+        'not swept in', () async {
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_android/'
+            'CHANGES',
+        'a fix',
+      );
+      await fixture.commit('fix: something in the android impl');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_flutter_plugin']),
+      );
+
+      expect(result.packages.map((e) => e.package.name), [
+        'datadog_flutter_plugin',
+      ]);
+    });
+
+    test(
+      '--include-federated is a no-op for a non-federated package',
+      () async {
+        await fixture.tag('datadog_dio/v2.2.0');
+        fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+        await fixture.commit('feat: something new');
+
+        final result = await plan(
+          mainlineCtx(
+            requestedPackages: ['datadog_dio'],
+            includeFederated: true,
+          ),
+          published: {
+            'datadog_dio': ['2.2.0'],
+          },
+        );
+
+        expect(result.packages.map((e) => e.package.name), ['datadog_dio']);
+      },
+    );
+
     test('--all excludes packages with no qualifying commits', () async {
       await fixture.tag('datadog_dio/v2.2.0');
       fixture.writeFile('packages/datadog_dio/CHANGES', 'a real feature');
@@ -213,6 +308,144 @@ void main() {
         expect(names, isNot(contains('datadog_dio')));
       },
     );
+
+    test(
+      'a non-federated package with a matching dependency file still gets '
+      'no native SDK handling at all -- only the flagship group does',
+      () async {
+        // datadog_webview_tracking and datadog_inappwebview_tracking are the
+        // real shape this guards against: a loose Datadog pod/gradle
+        // dependency in a package that should keep it loose, not have this
+        // tooling start resolving and pinning it just because the file
+        // happens to match the same pattern the flagship group uses.
+        fixture.writeFile(
+          'packages/datadog_dio/ios/datadog_dio.podspec',
+          _iosPodspecWithDatadogDependency,
+        );
+        await fixture.commit(
+          'chore: add a podspec fixture to a non-federated package',
+        );
+
+        final result = await plan(
+          mainlineCtx(
+            requestedPackages: ['datadog_dio'],
+            iosSdkVersionOverride: '3.12.0',
+          ),
+        );
+
+        // Explicitly requested, so it still appears in the plan -- just
+        // with nothing native-SDK-related resolved for it. An
+        // IOS_SDK_VERSION override must not be able to sweep it in either
+        // (unlike the flagship group, where the test above confirms it can).
+        expect(result.packages.single.nativeSdkDeltas, isEmpty);
+        // Never published, so there's nothing to compare against -- no
+        // drift warning either. See the dedicated group below for the case
+        // where a past release exists.
+        expect(result.packages.single.warnings, isEmpty);
+      },
+    );
+  });
+
+  group('native dependency changes (non-federated packages)', () {
+    test(
+      'reports a constraint that changed since the package\'s last release',
+      () async {
+        // datadog_webview_tracking's real shape: hand-edited from '~> 3' to
+        // '~> 3.15' to pick up a new dd-sdk-ios feature, with no release
+        // tooling involved.
+        fixture.writeFile(
+          'packages/datadog_dio/ios/datadog_dio.podspec',
+          _iosPodspecWithDatadogDependency, // '~> 3'
+        );
+        await fixture.commit('chore: pin for the 2.2.0 release');
+        await fixture.tag('datadog_dio/v2.2.0');
+
+        fixture.writeFile(
+          'packages/datadog_dio/ios/datadog_dio.podspec',
+          "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '~> 3.15'\nend\n",
+        );
+        await fixture.commit('feat: pick up a new dd-sdk-ios feature');
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_dio']),
+          published: {
+            'datadog_dio': ['2.2.0'],
+          },
+        );
+
+        expect(result.packages.single.nativeSdkDeltas, isEmpty);
+        expect(result.packages.single.warnings, isEmpty);
+
+        final change = result.packages.single.nativeDependencyChanges.single;
+        expect(change.sdk, NativeSdk.ios);
+        expect(change.previous, '~> 3');
+        expect(change.current, '~> 3.15');
+      },
+    );
+
+    test('nothing reported when the constraint has not changed', () async {
+      fixture.writeFile(
+        'packages/datadog_dio/ios/datadog_dio.podspec',
+        _iosPodspecWithDatadogDependency,
+      );
+      await fixture.commit('chore: pin for the 2.2.0 release');
+      await fixture.tag('datadog_dio/v2.2.0');
+
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'unrelated work');
+      await fixture.commit('fix: something unrelated to the native dependency');
+
+      final result = await plan(
+        mainlineCtx(),
+        published: {
+          'datadog_dio': ['2.2.0'],
+        },
+      );
+
+      expect(result.packages.single.nativeDependencyChanges, isEmpty);
+    });
+
+    test(
+      'nothing reported for a package that has never been published',
+      () async {
+        fixture.writeFile(
+          'packages/datadog_dio/ios/datadog_dio.podspec',
+          _iosPodspecWithDatadogDependency,
+        );
+        await fixture.commit(
+          'feat: the first release, with a native dependency',
+        );
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_dio']),
+        );
+
+        // Nothing to compare against -- not evidence of a change.
+        expect(result.packages.single.nativeDependencyChanges, isEmpty);
+      },
+    );
+
+    test(
+      'nothing reported when the last published version has no tag to read',
+      () async {
+        // datadog_session_replay's real shape: pub.dev knows 1.0.0-preview.14
+        // but no tag was ever pushed for it, so there is nothing reliable to
+        // compare the working tree against.
+        fixture.writeFile(
+          'packages/datadog_dio/ios/datadog_dio.podspec',
+          _iosPodspecWithDatadogDependency,
+        );
+        await fixture.commit('fix: something');
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_dio']),
+          published: {
+            'datadog_dio': ['1.0.0-preview.1', '1.0.0-preview.2'],
+          },
+        );
+
+        expect(result.packages.single.nativeDependencyChanges, isEmpty);
+      },
+    );
   });
 
   group('mainline, native SDK deltas', () {
@@ -239,6 +472,11 @@ void main() {
         final delta = result.packages.single.nativeSdkDeltas.single;
         expect(delta.sdk, NativeSdk.ios);
         expect(delta.targetVersion, '3.13.0');
+        // Never published, so there's no past release to read a "current"
+        // declaration from -- the live '~> 3' fixture podspec above must
+        // NOT leak in here as if it were evidence of one. See the
+        // dedicated group below for the case where a past release exists.
+        expect(delta.currentDeclaration, isNull);
       },
     );
 
@@ -291,6 +529,42 @@ void main() {
       final delta = result.packages.single.nativeSdkDeltas.single;
       expect(delta.targetVersion, 'v1.4.0');
       expect(delta.targetSha, 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2');
+    });
+
+    test('the current declaration comes from the last published tag, not the '
+        'working tree', () async {
+      // Simulates a real release: DatadogCore was pinned to exactly
+      // 3.10.0 when v3.10.0 was tagged and published, then development
+      // moved the working tree past it to a floating constraint again --
+      // the same shape as the real datadog_flutter_plugin_ios podspec.
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+            'datadog_flutter_plugin_ios.podspec',
+        "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '3.10.0'\nend\n",
+      );
+      await fixture.commit('chore: pin for the 3.10.0 release');
+      await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+        'datadog_flutter_plugin_ios.podspec',
+        _iosPodspecWithDatadogDependency, // floats again, back to '~> 3'
+      );
+      await fixture.commit('chore: float the constraint again post-release');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
+        published: {
+          'datadog_flutter_plugin_ios': ['3.10.0'],
+        },
+        fetchLatestNativeSdkVersion: (repoSlug) async => '3.13.0',
+      );
+
+      final delta = result.packages.single.nativeSdkDeltas.single;
+      expect(delta.targetVersion, '3.13.0');
+      // Must be what v3.10.0 actually shipped with (3.10.0), not the
+      // working tree's current floating '~> 3'.
+      expect(delta.currentDeclaration, '3.10.0');
     });
   });
 
@@ -633,6 +907,20 @@ void main() {
           ),
         ),
       );
+    });
+  });
+
+  group('resolveTriggerContext', () {
+    test('a patch branch name is recognised unconditionally', () {
+      expect(
+        resolveTriggerContext('release/datadog_dio/v1.1.x'),
+        TriggerContext.patch,
+      );
+    });
+
+    test('anything else defaults to mainline, including a pre-release', () {
+      expect(resolveTriggerContext('develop'), TriggerContext.mainline);
+      expect(resolveTriggerContext('v4'), TriggerContext.mainline);
     });
   });
 }

--- a/tools/releaser/test/trigger_context_test.dart
+++ b/tools/releaser/test/trigger_context_test.dart
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:releaser/trigger_context.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TriggerContext.parse', () {
+    test('parses each named context', () {
+      expect(TriggerContext.parse('mainline'), TriggerContext.mainline);
+      expect(TriggerContext.parse('patch'), TriggerContext.patch);
+      expect(TriggerContext.parse('prerelease'), TriggerContext.preRelease);
+    });
+
+    test('"auto" is null -- it asks for branch-name detection, not a name', () {
+      expect(TriggerContext.parse('auto'), isNull);
+    });
+
+    test('anything unrecognized is null', () {
+      expect(TriggerContext.parse('nonsense'), isNull);
+      expect(TriggerContext.parse(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
### What and why?

> [!NOTE]
> Note to reviewers - formatting changes have been isolated into a single commit. You can review each commit in isolate to avoid seeing formatting only changes.


`preview_release` is run locally to determine what will be in the next release of a set of libraries. This would be run locally to ensure that we're not releasing things unintentionally.

Uses the release_plan system directly which is what will be used in actual releases.

Also add a few features to `release_plan` 
- detect and report automatic upgrades to native libraries in `datadog_flutter_plugin` and reporting and reporting manual updates in all other packages.
- Support performing upgrades to an entire set of federated plugins as one package with the `--include-federated` flag.

Example output from the tool from current `develop`:
```
Package                        Current → New             Bump
datadog_flags                  1.0.1 → 1.1.0             minor
  ⚠️ 1.0.1 is published but has no tag -- the commit range falls back to v1.0.0, so this changelog may repeat entries already shipped in 1.0.1.
datadog_inappwebview_tracking  2.0.0 → 2.1.0             minor
datadog_session_replay         1.0.0-preview.14 → 1.0.0  first release
  ⚠️ 1.0.0-preview.14 is published but has no tag -- the commit range falls back to v1.0.0-preview.13, so this changelog may repeat entries already shipped in 1.0.0-preview.14.
datadog_tracking_http_client   3.2.0 → 3.3.0             minor
datadog_grpc_interceptor       2.0.0 → 2.1.0             minor
datadog_dio                    2.2.0 → 2.3.0             minor
datadog_flutter_plugin         3.5.0 → 3.5.1             patch  (ios: 3.15.0 -> 3.16.0, android: 3.12.1 -> 3.13.1)
datadog_gql_link               2.1.0 → 2.2.0             minor
datadog_flags_flutter          1.0.0 → 1.1.0             minor
datadog_webview_tracking       3.1.0 → 3.2.0             minor
```

Example output using `--packages=datadog_flutter_plugin --trigger=prerelease --prerelease-label=preview --include-federated --verbose`:

```
datadog_flutter_plugin_platform_interface  1.0.0 → 1.0.0-preview.1  prerelease
    feat: Update dependencies and regenerate affected code.
    feat: Require a `service` name when configuring Datadog  [BREAKING]
    feat: Rename all "featureOperations" to new "operations" naming.  [BREAKING]
    feat: Update all packages to Dart 3.10 / Flutter 3.38  [BREAKING]
    feat: Migrate main package to a federated plugin.
datadog_flutter_plugin_android             1.0.0 → 1.0.0-preview.1  prerelease  (android: -> 3.13.1)
    feat: Update dependencies and regenerate affected code.
    feat: Require a `service` name when configuring Datadog  [BREAKING]
    feat: Rename all "featureOperations" to new "operations" naming.  [BREAKING]
    feat: Update support for newer Kotlin, UIScene support.
    feat: Update all packages to Dart 3.10 / Flutter 3.38  [BREAKING]
    feat: Migrate main package to a federated plugin.
datadog_flutter_plugin_desktop             1.0.0 → 1.0.0-preview.1  prerelease  (cpp: -> 0.7.1)
    feat: Require a `service` name when configuring Datadog  [BREAKING]
    feat: Add long task reporting to desktop platforms
    feat: Add windows support (and untested linux support)
datadog_flutter_plugin_ios                 1.0.0 → 1.0.0-preview.1  prerelease  (ios: -> 3.16.0)
    feat: Require a `service` name when configuring Datadog  [BREAKING]
    feat: Rename all "featureOperations" to new "operations" naming.  [BREAKING]
    feat: Update all packages to Dart 3.10 / Flutter 3.38  [BREAKING]
    feat: Migrate main package to a federated plugin.
datadog_flutter_plugin_web                 1.0.0 → 1.0.0-preview.1  prerelease
    feat: Rename all "featureOperations" to new "operations" naming.  [BREAKING]
    feat: Update to v7 of the Browser SDK  [BREAKING]
    feat: Update all packages to Dart 3.10 / Flutter 3.38  [BREAKING]
    feat: Migrate main package to a federated plugin.
datadog_flutter_plugin                     3.5.0 → 4.0.0-preview.1  prerelease
    feat: Require a `service` name when configuring Datadog  [BREAKING]
    feat: Add long task reporting to desktop platforms
    feat: Rename all "featureOperations" to new "operations" naming.  [BREAKING]
    feat: Update to v7 of the Browser SDK  [BREAKING]
    feat: Add windows support (and untested linux support)
    feat: Update support for newer Kotlin, UIScene support.
    feat: Update all packages to Dart 3.10 / Flutter 3.38  [BREAKING]
    feat: Migrate main package to a federated plugin.
```


### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
