### PR TITLE
feat: Support grpc 5.x.

### DIFF
--- a/packages/datadog_grpc_interceptor/CHANGELOG.md
+++ b/packages/datadog_grpc_interceptor/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+* Support grpc 5.x. See [#1150](https://github.com/DataDog/dd-sdk-flutter/issues/1150).
+
 ## 2.0.0
 
 * Support RUM context in trace headers.

--- a/packages/datadog_grpc_interceptor/pubspec.yaml
+++ b/packages/datadog_grpc_interceptor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   datadog_flutter_plugin: ">=3.0.0 <5.0.0"
-  grpc: ">=3.0.2 <5.0.0"
+  grpc: ">=3.0.2 <6.0.0"
   uuid: ^4.0.0
 
 dev_dependencies:
@@ -20,6 +20,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^2.0.1
   mocktail: ^0.3.0
-  protobuf: ^2.1.0
+  protobuf: ^6.0.0
   datadog_common_test:
     path: ../datadog_common_test

--- a/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pb.dart
+++ b/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pb.dart
@@ -1,63 +1,61 @@
-///
-//  Generated code. Do not modify.
-//  source: helloworld.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// Generated from helloworld.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
-class HelloRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'HelloRequest',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'helloworld'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..hasRequiredFields = false;
+export 'package:protobuf/protobuf.dart' show GeneratedMessageGenericExtensions;
 
-  HelloRequest._() : super();
+/// The request message containing the user's name.
+class HelloRequest extends $pb.GeneratedMessage {
   factory HelloRequest({
     $core.String? name,
   }) {
-    final _result = create();
-    if (name != null) {
-      _result.name = name;
-    }
-    return _result;
+    final result = create();
+    if (name != null) result.name = name;
+    return result;
   }
-  factory HelloRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory HelloRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  HelloRequest clone() => HelloRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  HelloRequest._();
+
+  factory HelloRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HelloRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HelloRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'helloworld'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HelloRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   HelloRequest copyWith(void Function(HelloRequest) updates) =>
       super.copyWith((message) => updates(message as HelloRequest))
-          as HelloRequest; // ignore: deprecated_member_use
+          as HelloRequest;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static HelloRequest create() => HelloRequest._();
+  @$core.override
   HelloRequest createEmptyInstance() => create();
-  static $pb.PbList<HelloRequest> createRepeated() =>
-      $pb.PbList<HelloRequest>();
   @$core.pragma('dart2js:noInline')
   static HelloRequest getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<HelloRequest>(create);
@@ -66,64 +64,52 @@ class HelloRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
-  void clearName() => clearField(1);
+  void clearName() => $_clearField(1);
 }
 
+/// The response message containing the greetings
 class HelloReply extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'HelloReply',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'helloworld'),
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'message')
-    ..hasRequiredFields = false;
-
-  HelloReply._() : super();
   factory HelloReply({
     $core.String? message,
   }) {
-    final _result = create();
-    if (message != null) {
-      _result.message = message;
-    }
-    return _result;
+    final result = create();
+    if (message != null) result.message = message;
+    return result;
   }
-  factory HelloReply.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory HelloReply.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  HelloReply clone() => HelloReply()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
+
+  HelloReply._();
+
+  factory HelloReply.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory HelloReply.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      _omitMessageNames ? '' : 'HelloReply',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'helloworld'),
+      createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'message')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  HelloReply clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
   HelloReply copyWith(void Function(HelloReply) updates) =>
-      super.copyWith((message) => updates(message as HelloReply))
-          as HelloReply; // ignore: deprecated_member_use
+      super.copyWith((message) => updates(message as HelloReply)) as HelloReply;
+
+  @$core.override
   $pb.BuilderInfo get info_ => _i;
+
   @$core.pragma('dart2js:noInline')
   static HelloReply create() => HelloReply._();
+  @$core.override
   HelloReply createEmptyInstance() => create();
-  static $pb.PbList<HelloReply> createRepeated() => $pb.PbList<HelloReply>();
   @$core.pragma('dart2js:noInline')
   static HelloReply getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<HelloReply>(create);
@@ -132,12 +118,14 @@ class HelloReply extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) {
-    $_setString(0, v);
-  }
-
+  set message($core.String value) => $_setString(0, value);
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
-  void clearMessage() => clearField(1);
+  void clearMessage() => $_clearField(1);
 }
+
+const $core.bool _omitFieldNames =
+    $core.bool.fromEnvironment('protobuf.omit_field_names');
+const $core.bool _omitMessageNames =
+    $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pbenum.dart
+++ b/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pbenum.dart
@@ -1,6 +1,11 @@
-///
-//  Generated code. Do not modify.
-//  source: helloworld.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// Generated from helloworld.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports

--- a/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pbgrpc.dart
+++ b/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pbgrpc.dart
@@ -1,35 +1,55 @@
-///
-//  Generated code. Do not modify.
-//  source: helloworld.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// Generated from helloworld.proto.
+
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
 
 import 'dart:async' as $async;
-
 import 'dart:core' as $core;
 
 import 'package:grpc/service_api.dart' as $grpc;
+import 'package:protobuf/protobuf.dart' as $pb;
+
 import 'helloworld.pb.dart' as $0;
+
 export 'helloworld.pb.dart';
 
+/// The greeting service definition.
+@$pb.GrpcServiceName('helloworld.Greeter')
 class GreeterClient extends $grpc.Client {
+  /// The hostname for this service.
+  static const $core.String defaultHost = '';
+
+  /// OAuth scopes needed for the client.
+  static const $core.List<$core.String> oauthScopes = [
+    '',
+  ];
+
+  GreeterClient(super.channel, {super.options, super.interceptors});
+
+  /// Sends a greeting
+  $grpc.ResponseFuture<$0.HelloReply> sayHello(
+    $0.HelloRequest request, {
+    $grpc.CallOptions? options,
+  }) {
+    return $createUnaryCall(_$sayHello, request, options: options);
+  }
+
+  // method descriptors
+
   static final _$sayHello = $grpc.ClientMethod<$0.HelloRequest, $0.HelloReply>(
       '/helloworld.Greeter/SayHello',
       ($0.HelloRequest value) => value.writeToBuffer(),
-      ($core.List<$core.int> value) => $0.HelloReply.fromBuffer(value));
-
-  GreeterClient($grpc.ClientChannel channel,
-      {$grpc.CallOptions? options,
-      $core.Iterable<$grpc.ClientInterceptor>? interceptors})
-      : super(channel, options: options, interceptors: interceptors);
-
-  $grpc.ResponseFuture<$0.HelloReply> sayHello($0.HelloRequest request,
-      {$grpc.CallOptions? options}) {
-    return $createUnaryCall(_$sayHello, request, options: options);
-  }
+      $0.HelloReply.fromBuffer);
 }
 
+@$pb.GrpcServiceName('helloworld.Greeter')
 abstract class GreeterServiceBase extends $grpc.Service {
   $core.String get $name => 'helloworld.Greeter';
 
@@ -44,8 +64,8 @@ abstract class GreeterServiceBase extends $grpc.Service {
   }
 
   $async.Future<$0.HelloReply> sayHello_Pre(
-      $grpc.ServiceCall call, $async.Future<$0.HelloRequest> request) async {
-    return sayHello(call, await request);
+      $grpc.ServiceCall $call, $async.Future<$0.HelloRequest> $request) async {
+    return sayHello($call, await $request);
   }
 
   $async.Future<$0.HelloReply> sayHello(

--- a/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pbjson.dart
+++ b/packages/datadog_grpc_interceptor/test/src/generated/helloworld.pbjson.dart
@@ -1,30 +1,37 @@
-///
-//  Generated code. Do not modify.
-//  source: helloworld.proto
+// This is a generated file - do not edit.
 //
-// @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// Generated from helloworld.proto.
 
-import 'dart:core' as $core;
+// @dart = 3.3
+
+// ignore_for_file: annotate_overrides, camel_case_types, comment_references
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: curly_braces_in_flow_control_structures
+// ignore_for_file: deprecated_member_use_from_same_package, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_relative_imports
+// ignore_for_file: unused_import
+
 import 'dart:convert' as $convert;
+import 'dart:core' as $core;
 import 'dart:typed_data' as $typed_data;
 
 @$core.Deprecated('Use helloRequestDescriptor instead')
-const HelloRequest$json = const {
+const HelloRequest$json = {
   '1': 'HelloRequest',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
   ],
 };
 
 /// Descriptor for `HelloRequest`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List helloRequestDescriptor =
     $convert.base64Decode('CgxIZWxsb1JlcXVlc3QSEgoEbmFtZRgBIAEoCVIEbmFtZQ==');
+
 @$core.Deprecated('Use helloReplyDescriptor instead')
-const HelloReply$json = const {
+const HelloReply$json = {
   '1': 'HelloReply',
-  '2': const [
-    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+  '2': [
+    {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
   ],
 };
 


### PR DESCRIPTION
### What and why?

datadog_grpc_interceptor constrains grpc to >=3.0.2 <5.0.0. Apps whose generated clients need protobuf 6 require grpc 5.1, so resolution fails and the only workaround is a dependency_overrides entry in the app. 

Refs: #1150 

### How?

Widens the constraint to >=3.0.2 <6.0.0 and regenerates the test protos for protobuf 6. The interceptor source is unchanged.

### Review checklist

- [X] This pull request has appropriate unit and / or integration tests 
- [X] This pull request references a Github or JIRA issue
