### PR TITLE
tools(releaser): Add a tool to generate the CHANGELOG entries.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#988f98",
-        "activityBar.activeBorder": "#d7d787",
+        "activityBar.activeBorder": "#15202b",
         "activityBar.background": "#988f98",
         "activityBar.foreground": "#15202b",
         "activityBar.inactiveForeground": "#15202b99",
@@ -24,7 +24,8 @@
         "activityBarTop.inactiveForeground": "#15202b99",
         "commandCenter.foreground": "#e7e7e7",
         "statusBar.debuggingBackground": "#7f757f",
-        "statusBar.debuggingForeground": "#e7e7e7"
+        "statusBar.debuggingForeground": "#e7e7e7",
+        "activityBarTop.activeBorder": "#15202b"
     },
     "dart.analysisExcludedFolders": [
         ".fvm",

--- a/tools/releaser/bin/preview_changelog.dart
+++ b/tools/releaser/bin/preview_changelog.dart
@@ -30,7 +30,15 @@ Future<void> main(List<String> arguments) async {
 
   final argParser = ArgParser()
     ..addOption('repo-root', mandatory: true)
-    ..addOption('package', mandatory: true);
+    ..addOption('package', mandatory: true)
+    ..addOption(
+      'trigger',
+      allowed: ['auto', 'mainline', 'patch', 'prerelease'],
+      defaultsTo: 'auto',
+      help:
+          'Which trigger context to plan for. "auto" detects patch from '
+          'the current branch name, defaulting to mainline otherwise.',
+    );
   final args = argParser.parse(arguments);
 
   final gitDir = await getGitDir(args['repo-root'] as String);
@@ -40,10 +48,13 @@ Future<void> main(List<String> arguments) async {
   }
 
   final currentBranch = (await gitDir.currentBranch()).branchName;
+  final trigger =
+      TriggerContext.parse(args['trigger'] as String) ??
+      resolveTriggerContext(currentBranch);
   final plan = await computeReleasePlan(
     RunContext(
       repoRoot: gitDir.path,
-      trigger: resolveTriggerContext(currentBranch),
+      trigger: trigger,
       currentBranch: currentBranch,
       requestedPackages: [args['package'] as String],
     ),

--- a/tools/releaser/bin/preview_changelog.dart
+++ b/tools/releaser/bin/preview_changelog.dart
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// A local dev tool for the LLM changelog pipeline (`lib/llm/`): runs it for
+// real, against a real AI Gateway token, for one package -- the fast path
+// for iterating on the prompts in `lib/llm/changelog.dart` and eyeballing
+// real output. Not wired into CI or any other entry point.
+//
+// Usage: AI_GATEWAY_TOKEN=$(ddtool auth token rapid-ai-platform
+// --datacenter us1.ddbuild.io) dart run bin/preview_changelog.dart
+// --repo-root=/path/to/dd-sdk-flutter --package=datadog_flutter_plugin
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:logging/logging.dart';
+import 'package:releaser/github_cmd_wrapper.dart';
+import 'package:releaser/helpers.dart';
+import 'package:releaser/llm/ai_gateway.dart';
+import 'package:releaser/llm/changelog.dart';
+import 'package:releaser/llm/costs.dart';
+import 'package:releaser/release_plan.dart';
+
+final _log = Logger('preview_changelog');
+
+Future<void> main(List<String> arguments) async {
+  Logger.root.level = Level.ALL;
+  Logger.root.onRecord.listen((r) => print('${r.level.name}: ${r.message}'));
+
+  final argParser = ArgParser()
+    ..addOption('repo-root', mandatory: true)
+    ..addOption('package', mandatory: true);
+  final args = argParser.parse(arguments);
+
+  final gitDir = await getGitDir(args['repo-root'] as String);
+  if (gitDir == null) {
+    exitCode = 1;
+    return;
+  }
+
+  final currentBranch = (await gitDir.currentBranch()).branchName;
+  final plan = await computeReleasePlan(
+    RunContext(
+      repoRoot: gitDir.path,
+      trigger: resolveTriggerContext(currentBranch),
+      currentBranch: currentBranch,
+      requestedPackages: [args['package'] as String],
+    ),
+  );
+  final packagePlan = plan.packages.singleWhere(
+    (p) => p.package.name == args['package'],
+  );
+
+  final costTracker = LlmCostTracker();
+  final entries = await generateChangelogForPackage(
+    HttpAiGatewayClient.fromEnvironment(),
+    packagePlan,
+    github: GithubCommandWrapper(gitDir.path),
+    logger: _log,
+    costTracker: costTracker,
+  );
+
+  print('## ${packagePlan.newVersion}\n');
+  print(renderChangelogSection(entries));
+
+  print('\n--- LLM cost summary ---\n');
+  costTracker.printSummary(_log);
+}

--- a/tools/releaser/bin/preview_release.dart
+++ b/tools/releaser/bin/preview_release.dart
@@ -6,7 +6,10 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:logging/logging.dart';
+import 'package:releaser/github_cmd_wrapper.dart';
 import 'package:releaser/helpers.dart';
+import 'package:releaser/native_sdk_changelog.dart';
+import 'package:releaser/pr_resolution.dart';
 import 'package:releaser/release_plan.dart';
 
 final _log = Logger('preview_release');
@@ -137,10 +140,18 @@ Future<void> main(List<String> arguments) async {
     return;
   }
 
-  _printPlan(plan);
+  await _printPlan(
+    plan,
+    verbose: args['verbose'] as bool,
+    github: GithubCommandWrapper(gitDir.path),
+  );
 }
 
-void _printPlan(ReleasePlan plan) {
+Future<void> _printPlan(
+  ReleasePlan plan, {
+  required bool verbose,
+  required GithubCommandWrapper github,
+}) async {
   if (plan.packages.isEmpty) {
     _log.info('No packages would release from this run.');
     return;
@@ -174,9 +185,57 @@ void _printPlan(ReleasePlan plan) {
       '$bumpLabel$nativeSuffix',
     );
 
-    for (final commit in row.plan.contributingCommits) {
-      final flag = commit.isBreaking ? '  [BREAKING]' : '';
-      _log.fine('    ${commit.type}: ${commit.description}$flag');
+    if (verbose) {
+      for (final delta in row.plan.nativeSdkDeltas) {
+        final targetVersion = delta.targetVersion;
+        if (targetVersion == null) continue;
+
+        final result = await resolveNativeSdkChangelog(
+          delta.sdk,
+          currentDeclaration: delta.currentDeclaration,
+          targetVersion: targetVersion,
+          fetchChangelog: githubChangelogFetcher(_log, github),
+        );
+
+        if (result.warning != null) {
+          _log.warning('  ⚠️ ${result.warning}');
+          continue;
+        }
+
+        final sections = result.sections!;
+        if (sections.isEmpty) continue;
+
+        _log.fine(
+          '  ${delta.sdk.name} CHANGELOG '
+          '(${delta.currentDeclaration} → $targetVersion):',
+        );
+        for (final section in sections) {
+          _log.fine('    ${section.version}');
+          for (final entry in section.entries) {
+            _log.fine('      $entry');
+          }
+        }
+      }
+
+      for (final commit in row.plan.contributingCommits) {
+        final resolved = commit.sha == null
+            ? null
+            : await resolvePr(
+                commit.sha!,
+                commit.description,
+                (sha) => github.searchMergedPrBySha(_log, sha),
+              );
+        final prefix = resolved != null ? '#${resolved.number} ' : '';
+        final scope = commit.scope != null ? '(${commit.scope})' : '';
+        final bang = commit.hasBreakingMarker ? '!' : '';
+        final description = stripSquashSuffix(commit.description);
+        final flag = (commit.isBreaking && row.isMajor)
+            ? '  [BREAKING — caused MAJOR bump]'
+            : commit.isBreaking
+            ? '  [BREAKING]'
+            : '';
+        _log.fine('    $prefix${commit.type}$scope$bang: $description$flag');
+      }
     }
 
     for (final warning in row.plan.warnings) {

--- a/tools/releaser/lib/cmake_util.dart
+++ b/tools/releaser/lib/cmake_util.dart
@@ -18,10 +18,19 @@ final _gitTagPattern = RegExp(r'(?<prefix>GIT_TAG\s+)(?<ref>[\w./-]+)');
 /// and so a `#`-commented mention of `GIT_TAG` can't be mistaken for the pin.
 final _trailingCommentPattern = RegExp(r'\s*#.*$');
 
-/// Captures the text of a trailing `# ...` comment -- see
-/// [currentGitTagVersion], which reads it back as the tag [pinCppVersion]
-/// annotated a pinned SHA with.
-final _trailingCommentCapturePattern = RegExp(r'#\s*(?<comment>\S+)');
+/// A trailing comment holding *only* a version tag -- the annotation
+/// [pinCppVersion] writes beside a pinned SHA, read back by
+/// [currentGitTagVersion].
+///
+/// Anchored and version-shaped on purpose. A comment is free text, and a
+/// hand-pinned line may well explain itself (`GIT_TAG v1.4.0 # hold until
+/// #123 lands`); matching the first word of any comment would read `hold` as
+/// the version, which loses the bump baseline and -- worse, now that a pin
+/// means "hold" -- makes [isPinnedDeclaration] see a floating ref and go
+/// fetch a newer SDK, overriding the very pin the comment was explaining.
+final _versionAnnotationPattern = RegExp(
+  r'#\s*(?<version>v?\d+\.\d+\.\d+)\s*$',
+);
 
 final _ddSdkCppDeclareStartPattern = RegExp(
   r'FetchContent_Declare\(\s*dd-sdk-cpp\b',
@@ -101,6 +110,10 @@ String? currentGitTag(String cmakeListsContent) {
 /// `v1.4.0`) only survives as the trailing `# v1.4.0` comment [pinCppVersion]
 /// writes alongside it, so this prefers that annotation and falls back to
 /// the bare ref (a floating `develop`, or a tag with no annotation yet).
+///
+/// Only a comment that is *just* a version counts as that annotation -- see
+/// [_versionAnnotationPattern]. A hand-written explanation next to a pin is
+/// prose, not a version, and the ref itself is the better answer there.
 String? currentGitTagVersion(String cmakeListsContent) {
   final scanner = _DdSdkCppBlockScanner();
   for (final line in cmakeListsContent.split('\n')) {
@@ -108,10 +121,10 @@ String? currentGitTagVersion(String cmakeListsContent) {
     final bare = line.replaceFirst(_trailingCommentPattern, '');
     final match = _gitTagPattern.firstMatch(bare);
     if (match == null) continue;
-    final comment = _trailingCommentCapturePattern
+    final annotation = _versionAnnotationPattern
         .firstMatch(line)
-        ?.namedGroup('comment');
-    return comment ?? match.namedGroup('ref');
+        ?.namedGroup('version');
+    return annotation ?? match.namedGroup('ref');
   }
   return null;
 }

--- a/tools/releaser/lib/cmake_util.dart
+++ b/tools/releaser/lib/cmake_util.dart
@@ -18,6 +18,11 @@ final _gitTagPattern = RegExp(r'(?<prefix>GIT_TAG\s+)(?<ref>[\w./-]+)');
 /// and so a `#`-commented mention of `GIT_TAG` can't be mistaken for the pin.
 final _trailingCommentPattern = RegExp(r'\s*#.*$');
 
+/// Captures the text of a trailing `# ...` comment -- see
+/// [currentGitTagVersion], which reads it back as the tag [pinCppVersion]
+/// annotated a pinned SHA with.
+final _trailingCommentCapturePattern = RegExp(r'#\s*(?<comment>\S+)');
+
 final _ddSdkCppDeclareStartPattern = RegExp(
   r'FetchContent_Declare\(\s*dd-sdk-cpp\b',
 );
@@ -85,6 +90,28 @@ String? currentGitTag(String cmakeListsContent) {
       line.replaceFirst(_trailingCommentPattern, ''),
     );
     if (match != null) return match.namedGroup('ref');
+  }
+  return null;
+}
+
+/// The dd-sdk-cpp version [cmakeListsContent] is currently pinned to, for
+/// comparing against a resolved target -- unlike [currentGitTag], which
+/// returns the raw `GIT_TAG` ref. Once a package has gone through
+/// [pinCppVersion], that ref is a commit SHA and the actual version (e.g.
+/// `v1.4.0`) only survives as the trailing `# v1.4.0` comment [pinCppVersion]
+/// writes alongside it, so this prefers that annotation and falls back to
+/// the bare ref (a floating `develop`, or a tag with no annotation yet).
+String? currentGitTagVersion(String cmakeListsContent) {
+  final scanner = _DdSdkCppBlockScanner();
+  for (final line in cmakeListsContent.split('\n')) {
+    if (!scanner.accept(line)) continue;
+    final bare = line.replaceFirst(_trailingCommentPattern, '');
+    final match = _gitTagPattern.firstMatch(bare);
+    if (match == null) continue;
+    final comment = _trailingCommentCapturePattern
+        .firstMatch(line)
+        ?.namedGroup('comment');
+    return comment ?? match.namedGroup('ref');
   }
   return null;
 }

--- a/tools/releaser/lib/conventional_commits.dart
+++ b/tools/releaser/lib/conventional_commits.dart
@@ -113,14 +113,5 @@ class ConventionalCommit {
 
 /// The highest-severity bump implied by [commits] (major > minor > patch),
 /// or null if none of them carry semver weight.
-VersionBumpType? aggregateBumpLevel(Iterable<ConventionalCommit> commits) {
-  VersionBumpType? highest;
-  for (final commit in commits) {
-    final bump = commit.bumpType;
-    if (bump == null) continue;
-    if (highest == null || bump.severity > highest.severity) {
-      highest = bump;
-    }
-  }
-  return highest;
-}
+VersionBumpType? aggregateBumpLevel(Iterable<ConventionalCommit> commits) =>
+    highestBump(commits.map((c) => c.bumpType));

--- a/tools/releaser/lib/conventional_commits.dart
+++ b/tools/releaser/lib/conventional_commits.dart
@@ -28,6 +28,11 @@ class ConventionalCommit {
   /// (like `generate_changelog.dart`) picks those out itself.
   final List<String> refs;
 
+  /// The commit's full SHA, when parsed from real git history (`sha:` was
+  /// passed to [parse]) -- what `pr_resolution.dart` searches GitHub with.
+  /// Null for commits parsed in isolation, e.g. in tests.
+  final String? sha;
+
   ConventionalCommit({
     required this.type,
     required this.scope,
@@ -35,6 +40,7 @@ class ConventionalCommit {
     required this.description,
     required this.hasBreakingFooter,
     required this.refs,
+    this.sha,
   });
 
   bool get isBreaking => hasBreakingMarker || hasBreakingFooter;
@@ -79,7 +85,7 @@ class ConventionalCommit {
   /// Parses a full commit message (subject line plus body/footers) into
   /// its conventional-commit parts, or returns null if the subject line
   /// doesn't match the convention at all.
-  static ConventionalCommit? parse(String commitMessage) {
+  static ConventionalCommit? parse(String commitMessage, {String? sha}) {
     final lines = commitMessage.split('\n');
     final match = _headerPattern.firstMatch(lines.first);
     if (match == null) return null;
@@ -100,6 +106,7 @@ class ConventionalCommit {
       description: match.namedGroup('rest')!,
       hasBreakingFooter: _breakingFooterPattern.hasMatch(commitMessage),
       refs: refs,
+      sha: sha,
     );
   }
 }

--- a/tools/releaser/lib/git_history.dart
+++ b/tools/releaser/lib/git_history.dart
@@ -36,20 +36,17 @@ Future<String?> tagSha(GitDir gitDir, String tagName) async {
   return sha.isEmpty ? null : sha;
 }
 
-/// [relativePath]'s content as it existed at the commit tagged [tagName], or
-/// null if the tag can't be resolved (see [tagSha]) or the file didn't
-/// exist at that commit.
-Future<String?> fileContentAtTag(
+/// [relativePath]'s content as it existed at [ref] -- a tag name or a raw
+/// commit SHA, `git show` treats both the same way -- or null if [ref]
+/// doesn't resolve or the file didn't exist there.
+Future<String?> fileContentAtRef(
   GitDir gitDir,
-  String tagName,
+  String ref,
   String relativePath,
 ) async {
-  final sha = await tagSha(gitDir, tagName);
-  if (sha == null) return null;
-
   final result = await gitDir.runCommand([
     'show',
-    '$sha:$relativePath',
+    '$ref:$relativePath',
   ], throwOnError: false);
 
   return result.exitCode == 0 ? result.stdout as String : null;

--- a/tools/releaser/lib/git_history.dart
+++ b/tools/releaser/lib/git_history.dart
@@ -55,11 +55,21 @@ Future<String?> fileContentAtTag(
   return result.exitCode == 0 ? result.stdout as String : null;
 }
 
-/// Full commit messages (subject + body/footers) touching [pathspec], from
-/// just after [sinceSha] through HEAD. A null [sinceSha] walks the entire
-/// history of [pathspec] -- the "since inception" case for a package that has
-/// never been published.
-Future<List<String>> commitMessagesSince(
+/// A single commit's full SHA alongside its message -- the SHA is what
+/// [resolvePr] searches GitHub with for commits that didn't land via a
+/// squash merge (see `pr_resolution.dart`).
+class CommitRecord {
+  final String sha;
+  final String message;
+
+  const CommitRecord({required this.sha, required this.message});
+}
+
+/// Commits (SHA + full message: subject + body/footers) touching [pathspec],
+/// from just after [sinceSha] through HEAD. A null [sinceSha] walks the
+/// entire history of [pathspec] -- the "since inception" case for a package
+/// that has never been published.
+Future<List<CommitRecord>> commitsSince(
   GitDir gitDir, {
   required String pathspec,
   String? sinceSha,
@@ -69,14 +79,23 @@ Future<List<String>> commitMessagesSince(
     '--no-pager',
     'log',
     range,
-    '--pretty=format:%B|||END|||',
+    // %x1f/%x1e are ASCII unit/record separators -- content a commit
+    // message could plausibly contain, unlike a literal string delimiter.
+    '--pretty=format:%H%x1f%B%x1e',
     '--',
     pathspec,
   ]);
 
   return (result.stdout as String)
-      .split('|||END|||')
-      .map((m) => m.trim())
-      .where((m) => m.isNotEmpty)
+      .split('\x1e')
+      .map((e) => e.trim())
+      .where((e) => e.isNotEmpty)
+      .map((entry) {
+        final sepIndex = entry.indexOf('\x1f');
+        return CommitRecord(
+          sha: entry.substring(0, sepIndex),
+          message: entry.substring(sepIndex + 1).trim(),
+        );
+      })
       .toList();
 }

--- a/tools/releaser/lib/github_cmd_wrapper.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.dart
@@ -8,6 +8,7 @@ import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:logging/logging.dart';
 
+import 'pr_resolution.dart' show ResolvedPr;
 import 'process_helper.dart';
 
 part 'github_cmd_wrapper.g.dart';
@@ -110,6 +111,74 @@ class GithubCommandWrapper {
     }
 
     return buffer.toString().trim();
+  }
+
+  /// Raw content of [path] in [repoSlug] at its default branch HEAD -- via
+  /// `gh api`'s raw-media-type override, which returns the file's bytes
+  /// directly instead of the JSON+base64 envelope the endpoint returns by
+  /// default. `native_sdk_changelog.dart` uses this to fetch `CHANGELOG.md`.
+  Future<String> fetchFileContent(
+    Logger logger,
+    String repoSlug,
+    String path,
+  ) async {
+    final buffer = StringBuffer();
+    final exitCode = await runProcess(
+      'gh',
+      [
+        'api',
+        '-H',
+        'Accept: application/vnd.github.raw',
+        'repos/$repoSlug/contents/$path',
+      ],
+      workingDirectory: cwd,
+      stdout: (line) => buffer.writeln(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    if (exitCode != 0) {
+      throw Exception('gh returned exit code $exitCode.');
+    }
+
+    return buffer.toString();
+  }
+
+  /// `gh pr list --search "sha:{sha}"` -- the fallback `pr_resolution.dart`
+  /// uses for a commit that didn't land via a squash merge (no `(#N)`
+  /// suffix to parse locally). Merged PRs only; the newest match if somehow
+  /// more than one comes back.
+  Future<ResolvedPr?> searchMergedPrBySha(Logger logger, String sha) async {
+    final buffer = StringBuffer();
+    final exitCode = await runProcess(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--search',
+        'sha:$sha',
+        '--state',
+        'merged',
+        '--json',
+        'number,title',
+        '--limit',
+        '1',
+      ],
+      workingDirectory: cwd,
+      stdout: (line) => buffer.write(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    if (exitCode != 0) {
+      throw Exception('gh returned exit code $exitCode.');
+    }
+
+    final json = jsonDecode(buffer.toString()) as List;
+    if (json.isEmpty) return null;
+    final entry = json.first as Map<String, dynamic>;
+    return ResolvedPr(
+      number: entry['number'] as int,
+      title: entry['title'] as String,
+    );
   }
 
   Future<void> createRelease(

--- a/tools/releaser/lib/github_cmd_wrapper.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.dart
@@ -8,7 +8,7 @@ import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:logging/logging.dart';
 
-import 'pr_resolution.dart' show ResolvedPr;
+import 'pr_resolution.dart';
 import 'process_helper.dart';
 
 part 'github_cmd_wrapper.g.dart';
@@ -141,6 +141,32 @@ class GithubCommandWrapper {
     }
 
     return buffer.toString();
+  }
+
+  /// `gh pr view {number}`'s title + body -- the richer LLM input
+  /// `llm/changelog.dart`'s changelog pass needs, beyond what
+  /// [searchMergedPrBySha]/the squash-merge suffix already gives
+  /// [ResolvedPr] for free.
+  Future<PrDetails> fetchPrDetails(Logger logger, int number) async {
+    final buffer = StringBuffer();
+    final exitCode = await runProcess(
+      'gh',
+      ['pr', 'view', '$number', '--json', 'number,title,body'],
+      workingDirectory: cwd,
+      stdout: (line) => buffer.write(line),
+      stderr: (line) => logger.shout(line),
+    );
+
+    if (exitCode != 0) {
+      throw Exception('gh returned exit code $exitCode.');
+    }
+
+    final json = jsonDecode(buffer.toString()) as Map<String, dynamic>;
+    return PrDetails(
+      number: json['number'] as int,
+      title: json['title'] as String,
+      body: json['body'] as String? ?? '',
+    );
   }
 
   /// `gh pr list --search "sha:{sha}"` -- the fallback `pr_resolution.dart`

--- a/tools/releaser/lib/github_cmd_wrapper.dart
+++ b/tools/releaser/lib/github_cmd_wrapper.dart
@@ -31,10 +31,20 @@ class GHRelease {
 }
 
 /// Wraps the `gh` command line tool for performing operations with Github
+///
+/// Read-only lookups are cached for the life of the instance -- see
+/// [fetchReleases] and [getCommitSha]. Construct one per run (every call site
+/// already does) and the cache lifetime takes care of itself.
 class GithubCommandWrapper {
   final String cwd;
 
-  const GithubCommandWrapper(this.cwd);
+  /// Keyed by repo slug for [fetchReleases], and by `slug@ref` for
+  /// [getCommitSha]. Futures rather than results, so concurrent askers share
+  /// one in-flight call instead of racing to start their own.
+  final _releasesByRepo = <String, Future<List<GHRelease>>>{};
+  final _shaByRef = <String, Future<String>>{};
+
+  GithubCommandWrapper(this.cwd);
 
   Future<bool> checkAuth(Logger logger) async {
     final exitCode = await runProcess(
@@ -48,7 +58,23 @@ class GithubCommandWrapper {
     return exitCode == 0;
   }
 
-  Future<List<GHRelease>> fetchReleases(Logger logger, String repoSlug) async {
+  /// Every release of [repoSlug], fetched once per instance.
+  ///
+  /// Both [getLatestRelease] and [getReleaseByTagName] go through here, and
+  /// each is asked once per package being planned -- "what is the latest
+  /// dd-sdk-ios release" has the same answer for all six members of a
+  /// federated group, so without this an `--include-federated` run makes a
+  /// dozen identical `gh release list` calls.
+  ///
+  /// A failed lookup stays failed for the life of the instance; nothing here
+  /// retries, and a run that can't reach GitHub has no path to succeeding.
+  Future<List<GHRelease>> fetchReleases(Logger logger, String repoSlug) =>
+      _releasesByRepo.putIfAbsent(
+        repoSlug,
+        () => _fetchReleases(logger, repoSlug),
+      );
+
+  Future<List<GHRelease>> _fetchReleases(Logger logger, String repoSlug) async {
     final buffer = StringBuffer();
     final exitCode = await runProcess(
       'gh',
@@ -92,7 +118,17 @@ class GithubCommandWrapper {
   /// currently points to, for pinning native SDKs whose config has no
   /// dedicated "verify this tag against this commit" field (CMake's
   /// `FetchContent_Declare`, notably) -- the SHA is what's actually pinned.
-  Future<String> getCommitSha(
+  ///
+  /// Cached per `slug@ref` for the life of the instance, like
+  /// [fetchReleases]: every desktop package resolving the same dd-sdk-cpp
+  /// tag should cost one call, not one each.
+  Future<String> getCommitSha(Logger logger, String repoSlug, String ref) =>
+      _shaByRef.putIfAbsent(
+        '$repoSlug@$ref',
+        () => _getCommitSha(logger, repoSlug, ref),
+      );
+
+  Future<String> _getCommitSha(
     Logger logger,
     String repoSlug,
     String ref,
@@ -169,10 +205,10 @@ class GithubCommandWrapper {
     );
   }
 
-  /// `gh pr list --search "sha:{sha}"` -- the fallback `pr_resolution.dart`
-  /// uses for a commit that didn't land via a squash merge (no `(#N)`
-  /// suffix to parse locally). Merged PRs only; the newest match if somehow
-  /// more than one comes back.
+  /// `gh pr list --search "{sha}"` -- the fallback `pr_resolution.dart` uses
+  /// for a commit that didn't land via a squash merge (no `(#N)` suffix to
+  /// parse locally). Merged PRs only; the newest match if somehow more than
+  /// one comes back.
   Future<ResolvedPr?> searchMergedPrBySha(Logger logger, String sha) async {
     final buffer = StringBuffer();
     final exitCode = await runProcess(
@@ -181,7 +217,7 @@ class GithubCommandWrapper {
         'pr',
         'list',
         '--search',
-        'sha:$sha',
+        sha,
         '--state',
         'merged',
         '--json',

--- a/tools/releaser/lib/llm/ai_gateway.dart
+++ b/tools/releaser/lib/llm/ai_gateway.dart
@@ -1,0 +1,214 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'ai_gateway.g.dart';
+
+const defaultModel = 'claude-sonnet-4-6';
+
+/// This tool's AI Gateway feature id, registered via #project-gamma-q-and-a.
+const mlAppId = 'dd-sdk-flutter.releaser.changelog';
+
+/// One LLM call's token usage, for [LlmCostTracker] (`costs.dart`).
+class LlmUsage {
+  final String model;
+  final int inputTokens;
+  final int outputTokens;
+
+  const LlmUsage({
+    required this.model,
+    required this.inputTokens,
+    required this.outputTokens,
+  });
+}
+
+/// The result of a schema-constrained prompt: the raw parsed JSON payload
+/// (deserialized by the caller into its own response type -- see
+/// `prompt.dart`'s `runStructuredPrompt`) plus usage for cost tracking.
+class StructuredResponse {
+  final Map<String, dynamic> content;
+  final LlmUsage usage;
+
+  const StructuredResponse({required this.content, required this.usage});
+}
+
+/// The Anthropic Messages API response shape the AI Gateway returns --
+/// only the fields this tool reads. Read-only: never re-serialized.
+@JsonSerializable(createToJson: false)
+class AnthropicMessageResponse {
+  final String model;
+  final List<AnthropicContentBlock> content;
+  final AnthropicUsage usage;
+
+  AnthropicMessageResponse({
+    required this.model,
+    required this.content,
+    required this.usage,
+  });
+
+  factory AnthropicMessageResponse.fromJson(Map<String, dynamic> json) =>
+      _$AnthropicMessageResponseFromJson(json);
+}
+
+@JsonSerializable(createToJson: false)
+class AnthropicContentBlock {
+  final String text;
+
+  AnthropicContentBlock({required this.text});
+
+  factory AnthropicContentBlock.fromJson(Map<String, dynamic> json) =>
+      _$AnthropicContentBlockFromJson(json);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake, createToJson: false)
+class AnthropicUsage {
+  final int inputTokens;
+  final int outputTokens;
+
+  AnthropicUsage({required this.inputTokens, required this.outputTokens});
+
+  factory AnthropicUsage.fromJson(Map<String, dynamic> json) =>
+      _$AnthropicUsageFromJson(json);
+}
+
+/// An Anthropic Messages API request body, schema-constrained via
+/// `output_config`. Write-only: never deserialized.
+@JsonSerializable(fieldRename: FieldRename.snake, createFactory: false)
+class AnthropicMessageRequest {
+  final String model;
+  final int maxTokens;
+  final AnthropicOutputConfig outputConfig;
+  final List<AnthropicMessage> messages;
+
+  AnthropicMessageRequest({
+    required this.model,
+    required this.maxTokens,
+    required this.outputConfig,
+    required this.messages,
+  });
+
+  Map<String, dynamic> toJson() => _$AnthropicMessageRequestToJson(this);
+}
+
+@JsonSerializable(createFactory: false)
+class AnthropicOutputConfig {
+  final AnthropicFormat format;
+
+  AnthropicOutputConfig({required this.format});
+
+  Map<String, dynamic> toJson() => _$AnthropicOutputConfigToJson(this);
+}
+
+@JsonSerializable(createFactory: false)
+class AnthropicFormat {
+  final String type;
+  final Map<String, dynamic> schema;
+
+  AnthropicFormat({required this.type, required this.schema});
+
+  Map<String, dynamic> toJson() => _$AnthropicFormatToJson(this);
+}
+
+@JsonSerializable(createFactory: false)
+class AnthropicMessage {
+  final String role;
+  final String content;
+
+  AnthropicMessage({required this.role, required this.content});
+
+  Map<String, dynamic> toJson() => _$AnthropicMessageToJson(this);
+}
+
+/// What `changelog.dart`'s 3-pass pipeline needs from an AI Gateway client --
+/// injected so a fake can stand in for [HttpAiGatewayClient] in tests.
+abstract class AiGatewayClient {
+  Future<StructuredResponse> createStructuredMessage({
+    required String prompt,
+    required Map<String, dynamic> schema,
+    String model = defaultModel,
+    int maxTokens = 4096,
+  });
+}
+
+/// A real [AiGatewayClient] against `ai-gateway.us1.ddbuild.io`. Header
+/// values (`provider`/`source`/`org-id`) are likely gateway-side
+/// allowlisted for this audience, so they're kept fixed rather than made
+/// configurable.
+class HttpAiGatewayClient implements AiGatewayClient {
+  static final _endpoint = Uri.parse(
+    'https://ai-gateway.us1.ddbuild.io/v1/messages',
+  );
+
+  final String token;
+  final HttpClient _httpClient;
+
+  HttpAiGatewayClient(this.token, {HttpClient? httpClient})
+    : _httpClient = httpClient ?? HttpClient();
+
+  /// Reads `AI_GATEWAY_TOKEN` (e.g. from `ddtool auth token
+  /// rapid-ai-platform --datacenter us1.ddbuild.io` locally, or
+  /// `authanywhere` in CI).
+  factory HttpAiGatewayClient.fromEnvironment() {
+    final token = Platform.environment['AI_GATEWAY_TOKEN'];
+    if (token == null) {
+      throw StateError('AI_GATEWAY_TOKEN is not set.');
+    }
+    return HttpAiGatewayClient(token);
+  }
+
+  @override
+  Future<StructuredResponse> createStructuredMessage({
+    required String prompt,
+    required Map<String, dynamic> schema,
+    String model = defaultModel,
+    int maxTokens = 4096,
+  }) async {
+    final request = await _httpClient.postUrl(_endpoint);
+    request.headers.contentType = ContentType(
+      'application',
+      'json',
+      charset: 'utf-8',
+    );
+    request.headers.set(HttpHeaders.authorizationHeader, 'Bearer $token');
+    request.headers.set('provider', 'anthropic');
+    request.headers.set('source', 'claude-code');
+    request.headers.set('org-id', '2');
+    request.headers.set('ml_app_id', mlAppId);
+    final requestBody = AnthropicMessageRequest(
+      model: model,
+      maxTokens: maxTokens,
+      outputConfig: AnthropicOutputConfig(
+        format: AnthropicFormat(type: 'json_schema', schema: schema),
+      ),
+      messages: [AnthropicMessage(role: 'user', content: prompt)],
+    );
+    // request.write() defaults to Latin-1, which throws on the em-dashes
+    // and smart quotes these prompts contain -- add() writes raw UTF-8
+    // bytes instead.
+    request.add(utf8.encode(jsonEncode(requestBody.toJson())));
+
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+    if (response.statusCode != 200) {
+      throw Exception('AI Gateway returned ${response.statusCode}: $body');
+    }
+
+    final message = AnthropicMessageResponse.fromJson(
+      jsonDecode(body) as Map<String, dynamic>,
+    );
+
+    return StructuredResponse(
+      content: jsonDecode(message.content.first.text) as Map<String, dynamic>,
+      usage: LlmUsage(
+        model: message.model,
+        inputTokens: message.usage.inputTokens,
+        outputTokens: message.usage.outputTokens,
+      ),
+    );
+  }
+}

--- a/tools/releaser/lib/llm/ai_gateway.g.dart
+++ b/tools/releaser/lib/llm/ai_gateway.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ai_gateway.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AnthropicMessageResponse _$AnthropicMessageResponseFromJson(
+  Map<String, dynamic> json,
+) => AnthropicMessageResponse(
+  model: json['model'] as String,
+  content: (json['content'] as List<dynamic>)
+      .map((e) => AnthropicContentBlock.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  usage: AnthropicUsage.fromJson(json['usage'] as Map<String, dynamic>),
+);
+
+AnthropicContentBlock _$AnthropicContentBlockFromJson(
+  Map<String, dynamic> json,
+) => AnthropicContentBlock(text: json['text'] as String);
+
+AnthropicUsage _$AnthropicUsageFromJson(Map<String, dynamic> json) =>
+    AnthropicUsage(
+      inputTokens: (json['input_tokens'] as num).toInt(),
+      outputTokens: (json['output_tokens'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$AnthropicMessageRequestToJson(
+  AnthropicMessageRequest instance,
+) => <String, dynamic>{
+  'model': instance.model,
+  'max_tokens': instance.maxTokens,
+  'output_config': instance.outputConfig,
+  'messages': instance.messages,
+};
+
+Map<String, dynamic> _$AnthropicOutputConfigToJson(
+  AnthropicOutputConfig instance,
+) => <String, dynamic>{'format': instance.format};
+
+Map<String, dynamic> _$AnthropicFormatToJson(AnthropicFormat instance) =>
+    <String, dynamic>{'type': instance.type, 'schema': instance.schema};
+
+Map<String, dynamic> _$AnthropicMessageToJson(AnthropicMessage instance) =>
+    <String, dynamic>{'role': instance.role, 'content': instance.content};

--- a/tools/releaser/lib/llm/changelog.dart
+++ b/tools/releaser/lib/llm/changelog.dart
@@ -5,125 +5,29 @@
 import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 
-import '../github_cmd_wrapper.dart' show GithubCommandWrapper;
-import '../native_sdk.dart' show NativeSdkDelta;
-import '../native_sdk_changelog.dart'
-    show
-        ChangelogFetcher,
-        nativeSdkChangelogUrl,
-        resolveNativeSdkChangelog,
-        githubChangelogFetcher;
-import '../pr_resolution.dart' show PrDetails, resolvePr;
-import '../release_plan.dart' show PackagePlan;
-import '../version_bump.dart';
+import '../github_cmd_wrapper.dart';
+import '../native_sdk.dart';
+import '../native_sdk_changelog.dart';
+import '../pr_resolution.dart';
+import '../release_plan.dart';
 import 'ai_gateway.dart';
 import 'costs.dart';
 import 'prompt.dart';
+import 'prompts/changelog_entry_list_prompt.dart';
+import 'prompts/grouped_prs_prompt.dart';
+import 'prompts/native_sdk_sub_entries_prompt.dart';
+
+export 'prompts/changelog_entry_list_prompt.dart'
+    show ChangelogEntry, ChangelogEntryList;
+export 'prompts/grouped_prs_prompt.dart' show GroupedPr, GroupedPrs, PrGroup;
+export 'prompts/native_sdk_sub_entries_prompt.dart'
+    show NativeSdkChangelogContext;
 
 // == LLM Pass 1: Collect related PRs into groups with a common label
 
-class GroupedPr {
-  final int number;
-  final String title;
-
-  const GroupedPr({required this.number, required this.title});
-
-  factory GroupedPr.fromJson(Map<String, dynamic> json) =>
-      GroupedPr(number: json['number'] as int, title: json['title'] as String);
-}
-
-class PrGroup {
-  final String label;
-  final List<GroupedPr> prs;
-
-  const PrGroup({required this.label, required this.prs});
-
-  factory PrGroup.fromJson(Map<String, dynamic> json) => PrGroup(
-    label: json['label'] as String,
-    prs: (json['prs'] as List)
-        .map((e) => GroupedPr.fromJson(e as Map<String, dynamic>))
-        .toList(),
-  );
-}
-
-class GroupedPrs {
-  final List<PrGroup> groups;
-
-  const GroupedPrs({required this.groups});
-
-  factory GroupedPrs.fromJson(Map<String, dynamic> json) => GroupedPrs(
-    groups: (json['groups'] as List)
-        .map((e) => PrGroup.fromJson(e as Map<String, dynamic>))
-        .toList(),
-  );
-}
-
-final groupedPrsSchema = {
-  'type': 'object',
-  'properties': {
-    'groups': {
-      'type': 'array',
-      'items': {
-        'type': 'object',
-        'properties': {
-          'label': {
-            'type': 'string',
-            'description':
-                'Short string describing the purpose of this group of PRs. '
-                'Infer from the titles of constituent PRs.',
-          },
-          'prs': {
-            'type': 'array',
-            'items': {
-              'type': 'object',
-              'properties': {
-                'number': {
-                  'type': 'integer',
-                  'description':
-                      'Integer PR number. Use the original PR number exactly.',
-                },
-                'title': {
-                  'type': 'string',
-                  'description':
-                      'Single-line string describing the PR. Use the '
-                      'original text exactly.',
-                },
-              },
-              'required': ['number', 'title'],
-              'additionalProperties': false,
-            },
-          },
-        },
-        'required': ['label', 'prs'],
-        'additionalProperties': false,
-      },
-    },
-  },
-  'required': ['groups'],
-  'additionalProperties': false,
-};
-
-String _groupedPrsPrompt(List<PrDetails> prs) {
-  final prText = prs
-      .map((pr) => '${pr.number.toString().padLeft(5)} ${pr.title}')
-      .join('\n');
-  return '''
-You are preparing to write a customer-facing changelog for an SDK. Below is a list of PRs that have been merged since the last release.
-
-Your task: group these PRs so that closely-related PRs can be considered together. A group should capture a coherent user-visible change: for example, several PRs that together implement one feature, or a fix that directly relates to a feature in the same release. PRs with no clear relationship to others should each be their own group.
-
-Your response will be a JSON array where each element is an object representing a related group of one or more PRs. This JSON value will adhere to the provided schema. Your response will include no prose or formatting.
-
-Use only the data provided below. Do not consult external sources.
-
-<prs>
-$prText
-</prs>''';
-}
-
-/// Runs the grouping pass and sanity-checks that it partitioned the PRs it
-/// was given -- every input number used, nothing invented, and each in
-/// exactly one group.
+/// Runs the grouping pass (see `prompts/grouped_prs_prompt.dart`) and
+/// sanity-checks that it partitioned the PRs it was given -- every input
+/// number used, nothing invented, and each in exactly one group.
 ///
 /// Inventing or dropping a number throws: the changelog would be wrong in a
 /// way nothing downstream can detect, and there's no sound way to guess what
@@ -140,9 +44,7 @@ Future<GroupedPrs> runGroupedPrsPrompt(
 }) async {
   final result = await runStructuredPrompt(
     client,
-    _groupedPrsPrompt(prs),
-    groupedPrsSchema,
-    GroupedPrs.fromJson,
+    groupedPrsPrompt(prs),
     costTracker: costTracker,
     costLabel: 'GroupedPrs',
   );
@@ -191,146 +93,6 @@ Future<GroupedPrs> runGroupedPrsPrompt(
 
 // == LLM Pass 2: Given full PRs from each group, synthesize 0 or more changelog items
 
-class ChangelogEntry {
-  final String text;
-
-  /// Nested bullets under [text] -- a native SDK update entry's filtered,
-  /// customer-facing changes (see [buildNativeSdkUpdateEntry]). Empty for
-  /// every PR-derived entry.
-  final List<String> subEntries;
-
-  const ChangelogEntry(this.text, {this.subEntries = const []});
-
-  factory ChangelogEntry.fromJson(Map<String, dynamic> json) =>
-      ChangelogEntry(json['text'] as String);
-}
-
-/// A draft or final changelog's entries, split into the three sections this
-/// design standardizes on. Breaking/feature/fix is mutually exclusive: an
-/// entry that qualifies as both a breaking change and a feature or fix goes
-/// in [breakingChanges] only.
-class ChangelogEntryList {
-  final List<ChangelogEntry> breakingChanges;
-  final List<ChangelogEntry> features;
-  final List<ChangelogEntry> fixes;
-
-  const ChangelogEntryList({
-    this.breakingChanges = const [],
-    this.features = const [],
-    this.fixes = const [],
-  });
-
-  factory ChangelogEntryList.fromJson(Map<String, dynamic> json) =>
-      ChangelogEntryList(
-        breakingChanges: _entriesOf(json['breaking_changes']),
-        features: _entriesOf(json['features']),
-        fixes: _entriesOf(json['fixes']),
-      );
-
-  static List<ChangelogEntry> _entriesOf(dynamic value) => (value as List)
-      .map((e) => ChangelogEntry.fromJson(e as Map<String, dynamic>))
-      .toList();
-
-  ChangelogEntryList mergedWith(ChangelogEntryList other) => ChangelogEntryList(
-    breakingChanges: [...breakingChanges, ...other.breakingChanges],
-    features: [...features, ...other.features],
-    fixes: [...fixes, ...other.fixes],
-  );
-
-  /// [entry] appended to [breakingChanges] if [breaking], else [features].
-  /// Used for a native SDK update entry, whose category is decided in Dart
-  /// from the version delta rather than asked of an LLM (see
-  /// [NativeSdkDelta.getImpliedBump]).
-  ChangelogEntryList withEntry(
-    ChangelogEntry entry, {
-    required bool breaking,
-  }) => ChangelogEntryList(
-    breakingChanges: breaking ? [...breakingChanges, entry] : breakingChanges,
-    features: breaking ? features : [...features, entry],
-    fixes: fixes,
-  );
-
-  bool get isEmpty =>
-      breakingChanges.isEmpty && features.isEmpty && fixes.isEmpty;
-}
-
-final changelogEntryListSchema = {
-  'type': 'object',
-  'properties': {
-    for (final key in ['breaking_changes', 'features', 'fixes'])
-      key: {
-        'type': 'array',
-        'items': {
-          'type': 'object',
-          'properties': {
-            'text': {
-              'type': 'string',
-              'description':
-                  'Full text of a single-line changelog entry, formatted as '
-                  'markdown.',
-            },
-          },
-          'required': ['text'],
-          'additionalProperties': false,
-        },
-      },
-  },
-  'required': ['breaking_changes', 'features', 'fixes'],
-  'additionalProperties': false,
-};
-
-String _formatPrForPrompt(PrDetails pr) =>
-    '''
-<pr number="${pr.number}">
-<title>${pr.title}</title>
-<body>
-${pr.body}
-</body>
-</pr>''';
-
-String _changelogEntryListPrompt(String groupLabel, List<PrDetails> groupPrs) {
-  final prText = groupPrs.map(_formatPrForPrompt).join('\n');
-  return '''
-You are writing a customer-facing changelog for a Flutter package. You have been given a group of related pull requests that together represent a single logical change.
-
-Your task: synthesize 0 or more changelog entries describing the user-visible impact of this change on developers who use the package as a library dependency.
-
-Include an entry for:
-- New or modified public APIs: functions, types, configuration options, or constants added, changed, or removed
-- Observable behavior changes: anything a developer would notice at runtime, including bug fixes that corrected incorrect data, crashes, or wrong behavior
-- Breaking changes to any public API or previously-documented behavior
-
-Omit entries for:
-- Internal refactors, test infrastructure, or build system changes
-- Changes to private implementation details that are not reachable through the public API and whose effects are not observable to library consumers
-- chore work with no user-visible effect
-- Sub-changes that are already fully captured by another entry in this group
-
-If every change in the group falls into the omit list, return empty lists for all three categories. An empty response is correct and preferred over producing a thin or redundant entry.
-
-A group may produce multiple entries only when it contains genuinely distinct user-facing changes that each deserve to be called out separately. When in doubt, prefer a single consolidated entry over splitting.
-
-Categorize each entry as exactly one of:
-- breaking_changes: removes or incompatibly alters a public API or previously-documented behavior, requiring users to update their code on upgrade. When an entry qualifies as both a breaking change and a feature or fix, categorize it as a breaking change.
-- features: adds new capability, APIs, or configuration options without breaking existing usage.
-- fixes: corrects incorrect behavior, data, or crashes without breaking existing usage.
-
-Style:
-- Write from the user's perspective — describe the impact, not the implementation.
-- Use present tense: e.g. "Crash timestamps are now reported in milliseconds."
-- Be concise: one sentence is almost always sufficient.
-- Do not reference PR numbers, branch names, or internal type names.
-- Format the entry as plain markdown (inline `code` for public API identifiers; no headers or bullet lists within an entry).
-
-Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
-
-Use only the data provided below. Do not consult external sources. Ignore boilerplate sections in PR bodies (e.g. checklists, test plans, or template scaffolding) — focus on the description of what changed and why.
-
-<group label="$groupLabel">
-$prText
-</group>''';
-}
-
 Future<ChangelogEntryList> runChangelogEntryListPrompt(
   AiGatewayClient client,
   String groupLabel,
@@ -339,52 +101,13 @@ Future<ChangelogEntryList> runChangelogEntryListPrompt(
 }) {
   return runStructuredPrompt(
     client,
-    _changelogEntryListPrompt(groupLabel, groupPrs),
-    changelogEntryListSchema,
-    ChangelogEntryList.fromJson,
+    changelogEntryListPrompt(groupLabel, groupPrs),
     costTracker: costTracker,
     costLabel: 'ChangelogEntryList($groupLabel)',
   );
 }
 
 // == LLM Pass 3: Final editorial pass to deduplicate, normalize, and order entries
-
-String _formatEntriesForPrompt(List<ChangelogEntry> entries) {
-  if (entries.isEmpty) return '(none)';
-  return entries.mapIndexed((i, e) => '${i + 1}. ${e.text}').join('\n');
-}
-
-String _cleanupPrompt(ChangelogEntryList changelog) =>
-    '''
-You are performing a final editorial pass on a draft changelog for a Flutter package. The entries below were generated independently for each group of related PRs and then merged; as a result, they may contain redundancies, inconsistencies in tone or style, or suboptimal ordering.
-
-Your tasks:
-
-1. Deduplicate. Remove or merge entries that describe the same user-visible change. Pay particular attention to cross-category duplication: if a breaking_changes entry already captures a change, remove the corresponding feature or fix entry rather than keeping both. If two entries partially overlap, consolidate them into one entry in whichever category is most appropriate.
-
-2. Normalize tone and style. All entries should:
-   - Be written from the user's perspective — describe the impact, not the implementation.
-   - Use present tense: e.g. "X now does Y."
-   - Be concise: one sentence is almost always sufficient.
-   - Use inline `code` only for public API identifiers.
-   - Not reference PR numbers, branch names, or internal type names.
-
-3. Sort entries within each category. Order primarily by importance: the most significant and impactful changes first. As a secondary concern, place related entries adjacent to one another.
-
-Do not invent entries that were not present in the input. Produce output in the same three-category schema. If an entry contains a markdown link (e.g. a link to a native SDK's own changelog), preserve that link verbatim in whichever entry it ends up in -- never drop or paraphrase it away.
-
-Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
-
-Use only the data provided below. Do not consult external sources.
-
-### Breaking Changes
-${_formatEntriesForPrompt(changelog.breakingChanges)}
-
-### Features
-${_formatEntriesForPrompt(changelog.features)}
-
-### Fixes
-${_formatEntriesForPrompt(changelog.fixes)}''';
 
 Future<ChangelogEntryList> runCleanupPrompt(
   AiGatewayClient client,
@@ -393,107 +116,13 @@ Future<ChangelogEntryList> runCleanupPrompt(
 }) {
   return runStructuredPrompt(
     client,
-    _cleanupPrompt(changelog),
-    changelogEntryListSchema,
-    ChangelogEntryList.fromJson,
+    cleanupPrompt(changelog),
     costTracker: costTracker,
     costLabel: 'Cleanup',
   );
 }
 
 // == LLM Pass 2b: Filter a native SDK's own changelog to customer-facing sub-bullets
-
-/// Raw changelog entries from one native SDK, covering the version range a
-/// package's [NativeSdkDelta] is picking up this release -- resolved via
-/// `native_sdk_changelog.dart`'s `resolveNativeSdkChangelog`.
-///
-/// [impliedBump] decides which category the resulting entry lands in (see
-/// [buildNativeSdkUpdateEntry]) -- computed in Dart from the version delta
-/// itself ([NativeSdkDelta.getImpliedBump]), not asked of the LLM, since it's a
-/// deterministic fact this tooling already knows.
-class NativeSdkChangelogContext {
-  final String displayName;
-  final String targetVersion;
-  final List<String> entries;
-  final String changelogUrl;
-  final VersionBumpType? impliedBump;
-
-  const NativeSdkChangelogContext({
-    required this.displayName,
-    required this.targetVersion,
-    required this.entries,
-    required this.changelogUrl,
-    this.impliedBump,
-  });
-}
-
-/// A single-line entry, no category -- what
-/// [synthesizeNativeSdkSubEntries] asks for, distinct from
-/// [changelogEntryListSchema]'s three-category shape since these become
-/// sub-bullets under one entry, not top-level entries in their own right.
-final _nativeSdkSubEntriesSchema = {
-  'type': 'object',
-  'properties': {
-    'entries': {
-      'type': 'array',
-      'items': {
-        'type': 'object',
-        'properties': {
-          'text': {
-            'type': 'string',
-            'description':
-                'Full text of a single-line changelog entry, formatted as '
-                'markdown.',
-          },
-        },
-        'required': ['text'],
-        'additionalProperties': false,
-      },
-    },
-  },
-  'required': ['entries'],
-  'additionalProperties': false,
-};
-
-List<String> _parseNativeSdkSubEntries(Map<String, dynamic> json) =>
-    (json['entries'] as List)
-        .map((e) => (e as Map<String, dynamic>)['text'] as String)
-        .toList();
-
-String _nativeSdkSubEntriesPrompt(NativeSdkChangelogContext context) {
-  final entryText = context.entries.map((e) => '- $e').join('\n');
-  return '''
-You are preparing the sub-bullets that will appear under a single changelog line noting an update to the ${context.displayName} native SDK, inside a Flutter package's changelog. Below are that native SDK's own raw changelog entries, covering the version range being picked up in this release.
-
-Your task: reduce these to a flat list of concise, customer-facing bullet points describing the user-visible impact on developers who use the Flutter package.
-
-Include an entry for customer-facing changes: new features, behavior changes, and bug fixes.
-
-Omit entries for:
-- Anything labeled [MAINTENANCE], or otherwise about internal tooling, CI, build systems, or tests
-- Internal refactors with no observable effect on the Flutter package's own consumers
-- Changes only reachable through the native SDK's own internal API, not through the Flutter package's public API
-- Session Replay or Feature Flags -- both are custom-implemented in Flutter rather than wrapping the native SDK's version of that feature, so changes and fixes to either in the native SDK's changelog don't apply here
-
-Do not reproduce PR or issue links from the native repository (e.g. "See [#1234](...)" or "[#1234][]") -- drop that trailing reference entirely from each entry.
-
-Do not add a link to the native SDK's own changelog yourself -- one is already shown above this list, so repeating it here would be redundant.
-
-Style:
-- Write from the user's perspective — describe the impact, not the implementation.
-- Use present tense.
-- Be concise: one sentence is almost always sufficient.
-- Format each entry as plain markdown (inline `code` for public API identifiers).
-- Drop any leading bracketed tag from the source entry (e.g. "[FEATURE]", "[BUGFIX]", "[IMPROVEMENT]", "[FIX]") -- write plain prose instead, consistent with the rest of this changelog.
-
-Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
-
-Use only the data provided below. Do not consult external sources.
-
-<native-sdk-changelog name="${context.displayName}">
-$entryText
-</native-sdk-changelog>''';
-}
 
 Future<List<String>> synthesizeNativeSdkSubEntries(
   AiGatewayClient client,
@@ -502,9 +131,7 @@ Future<List<String>> synthesizeNativeSdkSubEntries(
 }) {
   return runStructuredPrompt(
     client,
-    _nativeSdkSubEntriesPrompt(context),
-    _nativeSdkSubEntriesSchema,
-    _parseNativeSdkSubEntries,
+    nativeSdkSubEntriesPrompt(context),
     costTracker: costTracker,
     costLabel: 'NativeSdkChangelog(${context.displayName})',
   );

--- a/tools/releaser/lib/llm/changelog.dart
+++ b/tools/releaser/lib/llm/changelog.dart
@@ -6,7 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 
 import '../github_cmd_wrapper.dart' show GithubCommandWrapper;
-import '../native_sdk.dart' show NativeSdkDelta, nativeSdkImpliedBump;
+import '../native_sdk.dart' show NativeSdkDelta;
 import '../native_sdk_changelog.dart'
     show
         ChangelogFetcher,
@@ -202,7 +202,7 @@ class ChangelogEntryList {
   /// [entry] appended to [breakingChanges] if [breaking], else [features].
   /// Used for a native SDK update entry, whose category is decided in Dart
   /// from the version delta rather than asked of an LLM (see
-  /// [nativeSdkImpliedBump]).
+  /// [NativeSdkDelta.getImpliedBump]).
   ChangelogEntryList withEntry(
     ChangelogEntry entry, {
     required bool breaking,
@@ -371,7 +371,7 @@ Future<ChangelogEntryList> runCleanupPrompt(
 ///
 /// [impliedBump] decides which category the resulting entry lands in (see
 /// [buildNativeSdkUpdateEntry]) -- computed in Dart from the version delta
-/// itself ([nativeSdkImpliedBump]), not asked of the LLM, since it's a
+/// itself ([NativeSdkDelta.getImpliedBump]), not asked of the LLM, since it's a
 /// deterministic fact this tooling already knows.
 class NativeSdkChangelogContext {
   final String displayName;
@@ -521,7 +521,7 @@ Future<List<NativeSdkChangelogContext>> resolveNativeSdkChangelogContexts(
         targetVersion: targetVersion,
         entries: entries,
         changelogUrl: nativeSdkChangelogUrl(delta.sdk),
-        impliedBump: nativeSdkImpliedBump(delta),
+        impliedBump: delta.getImpliedBump(),
       ),
     );
   }

--- a/tools/releaser/lib/llm/changelog.dart
+++ b/tools/releaser/lib/llm/changelog.dart
@@ -1,0 +1,671 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:collection/collection.dart';
+import 'package:logging/logging.dart';
+
+import '../github_cmd_wrapper.dart' show GithubCommandWrapper;
+import '../native_sdk.dart' show NativeSdkDelta, nativeSdkImpliedBump;
+import '../native_sdk_changelog.dart'
+    show
+        ChangelogFetcher,
+        nativeSdkChangelogUrl,
+        resolveNativeSdkChangelog,
+        githubChangelogFetcher;
+import '../pr_resolution.dart' show PrDetails, resolvePr;
+import '../release_plan.dart' show PackagePlan;
+import '../version_bump.dart';
+import 'ai_gateway.dart';
+import 'costs.dart';
+import 'prompt.dart';
+
+// == LLM Pass 1: Collect related PRs into groups with a common label
+
+class GroupedPr {
+  final int number;
+  final String title;
+
+  const GroupedPr({required this.number, required this.title});
+
+  factory GroupedPr.fromJson(Map<String, dynamic> json) =>
+      GroupedPr(number: json['number'] as int, title: json['title'] as String);
+}
+
+class PrGroup {
+  final String label;
+  final List<GroupedPr> prs;
+
+  const PrGroup({required this.label, required this.prs});
+
+  factory PrGroup.fromJson(Map<String, dynamic> json) => PrGroup(
+    label: json['label'] as String,
+    prs: (json['prs'] as List)
+        .map((e) => GroupedPr.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+class GroupedPrs {
+  final List<PrGroup> groups;
+
+  const GroupedPrs({required this.groups});
+
+  factory GroupedPrs.fromJson(Map<String, dynamic> json) => GroupedPrs(
+    groups: (json['groups'] as List)
+        .map((e) => PrGroup.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+final groupedPrsSchema = {
+  'type': 'object',
+  'properties': {
+    'groups': {
+      'type': 'array',
+      'items': {
+        'type': 'object',
+        'properties': {
+          'label': {
+            'type': 'string',
+            'description':
+                'Short string describing the purpose of this group of PRs. '
+                'Infer from the titles of constituent PRs.',
+          },
+          'prs': {
+            'type': 'array',
+            'items': {
+              'type': 'object',
+              'properties': {
+                'number': {
+                  'type': 'integer',
+                  'description':
+                      'Integer PR number. Use the original PR number exactly.',
+                },
+                'title': {
+                  'type': 'string',
+                  'description':
+                      'Single-line string describing the PR. Use the '
+                      'original text exactly.',
+                },
+              },
+              'required': ['number', 'title'],
+              'additionalProperties': false,
+            },
+          },
+        },
+        'required': ['label', 'prs'],
+        'additionalProperties': false,
+      },
+    },
+  },
+  'required': ['groups'],
+  'additionalProperties': false,
+};
+
+String _groupedPrsPrompt(List<PrDetails> prs) {
+  final prText = prs
+      .map((pr) => '${pr.number.toString().padLeft(5)} ${pr.title}')
+      .join('\n');
+  return '''
+You are preparing to write a customer-facing changelog for an SDK. Below is a list of PRs that have been merged since the last release.
+
+Your task: group these PRs so that closely-related PRs can be considered together. A group should capture a coherent user-visible change: for example, several PRs that together implement one feature, or a fix that directly relates to a feature in the same release. PRs with no clear relationship to others should each be their own group.
+
+Your response will be a JSON array where each element is an object representing a related group of one or more PRs. This JSON value will adhere to the provided schema. Your response will include no prose or formatting.
+
+Use only the data provided below. Do not consult external sources.
+
+<prs>
+$prText
+</prs>''';
+}
+
+/// Runs the grouping pass and sanity-checks that the PR numbers it
+/// referenced exactly match the set of PRs it was given -- an LLM
+/// inventing or dropping a PR number here would silently corrupt the
+/// changelog, so this fails loudly instead.
+Future<GroupedPrs> runGroupedPrsPrompt(
+  AiGatewayClient client,
+  List<PrDetails> prs, {
+  LlmCostTracker? costTracker,
+}) async {
+  final result = await runStructuredPrompt(
+    client,
+    _groupedPrsPrompt(prs),
+    groupedPrsSchema,
+    GroupedPrs.fromJson,
+    costTracker: costTracker,
+    costLabel: 'GroupedPrs',
+  );
+
+  final expected = prs.map((pr) => pr.number).toSet();
+  final got = result.groups.expand((g) => g.prs).map((pr) => pr.number).toSet();
+  if (!const SetEquality<int>().equals(expected, got)) {
+    throw StateError(
+      'AI Gateway response PR numbers do not match input: expected '
+      '${expected.join(',')}; got ${got.join(',')}',
+    );
+  }
+
+  return result;
+}
+
+// == LLM Pass 2: Given full PRs from each group, synthesize 0 or more changelog items
+
+class ChangelogEntry {
+  final String text;
+
+  /// Nested bullets under [text] -- a native SDK update entry's filtered,
+  /// customer-facing changes (see [buildNativeSdkUpdateEntry]). Empty for
+  /// every PR-derived entry.
+  final List<String> subEntries;
+
+  const ChangelogEntry(this.text, {this.subEntries = const []});
+
+  factory ChangelogEntry.fromJson(Map<String, dynamic> json) =>
+      ChangelogEntry(json['text'] as String);
+}
+
+/// A draft or final changelog's entries, split into the three sections this
+/// design standardizes on. Breaking/feature/fix is mutually exclusive: an
+/// entry that qualifies as both a breaking change and a feature or fix goes
+/// in [breakingChanges] only.
+class ChangelogEntryList {
+  final List<ChangelogEntry> breakingChanges;
+  final List<ChangelogEntry> features;
+  final List<ChangelogEntry> fixes;
+
+  const ChangelogEntryList({
+    this.breakingChanges = const [],
+    this.features = const [],
+    this.fixes = const [],
+  });
+
+  factory ChangelogEntryList.fromJson(Map<String, dynamic> json) =>
+      ChangelogEntryList(
+        breakingChanges: _entriesOf(json['breaking_changes']),
+        features: _entriesOf(json['features']),
+        fixes: _entriesOf(json['fixes']),
+      );
+
+  static List<ChangelogEntry> _entriesOf(dynamic value) => (value as List)
+      .map((e) => ChangelogEntry.fromJson(e as Map<String, dynamic>))
+      .toList();
+
+  ChangelogEntryList mergedWith(ChangelogEntryList other) => ChangelogEntryList(
+    breakingChanges: [...breakingChanges, ...other.breakingChanges],
+    features: [...features, ...other.features],
+    fixes: [...fixes, ...other.fixes],
+  );
+
+  /// [entry] appended to [breakingChanges] if [breaking], else [features].
+  /// Used for a native SDK update entry, whose category is decided in Dart
+  /// from the version delta rather than asked of an LLM (see
+  /// [nativeSdkImpliedBump]).
+  ChangelogEntryList withEntry(
+    ChangelogEntry entry, {
+    required bool breaking,
+  }) => ChangelogEntryList(
+    breakingChanges: breaking ? [...breakingChanges, entry] : breakingChanges,
+    features: breaking ? features : [...features, entry],
+    fixes: fixes,
+  );
+
+  bool get isEmpty =>
+      breakingChanges.isEmpty && features.isEmpty && fixes.isEmpty;
+}
+
+final changelogEntryListSchema = {
+  'type': 'object',
+  'properties': {
+    for (final key in ['breaking_changes', 'features', 'fixes'])
+      key: {
+        'type': 'array',
+        'items': {
+          'type': 'object',
+          'properties': {
+            'text': {
+              'type': 'string',
+              'description':
+                  'Full text of a single-line changelog entry, formatted as '
+                  'markdown.',
+            },
+          },
+          'required': ['text'],
+          'additionalProperties': false,
+        },
+      },
+  },
+  'required': ['breaking_changes', 'features', 'fixes'],
+  'additionalProperties': false,
+};
+
+String _formatPrForPrompt(PrDetails pr) =>
+    '''
+<pr number="${pr.number}">
+<title>${pr.title}</title>
+<body>
+${pr.body}
+</body>
+</pr>''';
+
+String _changelogEntryListPrompt(String groupLabel, List<PrDetails> groupPrs) {
+  final prText = groupPrs.map(_formatPrForPrompt).join('\n');
+  return '''
+You are writing a customer-facing changelog for a Flutter package. You have been given a group of related pull requests that together represent a single logical change.
+
+Your task: synthesize 0 or more changelog entries describing the user-visible impact of this change on developers who use the package as a library dependency.
+
+Include an entry for:
+- New or modified public APIs: functions, types, configuration options, or constants added, changed, or removed
+- Observable behavior changes: anything a developer would notice at runtime, including bug fixes that corrected incorrect data, crashes, or wrong behavior
+- Breaking changes to any public API or previously-documented behavior
+
+Omit entries for:
+- Internal refactors, test infrastructure, or build system changes
+- Changes to private implementation details that are not reachable through the public API and whose effects are not observable to library consumers
+- chore work with no user-visible effect
+- Sub-changes that are already fully captured by another entry in this group
+
+If every change in the group falls into the omit list, return empty lists for all three categories. An empty response is correct and preferred over producing a thin or redundant entry.
+
+A group may produce multiple entries only when it contains genuinely distinct user-facing changes that each deserve to be called out separately. When in doubt, prefer a single consolidated entry over splitting.
+
+Categorize each entry as exactly one of:
+- breaking_changes: removes or incompatibly alters a public API or previously-documented behavior, requiring users to update their code on upgrade. When an entry qualifies as both a breaking change and a feature or fix, categorize it as a breaking change.
+- features: adds new capability, APIs, or configuration options without breaking existing usage.
+- fixes: corrects incorrect behavior, data, or crashes without breaking existing usage.
+
+Style:
+- Write from the user's perspective — describe the impact, not the implementation.
+- Use present tense: e.g. "Crash timestamps are now reported in milliseconds."
+- Be concise: one sentence is almost always sufficient.
+- Do not reference PR numbers, branch names, or internal type names.
+- Format the entry as plain markdown (inline `code` for public API identifiers; no headers or bullet lists within an entry).
+
+Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
+
+Use only the data provided below. Do not consult external sources. Ignore boilerplate sections in PR bodies (e.g. checklists, test plans, or template scaffolding) — focus on the description of what changed and why.
+
+<group label="$groupLabel">
+$prText
+</group>''';
+}
+
+Future<ChangelogEntryList> runChangelogEntryListPrompt(
+  AiGatewayClient client,
+  String groupLabel,
+  List<PrDetails> groupPrs, {
+  LlmCostTracker? costTracker,
+}) {
+  return runStructuredPrompt(
+    client,
+    _changelogEntryListPrompt(groupLabel, groupPrs),
+    changelogEntryListSchema,
+    ChangelogEntryList.fromJson,
+    costTracker: costTracker,
+    costLabel: 'ChangelogEntryList($groupLabel)',
+  );
+}
+
+// == LLM Pass 3: Final editorial pass to deduplicate, normalize, and order entries
+
+String _formatEntriesForPrompt(List<ChangelogEntry> entries) {
+  if (entries.isEmpty) return '(none)';
+  return entries.mapIndexed((i, e) => '${i + 1}. ${e.text}').join('\n');
+}
+
+String _cleanupPrompt(ChangelogEntryList changelog) =>
+    '''
+You are performing a final editorial pass on a draft changelog for a Flutter package. The entries below were generated independently for each group of related PRs and then merged; as a result, they may contain redundancies, inconsistencies in tone or style, or suboptimal ordering.
+
+Your tasks:
+
+1. Deduplicate. Remove or merge entries that describe the same user-visible change. Pay particular attention to cross-category duplication: if a breaking_changes entry already captures a change, remove the corresponding feature or fix entry rather than keeping both. If two entries partially overlap, consolidate them into one entry in whichever category is most appropriate.
+
+2. Normalize tone and style. All entries should:
+   - Be written from the user's perspective — describe the impact, not the implementation.
+   - Use present tense: e.g. "X now does Y."
+   - Be concise: one sentence is almost always sufficient.
+   - Use inline `code` only for public API identifiers.
+   - Not reference PR numbers, branch names, or internal type names.
+
+3. Sort entries within each category. Order primarily by importance: the most significant and impactful changes first. As a secondary concern, place related entries adjacent to one another.
+
+Do not invent entries that were not present in the input. Produce output in the same three-category schema. If an entry contains a markdown link (e.g. a link to a native SDK's own changelog), preserve that link verbatim in whichever entry it ends up in -- never drop or paraphrase it away.
+
+Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
+
+Use only the data provided below. Do not consult external sources.
+
+### Breaking Changes
+${_formatEntriesForPrompt(changelog.breakingChanges)}
+
+### Features
+${_formatEntriesForPrompt(changelog.features)}
+
+### Fixes
+${_formatEntriesForPrompt(changelog.fixes)}''';
+
+Future<ChangelogEntryList> runCleanupPrompt(
+  AiGatewayClient client,
+  ChangelogEntryList changelog, {
+  LlmCostTracker? costTracker,
+}) {
+  return runStructuredPrompt(
+    client,
+    _cleanupPrompt(changelog),
+    changelogEntryListSchema,
+    ChangelogEntryList.fromJson,
+    costTracker: costTracker,
+    costLabel: 'Cleanup',
+  );
+}
+
+// == LLM Pass 2b: Filter a native SDK's own changelog to customer-facing sub-bullets
+
+/// Raw changelog entries from one native SDK, covering the version range a
+/// package's [NativeSdkDelta] is picking up this release -- resolved via
+/// `native_sdk_changelog.dart`'s `resolveNativeSdkChangelog`.
+///
+/// [impliedBump] decides which category the resulting entry lands in (see
+/// [buildNativeSdkUpdateEntry]) -- computed in Dart from the version delta
+/// itself ([nativeSdkImpliedBump]), not asked of the LLM, since it's a
+/// deterministic fact this tooling already knows.
+class NativeSdkChangelogContext {
+  final String displayName;
+  final String targetVersion;
+  final List<String> entries;
+  final String changelogUrl;
+  final VersionBumpType? impliedBump;
+
+  const NativeSdkChangelogContext({
+    required this.displayName,
+    required this.targetVersion,
+    required this.entries,
+    required this.changelogUrl,
+    this.impliedBump,
+  });
+}
+
+/// A single-line entry, no category -- what
+/// [synthesizeNativeSdkSubEntries] asks for, distinct from
+/// [changelogEntryListSchema]'s three-category shape since these become
+/// sub-bullets under one entry, not top-level entries in their own right.
+final _nativeSdkSubEntriesSchema = {
+  'type': 'object',
+  'properties': {
+    'entries': {
+      'type': 'array',
+      'items': {
+        'type': 'object',
+        'properties': {
+          'text': {
+            'type': 'string',
+            'description':
+                'Full text of a single-line changelog entry, formatted as '
+                'markdown.',
+          },
+        },
+        'required': ['text'],
+        'additionalProperties': false,
+      },
+    },
+  },
+  'required': ['entries'],
+  'additionalProperties': false,
+};
+
+List<String> _parseNativeSdkSubEntries(Map<String, dynamic> json) =>
+    (json['entries'] as List)
+        .map((e) => (e as Map<String, dynamic>)['text'] as String)
+        .toList();
+
+String _nativeSdkSubEntriesPrompt(NativeSdkChangelogContext context) {
+  final entryText = context.entries.map((e) => '- $e').join('\n');
+  return '''
+You are preparing the sub-bullets that will appear under a single changelog line noting an update to the ${context.displayName} native SDK, inside a Flutter package's changelog. Below are that native SDK's own raw changelog entries, covering the version range being picked up in this release.
+
+Your task: reduce these to a flat list of concise, customer-facing bullet points describing the user-visible impact on developers who use the Flutter package.
+
+Include an entry for customer-facing changes: new features, behavior changes, and bug fixes.
+
+Omit entries for:
+- Anything labeled [MAINTENANCE], or otherwise about internal tooling, CI, build systems, or tests
+- Internal refactors with no observable effect on the Flutter package's own consumers
+- Changes only reachable through the native SDK's own internal API, not through the Flutter package's public API
+- Session Replay or Feature Flags -- both are custom-implemented in Flutter rather than wrapping the native SDK's version of that feature, so changes and fixes to either in the native SDK's changelog don't apply here
+
+Do not reproduce PR or issue links from the native repository (e.g. "See [#1234](...)" or "[#1234][]") -- drop that trailing reference entirely from each entry.
+
+Do not add a link to the native SDK's own changelog yourself -- one is already shown above this list, so repeating it here would be redundant.
+
+Style:
+- Write from the user's perspective — describe the impact, not the implementation.
+- Use present tense.
+- Be concise: one sentence is almost always sufficient.
+- Format each entry as plain markdown (inline `code` for public API identifiers).
+- Drop any leading bracketed tag from the source entry (e.g. "[FEATURE]", "[BUGFIX]", "[IMPROVEMENT]", "[FIX]") -- write plain prose instead, consistent with the rest of this changelog.
+
+Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
+
+Use only the data provided below. Do not consult external sources.
+
+<native-sdk-changelog name="${context.displayName}">
+$entryText
+</native-sdk-changelog>''';
+}
+
+Future<List<String>> synthesizeNativeSdkSubEntries(
+  AiGatewayClient client,
+  NativeSdkChangelogContext context, {
+  LlmCostTracker? costTracker,
+}) {
+  return runStructuredPrompt(
+    client,
+    _nativeSdkSubEntriesPrompt(context),
+    _nativeSdkSubEntriesSchema,
+    _parseNativeSdkSubEntries,
+    costTracker: costTracker,
+    costLabel: 'NativeSdkChangelog(${context.displayName})',
+  );
+}
+
+/// The single top-level entry for a native SDK update -- exact wording and
+/// link are built here, deterministically, rather than asked of an LLM:
+/// "Update to Android SDK 3.13.0. For a complete list of changes, see the
+/// [Android SDK CHANGELOG](url)." with [subEntries] nested underneath.
+ChangelogEntry buildNativeSdkUpdateEntry(
+  NativeSdkChangelogContext context,
+  List<String> subEntries,
+) => ChangelogEntry(
+  'Update to ${context.displayName} SDK ${context.targetVersion}. For a '
+  'complete list of changes, see the [${context.displayName} SDK '
+  'CHANGELOG](${context.changelogUrl}).',
+  subEntries: subEntries,
+);
+
+/// Resolves [deltas] into [NativeSdkChangelogContext]s ready for
+/// [generateChangelogEntries] -- skips (reporting via [onWarning], not
+/// silently) whichever deltas [resolveNativeSdkChangelog] couldn't find a
+/// comparable baseline for, same as `preview_release.dart`'s `--verbose`
+/// display.
+Future<List<NativeSdkChangelogContext>> resolveNativeSdkChangelogContexts(
+  List<NativeSdkDelta> deltas, {
+  required ChangelogFetcher fetchChangelog,
+  required void Function(String warning) onWarning,
+}) async {
+  final contexts = <NativeSdkChangelogContext>[];
+  for (final delta in deltas) {
+    final targetVersion = delta.targetVersion;
+    if (targetVersion == null) continue;
+
+    final result = await resolveNativeSdkChangelog(
+      delta.sdk,
+      currentDeclaration: delta.currentDeclaration,
+      targetVersion: targetVersion,
+      fetchChangelog: fetchChangelog,
+    );
+    if (result.warning != null) {
+      onWarning(result.warning!);
+      continue;
+    }
+
+    final entries = result.sections!.expand((s) => s.entries).toList();
+    if (entries.isEmpty) continue;
+
+    contexts.add(
+      NativeSdkChangelogContext(
+        displayName: delta.sdk.displayName,
+        targetVersion: targetVersion,
+        entries: entries,
+        changelogUrl: nativeSdkChangelogUrl(delta.sdk),
+        impliedBump: nativeSdkImpliedBump(delta),
+      ),
+    );
+  }
+  return contexts;
+}
+
+// == Orchestration
+
+/// Runs the PR pipeline (group -> synthesize -> cleanup/dedup) against
+/// [prs] -- the significant subset of PRs for one package's release --
+/// then appends one entry per [nativeSdkContexts] (see
+/// [resolveNativeSdkChangelogContexts]). Native SDK entries deliberately
+/// skip the cleanup pass: their exact wording and link are built in Dart
+/// (see [buildNativeSdkUpdateEntry]), and routing them through another LLM
+/// call risks the cleanup pass paraphrasing away the link or flattening
+/// the parent/sub-bullet structure the response schema doesn't carry.
+/// `chore:`/`docs:`/`test:`-only commits are already excluded upstream by
+/// `release_plan.dart`'s bump-weight filtering (see
+/// `PackagePlan.contributingCommits`), so every [PrDetails] passed here is
+/// assumed to already be in scope.
+///
+/// Returns an empty, un-prompted [ChangelogEntryList] when both [prs] and
+/// [nativeSdkContexts] are empty -- no LLM calls for a release with
+/// nothing to summarize.
+Future<ChangelogEntryList> generateChangelogEntries(
+  AiGatewayClient client,
+  List<PrDetails> prs, {
+  List<NativeSdkChangelogContext> nativeSdkContexts = const [],
+  LlmCostTracker? costTracker,
+}) async {
+  if (prs.isEmpty && nativeSdkContexts.isEmpty) {
+    return const ChangelogEntryList();
+  }
+
+  var changelog = const ChangelogEntryList();
+
+  if (prs.isNotEmpty) {
+    final groups = (await runGroupedPrsPrompt(
+      client,
+      prs,
+      costTracker: costTracker,
+    )).groups;
+
+    for (final group in groups) {
+      final numbers = group.prs.map((pr) => pr.number).toSet();
+      final groupPrs = prs.where((pr) => numbers.contains(pr.number)).toList();
+      final entries = await runChangelogEntryListPrompt(
+        client,
+        group.label,
+        groupPrs,
+        costTracker: costTracker,
+      );
+      changelog = changelog.mergedWith(entries);
+    }
+
+    changelog = await runCleanupPrompt(
+      client,
+      changelog,
+      costTracker: costTracker,
+    );
+  }
+
+  for (final context in nativeSdkContexts) {
+    final subEntries = await synthesizeNativeSdkSubEntries(
+      client,
+      context,
+      costTracker: costTracker,
+    );
+    changelog = changelog.withEntry(
+      buildNativeSdkUpdateEntry(context, subEntries),
+      breaking: context.impliedBump == VersionBumpType.major,
+    );
+  }
+
+  return changelog;
+}
+
+/// Resolves everything [generateChangelogEntries] needs directly from
+/// [packagePlan] -- each contributing commit's PR, that PR's full title and
+/// body, and native SDK changelog contexts from [packagePlan]'s native SDK
+/// deltas -- then runs the pipeline. The one call a caller holding a
+/// [PackagePlan] needs.
+Future<ChangelogEntryList> generateChangelogForPackage(
+  AiGatewayClient client,
+  PackagePlan packagePlan, {
+  required GithubCommandWrapper github,
+  required Logger logger,
+  LlmCostTracker? costTracker,
+}) async {
+  final prNumbers = <int>{};
+  for (final commit in packagePlan.contributingCommits) {
+    if (commit.sha == null) continue;
+    final resolved = await resolvePr(
+      commit.sha!,
+      commit.description,
+      (sha) => github.searchMergedPrBySha(logger, sha),
+    );
+    if (resolved != null) prNumbers.add(resolved.number);
+  }
+
+  final prDetails = [
+    for (final number in prNumbers) await github.fetchPrDetails(logger, number),
+  ];
+
+  final nativeSdkContexts = await resolveNativeSdkChangelogContexts(
+    packagePlan.nativeSdkDeltas,
+    fetchChangelog: githubChangelogFetcher(logger, github),
+    onWarning: (w) => logger.warning('⚠️ $w'),
+  );
+
+  return generateChangelogEntries(
+    client,
+    prDetails,
+    nativeSdkContexts: nativeSdkContexts,
+    costTracker: costTracker,
+  );
+}
+
+/// Renders [entries] as grouped-subsection markdown: `### Breaking Changes`/
+/// `### Features`/`### Fixes`, each omitted when empty, under the
+/// package's own `## {version}` heading -- this only produces the body,
+/// not the heading itself.
+String renderChangelogSection(ChangelogEntryList entries) {
+  if (entries.isEmpty) {
+    return '- Maintenance release; no significant changes.\n';
+  }
+
+  final buffer = StringBuffer();
+  for (final (heading, list) in [
+    ('### Breaking Changes', entries.breakingChanges),
+    ('### Features', entries.features),
+    ('### Fixes', entries.fixes),
+  ]) {
+    if (list.isEmpty) continue;
+    buffer.writeln(heading);
+    buffer.writeln();
+    for (final entry in list) {
+      buffer.writeln('- ${entry.text}');
+      for (final sub in entry.subEntries) {
+        buffer.writeln('  - $sub');
+      }
+    }
+    buffer.writeln();
+  }
+
+  return buffer.toString().trimRight();
+}

--- a/tools/releaser/lib/llm/changelog.dart
+++ b/tools/releaser/lib/llm/changelog.dart
@@ -121,14 +121,22 @@ $prText
 </prs>''';
 }
 
-/// Runs the grouping pass and sanity-checks that the PR numbers it
-/// referenced exactly match the set of PRs it was given -- an LLM
-/// inventing or dropping a PR number here would silently corrupt the
-/// changelog, so this fails loudly instead.
+/// Runs the grouping pass and sanity-checks that it partitioned the PRs it
+/// was given -- every input number used, nothing invented, and each in
+/// exactly one group.
+///
+/// Inventing or dropping a number throws: the changelog would be wrong in a
+/// way nothing downstream can detect, and there's no sound way to guess what
+/// was meant. Assigning one PR to two groups is recoverable, though -- the
+/// grouping is still complete, just not a partition -- so the repeat is
+/// dropped from the later group and reported via [onWarning] rather than
+/// failing the build. Left in, pass 2 would write that PR up twice, from two
+/// angles, with nothing to reconcile them.
 Future<GroupedPrs> runGroupedPrsPrompt(
   AiGatewayClient client,
   List<PrDetails> prs, {
   LlmCostTracker? costTracker,
+  void Function(String warning)? onWarning,
 }) async {
   final result = await runStructuredPrompt(
     client,
@@ -140,15 +148,45 @@ Future<GroupedPrs> runGroupedPrsPrompt(
   );
 
   final expected = prs.map((pr) => pr.number).toSet();
-  final got = result.groups.expand((g) => g.prs).map((pr) => pr.number).toSet();
-  if (!const SetEquality<int>().equals(expected, got)) {
+  final assigned = result.groups
+      .expand((g) => g.prs)
+      .map((pr) => pr.number)
+      .toList();
+
+  if (!const SetEquality<int>().equals(expected, assigned.toSet())) {
     throw StateError(
       'AI Gateway response PR numbers do not match input: expected '
-      '${expected.join(',')}; got ${got.join(',')}',
+      '${expected.join(',')}; got ${assigned.toSet().join(',')}',
     );
   }
 
-  return result;
+  // Checked on the list, not the set the comparison above collapses to --
+  // a repeat leaves the set equal while duplicating the entry downstream.
+  if (assigned.length == expected.length) return result;
+
+  final seen = <int>{};
+  final duplicated = <int>[];
+  final deduped = <PrGroup>[];
+
+  for (final group in result.groups) {
+    final kept = <GroupedPr>[];
+    for (final pr in group.prs) {
+      if (seen.add(pr.number)) {
+        kept.add(pr);
+      } else {
+        duplicated.add(pr.number);
+      }
+    }
+    // A group whose every PR was a repeat has nothing left to summarize.
+    if (kept.isNotEmpty) deduped.add(PrGroup(label: group.label, prs: kept));
+  }
+
+  onWarning?.call(
+    'AI Gateway put ${duplicated.map((n) => '#$n').join(', ')} in more than '
+    'one group; keeping the first of each so the entry is written once.',
+  );
+
+  return GroupedPrs(groups: deduped);
 }
 
 // == LLM Pass 2: Given full PRs from each group, synthesize 0 or more changelog items
@@ -551,6 +589,7 @@ Future<ChangelogEntryList> generateChangelogEntries(
   List<PrDetails> prs, {
   List<NativeSdkChangelogContext> nativeSdkContexts = const [],
   LlmCostTracker? costTracker,
+  void Function(String warning)? onWarning,
 }) async {
   if (prs.isEmpty && nativeSdkContexts.isEmpty) {
     return const ChangelogEntryList();
@@ -563,6 +602,7 @@ Future<ChangelogEntryList> generateChangelogEntries(
       client,
       prs,
       costTracker: costTracker,
+      onWarning: onWarning,
     )).groups;
 
     for (final group in groups) {
@@ -637,6 +677,7 @@ Future<ChangelogEntryList> generateChangelogForPackage(
     prDetails,
     nativeSdkContexts: nativeSdkContexts,
     costTracker: costTracker,
+    onWarning: (w) => logger.warning('⚠️ $w'),
   );
 }
 

--- a/tools/releaser/lib/llm/costs.dart
+++ b/tools/releaser/lib/llm/costs.dart
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:logging/logging.dart';
+
+import 'ai_gateway.dart';
+
+/// (input, output) advertised price per million tokens. Quick-and-dirty by
+/// design: an estimate for a human glancing at CI output, not a billing
+/// record.
+const _pricePerMillionTokens = {
+  'claude-sonnet-4-6': (input: 3.00, output: 15.00),
+};
+
+/// Aggregates [LlmUsage] across a run's LLM calls and prints an estimated
+/// cost summary.
+class LlmCostTracker {
+  final _calls = <(String label, LlmUsage usage)>[];
+
+  void record(LlmUsage usage, [String label = '']) {
+    _calls.add((label, usage));
+  }
+
+  void printSummary(Logger logger) {
+    var totalInputTokens = 0;
+    var totalOutputTokens = 0;
+    var totalCost = 0.0;
+
+    for (final (label, usage) in _calls) {
+      final prices = _pricePerMillionTokens[usage.model];
+      if (prices == null) {
+        logger.warning(
+          'Usage costs for model ${usage.model} not known; falling back to '
+          'claude-sonnet-4-6 pricing.',
+        );
+      }
+      final (:input, :output) =
+          prices ?? _pricePerMillionTokens['claude-sonnet-4-6']!;
+      final cost =
+          usage.inputTokens / 1e6 * input + usage.outputTokens / 1e6 * output;
+      totalInputTokens += usage.inputTokens;
+      totalOutputTokens += usage.outputTokens;
+      totalCost += cost;
+
+      final suffix = label.isEmpty ? '' : ' ($label)';
+      logger.info(
+        '  ${usage.model}$suffix: ${usage.inputTokens}in + '
+        '${usage.outputTokens}out = \$${cost.toStringAsFixed(4)}',
+      );
+    }
+
+    logger.info(
+      '  Estimated cost: \$${totalCost.toStringAsFixed(4)} '
+      '(${_calls.length} LLM calls with $totalInputTokens input tokens, '
+      '$totalOutputTokens output tokens)',
+    );
+  }
+}

--- a/tools/releaser/lib/llm/prompt.dart
+++ b/tools/releaser/lib/llm/prompt.dart
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'ai_gateway.dart';
+import 'costs.dart';
+
+/// Sends [prompt] to [client] with [schema] as the required output shape,
+/// and returns the response deserialized by [fromJson].
+///
+/// [schema] is hand-written per response type rather than derived from a
+/// class at runtime as there are only a few response shapes in this
+/// pipeline (`changelog.dart`'s `groupedPrsSchema`/`changelogEntryListSchema`),
+/// so writing them out is simpler than building a reflection-based
+/// generator for a handful of call sites.
+Future<T> runStructuredPrompt<T>(
+  AiGatewayClient client,
+  String prompt,
+  Map<String, dynamic> schema,
+  T Function(Map<String, dynamic>) fromJson, {
+  String model = defaultModel,
+  int maxTokens = 4096,
+  LlmCostTracker? costTracker,
+  String costLabel = '',
+}) async {
+  final response = await client.createStructuredMessage(
+    prompt: prompt,
+    schema: schema,
+    model: model,
+    maxTokens: maxTokens,
+  );
+  costTracker?.record(response.usage, costLabel);
+  return fromJson(response.content);
+}

--- a/tools/releaser/lib/llm/prompt.dart
+++ b/tools/releaser/lib/llm/prompt.dart
@@ -5,30 +5,45 @@
 import 'ai_gateway.dart';
 import 'costs.dart';
 
-/// Sends [prompt] to [client] with [schema] as the required output shape,
-/// and returns the response deserialized by [fromJson].
+/// One structured-output LLM call, bundled as a single value: the rendered
+/// prompt [text], the [schema] its response must satisfy, and [fromJson] to
+/// turn that response back into [T]. The three are never useful apart from
+/// each other -- a schema with no matching parser is meaningless, and a
+/// prompt written against a schema nobody enforces is just a hope -- so one
+/// object carries all three rather than three parameters that happen to be
+/// passed around together.
 ///
-/// [schema] is hand-written per response type rather than derived from a
-/// class at runtime as there are only a few response shapes in this
-/// pipeline (`changelog.dart`'s `groupedPrsSchema`/`changelogEntryListSchema`),
-/// so writing them out is simpler than building a reflection-based
-/// generator for a handful of call sites.
+/// Each concrete prompt (see `prompts/`) is a top-level function that builds
+/// one of these from its specific inputs, rather than a subclass -- there's
+/// no behaviour to override, only data to assemble.
+class Prompt<T> {
+  final String text;
+  final Map<String, dynamic> schema;
+  final T Function(Map<String, dynamic>) fromJson;
+
+  const Prompt({
+    required this.text,
+    required this.schema,
+    required this.fromJson,
+  });
+}
+
+/// Sends [prompt]'s text to [client] with its schema as the required output
+/// shape, and returns the response deserialized by its `fromJson`.
 Future<T> runStructuredPrompt<T>(
   AiGatewayClient client,
-  String prompt,
-  Map<String, dynamic> schema,
-  T Function(Map<String, dynamic>) fromJson, {
+  Prompt<T> prompt, {
   String model = defaultModel,
   int maxTokens = 4096,
   LlmCostTracker? costTracker,
   String costLabel = '',
 }) async {
   final response = await client.createStructuredMessage(
-    prompt: prompt,
-    schema: schema,
+    prompt: prompt.text,
+    schema: prompt.schema,
     model: model,
     maxTokens: maxTokens,
   );
   costTracker?.record(response.usage, costLabel);
-  return fromJson(response.content);
+  return prompt.fromJson(response.content);
 }

--- a/tools/releaser/lib/llm/prompts/changelog_entry_list_prompt.dart
+++ b/tools/releaser/lib/llm/prompts/changelog_entry_list_prompt.dart
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// == LLM Pass 2: Given full PRs from each group, synthesize 0 or more
+//    changelog items.
+// == LLM Pass 3: Final editorial pass to deduplicate, normalize, and order
+//    entries.
+//
+// Both passes answer in the same three-category shape, so they share one
+// schema/model and this one file, even though their prompt text and inputs
+// differ.
+
+import 'package:collection/collection.dart';
+
+import '../../pr_resolution.dart' show PrDetails;
+import '../prompt.dart';
+
+class ChangelogEntry {
+  final String text;
+
+  /// Nested bullets under [text] -- a native SDK update entry's filtered,
+  /// customer-facing changes (see `changelog.dart`'s
+  /// `buildNativeSdkUpdateEntry`). Empty for every PR-derived entry.
+  final List<String> subEntries;
+
+  const ChangelogEntry(this.text, {this.subEntries = const []});
+
+  factory ChangelogEntry.fromJson(Map<String, dynamic> json) =>
+      ChangelogEntry(json['text'] as String);
+}
+
+/// A draft or final changelog's entries, split into the three sections this
+/// design standardizes on. Breaking/feature/fix is mutually exclusive: an
+/// entry that qualifies as both a breaking change and a feature or fix goes
+/// in [breakingChanges] only.
+class ChangelogEntryList {
+  final List<ChangelogEntry> breakingChanges;
+  final List<ChangelogEntry> features;
+  final List<ChangelogEntry> fixes;
+
+  const ChangelogEntryList({
+    this.breakingChanges = const [],
+    this.features = const [],
+    this.fixes = const [],
+  });
+
+  factory ChangelogEntryList.fromJson(Map<String, dynamic> json) =>
+      ChangelogEntryList(
+        breakingChanges: _entriesOf(json['breaking_changes']),
+        features: _entriesOf(json['features']),
+        fixes: _entriesOf(json['fixes']),
+      );
+
+  static List<ChangelogEntry> _entriesOf(dynamic value) => (value as List)
+      .map((e) => ChangelogEntry.fromJson(e as Map<String, dynamic>))
+      .toList();
+
+  ChangelogEntryList mergedWith(ChangelogEntryList other) => ChangelogEntryList(
+    breakingChanges: [...breakingChanges, ...other.breakingChanges],
+    features: [...features, ...other.features],
+    fixes: [...fixes, ...other.fixes],
+  );
+
+  /// [entry] appended to [breakingChanges] if [breaking], else [features].
+  /// Used for a native SDK update entry, whose category is decided in Dart
+  /// from the version delta rather than asked of an LLM (see
+  /// `native_sdk.dart`'s `NativeSdkDelta.getImpliedBump`).
+  ChangelogEntryList withEntry(
+    ChangelogEntry entry, {
+    required bool breaking,
+  }) => ChangelogEntryList(
+    breakingChanges: breaking ? [...breakingChanges, entry] : breakingChanges,
+    features: breaking ? features : [...features, entry],
+    fixes: fixes,
+  );
+
+  bool get isEmpty =>
+      breakingChanges.isEmpty && features.isEmpty && fixes.isEmpty;
+}
+
+final _schema = {
+  'type': 'object',
+  'properties': {
+    for (final key in ['breaking_changes', 'features', 'fixes'])
+      key: {
+        'type': 'array',
+        'items': {
+          'type': 'object',
+          'properties': {
+            'text': {
+              'type': 'string',
+              'description':
+                  'Full text of a single-line changelog entry, formatted as '
+                  'markdown.',
+            },
+          },
+          'required': ['text'],
+          'additionalProperties': false,
+        },
+      },
+  },
+  'required': ['breaking_changes', 'features', 'fixes'],
+  'additionalProperties': false,
+};
+
+String _formatPr(PrDetails pr) =>
+    '''
+<pr number="${pr.number}">
+<title>${pr.title}</title>
+<body>
+${pr.body}
+</body>
+</pr>''';
+
+String _synthesizeText(String groupLabel, List<PrDetails> groupPrs) {
+  final prText = groupPrs.map(_formatPr).join('\n');
+  return '''
+You are writing a customer-facing changelog for a Flutter package. You have been given a group of related pull requests that together represent a single logical change.
+
+Your task: synthesize 0 or more changelog entries describing the user-visible impact of this change on developers who use the package as a library dependency.
+
+Include an entry for:
+- New or modified public APIs: functions, types, configuration options, or constants added, changed, or removed
+- Observable behavior changes: anything a developer would notice at runtime, including bug fixes that corrected incorrect data, crashes, or wrong behavior
+- Breaking changes to any public API or previously-documented behavior
+
+Omit entries for:
+- Internal refactors, test infrastructure, or build system changes
+- Changes to private implementation details that are not reachable through the public API and whose effects are not observable to library consumers
+- chore work with no user-visible effect
+- Sub-changes that are already fully captured by another entry in this group
+
+If every change in the group falls into the omit list, return empty lists for all three categories. An empty response is correct and preferred over producing a thin or redundant entry.
+
+A group may produce multiple entries only when it contains genuinely distinct user-facing changes that each deserve to be called out separately. When in doubt, prefer a single consolidated entry over splitting.
+
+Categorize each entry as exactly one of:
+- breaking_changes: removes or incompatibly alters a public API or previously-documented behavior, requiring users to update their code on upgrade. When an entry qualifies as both a breaking change and a feature or fix, categorize it as a breaking change.
+- features: adds new capability, APIs, or configuration options without breaking existing usage.
+- fixes: corrects incorrect behavior, data, or crashes without breaking existing usage.
+
+Style:
+- Write from the user's perspective — describe the impact, not the implementation.
+- Use present tense: e.g. "Crash timestamps are now reported in milliseconds."
+- Be concise: one sentence is almost always sufficient.
+- Do not reference PR numbers, branch names, or internal type names.
+- Format the entry as plain markdown (inline `code` for public API identifiers; no headers or bullet lists within an entry).
+
+Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
+
+Use only the data provided below. Do not consult external sources. Ignore boilerplate sections in PR bodies (e.g. checklists, test plans, or template scaffolding) — focus on the description of what changed and why.
+
+<group label="$groupLabel">
+$prText
+</group>''';
+}
+
+/// Synthesizes 0 or more changelog entries for one group of related PRs.
+Prompt<ChangelogEntryList> changelogEntryListPrompt(
+  String groupLabel,
+  List<PrDetails> groupPrs,
+) => Prompt(
+  text: _synthesizeText(groupLabel, groupPrs),
+  schema: _schema,
+  fromJson: ChangelogEntryList.fromJson,
+);
+
+String _formatEntries(List<ChangelogEntry> entries) {
+  if (entries.isEmpty) return '(none)';
+  return entries.mapIndexed((i, e) => '${i + 1}. ${e.text}').join('\n');
+}
+
+String _cleanupText(ChangelogEntryList changelog) =>
+    '''
+You are performing a final editorial pass on a draft changelog for a Flutter package. The entries below were generated independently for each group of related PRs and then merged; as a result, they may contain redundancies, inconsistencies in tone or style, or suboptimal ordering.
+
+Your tasks:
+
+1. Deduplicate. Remove or merge entries that describe the same user-visible change. Pay particular attention to cross-category duplication: if a breaking_changes entry already captures a change, remove the corresponding feature or fix entry rather than keeping both. If two entries partially overlap, consolidate them into one entry in whichever category is most appropriate.
+
+2. Normalize tone and style. All entries should:
+   - Be written from the user's perspective — describe the impact, not the implementation.
+   - Use present tense: e.g. "X now does Y."
+   - Be concise: one sentence is almost always sufficient.
+   - Use inline `code` only for public API identifiers.
+   - Not reference PR numbers, branch names, or internal type names.
+
+3. Sort entries within each category. Order primarily by importance: the most significant and impactful changes first. As a secondary concern, place related entries adjacent to one another.
+
+Do not invent entries that were not present in the input. Produce output in the same three-category schema. If an entry contains a markdown link (e.g. a link to a native SDK's own changelog), preserve that link verbatim in whichever entry it ends up in -- never drop or paraphrase it away.
+
+Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
+
+Use only the data provided below. Do not consult external sources.
+
+### Breaking Changes
+${_formatEntries(changelog.breakingChanges)}
+
+### Features
+${_formatEntries(changelog.features)}
+
+### Fixes
+${_formatEntries(changelog.fixes)}''';
+
+/// Deduplicates, normalizes, and orders a draft changelog assembled from
+/// independently-synthesized groups.
+Prompt<ChangelogEntryList> cleanupPrompt(ChangelogEntryList changelog) =>
+    Prompt(
+      text: _cleanupText(changelog),
+      schema: _schema,
+      fromJson: ChangelogEntryList.fromJson,
+    );

--- a/tools/releaser/lib/llm/prompts/grouped_prs_prompt.dart
+++ b/tools/releaser/lib/llm/prompts/grouped_prs_prompt.dart
@@ -1,0 +1,113 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// == LLM Pass 1: Collect related PRs into groups with a common label
+
+import '../../pr_resolution.dart' show PrDetails;
+import '../prompt.dart';
+
+class GroupedPr {
+  final int number;
+  final String title;
+
+  const GroupedPr({required this.number, required this.title});
+
+  factory GroupedPr.fromJson(Map<String, dynamic> json) =>
+      GroupedPr(number: json['number'] as int, title: json['title'] as String);
+}
+
+class PrGroup {
+  final String label;
+  final List<GroupedPr> prs;
+
+  const PrGroup({required this.label, required this.prs});
+
+  factory PrGroup.fromJson(Map<String, dynamic> json) => PrGroup(
+    label: json['label'] as String,
+    prs: (json['prs'] as List)
+        .map((e) => GroupedPr.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+class GroupedPrs {
+  final List<PrGroup> groups;
+
+  const GroupedPrs({required this.groups});
+
+  factory GroupedPrs.fromJson(Map<String, dynamic> json) => GroupedPrs(
+    groups: (json['groups'] as List)
+        .map((e) => PrGroup.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+final _schema = {
+  'type': 'object',
+  'properties': {
+    'groups': {
+      'type': 'array',
+      'items': {
+        'type': 'object',
+        'properties': {
+          'label': {
+            'type': 'string',
+            'description':
+                'Short string describing the purpose of this group of PRs. '
+                'Infer from the titles of constituent PRs.',
+          },
+          'prs': {
+            'type': 'array',
+            'items': {
+              'type': 'object',
+              'properties': {
+                'number': {
+                  'type': 'integer',
+                  'description':
+                      'Integer PR number. Use the original PR number exactly.',
+                },
+                'title': {
+                  'type': 'string',
+                  'description':
+                      'Single-line string describing the PR. Use the '
+                      'original text exactly.',
+                },
+              },
+              'required': ['number', 'title'],
+              'additionalProperties': false,
+            },
+          },
+        },
+        'required': ['label', 'prs'],
+        'additionalProperties': false,
+      },
+    },
+  },
+  'required': ['groups'],
+  'additionalProperties': false,
+};
+
+String _text(List<PrDetails> prs) {
+  final prText = prs
+      .map((pr) => '${pr.number.toString().padLeft(5)} ${pr.title}')
+      .join('\n');
+  return '''
+You are preparing to write a customer-facing changelog for an SDK. Below is a list of PRs that have been merged since the last release.
+
+Your task: group these PRs so that closely-related PRs can be considered together. A group should capture a coherent user-visible change: for example, several PRs that together implement one feature, or a fix that directly relates to a feature in the same release. PRs with no clear relationship to others should each be their own group.
+
+Your response will be a JSON array where each element is an object representing a related group of one or more PRs. This JSON value will adhere to the provided schema. Your response will include no prose or formatting.
+
+Use only the data provided below. Do not consult external sources.
+
+<prs>
+$prText
+</prs>''';
+}
+
+/// Groups [prs] so closely-related PRs are considered together in the next
+/// pass -- see `changelog.dart`'s `runGroupedPrsPrompt` for the validation
+/// layered on top of this raw call.
+Prompt<GroupedPrs> groupedPrsPrompt(List<PrDetails> prs) =>
+    Prompt(text: _text(prs), schema: _schema, fromJson: GroupedPrs.fromJson);

--- a/tools/releaser/lib/llm/prompts/native_sdk_sub_entries_prompt.dart
+++ b/tools/releaser/lib/llm/prompts/native_sdk_sub_entries_prompt.dart
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+// == LLM Pass 2b: Filter a native SDK's own changelog to customer-facing
+//    sub-bullets.
+
+import '../../version_bump.dart';
+import '../prompt.dart';
+
+/// Raw changelog entries from one native SDK, covering the version range a
+/// package's `NativeSdkDelta` is picking up this release -- resolved via
+/// `native_sdk_changelog.dart`'s `resolveNativeSdkChangelog`.
+///
+/// [impliedBump] decides which category the resulting entry lands in (see
+/// `changelog.dart`'s `buildNativeSdkUpdateEntry`) -- computed in Dart from
+/// the version delta itself (`NativeSdkDelta.getImpliedBump`), not asked of
+/// the LLM, since it's a deterministic fact this tooling already knows.
+class NativeSdkChangelogContext {
+  final String displayName;
+  final String targetVersion;
+  final List<String> entries;
+  final String changelogUrl;
+  final VersionBumpType? impliedBump;
+
+  const NativeSdkChangelogContext({
+    required this.displayName,
+    required this.targetVersion,
+    required this.entries,
+    required this.changelogUrl,
+    this.impliedBump,
+  });
+}
+
+/// A single-line entry, no category -- what this prompt asks for, distinct
+/// from `changelog_entry_list_prompt.dart`'s three-category shape since
+/// these become sub-bullets under one entry, not top-level entries in their
+/// own right.
+final _schema = {
+  'type': 'object',
+  'properties': {
+    'entries': {
+      'type': 'array',
+      'items': {
+        'type': 'object',
+        'properties': {
+          'text': {
+            'type': 'string',
+            'description':
+                'Full text of a single-line changelog entry, formatted as '
+                'markdown.',
+          },
+        },
+        'required': ['text'],
+        'additionalProperties': false,
+      },
+    },
+  },
+  'required': ['entries'],
+  'additionalProperties': false,
+};
+
+List<String> _fromJson(Map<String, dynamic> json) => (json['entries'] as List)
+    .map((e) => (e as Map<String, dynamic>)['text'] as String)
+    .toList();
+
+String _text(NativeSdkChangelogContext context) {
+  final entryText = context.entries.map((e) => '- $e').join('\n');
+  return '''
+You are preparing the sub-bullets that will appear under a single changelog line noting an update to the ${context.displayName} native SDK, inside a Flutter package's changelog. Below are that native SDK's own raw changelog entries, covering the version range being picked up in this release.
+
+Your task: reduce these to a flat list of concise, customer-facing bullet points describing the user-visible impact on developers who use the Flutter package.
+
+Include an entry for customer-facing changes: new features, behavior changes, and bug fixes.
+
+Omit entries for:
+- Anything labeled [MAINTENANCE], or otherwise about internal tooling, CI, build systems, or tests
+- Internal refactors with no observable effect on the Flutter package's own consumers
+- Changes only reachable through the native SDK's own internal API, not through the Flutter package's public API
+- Session Replay or Feature Flags -- both are custom-implemented in Flutter rather than wrapping the native SDK's version of that feature, so changes and fixes to either in the native SDK's changelog don't apply here
+
+Do not reproduce PR or issue links from the native repository (e.g. "See [#1234](...)" or "[#1234][]") -- drop that trailing reference entirely from each entry.
+
+Do not add a link to the native SDK's own changelog yourself -- one is already shown above this list, so repeating it here would be redundant.
+
+Style:
+- Write from the user's perspective — describe the impact, not the implementation.
+- Use present tense.
+- Be concise: one sentence is almost always sufficient.
+- Format each entry as plain markdown (inline `code` for public API identifiers).
+- Drop any leading bracketed tag from the source entry (e.g. "[FEATURE]", "[BUGFIX]", "[IMPROVEMENT]", "[FIX]") -- write plain prose instead, consistent with the rest of this changelog.
+
+Your response will adhere to the provided schema. Include no prose or formatting outside the JSON.
+
+Use only the data provided below. Do not consult external sources.
+
+<native-sdk-changelog name="${context.displayName}">
+$entryText
+</native-sdk-changelog>''';
+}
+
+/// Filters [context]'s native SDK changelog entries down to a flat,
+/// customer-facing list of sub-bullets.
+Prompt<List<String>> nativeSdkSubEntriesPrompt(
+  NativeSdkChangelogContext context,
+) => Prompt(text: _text(context), schema: _schema, fromJson: _fromJson);

--- a/tools/releaser/lib/native_sdk.dart
+++ b/tools/releaser/lib/native_sdk.dart
@@ -179,25 +179,50 @@ String? normalizeVersion(String? declaration) {
   return RegExp(r'\d+\.\d+\.\d+').firstMatch(declaration)?.group(0);
 }
 
+/// A full 40-character commit SHA -- what `pinCppVersion` writes to `GIT_TAG`,
+/// and the one non-semver shape that still names exactly one immutable thing.
+final _fullShaPattern = RegExp(r'^[0-9a-f]{40}$');
+
+/// Anything that makes a declaration name a *range* or a *moving ref* rather
+/// than one immutable version: CocoaPods' `~>`, Gradle's `+` prefix-match,
+/// SPM's `from:`/`branch:` forms, and a comparison operator in any of them.
+const _floatingConstraintMarkers = ['~>', '+', '<', '>', 'from', 'branch'];
+
+/// Whether [declaration] pins exactly one immutable version, as opposed to
+/// naming a range or a moving ref.
+bool isPinnedDeclaration(String? declaration) {
+  if (declaration == null) return false;
+
+  final value = declaration.trim();
+  if (value.isEmpty) return false;
+  if (_floatingConstraintMarkers.any(value.contains)) return false;
+  if (_fullShaPattern.hasMatch(value)) return true;
+
+  // A complete semver and nothing else -- `3.15.0`, `v1.4.0`, `'3.13.1'`.
+  // A bare major (`3`) or major.minor (`3.15`) is a range, not a pin.
+  return RegExp(r'^\D*\d+\.\d+\.\d+\D*$').hasMatch(value);
+}
+
 /// What one native SDK dependency of a package resolves to this run.
 ///
 /// [targetVersion]/[targetSha] are a *target*, not a diff: `develop` (and a
 /// long-lived pre-release branch) deliberately keeps its manifests on
 /// floating constraints (`~> 3`, `branch: "develop"`, `GIT_TAG develop`), and
 /// only the release-prep branch's copy is ever pinned. Eligibility never
-/// compares against a "current" value for exactly that reason -- whether a
-/// package ships is a commits/override question, not a native-SDK-drift
-/// question. Bump *level* is the one planning decision that does compare
+/// compares against a "current" value for exactly that reason.
+///
+/// Bump *level* is the one planning decision that does compare
 /// [currentDeclaration] against [targetVersion] -- see
 /// [nativeSdkAggregateBump] -- since a native SDK's own minor/major bump
 /// should carry through to the Flutter package wrapping it. The plan
 /// otherwise just says what to pin to, and `prepare_release.dart` rewrites
 /// [files] to match.
 ///
-/// [currentDeclaration] is purely informational, shown alongside
-/// [targetVersion]. Must be sourced from the last published version's git
-/// history (`fileContentAtTag` in `git_history.dart`), not from [files] as
-/// they sit in the working tree -- the working tree floats, so it isn't
+/// [currentDeclaration] is what this SDK was pinned to by the last release
+/// *on the line being released*, and is what [NativeSdkDelta.getImpliedBump] compares
+/// [targetVersion] against. Must be sourced from that release's git history
+/// (`fileContentAtTag` in `git_history.dart`), not from [files] as they sit
+/// in the working tree -- the working tree normally floats, so it isn't
 /// evidence of what anything previously released with.
 ///
 /// [targetSha] is only meaningful for [NativeSdk.cpp]: CMake's
@@ -235,50 +260,56 @@ class NativeSdkDelta {
         ? '${sdk.name}: -> $targetVersion'
         : '${sdk.name}: $from -> $targetVersion';
   }
+
+  /// The bump [delta] implies on its own -- e.g. dd-sdk-ios 3.15.0 -> 3.16.0
+  /// implies at least a minor bump on the Flutter package wrapping it, with
+  /// or without any qualifying commits of its own. Null when there's nothing
+  /// to compare (no target, or no resolvable current version) or the target
+  /// isn't actually newer.
+  VersionBumpType? getImpliedBump() {
+    if (targetVersion == null) return null;
+
+    final fromRaw = normalizeVersion(currentDeclaration);
+    if (fromRaw == null) return null;
+    final toRaw = normalizeVersion(targetVersion);
+    if (toRaw == null) return null;
+
+    final from = Version.parse(fromRaw);
+    final to = Version.parse(toRaw);
+    if (to <= from) return null;
+    if (to.major != from.major) return VersionBumpType.major;
+    if (to.minor != from.minor) return VersionBumpType.minor;
+    if (to.patch != from.patch) return VersionBumpType.patch;
+    return null;
+  }
 }
 
-/// The bump [delta] implies on its own -- e.g. dd-sdk-ios 3.15.0 -> 3.16.0
-/// implies at least a minor bump on the Flutter package wrapping it, with
-/// or without any qualifying commits of its own. Null when there's nothing
-/// to compare (no target, or no resolvable current version) or the target
-/// isn't actually newer.
-VersionBumpType? nativeSdkImpliedBump(NativeSdkDelta delta) {
-  final targetVersion = delta.targetVersion;
-  if (targetVersion == null) return null;
-
-  final fromRaw = normalizeVersion(delta.currentDeclaration);
-  if (fromRaw == null) return null;
-  final toRaw = normalizeVersion(targetVersion);
-  if (toRaw == null) return null;
-
-  final from = Version.parse(fromRaw);
-  final to = Version.parse(toRaw);
-  if (to <= from) return null;
-  if (to.major != from.major) return VersionBumpType.major;
-  if (to.minor != from.minor) return VersionBumpType.minor;
-  if (to.patch != from.patch) return VersionBumpType.patch;
-  return null;
-}
-
-/// The highest bump implied across [deltas] -- see [nativeSdkImpliedBump].
+/// The highest bump implied across [deltas] -- see [NativeSdkDelta.getImpliedBump].
 VersionBumpType? nativeSdkAggregateBump(List<NativeSdkDelta> deltas) =>
-    highestBump(deltas.map(nativeSdkImpliedBump));
+    highestBump(deltas.map((e) => e.getImpliedBump()));
 
 /// The network calls native SDK resolution needs -- bundled so callers
 /// (`release_plan.dart`) don't thread three separate function parameters
 /// through every layer between `computeReleasePlan` and
 /// [resolveNativeSdkTarget]. All three are keyed by a GitHub repo slug
 /// (e.g. `DataDog/dd-sdk-ios`) so one instance covers all three SDKs.
-class NativeSdkGateways {
-  final Future<String> Function(String repoSlug) fetchLatest;
-  final Future<String> Function(String repoSlug, String ref) resolveCommitSha;
-  final Future<bool> Function(String repoSlug, String version) releaseExists;
+///
+/// An interface rather than a record of closures, because an implementation
+/// may need to remember things across calls -- the real one answers "what is
+/// the latest dd-sdk-ios release" once per run rather than once per package.
+/// State belongs in a field on a named class, not captured in a closure.
+abstract class NativeSdkGateways {
+  const NativeSdkGateways();
 
-  const NativeSdkGateways({
-    required this.fetchLatest,
-    required this.resolveCommitSha,
-    required this.releaseExists,
-  });
+  /// The newest published release of [repoSlug], as a tag name.
+  Future<String> fetchLatest(String repoSlug);
+
+  /// [ref] (a tag or branch) resolved to the full commit SHA it points at.
+  Future<String> resolveCommitSha(String repoSlug, String ref);
+
+  /// Whether [version] names a real release of [repoSlug] -- what catches a
+  /// typo'd `IOS_SDK_VERSION` before it reaches a build.
+  Future<bool> releaseExists(String repoSlug, String version);
 }
 
 /// Resolves what a native SDK's pin should become this run:
@@ -287,17 +318,32 @@ class NativeSdkGateways {
 ///   `_validateReleaseVersion` already did for iOS/Android before this file
 ///   existed; skipping it would let a typo'd `IOS_SDK_VERSION`/
 ///   `ANDROID_SDK_VERSION` sail through undetected until a much later,
-///   harder-to-diagnose build failure;
+///   harder-to-diagnose build failure. An override beats a pin: passing one
+///   on the run is a more specific instruction than a pin someone left in a
+///   file earlier;
 /// - on a patch branch (default: no change) the pin is left alone, since
 ///   auto-jumping to the latest native SDK defeats the point of an
-///   isolated patch;
-/// - otherwise (mainline or pre-release), it defaults to the latest
-///   published release, resolved via [fetchLatest].
+///   isolated patch.
+/// - when [workingTreeDeclaration] is already pinned to one immutable
+///   version (see [isPinnedDeclaration]), that pin is the target and no
+///   "what's newest" lookup happens at all. The dev line normally floats, so
+///   an exact version sitting there is a deliberate hold -- typically while
+///   working against a specific native SDK. It is still a *target*, so a pin
+///   that differs from what the line last shipped remains a real version
+///   change: it contributes its bump and gets its changelog section;
+/// - otherwise (a floating declaration on mainline or pre-release), it
+///   defaults to the latest published release, resolved via [fetchLatest].
+///
+/// [onPinned] is called with the honoured pin when that branch is taken, so
+/// the caller can surface it -- silently declining to update a native SDK is
+/// exactly the kind of thing a release reviewer needs told.
 Future<String?> resolveNativeSdkTarget({
   required TriggerContext trigger,
   required String? override,
+  required String? workingTreeDeclaration,
   required Future<String> Function() fetchLatest,
   required Future<bool> Function(String version) releaseExists,
+  void Function(String pin)? onPinned,
 }) async {
   if (override != null) {
     if (!await releaseExists(override)) {
@@ -306,5 +352,12 @@ Future<String?> resolveNativeSdkTarget({
     return override;
   }
   if (trigger == TriggerContext.patch) return null;
+
+  if (isPinnedDeclaration(workingTreeDeclaration)) {
+    final pin = workingTreeDeclaration!.trim();
+    onPinned?.call(pin);
+    return pin;
+  }
+
   return await fetchLatest();
 }

--- a/tools/releaser/lib/native_sdk.dart
+++ b/tools/releaser/lib/native_sdk.dart
@@ -158,10 +158,13 @@ String? currentAndroidDeclaration(String? gradleContent) {
       ?.namedGroup('version');
 }
 
-/// The dd-sdk-cpp `GIT_TAG` declared in [cmakeListsContent], or null.
+/// The dd-sdk-cpp version declared in [cmakeListsContent], or null. Reads
+/// [currentGitTagVersion] rather than the raw ref, since a previously-pinned
+/// package's `GIT_TAG` is a commit SHA whose version only survives in its
+/// trailing `# <tag>` annotation -- see [currentGitTagVersion].
 String? currentCppDeclaration(String? cmakeListsContent) {
   if (cmakeListsContent == null) return null;
-  return currentGitTag(cmakeListsContent);
+  return currentGitTagVersion(cmakeListsContent);
 }
 
 /// The first bare semver found in [declaration], or null.

--- a/tools/releaser/lib/native_sdk.dart
+++ b/tools/releaser/lib/native_sdk.dart
@@ -221,7 +221,7 @@ bool isPinnedDeclaration(String? declaration) {
 /// [currentDeclaration] is what this SDK was pinned to by the last release
 /// *on the line being released*, and is what [NativeSdkDelta.getImpliedBump] compares
 /// [targetVersion] against. Must be sourced from that release's git history
-/// (`fileContentAtTag` in `git_history.dart`), not from [files] as they sit
+/// (`fileContentAtRef` in `git_history.dart`), not from [files] as they sit
 /// in the working tree -- the working tree normally floats, so it isn't
 /// evidence of what anything previously released with.
 ///
@@ -321,9 +321,12 @@ abstract class NativeSdkGateways {
 ///   harder-to-diagnose build failure. An override beats a pin: passing one
 ///   on the run is a more specific instruction than a pin someone left in a
 ///   file earlier;
-/// - on a patch branch (default: no change) the pin is left alone, since
-///   auto-jumping to the latest native SDK defeats the point of an
-///   isolated patch.
+/// - on a patch branch, no "what's newest" lookup ever happens -- auto-jumping
+///   to the latest native SDK defeats the point of an isolated patch -- but
+///   an already-pinned working tree still resolves to its own pin rather
+///   than null, so a cherry-picked commit that itself bumped the pin is
+///   still compared against what the line last shipped, instead of the size
+///   check below silently seeing nothing to compare.
 /// - when [workingTreeDeclaration] is already pinned to one immutable
 ///   version (see [isPinnedDeclaration]), that pin is the target and no
 ///   "what's newest" lookup happens at all. The dev line normally floats, so
@@ -334,9 +337,12 @@ abstract class NativeSdkGateways {
 /// - otherwise (a floating declaration on mainline or pre-release), it
 ///   defaults to the latest published release, resolved via [fetchLatest].
 ///
-/// [onPinned] is called with the honoured pin when that branch is taken, so
-/// the caller can surface it -- silently declining to update a native SDK is
-/// exactly the kind of thing a release reviewer needs told.
+/// [onPinned] is called with the honoured pin when that branch is taken
+/// outside a patch run, so the caller can surface it -- silently declining
+/// to update a native SDK is exactly the kind of thing a release reviewer
+/// needs told. A patch branch's manifest is pinned as a matter of course
+/// (see above), so the same event there is routine, not news -- calling
+/// [onPinned] for it would warn on every single patch run.
 Future<String?> resolveNativeSdkTarget({
   required TriggerContext trigger,
   required String? override,
@@ -351,13 +357,14 @@ Future<String?> resolveNativeSdkTarget({
     }
     return override;
   }
-  if (trigger == TriggerContext.patch) return null;
 
   if (isPinnedDeclaration(workingTreeDeclaration)) {
     final pin = workingTreeDeclaration!.trim();
-    onPinned?.call(pin);
+    if (trigger != TriggerContext.patch) onPinned?.call(pin);
     return pin;
   }
+
+  if (trigger == TriggerContext.patch) return null;
 
   return await fetchLatest();
 }

--- a/tools/releaser/lib/native_sdk.dart
+++ b/tools/releaser/lib/native_sdk.dart
@@ -5,19 +5,22 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:version/version.dart';
 
 import 'cmake_util.dart';
 import 'trigger_context.dart';
+import 'version_bump.dart';
 
 /// A native SDK a Flutter package can depend on.
 enum NativeSdk {
-  ios(repoSlug: 'DataDog/dd-sdk-ios'),
-  android(repoSlug: 'DataDog/dd-sdk-android'),
-  cpp(repoSlug: 'DataDog/dd-sdk-cpp');
+  ios(repoSlug: 'DataDog/dd-sdk-ios', displayName: 'iOS'),
+  android(repoSlug: 'DataDog/dd-sdk-android', displayName: 'Android'),
+  cpp(repoSlug: 'DataDog/dd-sdk-cpp', displayName: 'C++');
 
   final String repoSlug;
+  final String displayName;
 
-  const NativeSdk({required this.repoSlug});
+  const NativeSdk({required this.repoSlug, required this.displayName});
 }
 
 /// Matches a podspec's `s.dependency 'Datadog...', '<constraint>'` lines.
@@ -161,15 +164,32 @@ String? currentCppDeclaration(String? cmakeListsContent) {
   return currentGitTag(cmakeListsContent);
 }
 
+/// The first bare semver found in [declaration], or null.
+///
+/// Handles every real shape a native SDK pin is declared in: a CocoaPods
+/// constraint (`~> 3.5.0`), an SPM version argument (`from: "3.0.0"`), and
+/// a bare version (Android's `ext.datadog_version`, C++'s resolved
+/// `GIT_TAG`) -- all reduce to "pull out the semver", so one pattern
+/// covers them instead of a stripper per format.
+String? normalizeVersion(String? declaration) {
+  if (declaration == null) return null;
+  return RegExp(r'\d+\.\d+\.\d+').firstMatch(declaration)?.group(0);
+}
+
 /// What one native SDK dependency of a package resolves to this run.
 ///
 /// [targetVersion]/[targetSha] are a *target*, not a diff: `develop` (and a
 /// long-lived pre-release branch) deliberately keeps its manifests on
 /// floating constraints (`~> 3`, `branch: "develop"`, `GIT_TAG develop`), and
-/// only the release-prep branch's copy is ever pinned. Planning decisions
-/// (eligibility, bump level) never compare against a "current" value for
-/// exactly that reason -- the plan just says what to pin to, and
-/// `prepare_release.dart` rewrites [files] to match.
+/// only the release-prep branch's copy is ever pinned. Eligibility never
+/// compares against a "current" value for exactly that reason -- whether a
+/// package ships is a commits/override question, not a native-SDK-drift
+/// question. Bump *level* is the one planning decision that does compare
+/// [currentDeclaration] against [targetVersion] -- see
+/// [nativeSdkAggregateBump] -- since a native SDK's own minor/major bump
+/// should carry through to the Flutter package wrapping it. The plan
+/// otherwise just says what to pin to, and `prepare_release.dart` rewrites
+/// [files] to match.
 ///
 /// [currentDeclaration] is purely informational, shown alongside
 /// [targetVersion]. Must be sourced from the last published version's git
@@ -213,6 +233,33 @@ class NativeSdkDelta {
         : '${sdk.name}: $from -> $targetVersion';
   }
 }
+
+/// The bump [delta] implies on its own -- e.g. dd-sdk-ios 3.15.0 -> 3.16.0
+/// implies at least a minor bump on the Flutter package wrapping it, with
+/// or without any qualifying commits of its own. Null when there's nothing
+/// to compare (no target, or no resolvable current version) or the target
+/// isn't actually newer.
+VersionBumpType? nativeSdkImpliedBump(NativeSdkDelta delta) {
+  final targetVersion = delta.targetVersion;
+  if (targetVersion == null) return null;
+
+  final fromRaw = normalizeVersion(delta.currentDeclaration);
+  if (fromRaw == null) return null;
+  final toRaw = normalizeVersion(targetVersion);
+  if (toRaw == null) return null;
+
+  final from = Version.parse(fromRaw);
+  final to = Version.parse(toRaw);
+  if (to <= from) return null;
+  if (to.major != from.major) return VersionBumpType.major;
+  if (to.minor != from.minor) return VersionBumpType.minor;
+  if (to.patch != from.patch) return VersionBumpType.patch;
+  return null;
+}
+
+/// The highest bump implied across [deltas] -- see [nativeSdkImpliedBump].
+VersionBumpType? nativeSdkAggregateBump(List<NativeSdkDelta> deltas) =>
+    highestBump(deltas.map(nativeSdkImpliedBump));
 
 /// The network calls native SDK resolution needs -- bundled so callers
 /// (`release_plan.dart`) don't thread three separate function parameters

--- a/tools/releaser/lib/native_sdk_changelog.dart
+++ b/tools/releaser/lib/native_sdk_changelog.dart
@@ -132,16 +132,20 @@ Future<NativeSdkChangelogResult> resolveNativeSdkChangelog(
     );
   }
 
+  // A C++ target is a tag like `v1.4.0`, but `parseChangelog` records bare
+  // `1.4.0` headings -- normalize so `sectionsBetween` can find it.
+  final toVersion = normalizeVersion(targetVersion) ?? targetVersion;
+
   final sections = await fetchChangelog(sdk.repoSlug);
   final sliced = sectionsBetween(
     sections,
     fromVersion: fromVersion,
-    toVersion: targetVersion,
+    toVersion: toVersion,
   );
   if (sliced == null) {
     return NativeSdkChangelogResult(
       warning:
-          '${sdk.name}: could not find $fromVersion and/or $targetVersion '
+          '${sdk.name}: could not find $fromVersion and/or $toVersion '
           'in CHANGELOG.md -- skipping changelog.',
     );
   }

--- a/tools/releaser/lib/native_sdk_changelog.dart
+++ b/tools/releaser/lib/native_sdk_changelog.dart
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:logging/logging.dart';
+
+import 'github_cmd_wrapper.dart';
+import 'native_sdk.dart';
+
+/// One version's worth of entries from a native SDK's `CHANGELOG.md`.
+class ChangelogSection {
+  final String version;
+  final List<String> entries;
+
+  const ChangelogSection({required this.version, required this.entries});
+}
+
+/// A changelog heading's bare semver, across all three native SDKs' real
+/// formats: `# 3.16.0 / 19-08-2026` (iOS), `# 3.12.1 / 2026-07-16`
+/// (Android), `## 0.7.0` (C++). All start with `#`/`##` then a bare semver
+/// -- nothing else about the three formats is shared, but that's enough.
+/// `#{1,2}` also excludes C++'s `### Breaking Changes`/`### Features`
+/// sub-headings, which aren't version boundaries.
+final _headingPattern = RegExp(r'^#{1,2}\s*(?<version>\d+\.\d+\.\d+)\b');
+
+/// The first bare semver found in [declaration], or null.
+///
+/// Handles every real shape a native SDK pin is declared in: a CocoaPods
+/// constraint (`~> 3.5.0`), an SPM version argument (`from: "3.0.0"`), and
+/// a bare version (Android's `ext.datadog_version`, C++'s resolved
+/// `GIT_TAG`) -- all reduce to "pull out the semver", so one pattern
+/// covers them instead of a stripper per format.
+String? normalizeVersion(String? declaration) {
+  if (declaration == null) return null;
+  return RegExp(r'\d+\.\d+\.\d+').firstMatch(declaration)?.group(0);
+}
+
+/// Parses raw `CHANGELOG.md` content into ordered sections, newest first
+/// (the file's own order). Content before the first version heading (an
+/// `# Unreleased` section, if present) is dropped -- it isn't a resolved
+/// version, so it can never be a diff boundary. A sub-heading like C++'s
+/// `### Breaking Changes` doesn't start a new section; its line is kept as
+/// a plain entry, since it's still meaningful content for a human or an
+/// LLM reading the section.
+List<ChangelogSection> parseChangelog(String content) {
+  final sections = <ChangelogSection>[];
+  String? version;
+  var entries = <String>[];
+
+  void flush() {
+    if (version != null) {
+      sections.add(ChangelogSection(version: version, entries: entries));
+    }
+  }
+
+  for (final line in content.split('\n')) {
+    final match = _headingPattern.firstMatch(line);
+    if (match != null) {
+      flush();
+      version = match.namedGroup('version');
+      entries = [];
+    } else if (version != null && line.trim().isNotEmpty) {
+      entries.add(line.trim());
+    }
+  }
+  flush();
+
+  return sections;
+}
+
+/// The sections strictly newer than [fromVersion] down through [toVersion]
+/// (inclusive), newest first -- what actually changed for this bump.
+///
+/// Null if either version isn't a heading anywhere in [sections]: there's
+/// no reliable boundary to slice at, and unlike a git tag lookup there's no
+/// bound on how far back an unmatched version's changelog goes -- showing
+/// "everything" risks dumping years of another repo's history into preview
+/// output. The caller skips display with a warning instead.
+List<ChangelogSection>? sectionsBetween(
+  List<ChangelogSection> sections, {
+  required String fromVersion,
+  required String toVersion,
+}) {
+  final fromIndex = sections.indexWhere((s) => s.version == fromVersion);
+  final toIndex = sections.indexWhere((s) => s.version == toVersion);
+  if (fromIndex == -1 || toIndex == -1 || toIndex > fromIndex) return null;
+
+  return sections.sublist(toIndex, fromIndex);
+}
+
+/// Fetches [repoSlug]'s `CHANGELOG.md` and parses it -- the sole network
+/// call this module needs, injected (see [githubChangelogFetcher]) so
+/// [resolveNativeSdkChangelog]'s parsing/slicing logic stays testable
+/// without shelling out to `gh`.
+typedef ChangelogFetcher =
+    Future<List<ChangelogSection>> Function(String repoSlug);
+
+/// A [ChangelogFetcher] backed by a real `gh api` call against [repoSlug]'s
+/// default branch -- not a specific tag, since `CHANGELOG.md` is append-only
+/// in practice and this way there's exactly one fetch per SDK regardless of
+/// which version range is being displayed.
+ChangelogFetcher githubChangelogFetcher(
+  Logger logger,
+  GithubCommandWrapper github,
+) {
+  return (repoSlug) async {
+    final content = await github.fetchFileContent(
+      logger,
+      repoSlug,
+      'CHANGELOG.md',
+    );
+    return parseChangelog(content);
+  };
+}
+
+/// What changed for one native SDK bump -- exactly one of [sections] or
+/// [warning] is set. [sections] can be empty (current and target are the
+/// same version once normalized, or genuinely adjacent with nothing
+/// between them); [warning] means the display should be skipped entirely,
+/// not shown with an empty range.
+class NativeSdkChangelogResult {
+  final List<ChangelogSection>? sections;
+  final String? warning;
+
+  const NativeSdkChangelogResult({this.sections, this.warning});
+}
+
+/// Resolves what changed in [sdk] between [currentDeclaration] (as read
+/// from the working tree/last release, in whatever format that SDK's
+/// dependency file declares it) and [targetVersion] (this run's resolved
+/// pin) -- see [NativeSdkChangelogResult].
+Future<NativeSdkChangelogResult> resolveNativeSdkChangelog(
+  NativeSdk sdk, {
+  required String? currentDeclaration,
+  required String targetVersion,
+  required ChangelogFetcher fetchChangelog,
+}) async {
+  final fromVersion = normalizeVersion(currentDeclaration);
+  if (fromVersion == null) {
+    return NativeSdkChangelogResult(
+      warning:
+          '${sdk.name}: no resolvable current version ("$currentDeclaration") '
+          'to diff from -- skipping changelog.',
+    );
+  }
+
+  final sections = await fetchChangelog(sdk.repoSlug);
+  final sliced = sectionsBetween(
+    sections,
+    fromVersion: fromVersion,
+    toVersion: targetVersion,
+  );
+  if (sliced == null) {
+    return NativeSdkChangelogResult(
+      warning:
+          '${sdk.name}: could not find $fromVersion and/or $targetVersion '
+          'in CHANGELOG.md -- skipping changelog.',
+    );
+  }
+
+  return NativeSdkChangelogResult(sections: sliced);
+}

--- a/tools/releaser/lib/native_sdk_changelog.dart
+++ b/tools/releaser/lib/native_sdk_changelog.dart
@@ -23,18 +23,6 @@ class ChangelogSection {
 /// sub-headings, which aren't version boundaries.
 final _headingPattern = RegExp(r'^#{1,2}\s*(?<version>\d+\.\d+\.\d+)\b');
 
-/// The first bare semver found in [declaration], or null.
-///
-/// Handles every real shape a native SDK pin is declared in: a CocoaPods
-/// constraint (`~> 3.5.0`), an SPM version argument (`from: "3.0.0"`), and
-/// a bare version (Android's `ext.datadog_version`, C++'s resolved
-/// `GIT_TAG`) -- all reduce to "pull out the semver", so one pattern
-/// covers them instead of a stripper per format.
-String? normalizeVersion(String? declaration) {
-  if (declaration == null) return null;
-  return RegExp(r'\d+\.\d+\.\d+').firstMatch(declaration)?.group(0);
-}
-
 /// Parses raw `CHANGELOG.md` content into ordered sections, newest first
 /// (the file's own order). Content before the first version heading (an
 /// `# Unreleased` section, if present) is dropped -- it isn't a resolved
@@ -160,3 +148,9 @@ Future<NativeSdkChangelogResult> resolveNativeSdkChangelog(
 
   return NativeSdkChangelogResult(sections: sliced);
 }
+
+/// A stable, browsable link to [sdk]'s full `CHANGELOG.md` -- `HEAD` lets
+/// GitHub resolve to whatever the repo's actual default branch is, without
+/// hardcoding it here.
+String nativeSdkChangelogUrl(NativeSdk sdk) =>
+    'https://github.com/${sdk.repoSlug}/blob/HEAD/CHANGELOG.md';

--- a/tools/releaser/lib/pr_resolution.dart
+++ b/tools/releaser/lib/pr_resolution.dart
@@ -45,14 +45,14 @@ String stripSquashSuffix(String description) {
 /// Resolves the PR [subjectLine] (a commit's parsed description, or the raw
 /// subject) landed through.
 ///
-/// Tries the free, network-free path first: GitHub's squash-merge commits
-/// append `(#N)` to the subject, and that covers the overwhelming majority
-/// of commits into this repo. [searchBySha] (`gh pr list --search
-/// "sha:{sha}"`) is the fallback for anything else -- a merge commit, a
-/// rebase-and-merge -- and is injected here (see `GithubCommandWrapper
-/// .searchMergedPrBySha`) so this stays testable without shelling out to
-/// `gh`. Returns null if neither finds a PR -- a direct push with no PR is
-/// rare, but real.
+/// Tries the free, network-free path first: a squash-merge commit's subject
+/// gets `(#N)` appended by GitHub, and it's a cheap check even though this
+/// repo merges rather than squashes, so most commits fall through to
+/// [searchBySha] (`gh pr list --search "{sha}"`) -- the fallback for a merge
+/// commit, a rebase-and-merge, or the rare squash. It's injected here (see
+/// `GithubCommandWrapper.searchMergedPrBySha`) so this stays testable
+/// without shelling out to `gh`. Returns null if neither finds a PR -- a
+/// direct push with no PR is rare, but real.
 Future<ResolvedPr?> resolvePr(
   String sha,
   String subjectLine,

--- a/tools/releaser/lib/pr_resolution.dart
+++ b/tools/releaser/lib/pr_resolution.dart
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+/// The PR a contributing commit landed through -- see [resolvePr].
+class ResolvedPr {
+  final int number;
+  final String title;
+
+  const ResolvedPr({required this.number, required this.title});
+
+  @override
+  String toString() => '#$number $title';
+}
+
+/// GitHub's squash-merge suffix, appended to the commit subject: `... (#N)`.
+final _squashSuffixPattern = RegExp(r'^(?<title>.*)\(#(?<number>\d+)\)\s*$');
+
+/// Strips a trailing squash-merge `(#N)` suffix from [description], for
+/// display once the PR number's been pulled out and shown separately.
+/// A no-op if there's no suffix to strip.
+String stripSquashSuffix(String description) {
+  final match = _squashSuffixPattern.firstMatch(description);
+  return match == null ? description : match.namedGroup('title')!.trim();
+}
+
+/// Resolves the PR [subjectLine] (a commit's parsed description, or the raw
+/// subject) landed through.
+///
+/// Tries the free, network-free path first: GitHub's squash-merge commits
+/// append `(#N)` to the subject, and that covers the overwhelming majority
+/// of commits into this repo. [searchBySha] (`gh pr list --search
+/// "sha:{sha}"`) is the fallback for anything else -- a merge commit, a
+/// rebase-and-merge -- and is injected here (see `GithubCommandWrapper
+/// .searchMergedPrBySha`) so this stays testable without shelling out to
+/// `gh`. Returns null if neither finds a PR -- a direct push with no PR is
+/// rare, but real.
+Future<ResolvedPr?> resolvePr(
+  String sha,
+  String subjectLine,
+  Future<ResolvedPr?> Function(String sha) searchBySha,
+) async {
+  final match = _squashSuffixPattern.firstMatch(subjectLine);
+  if (match != null) {
+    return ResolvedPr(
+      number: int.parse(match.namedGroup('number')!),
+      title: match.namedGroup('title')!.trim(),
+    );
+  }
+
+  return searchBySha(sha);
+}

--- a/tools/releaser/lib/pr_resolution.dart
+++ b/tools/releaser/lib/pr_resolution.dart
@@ -13,6 +13,24 @@ class ResolvedPr {
   String toString() => '#$number $title';
 }
 
+/// A PR's full title and body -- richer LLM input than a commit message or
+/// [ResolvedPr]'s bare title alone (see `llm/changelog.dart`). Fetched
+/// separately from resolution itself: most commits resolve to a PR number
+/// for free via the squash-merge suffix, but the LLM changelog pass needs
+/// the body too, which only a `gh pr view` call provides (see
+/// `GithubCommandWrapper.fetchPrDetails`).
+class PrDetails {
+  final int number;
+  final String title;
+  final String body;
+
+  const PrDetails({
+    required this.number,
+    required this.title,
+    required this.body,
+  });
+}
+
 /// GitHub's squash-merge suffix, appended to the commit subject: `... (#N)`.
 final _squashSuffixPattern = RegExp(r'^(?<title>.*)\(#(?<number>\d+)\)\s*$');
 

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -565,9 +565,18 @@ PackagePlan _computeMainlinePlan(
   // With nothing auto-detected, this package is here because it was asked for
   // by name or a forced native SDK update is driving it -- still worth a
   // release, treated as a maintenance patch.
+  //
+  // A native SDK's own bump carries through even without a qualifying
+  // commit of the wrapper package's own -- a dd-sdk-ios minor release
+  // pinned here is itself a minor change for whoever depends on this
+  // package. An explicit BUMP_TYPE override still wins outright, since
+  // that's a human's direct instruction.
   final bump =
       VersionBumpType.parseOverride(ctx.bumpTypeOverride) ??
-      aggregateBumpLevel(commits) ??
+      highestBump([
+        aggregateBumpLevel(commits),
+        nativeSdkAggregateBump(nativeSdkDeltas),
+      ]) ??
       VersionBumpType.patch;
 
   return PackagePlan(

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -264,6 +264,18 @@ Future<PackagePlan?> _computePackagePlan(
   final Version? commitBase;
   final warnings = <String>[];
 
+  final files = resolveNativeDependencyFiles(pkg.absolutePath(ctx.repoRoot));
+
+  // See [_nativeSdkEligibleGroupKey]. Non-eligible packages' files are
+  // still discovered, for [_nativeDependencyChanges] below.
+  final isNativeSdkEligible = pkg.groupKey == _nativeSdkEligibleGroupKey;
+
+  // Resolved early only for a pre-release run, which needs the native SDK
+  // signal to compute its target below -- see [_prereleaseTarget]. Other
+  // triggers resolve it after the "does this package release at all" check,
+  // to avoid the network cost when there's nothing to ship.
+  List<NativeSdkDelta>? nativeSdkDeltas;
+
   switch (ctx.trigger) {
     case TriggerContext.mainline:
       final latestPrerelease = published.latest;
@@ -294,7 +306,23 @@ Future<PackagePlan?> _computePackagePlan(
         );
       }
     case TriggerContext.preRelease:
-      final target = await _prereleaseTarget(pkg, published, gitDir, warnings);
+      nativeSdkDeltas = isNativeSdkEligible
+          ? await _computeNativeSdkDeltas(
+              pkg,
+              files,
+              ctx,
+              gitDir,
+              published,
+              gateways,
+            )
+          : const <NativeSdkDelta>[];
+      final target = await _prereleaseTarget(
+        pkg,
+        published,
+        gitDir,
+        warnings,
+        nativeSdkDeltas,
+      );
       versionBase = target;
       // Scoped to the target's own line. The global newest release is the
       // wrong answer here: a concurrent pre-release effort (a `v5` branch
@@ -321,12 +349,6 @@ Future<PackagePlan?> _computePackagePlan(
     sinceSha: sinceSha,
   );
 
-  final files = resolveNativeDependencyFiles(pkg.absolutePath(ctx.repoRoot));
-
-  // See [_nativeSdkEligibleGroupKey]. Non-eligible packages' files are
-  // still discovered, for [_nativeDependencyChanges] below.
-  final isNativeSdkEligible = pkg.groupKey == _nativeSdkEligibleGroupKey;
-
   // Whether this package releases at all is decided before anything touches
   // the network -- resolving native SDK targets for a package with nothing to
   // ship is pure waste.
@@ -340,7 +362,9 @@ Future<PackagePlan?> _computePackagePlan(
     return null;
   }
 
-  final nativeSdkDeltas = isNativeSdkEligible
+  // A pre-release run already resolved this above, to feed its target
+  // computation -- see [_prereleaseTarget].
+  nativeSdkDeltas ??= isNativeSdkEligible
       ? await _computeNativeSdkDeltas(
           pkg,
           files,
@@ -408,11 +432,18 @@ Future<PackagePlan?> _computePackagePlan(
 ///
 /// A package with no stable release takes `pubspec.yaml`'s version, which for
 /// something never published is the only declaration of what it's aiming at.
+///
+/// [nativeSdkDeltas] folds in the same native-SDK bump signal a stable
+/// release's mainline plan uses (see [_computeMainlinePlan]) -- otherwise a
+/// wrapper package sitting on a patch-only commit set but pinning a major
+/// native SDK bump would compute a prerelease target one line below where
+/// the eventual stable release lands.
 Future<Version> _prereleaseTarget(
   DiscoveredPackage pkg,
   PublishedVersions published,
   GitDir gitDir,
   List<String> warnings,
+  List<NativeSdkDelta> nativeSdkDeltas,
 ) async {
   final stableBase = published.latestStable;
   if (stableBase == null) return Version.parse(pkg.version);
@@ -427,13 +458,17 @@ Future<Version> _prereleaseTarget(
     if (!warnings.contains(warning)) warnings.add(warning);
   }
 
-  final bump = aggregateBumpLevel(
+  final commitBump = aggregateBumpLevel(
     await _conventionalCommitsSince(
       gitDir,
       pathspec: pkg.relativePath,
       sinceSha: sinceSha,
     ),
   );
+  final bump = highestBump([
+    commitBump,
+    nativeSdkAggregateBump(nativeSdkDeltas),
+  ]);
 
   // Nothing since the last stable carries semver weight -- this package is
   // only here because it was named or a native SDK override is driving it, so

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -76,13 +76,18 @@ class RunContext {
 class PackagePlan {
   final DiscoveredPackage package;
 
-  /// What is currently published, or `pubspec.yaml`'s version for a package
-  /// that has never been published.
+  /// The last release *on the line being released* -- or `pubspec.yaml`'s
+  /// version for a package that has never been published.
   ///
   /// Read from pub.dev rather than `pubspec.yaml` for anything published:
-  /// every release ends by bumping pubspec to a "next potential" version that
+  /// old releases ended by bumping pubspec to a "next potential" version that
   /// doesn't exist, so pubspec routinely names something never shipped
   /// (`3.6.0` while `3.5.0` is the newest release).
+  ///
+  /// Scoped to the line rather than "newest published anywhere", because
+  /// release branches never merge back and the lines are disjoint: rendering
+  /// `3.0.0 -> 2.1.3` for a patch of the `2.1.x` line names a version from a
+  /// branch this release has nothing to do with.
   final String currentVersion;
 
   final String newVersion;
@@ -162,10 +167,14 @@ Future<ReleasePlan> computeReleasePlan(
       gitDir ??
       await GitDir.fromExisting(ctx.repoRoot, allowSubdirectory: true);
   final published = publishedVersions ?? fetchPublishedVersions;
-  final gateways = nativeSdkGateways ?? _githubGateways(ctx.repoRoot);
+  final gateways = nativeSdkGateways ?? GithubSdkGateways.forRepo(ctx.repoRoot);
 
   final groups = await _resolveGroups(ctx);
   final selected = _selectPackages(groups, ctx);
+
+  // Collected across every package so an `--all` run reports every stale pubspec
+  // at once instead of dying on the first.
+  final targetConflicts = <String>[];
 
   final plans = <PackagePlan>[];
   for (final pkg in selected) {
@@ -176,23 +185,49 @@ Future<ReleasePlan> computeReleasePlan(
       gateways,
       await published(pkg.name),
       isExplicitlyRequested: ctx.requestedPackages.contains(pkg.name),
+      targetConflicts: targetConflicts,
     );
     if (plan != null) plans.add(plan);
+  }
+
+  if (targetConflicts.isNotEmpty) {
+    throw StateError(
+      'Pre-release target${targetConflicts.length == 1 ? '' : 's'} not ahead '
+      'of what pub.dev already has:\n\n'
+      '${targetConflicts.map((c) => '  - $c').join('\n\n')}',
+    );
   }
 
   return ReleasePlan(trigger: ctx.trigger, packages: plans);
 }
 
-NativeSdkGateways _githubGateways(String repoRoot) {
-  final github = GithubCommandWrapper(repoRoot);
-  return NativeSdkGateways(
-    fetchLatest: (repoSlug) async =>
-        (await github.getLatestRelease(_log, repoSlug)).tagName,
-    resolveCommitSha: (repoSlug, ref) =>
-        github.getCommitSha(_log, repoSlug, ref),
-    releaseExists: (repoSlug, version) async =>
-        await github.getReleaseByTagName(_log, repoSlug, version) != null,
-  );
+/// [NativeSdkGateways] backed by real `gh` calls.
+///
+/// A thin adapter with no state of its own -- [github] does the remembering,
+/// caching each repo's release list and each resolved ref for its own
+/// lifetime. One wrapper per run therefore means the same "latest
+/// dd-sdk-ios release" question costs one call, not one per package: all six
+/// members of a federated group share the answer.
+class GithubSdkGateways extends NativeSdkGateways {
+  final GithubCommandWrapper github;
+  final Logger logger;
+
+  GithubSdkGateways(this.github, {Logger? logger}) : logger = logger ?? _log;
+
+  GithubSdkGateways.forRepo(String repoRoot, {Logger? logger})
+    : this(GithubCommandWrapper(repoRoot), logger: logger);
+
+  @override
+  Future<String> fetchLatest(String repoSlug) async =>
+      (await github.getLatestRelease(logger, repoSlug)).tagName;
+
+  @override
+  Future<String> resolveCommitSha(String repoSlug, String ref) =>
+      github.getCommitSha(logger, repoSlug, ref);
+
+  @override
+  Future<bool> releaseExists(String repoSlug, String version) async =>
+      await github.getReleaseByTagName(logger, repoSlug, version) != null;
 }
 
 /// Rejects per-run overrides the run has no coherent way to honour, rather
@@ -234,9 +269,9 @@ void _validateTriggerInputs(RunContext ctx) {
     case TriggerContext.preRelease:
       throw StateError(
         'BUMP_TYPE="$bumpType" does not apply on a pre-release branch -- the '
-        'version comes from the prerelease counter against a target computed '
-        'from the last stable release. Use PRERELEASE_LABEL to start a new '
-        'label.',
+        'version comes from the prerelease counter against the target the '
+        'package declares in its pubspec.yaml. Edit that version to move the '
+        'line, or use PRERELEASE_LABEL to start a new label.',
       );
   }
 }
@@ -248,18 +283,26 @@ Future<PackagePlan?> _computePackagePlan(
   NativeSdkGateways gateways,
   PublishedVersions published, {
   required bool isExplicitlyRequested,
+  required List<String> targetConflicts,
 }) async {
   // Two questions, answered separately because on a pre-release line they
   // have different answers:
   //
   //   versionBase -- what the new version is derived from.
-  //   commitBase  -- what "since we last shipped" means, for the changelog
-  //                  range and for whether this package ships at all.
+  //   commitBase  -- the last release *on the line being released*: what
+  //                  "since we last shipped" means, for the changelog range,
+  //                  for whether this package ships at all, and for what the
+  //                  native SDK pins are compared against.
   //
   // They coincide on mainline (a stable release supersedes the whole line)
-  // and on a patch branch (confined to its own line). A pre-release run has
-  // to resolve its target first, because both its baselines are scoped to
-  // that target's line -- see [_prereleaseTarget].
+  // and on a patch branch (confined to its own line), and diverge on a
+  // pre-release, whose version comes from pubspec while its changelog still
+  // runs from the previous beta.
+  //
+  // commitBase is deliberately not `published.latest`. Release branches never
+  // merge back, so release lines are disjoint: on a `2.1.x` patch branch a
+  // published `3.0.0` lives on a branch with no relationship to this one, and
+  // its pins describe nothing about what this line last shipped.
   final Version? versionBase;
   final Version? commitBase;
   final warnings = <String>[];
@@ -269,12 +312,6 @@ Future<PackagePlan?> _computePackagePlan(
   // See [_nativeSdkEligibleGroupKey]. Non-eligible packages' files are
   // still discovered, for [_nativeDependencyChanges] below.
   final isNativeSdkEligible = pkg.groupKey == _nativeSdkEligibleGroupKey;
-
-  // Resolved early only for a pre-release run, which needs the native SDK
-  // signal to compute its target below -- see [_prereleaseTarget]. Other
-  // triggers resolve it after the "does this package release at all" check,
-  // to avoid the network cost when there's nothing to ship.
-  List<NativeSdkDelta>? nativeSdkDeltas;
 
   switch (ctx.trigger) {
     case TriggerContext.mainline:
@@ -306,23 +343,7 @@ Future<PackagePlan?> _computePackagePlan(
         );
       }
     case TriggerContext.preRelease:
-      nativeSdkDeltas = isNativeSdkEligible
-          ? await _computeNativeSdkDeltas(
-              pkg,
-              files,
-              ctx,
-              gitDir,
-              published,
-              gateways,
-            )
-          : const <NativeSdkDelta>[];
-      final target = await _prereleaseTarget(
-        pkg,
-        published,
-        gitDir,
-        warnings,
-        nativeSdkDeltas,
-      );
+      final target = declaredPrereleaseTarget(pkg);
       versionBase = target;
       // Scoped to the target's own line. The global newest release is the
       // wrong answer here: a concurrent pre-release effort (a `v5` branch
@@ -334,20 +355,32 @@ Future<PackagePlan?> _computePackagePlan(
           published.prereleasesAt(target).lastOrNull ?? published.latestStable;
   }
 
-  final (sinceSha, rangeWarnings) = await _commitRangeStart(
-    gitDir,
-    pkg.name,
-    published,
-    commitBase,
-  );
-  for (final warning in rangeWarnings) {
-    if (!warnings.contains(warning)) warnings.add(warning);
+  // Memoized because a pre-release asks for two ranges -- since the previous
+  // beta for the changelog, since the last stable for the advisory -- and on
+  // a first beta those are the same baseline. Walking twice would also emit
+  // the missing-tag warning twice.
+  final commitsByBaseline = <Version?, List<ConventionalCommit>>{};
+  Future<List<ConventionalCommit>> commitsSince(Version? baseline) async {
+    final cached = commitsByBaseline[baseline];
+    if (cached != null) return cached;
+
+    final (sinceSha, rangeWarnings) = await _commitRangeStart(
+      gitDir,
+      pkg.name,
+      published,
+      baseline,
+    );
+    for (final warning in rangeWarnings) {
+      if (!warnings.contains(warning)) warnings.add(warning);
+    }
+    return commitsByBaseline[baseline] = await _conventionalCommitsSince(
+      gitDir,
+      pathspec: pkg.relativePath,
+      sinceSha: sinceSha,
+    );
   }
-  final commits = await _conventionalCommitsSince(
-    gitDir,
-    pathspec: pkg.relativePath,
-    sinceSha: sinceSha,
-  );
+
+  final commits = await commitsSince(commitBase);
 
   // Whether this package releases at all is decided before anything touches
   // the network -- resolving native SDK targets for a package with nothing to
@@ -362,16 +395,26 @@ Future<PackagePlan?> _computePackagePlan(
     return null;
   }
 
-  // A pre-release run already resolved this above, to feed its target
-  // computation -- see [_prereleaseTarget].
-  nativeSdkDeltas ??= isNativeSdkEligible
+  // Deliberately after the eligibility gate: a package that isn't shipping
+  // this run has no target to conflict with, and letting an untouched sibling
+  // fail an `--all` run is the exact thing the gate exists to prevent.
+  if (ctx.trigger == TriggerContext.preRelease) {
+    final conflict = _prereleaseTargetConflict(pkg, versionBase!, published);
+    if (conflict != null) {
+      targetConflicts.add(conflict);
+      return null;
+    }
+  }
+
+  final nativeSdkDeltas = isNativeSdkEligible
       ? await _computeNativeSdkDeltas(
           pkg,
           files,
           ctx,
           gitDir,
-          published,
+          commitBase,
           gateways,
+          warnings,
         )
       : const <NativeSdkDelta>[];
 
@@ -379,14 +422,31 @@ Future<PackagePlan?> _computePackagePlan(
       ? const <NativeDependencyChange>[]
       : await _nativeDependencyChanges(pkg, files, ctx, gitDir, published);
 
-  final currentVersion = published.latest?.toString() ?? pkg.version;
+  // The line's own last release, not the newest published anywhere -- see the
+  // commitBase note above. Rendering "3.0.0 -> 2.1.3" for a patch of the
+  // 2.1.x line names a version from a branch this release has nothing to do
+  // with.
+  final currentVersion = commitBase?.toString() ?? pkg.version;
+
+  if (ctx.trigger == TriggerContext.preRelease) {
+    final advisory = _prereleaseTargetAdvisory(
+      pkg: pkg,
+      target: versionBase!,
+      latestStable: published.latestStable,
+      commitsSinceStable: await commitsSince(published.latestStable),
+      nativeSdkDeltas: nativeSdkDeltas,
+    );
+    if (advisory != null) warnings.add(advisory);
+  }
 
   return switch (ctx.trigger) {
     TriggerContext.patch => _computePatchPlan(
       pkg,
       currentVersion,
       commits,
-      versionBase,
+      // Non-null on this path: the patch arm of the switch above throws
+      // rather than leaving a branch with no release to patch.
+      versionBase!,
       nativeSdkDeltas,
       nativeDependencyChanges,
       warnings,
@@ -396,7 +456,8 @@ Future<PackagePlan?> _computePackagePlan(
       ctx,
       currentVersion,
       commits,
-      versionBase,
+      // Non-null on this path: declaredPrereleaseTarget always returns one.
+      versionBase!,
       published,
       nativeSdkDeltas,
       nativeDependencyChanges,
@@ -416,64 +477,62 @@ Future<PackagePlan?> _computePackagePlan(
   };
 }
 
-/// The version a pre-release run is working towards.
+/// The version a pre-release line is working towards, as declared in the
+/// package's own `pubspec.yaml`.
 ///
-/// Computed, not declared: the last stable release plus the bump aggregated
-/// from every commit since it (`3.5.0` + a `feat!` on `v4` -> `4.0.0`). This
-/// is the same derivation a stable release would use, which is what makes a
-/// pre-release "mainline plus a suffix" and makes the path self-correcting --
-/// once `4.0.0` ships stably the base moves on and the target becomes
-/// `4.1.0`.
+/// Declared, not computed. A computed target has to be re-derived on every
+/// run, from a baseline that moves as the line progresses -- which means every
+/// signal feeding it must be measured since the last *stable* release or the
+/// target silently regresses (`4.0.0-beta.1`, then `3.5.1-beta.1` once a prior
+/// beta has already absorbed the evidence). That invariant is invisible at the
+/// call site and was broken twice. A declared target cannot regress.
 ///
-/// Note this aggregates from the last **stable** release, not the last
-/// pre-release. Measuring from the previous beta would make the target
-/// collapse as the line progresses: after `4.0.0-beta.1`, a lone `fix:` would
-/// compute `3.5.1` instead of `4.0.0`.
+/// Any pre-release suffix and build metadata are stripped: after
+/// `4.0.0-beta.1` ships, the content commit leaves pubspec reading
+/// `4.0.0-beta.1`, and that is still a declaration of `4.0.0`. This matches
+/// [PublishedVersions.prereleasesAt], which ignores the target's own suffix
+/// for the same reason.
 ///
-/// A package with no stable release takes `pubspec.yaml`'s version, which for
-/// something never published is the only declaration of what it's aiming at.
-///
-/// [nativeSdkDeltas] folds in the same native-SDK bump signal a stable
-/// release's mainline plan uses (see [_computeMainlinePlan]) -- otherwise a
-/// wrapper package sitting on a patch-only commit set but pinning a major
-/// native SDK bump would compute a prerelease target one line below where
-/// the eventual stable release lands.
-Future<Version> _prereleaseTarget(
-  DiscoveredPackage pkg,
-  PublishedVersions published,
-  GitDir gitDir,
-  List<String> warnings,
-  List<NativeSdkDelta> nativeSdkDeltas,
-) async {
-  final stableBase = published.latestStable;
-  if (stableBase == null) return Version.parse(pkg.version);
+/// The objection this design has to answer -- that pubspec is a second source
+/// of truth free to disagree with what has shipped -- is handled by
+/// [_prereleaseTargetConflict], which refuses a target that isn't ahead of
+/// pub.dev, and by [_prereleaseTargetAdvisory], which flags a target the
+/// commits say is too low.
+Version declaredPrereleaseTarget(DiscoveredPackage pkg) {
+  final declared = Version.parse(pkg.version);
+  return Version(declared.major, declared.minor, declared.patch);
+}
 
-  final (sinceSha, stableWarnings) = await _commitRangeStart(
-    gitDir,
-    pkg.name,
-    published,
-    stableBase,
-  );
-  for (final warning in stableWarnings) {
-    if (!warnings.contains(warning)) warnings.add(warning);
+/// Why [target] can't be released as a pre-release, or null if it can.
+///
+/// Returned rather than thrown so `computeReleasePlan` can preflight every
+/// selected package and report all of them at once: on an `--all` or
+/// `--include-federated` run, throwing from inside the per-package loop would
+/// kill the whole plan over a sibling nobody asked for.
+String? _prereleaseTargetConflict(
+  DiscoveredPackage pkg,
+  Version target,
+  PublishedVersions published,
+) {
+  if (published.hasStableAt(target)) {
+    return '${pkg.name}: pubspec.yaml declares $target, which has already '
+        'been released stably. A pre-release against it would sort below the '
+        'published version -- bump pubspec.yaml to the version this '
+        'pre-release line is working towards.';
   }
 
-  final commitBump = aggregateBumpLevel(
-    await _conventionalCommitsSince(
-      gitDir,
-      pathspec: pkg.relativePath,
-      sinceSha: sinceSha,
-    ),
-  );
-  final bump = highestBump([
-    commitBump,
-    nativeSdkAggregateBump(nativeSdkDeltas),
-  ]);
+  // Explicit null check rather than `target <= latestStable`: package:version's
+  // `<=` takes a dynamic and quietly returns false against null, so the
+  // shorter form would fail open for a never-published package.
+  final stable = published.latestStable;
+  if (stable != null && target <= stable) {
+    return '${pkg.name}: pubspec.yaml declares $target, but $stable is '
+        'already published. A pre-release has to work towards something newer '
+        '-- bump pubspec.yaml to the version this pre-release line is working '
+        'towards.';
+  }
 
-  // Nothing since the last stable carries semver weight -- this package is
-  // only here because it was named or a native SDK override is driving it, so
-  // the next patch is what it's aiming at.
-  return _applyBump(stableBase, bump ?? VersionBumpType.patch);
+  return null;
 }
 
 /// The sha a commit range starts from, plus anything a human should know
@@ -528,7 +587,7 @@ PackagePlan _computePatchPlan(
   DiscoveredPackage pkg,
   String currentVersion,
   List<ConventionalCommit> commits,
-  Version? versionBase,
+  Version versionBase,
   List<NativeSdkDelta> nativeSdkDeltas,
   List<NativeDependencyChange> nativeDependencyChanges,
   List<String> warnings,
@@ -544,15 +603,27 @@ PackagePlan _computePatchPlan(
     }
   }
 
+  // The same rejection, for the other way a change of that size can arrive.
+  // A patch branch's pins are left alone by default, so this is only
+  // reachable through an explicit override -- someone asking to jump the
+  // native SDK a minor or major on a line that can only ship patches.
+  for (final delta in nativeSdkDeltas) {
+    final bump = delta.getImpliedBump();
+    if (bump == VersionBumpType.major || bump == VersionBumpType.minor) {
+      throw StateError(
+        '${delta.sdk.displayName} SDK ${delta.currentDeclaration} -> '
+        '${delta.targetVersion} is a ${bump!.name} change, which does not '
+        'belong on a patch branch (only fixes are allowed here). Release it '
+        'from develop instead, or pick a patch-level version of the SDK.',
+      );
+    }
+  }
+
   return PackagePlan(
     package: pkg,
     currentVersion: currentVersion,
-    newVersion: versionBase == null
-        ? pkg.version
-        : versionBase.incrementPatch().toString(),
-    // Nothing to increment from means nothing was bumped -- see the same
-    // reasoning in _computeMainlinePlan.
-    bumpLevel: versionBase == null ? null : VersionBumpType.patch,
+    newVersion: versionBase.incrementPatch().toString(),
+    bumpLevel: VersionBumpType.patch,
     contributingCommits: commits,
     nativeSdkDeltas: nativeSdkDeltas,
     nativeDependencyChanges: nativeDependencyChanges,
@@ -600,18 +671,12 @@ PackagePlan _computeMainlinePlan(
   // With nothing auto-detected, this package is here because it was asked for
   // by name or a forced native SDK update is driving it -- still worth a
   // release, treated as a maintenance patch.
-  //
-  // A native SDK's own bump carries through even without a qualifying
-  // commit of the wrapper package's own -- a dd-sdk-ios minor release
-  // pinned here is itself a minor change for whoever depends on this
-  // package. An explicit BUMP_TYPE override still wins outright, since
-  // that's a human's direct instruction.
   final bump =
-      VersionBumpType.parseOverride(ctx.bumpTypeOverride) ??
-      highestBump([
-        aggregateBumpLevel(commits),
-        nativeSdkAggregateBump(nativeSdkDeltas),
-      ]) ??
+      _impliedBump(
+        commits: commits,
+        nativeSdkDeltas: nativeSdkDeltas,
+        bumpTypeOverride: ctx.bumpTypeOverride,
+      ) ??
       VersionBumpType.patch;
 
   return PackagePlan(
@@ -626,41 +691,32 @@ PackagePlan _computeMainlinePlan(
   );
 }
 
-/// A pre-release is mainline plus a suffix: the target is computed the same
-/// way a stable release would be, then a counter is appended.
+/// A pre-release is its declared target plus a counter: `4.0.0` from
+/// [declaredPrereleaseTarget], then `-beta.1`, `-beta.2`, and so on.
 ///
-/// The target is deliberately *not* read from `pubspec.yaml`, which would be
-/// a second source of truth free to disagree with what has actually shipped.
-/// Computing it also makes the path self-correcting: once `4.0.0` ships
-/// stably the base moves on, the target becomes `4.1.0` or `5.0.0`, and no
-/// state is left claiming otherwise.
+/// The target being declared rather than computed is what keeps the base
+/// still while the line progresses -- see [declaredPrereleaseTarget] for why
+/// a computed one couldn't be. Everything decided here is about the suffix.
 PackagePlan _computePrereleasePlan(
   DiscoveredPackage pkg,
   RunContext ctx,
   String currentVersion,
   List<ConventionalCommit> commits,
-  Version? target,
+  Version target,
   PublishedVersions published,
   List<NativeSdkDelta> nativeSdkDeltas,
   List<NativeDependencyChange> nativeDependencyChanges,
   List<String> warnings,
 ) {
-  target!;
   final counter = published.prereleasesAt(target).lastOrNull;
   final label = ctx.prereleaseLabel;
 
+  // A target already released stably was rejected by
+  // _prereleaseTargetConflict before this point, so there's no such case to
+  // handle here.
   final Version newVersion;
   if (counter != null && (label == null || counter.preRelease.first == label)) {
     newVersion = counter.incrementPreRelease();
-  } else if (published.hasStableAt(target)) {
-    // Can only happen when the target was reached by a path that doesn't
-    // consult the commits (a never-published package taking its version from
-    // pubspec, say) -- a new pre-release here would sort below a release
-    // that already exists.
-    throw StateError(
-      'Package "${pkg.name}" target $target has already been released stably '
-      '-- a pre-release against it would sort below the published version.',
-    );
   } else if (label != null) {
     newVersion = Version(
       target.major,
@@ -700,6 +756,19 @@ PackagePlan _computePrereleasePlan(
     );
   }
 
+  // Sorting below something already published is legitimate when another line
+  // is shipping concurrently (`4.0.0-beta.2` while `5.0.0-alpha.1` exists),
+  // so this can't be the error the invariant above is -- but it's also what a
+  // pubspec left behind looks like, and that's worth saying out loud.
+  final newestPublished = published.latest;
+  if (newestPublished != null && newVersion < newestPublished) {
+    warnings.add(
+      '${pkg.name}: $newVersion sorts below the published $newestPublished. '
+      'Expected if another release line is shipping concurrently; otherwise '
+      'pubspec.yaml is behind what has already gone out.',
+    );
+  }
+
   return PackagePlan(
     package: pkg,
     currentVersion: currentVersion,
@@ -712,6 +781,72 @@ PackagePlan _computePrereleasePlan(
     nativeDependencyChanges: nativeDependencyChanges,
     warnings: warnings,
   );
+}
+
+/// The bump the evidence implies, independent of how any target is chosen --
+/// null when nothing carries semver weight.
+///
+/// A native SDK's own bump carries through even without a qualifying commit
+/// of the wrapper package's own: a dd-sdk-ios minor release pinned here is
+/// itself a minor change for whoever depends on this package. An explicit
+/// `BUMP_TYPE` wins outright, since that's a human's direct instruction.
+///
+/// One function rather than one per caller: mainline uses it to pick the
+/// version, and [_prereleaseTargetAdvisory] uses it to sanity-check a
+/// declared one. Keeping them separate is how the native SDK signal came to
+/// be wired into the first and not the second.
+VersionBumpType? _impliedBump({
+  required List<ConventionalCommit> commits,
+  required List<NativeSdkDelta> nativeSdkDeltas,
+  String? bumpTypeOverride,
+}) =>
+    VersionBumpType.parseOverride(bumpTypeOverride) ??
+    highestBump([
+      aggregateBumpLevel(commits),
+      nativeSdkAggregateBump(nativeSdkDeltas),
+    ]);
+
+/// A warning when the pre-release target declared in pubspec sits *below*
+/// what the evidence implies -- null when there's nothing to say.
+///
+/// Deliberately one-directional. Declaring a target ahead of the commits is
+/// the whole point of declaring one (the `v4` line targets `4.0.0` from its
+/// first beta, long before every breaking change has landed), so warning on
+/// that would fire on every run. Worse, commits here are pathspec-scoped, so
+/// a breaking change living in `_platform_interface` is invisible to
+/// `datadog_flutter_plugin` -- a symmetric check would cry wolf on the
+/// flagship group forever.
+///
+/// A target that's too *low* is the real hazard: a `feat!:` landed and the
+/// line is about to ship `4.0.1-beta.3` as though nothing broke.
+String? _prereleaseTargetAdvisory({
+  required DiscoveredPackage pkg,
+  required Version target,
+  required Version? latestStable,
+  required List<ConventionalCommit> commitsSinceStable,
+  required List<NativeSdkDelta> nativeSdkDeltas,
+}) {
+  // Nothing to measure from: never published, or published only as
+  // pre-releases. Bumping a base that doesn't exist would invent a comparison.
+  if (latestStable == null) return null;
+
+  final implied = _impliedBump(
+    commits: commitsSinceStable,
+    nativeSdkDeltas: nativeSdkDeltas,
+  );
+  if (implied == null) return null;
+
+  final impliedTarget = _applyBump(latestStable, implied);
+  if (impliedTarget <= target) return null;
+
+  final reason = commitsSinceStable.firstWhereOrNull(
+    (c) => c.bumpType == implied,
+  );
+
+  return '${pkg.name}: pubspec.yaml targets $target, but changes since '
+      '$latestStable imply $impliedTarget'
+      '${reason == null ? '' : ' (${reason.type}: ${reason.description})'}. '
+      'Shipping $target as declared -- bump pubspec.yaml if that is wrong.';
 }
 
 Version _applyBump(Version base, VersionBumpType bump) {
@@ -742,74 +877,119 @@ bool _hasForcedNativeUpdate(NativeDependencyFiles files, RunContext ctx) =>
     (files.androidGradle != null && ctx.androidSdkVersionOverride != null) ||
     (files.cppCMakeLists.isNotEmpty && ctx.cppVersionOverride != null);
 
-/// [file]'s content as it existed in [pkg]'s last published version's git
-/// history, or null if there's no published version, no tag resolves (see
-/// [tagSha]), or [file] didn't exist at that commit.
-Future<String?> _lastPublishedContent(
+/// [file]'s content as it existed at [atVersion] in [pkg]'s git history, or
+/// null if [atVersion] is null, no tag resolves for it (see [tagSha]), or
+/// [file] didn't exist at that commit.
+Future<String?> _publishedContentAt(
   DiscoveredPackage pkg,
-  PublishedVersions published,
+  Version? atVersion,
   RunContext ctx,
   GitDir gitDir,
   File? file,
 ) async {
-  final latest = published.latest;
-  if (latest == null || file == null) return null;
+  if (atVersion == null || file == null) return null;
   return fileContentAtTag(
     gitDir,
-    '${pkg.name}/v$latest',
+    '${pkg.name}/v$atVersion',
     p.relative(file.path, from: ctx.repoRoot),
   );
 }
 
-/// One [NativeSdkDelta] per SDK [pkg] ships a manifest for.
+/// One [NativeSdkDelta] per SDK [pkg] ships a manifest for, comparing each
+/// SDK's resolved target against what that manifest declared at [baseline] --
+/// the last release *on the line being released*, i.e. `commitBase`. Release
+/// branches never merge back, so a version from another line's tag describes
+/// nothing about this one.
+///
+/// Two declarations are read per SDK, and they answer different questions:
+/// the one at [baseline] is what the line last shipped (the bump comparison),
+/// and the one in the working tree is what someone has asked for now (a pin
+/// means hold -- see [resolveNativeSdkTarget]).
+///
+/// Appends to [warnings] when a pin is honoured, and when the baseline
+/// declaration can't be read as a version.
 Future<List<NativeSdkDelta>> _computeNativeSdkDeltas(
   DiscoveredPackage pkg,
   NativeDependencyFiles files,
   RunContext ctx,
   GitDir gitDir,
-  PublishedVersions published,
+  Version? baseline,
   NativeSdkGateways gateways,
+  List<String> warnings,
 ) async {
   Future<String?> historicalContent(File? file) =>
-      _lastPublishedContent(pkg, published, ctx, gitDir, file);
+      _publishedContentAt(pkg, baseline, ctx, gitDir, file);
 
-  final iosPodspecContent = await historicalContent(files.iosPodspec);
-  final iosSpmContent = await historicalContent(files.iosSpmManifest);
-  final androidContent = await historicalContent(files.androidGradle);
-  final cppContent = await historicalContent(files.cppCMakeLists.firstOrNull);
+  String? workingTreeContent(File? file) => file?.readAsStringSync();
 
   final perSdkFiles = {
     NativeSdk.ios: (
       files: [?files.iosPodspec, ?files.iosSpmManifest],
       override: ctx.iosSdkVersionOverride,
       current: currentIosDeclaration(
-        podspecContent: iosPodspecContent,
-        spmContent: iosSpmContent,
+        podspecContent: await historicalContent(files.iosPodspec),
+        spmContent: await historicalContent(files.iosSpmManifest),
+      ),
+      declared: currentIosDeclaration(
+        podspecContent: workingTreeContent(files.iosPodspec),
+        spmContent: workingTreeContent(files.iosSpmManifest),
       ),
     ),
     NativeSdk.android: (
       files: [?files.androidGradle],
       override: ctx.androidSdkVersionOverride,
-      current: currentAndroidDeclaration(androidContent),
+      current: currentAndroidDeclaration(
+        await historicalContent(files.androidGradle),
+      ),
+      declared: currentAndroidDeclaration(
+        workingTreeContent(files.androidGradle),
+      ),
     ),
     NativeSdk.cpp: (
       files: files.cppCMakeLists,
       override: ctx.cppVersionOverride,
-      current: currentCppDeclaration(cppContent),
+      current: currentCppDeclaration(
+        await historicalContent(files.cppCMakeLists.firstOrNull),
+      ),
+      declared: currentCppDeclaration(
+        workingTreeContent(files.cppCMakeLists.firstOrNull),
+      ),
     ),
   };
 
   final deltas = <NativeSdkDelta>[];
-  for (final MapEntry(key: sdk, value: (:files, :override, :current))
+  for (final MapEntry(key: sdk, value: (:files, :override, :current, :declared))
       in perSdkFiles.entries) {
     if (files.isEmpty) continue;
 
     final target = await resolveNativeSdkTarget(
       trigger: ctx.trigger,
       override: override,
+      workingTreeDeclaration: declared,
       fetchLatest: () => gateways.fetchLatest(sdk.repoSlug),
       releaseExists: (version) => gateways.releaseExists(sdk.repoSlug, version),
+      onPinned: (pin) => warnings.add(
+        '${sdk.displayName} SDK is pinned at $pin in ${pkg.name}\'s manifest '
+        '-- honouring the pin and not checking for a newer release. Remove '
+        'the pin to resume tracking the latest, or pass an explicit override '
+        'to move it.',
+      ),
     );
+
+    // A baseline we can't read costs both the bump signal and the changelog
+    // section, so say so rather than silently contributing nothing. Only
+    // reachable for tags predating the current tooling (an Android `3+`, a
+    // hand-pinned GIT_TAG SHA with no `# vX.Y.Z` annotation) -- every tag it
+    // cuts carries a complete version.
+    if (target != null &&
+        current != null &&
+        normalizeVersion(current) == null) {
+      warnings.add(
+        '${sdk.displayName} SDK: ${pkg.name}\'s last release on this line '
+        'declared "$current", which is not a complete version -- it adds no '
+        'bump signal and has no changelog section this run.',
+      );
+    }
 
     deltas.add(
       NativeSdkDelta(
@@ -850,7 +1030,7 @@ Future<List<NativeDependencyChange>> _nativeDependencyChanges(
   }
 
   Future<String?> historicalContent(File? file) =>
-      _lastPublishedContent(pkg, published, ctx, gitDir, file);
+      _publishedContentAt(pkg, latest, ctx, gitDir, file);
 
   final changes = <NativeDependencyChange>[];
 

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -888,7 +888,7 @@ Future<String?> _publishedContentAt(
   File? file,
 ) async {
   if (atVersion == null || file == null) return null;
-  return fileContentAtTag(
+  return fileContentAtRef(
     gitDir,
     '${pkg.name}/v$atVersion',
     p.relative(file.path, from: ctx.repoRoot),

--- a/tools/releaser/lib/release_plan.dart
+++ b/tools/releaser/lib/release_plan.dart
@@ -851,23 +851,23 @@ Future<List<NativeDependencyChange>> _nativeDependencyChanges(
   return changes;
 }
 
-/// [commitMessagesSince]'s raw messages, parsed into [ConventionalCommit]s
-/// and narrowed to the ones that carry semver weight -- commits that fail
-/// to parse, or parse but don't bump anything (`chore:`, `docs:`, etc.),
-/// are dropped since nothing here cares about them either as bump input or
-/// as a [PackagePlan.contributingCommits] entry.
+/// [commitsSince]'s raw records, parsed into [ConventionalCommit]s and
+/// narrowed to the ones that carry semver weight -- commits that fail to
+/// parse, or parse but don't bump anything (`chore:`, `docs:`, etc.), are
+/// dropped since nothing here cares about them either as bump input or as a
+/// [PackagePlan.contributingCommits] entry.
 Future<List<ConventionalCommit>> _conventionalCommitsSince(
   GitDir gitDir, {
   required String pathspec,
   String? sinceSha,
 }) async {
-  final messages = await commitMessagesSince(
+  final records = await commitsSince(
     gitDir,
     pathspec: pathspec,
     sinceSha: sinceSha,
   );
-  return messages
-      .map(ConventionalCommit.parse)
+  return records
+      .map((r) => ConventionalCommit.parse(r.message, sha: r.sha))
       .nonNulls
       .where((c) => c.bumpType != null)
       .toList();

--- a/tools/releaser/lib/version_bump.dart
+++ b/tools/releaser/lib/version_bump.dart
@@ -46,3 +46,15 @@ enum VersionBumpType {
     }
   }
 }
+
+/// The highest-severity bump among [bumps], ignoring nulls -- null if every
+/// entry is null. Used to combine independent bump signals (conventional
+/// commits, a native SDK version delta) into one overall bump level.
+VersionBumpType? highestBump(Iterable<VersionBumpType?> bumps) {
+  VersionBumpType? highest;
+  for (final bump in bumps) {
+    if (bump == null) continue;
+    if (highest == null || bump.severity > highest.severity) highest = bump;
+  }
+  return highest;
+}

--- a/tools/releaser/pubspec.lock
+++ b/tools/releaser/pubspec.lock
@@ -273,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   node_preamble:
     dependency: transitive
     description:

--- a/tools/releaser/pubspec.yaml
+++ b/tools/releaser/pubspec.yaml
@@ -21,4 +21,5 @@ dev_dependencies:
   build_runner: ^2.15.0
   json_serializable: ^6.14.0
   lints: ^6.1.0
+  mocktail: ^1.0.4
   test: ^1.20.1

--- a/tools/releaser/test/cmake_util_test.dart
+++ b/tools/releaser/test/cmake_util_test.dart
@@ -196,4 +196,75 @@ FetchContent_Declare(some_other_dep
       );
     });
   });
+
+  group('currentGitTagVersion', () {
+    /// [gitTagLine] carries its own closing paren, because `pinCppVersion`
+    /// writes the annotation at end of line -- after the `)`, since a `#`
+    /// before it would comment the paren out and break the call.
+    String declaring(String gitTagLine) =>
+        '''
+FetchContent_Declare(dd-sdk-cpp
+  GIT_REPOSITORY https://github.com/DataDog/dd-sdk-cpp.git
+  $gitTagLine
+''';
+
+    test('recovers the version pinCppVersion annotated a SHA with', () {
+      // A bare SHA carries no version, so the annotation is the only record
+      // of what was actually pinned.
+      expect(
+        currentGitTagVersion(declaring('GIT_TAG $_sha)  # v1.4.0')),
+        'v1.4.0',
+      );
+    });
+
+    test('falls back to the ref when there is no annotation', () {
+      expect(currentGitTagVersion(declaring('GIT_TAG develop)')), 'develop');
+      expect(currentGitTagVersion(declaring('GIT_TAG v1.4.0)')), 'v1.4.0');
+    });
+
+    test(
+      'ignores a comment that explains a pin rather than naming a version',
+      () {
+        // The shape a human writes when deliberately holding a version.
+        // Taking the first word would yield "hold", which reads as a floating
+        // ref and makes the planner fetch a newer SDK -- overriding the very
+        // pin the comment is explaining.
+        expect(
+          currentGitTagVersion(
+            declaring('GIT_TAG v1.4.0)  # hold until #123 lands'),
+          ),
+          'v1.4.0',
+        );
+        expect(
+          currentGitTagVersion(declaring('GIT_TAG $_sha)  # hold until #123')),
+          _sha,
+        );
+      },
+    );
+
+    test('does not read a version out of surrounding prose', () {
+      // Only the exact shape pinCppVersion writes counts. Digging a version
+      // out of free text reads `# hold until 2.0.0 is out` as a pin at
+      // 2.0.0, which is the opposite of what the comment says. Falling back
+      // to the SHA loses the version, but `_computeNativeSdkDeltas` warns
+      // about an unreadable baseline rather than acting on a wrong one.
+      expect(
+        currentGitTagVersion(declaring('GIT_TAG $_sha)  # pinned to 1.4.0')),
+        _sha,
+      );
+      expect(
+        currentGitTagVersion(
+          declaring('GIT_TAG $_sha)  # hold until 2.0.0 is out'),
+        ),
+        _sha,
+      );
+    });
+
+    test('is null with no dd-sdk-cpp declaration at all', () {
+      expect(
+        currentGitTagVersion('cmake_minimum_required(VERSION 3.14)'),
+        isNull,
+      );
+    });
+  });
 }

--- a/tools/releaser/test/git_history_test.dart
+++ b/tools/releaser/test/git_history_test.dart
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:releaser/git_history.dart';
+import 'package:test/test.dart';
+
+import 'support/fixture_repo.dart';
+
+void main() {
+  late FixtureRepo fixture;
+  var fileCounter = 0;
+
+  setUp(() async {
+    fixture = await FixtureRepo.create();
+    fileCounter = 0;
+  });
+
+  tearDown(() => fixture.delete());
+
+  // commitsSince filters by pathspec, which means it filters by real
+  // changes -- an --allow-empty commit with no file touched wouldn't show
+  // up, unlike in real history.
+  Future<void> commitTouchingPathspec(
+    String subject, {
+    List<String> body = const [],
+  }) {
+    fileCounter++;
+    fixture.writeFile('CHANGES-$fileCounter', 'work');
+    return fixture.commit(subject, body: body);
+  }
+
+  group('commitsSince', () {
+    test('pairs each commit with its own SHA, newest first', () async {
+      final gitDir = await fixture.gitDir;
+      await commitTouchingPathspec('feat: add a thing (#42)');
+      await commitTouchingPathspec('fix: correct a bug');
+
+      final records = await commitsSince(gitDir, pathspec: '.');
+
+      expect(records, hasLength(3)); // plus the fixture's initial commit
+      expect(records[0].message, 'fix: correct a bug');
+      expect(records[1].message, 'feat: add a thing (#42)');
+      expect(records.map((r) => r.sha).toSet(), hasLength(3));
+      for (final record in records) {
+        expect(record.sha, hasLength(40));
+      }
+    });
+
+    test('a null sinceSha walks the entire history', () async {
+      final gitDir = await fixture.gitDir;
+      await commitTouchingPathspec('feat: add a thing');
+
+      final records = await commitsSince(gitDir, pathspec: '.');
+
+      expect(records, hasLength(2));
+    });
+
+    test('sinceSha excludes everything up to and including it', () async {
+      final gitDir = await fixture.gitDir;
+      await commitTouchingPathspec('feat: an earlier thing');
+      final baseline = (await commitsSince(gitDir, pathspec: '.')).first;
+      await commitTouchingPathspec('feat: add a thing');
+      await commitTouchingPathspec('fix: correct a bug');
+
+      final records = await commitsSince(
+        gitDir,
+        pathspec: '.',
+        sinceSha: baseline.sha,
+      );
+
+      expect(records, hasLength(2));
+      expect(records.any((r) => r.sha == baseline.sha), isFalse);
+    });
+
+    test(
+      'preserves a multi-line body, e.g. a BREAKING CHANGE footer',
+      () async {
+        final gitDir = await fixture.gitDir;
+        await commitTouchingPathspec(
+          'feat: add a thing',
+          body: ['BREAKING CHANGE: the old thing is gone'],
+        );
+
+        final record = (await commitsSince(gitDir, pathspec: '.')).first;
+
+        expect(
+          record.message,
+          contains('BREAKING CHANGE: the old thing is gone'),
+        );
+      },
+    );
+  });
+}

--- a/tools/releaser/test/llm/ai_gateway_test.dart
+++ b/tools/releaser/test/llm/ai_gateway_test.dart
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'dart:convert';
+
+import 'package:releaser/llm/ai_gateway.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AnthropicMessageResponse.fromJson', () {
+    test('parses a real-shaped Messages API response', () {
+      final response = AnthropicMessageResponse.fromJson(
+        jsonDecode('''
+{
+  "model": "claude-sonnet-4-6",
+  "content": [{"type": "text", "text": "{\\"greeting\\": \\"hello\\"}"}],
+  "usage": {"input_tokens": 100, "output_tokens": 50}
+}
+'''),
+      );
+
+      expect(response.model, 'claude-sonnet-4-6');
+      expect(response.content.single.text, '{"greeting": "hello"}');
+      expect(response.usage.inputTokens, 100);
+      expect(response.usage.outputTokens, 50);
+    });
+  });
+
+  group('AnthropicMessageRequest.toJson', () {
+    test(
+      'round-trips through jsonEncode, including nested request objects',
+      () {
+        final request = AnthropicMessageRequest(
+          model: 'claude-sonnet-4-6',
+          maxTokens: 4096,
+          outputConfig: AnthropicOutputConfig(
+            format: AnthropicFormat(
+              type: 'json_schema',
+              schema: {'type': 'object'},
+            ),
+          ),
+          messages: [AnthropicMessage(role: 'user', content: 'hi — there')],
+        );
+
+        final decoded =
+            jsonDecode(jsonEncode(request.toJson())) as Map<String, dynamic>;
+
+        expect(decoded, {
+          'model': 'claude-sonnet-4-6',
+          'max_tokens': 4096,
+          'output_config': {
+            'format': {
+              'type': 'json_schema',
+              'schema': {'type': 'object'},
+            },
+          },
+          'messages': [
+            {'role': 'user', 'content': 'hi — there'},
+          ],
+        });
+      },
+    );
+  });
+}

--- a/tools/releaser/test/llm/changelog_test.dart
+++ b/tools/releaser/test/llm/changelog_test.dart
@@ -1,0 +1,506 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:releaser/llm/changelog.dart';
+import 'package:releaser/native_sdk.dart';
+import 'package:releaser/native_sdk_changelog.dart';
+import 'package:releaser/pr_resolution.dart';
+import 'package:releaser/version_bump.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_ai_gateway_client.dart';
+
+const _emptyEntryList = {
+  'breaking_changes': <Map<String, dynamic>>[],
+  'features': <Map<String, dynamic>>[],
+  'fixes': <Map<String, dynamic>>[],
+};
+
+void main() {
+  group('runGroupedPrsPrompt', () {
+    final prs = [
+      const PrDetails(number: 1, title: 'feat: add a thing', body: ''),
+      const PrDetails(number: 2, title: 'fix: correct a bug', body: ''),
+    ];
+
+    test('returns the parsed groups when PR numbers match exactly', () async {
+      final client = FakeAiGatewayClient([
+        {
+          'groups': [
+            {
+              'label': 'a thing',
+              'prs': [
+                {'number': 1, 'title': 'feat: add a thing'},
+                {'number': 2, 'title': 'fix: correct a bug'},
+              ],
+            },
+          ],
+        },
+      ]);
+
+      final result = await runGroupedPrsPrompt(client, prs);
+
+      expect(result.groups, hasLength(1));
+      expect(result.groups.single.prs.map((p) => p.number), [1, 2]);
+    });
+
+    test('throws when the LLM drops a PR number', () async {
+      final client = FakeAiGatewayClient([
+        {
+          'groups': [
+            {
+              'label': 'a thing',
+              'prs': [
+                {'number': 1, 'title': 'feat: add a thing'},
+              ],
+            },
+          ],
+        },
+      ]);
+
+      expect(() => runGroupedPrsPrompt(client, prs), throwsStateError);
+    });
+
+    test('throws when the LLM invents a PR number', () async {
+      final client = FakeAiGatewayClient([
+        {
+          'groups': [
+            {
+              'label': 'a thing',
+              'prs': [
+                {'number': 1, 'title': 'feat: add a thing'},
+                {'number': 2, 'title': 'fix: correct a bug'},
+                {'number': 999, 'title': 'made up'},
+              ],
+            },
+          ],
+        },
+      ]);
+
+      expect(() => runGroupedPrsPrompt(client, prs), throwsStateError);
+    });
+  });
+
+  group('runChangelogEntryListPrompt', () {
+    test('parses breaking/feature/fix entries', () async {
+      final client = FakeAiGatewayClient([
+        {
+          'breaking_changes': [
+            {'text': 'Removed the old thing.'},
+          ],
+          'features': [
+            {'text': 'Added a new thing.'},
+          ],
+          'fixes': <Map<String, dynamic>>[],
+        },
+      ]);
+
+      final result = await runChangelogEntryListPrompt(client, 'a group', [
+        const PrDetails(number: 1, title: 't', body: 'b'),
+      ]);
+
+      expect(result.breakingChanges.single.text, 'Removed the old thing.');
+      expect(result.features.single.text, 'Added a new thing.');
+      expect(result.fixes, isEmpty);
+    });
+  });
+
+  group('runCleanupPrompt', () {
+    test('returns the cleaned-up entry list', () async {
+      final client = FakeAiGatewayClient([
+        {
+          ..._emptyEntryList,
+          'fixes': [
+            {'text': 'Fixed a bug.'},
+          ],
+        },
+      ]);
+
+      final result = await runCleanupPrompt(
+        client,
+        const ChangelogEntryList(
+          fixes: [ChangelogEntry('Fixed a bug (duplicated).')],
+        ),
+      );
+
+      expect(result.fixes.single.text, 'Fixed a bug.');
+    });
+  });
+
+  group('ChangelogEntryList', () {
+    test('mergedWith concatenates each category', () {
+      const a = ChangelogEntryList(features: [ChangelogEntry('a')]);
+      const b = ChangelogEntryList(
+        features: [ChangelogEntry('b')],
+        fixes: [ChangelogEntry('c')],
+      );
+
+      final merged = a.mergedWith(b);
+
+      expect(merged.features.map((e) => e.text), ['a', 'b']);
+      expect(merged.fixes.map((e) => e.text), ['c']);
+    });
+
+    test('isEmpty is true only when every category is empty', () {
+      expect(const ChangelogEntryList().isEmpty, isTrue);
+      expect(
+        const ChangelogEntryList(fixes: [ChangelogEntry('x')]).isEmpty,
+        isFalse,
+      );
+    });
+  });
+
+  group('generateChangelogEntries', () {
+    test('short-circuits with no LLM calls for an empty PR list', () async {
+      final client = FakeAiGatewayClient([]);
+
+      final result = await generateChangelogEntries(client, []);
+
+      expect(result.isEmpty, isTrue);
+      expect(client.prompts, isEmpty);
+    });
+
+    test('runs group -> synthesize -> cleanup end to end', () async {
+      final prs = [
+        const PrDetails(number: 1, title: 'feat: add a thing', body: 'b1'),
+        const PrDetails(number: 2, title: 'fix: correct a bug', body: 'b2'),
+      ];
+
+      final client = FakeAiGatewayClient([
+        // Pass 1: group
+        {
+          'groups': [
+            {
+              'label': 'thing',
+              'prs': [
+                {'number': 1, 'title': 'feat: add a thing'},
+              ],
+            },
+            {
+              'label': 'bugfix',
+              'prs': [
+                {'number': 2, 'title': 'fix: correct a bug'},
+              ],
+            },
+          ],
+        },
+        // Pass 2, group "thing"
+        {
+          ..._emptyEntryList,
+          'features': [
+            {'text': 'Adds a thing.'},
+          ],
+        },
+        // Pass 2, group "bugfix"
+        {
+          ..._emptyEntryList,
+          'fixes': [
+            {'text': 'Fixes a bug.'},
+          ],
+        },
+        // Pass 3: cleanup
+        {
+          ..._emptyEntryList,
+          'features': [
+            {'text': 'Adds a thing.'},
+          ],
+          'fixes': [
+            {'text': 'Fixes a bug.'},
+          ],
+        },
+      ]);
+
+      final result = await generateChangelogEntries(client, prs);
+
+      expect(result.features.single.text, 'Adds a thing.');
+      expect(result.fixes.single.text, 'Fixes a bug.');
+      expect(client.prompts, hasLength(4));
+    });
+  });
+
+  group('synthesizeNativeSdkSubEntries', () {
+    test('returns the filtered flat list of sub-entry texts', () async {
+      final client = FakeAiGatewayClient([
+        {
+          'entries': [
+            {'text': 'Adds UK1 site support.'},
+          ],
+        },
+      ]);
+
+      final result = await synthesizeNativeSdkSubEntries(
+        client,
+        const NativeSdkChangelogContext(
+          displayName: 'Android',
+          targetVersion: '3.12.1',
+          entries: ['[FEATURE] Add UK1 site. See [#3595](url)'],
+          changelogUrl:
+              'https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md',
+        ),
+      );
+
+      expect(result, ['Adds UK1 site support.']);
+    });
+  });
+
+  group('buildNativeSdkUpdateEntry', () {
+    test(
+      'builds the exact wording with a markdown link, and nests subEntries',
+      () {
+        const context = NativeSdkChangelogContext(
+          displayName: 'Android',
+          targetVersion: '3.12.1',
+          entries: [],
+          changelogUrl:
+              'https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md',
+        );
+
+        final entry = buildNativeSdkUpdateEntry(context, [
+          'Adds UK1 site support.',
+        ]);
+
+        expect(
+          entry.text,
+          'Update to Android SDK 3.12.1. For a complete list of changes, see '
+          'the [Android SDK CHANGELOG](https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md).',
+        );
+        expect(entry.subEntries, ['Adds UK1 site support.']);
+      },
+    );
+  });
+
+  group('resolveNativeSdkChangelogContexts', () {
+    NativeSdkDelta delta({String? currentDeclaration, String? targetVersion}) =>
+        NativeSdkDelta(
+          sdk: NativeSdk.android,
+          targetVersion: targetVersion,
+          currentDeclaration: currentDeclaration,
+        );
+
+    test('builds a context from the resolved changelog sections', () async {
+      final warnings = <String>[];
+
+      final contexts = await resolveNativeSdkChangelogContexts(
+        [delta(currentDeclaration: '3.12.0', targetVersion: '3.12.1')],
+        fetchChangelog: (repoSlug) async => [
+          const ChangelogSection(
+            version: '3.12.1',
+            entries: ['[BUGFIX] Fix R8 failures. See [#3642](url)'],
+          ),
+          const ChangelogSection(version: '3.12.0', entries: ['[FEATURE] X']),
+        ],
+        onWarning: warnings.add,
+      );
+
+      expect(contexts, hasLength(1));
+      expect(contexts.single.displayName, 'Android');
+      expect(contexts.single.targetVersion, '3.12.1');
+      expect(contexts.single.entries, [
+        '[BUGFIX] Fix R8 failures. See [#3642](url)',
+      ]);
+      expect(
+        contexts.single.changelogUrl,
+        'https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md',
+      );
+      // 3.12.0 -> 3.12.1 is a patch bump.
+      expect(contexts.single.impliedBump, VersionBumpType.patch);
+      expect(warnings, isEmpty);
+    });
+
+    test('a major native SDK bump is reflected in impliedBump', () async {
+      final contexts = await resolveNativeSdkChangelogContexts(
+        [delta(currentDeclaration: '3.12.0', targetVersion: '4.0.0')],
+        fetchChangelog: (_) async => [
+          const ChangelogSection(version: '4.0.0', entries: ['x']),
+          const ChangelogSection(version: '3.12.0', entries: ['y']),
+        ],
+        onWarning: (_) => fail('should not warn'),
+      );
+
+      expect(contexts.single.impliedBump, VersionBumpType.major);
+    });
+
+    test(
+      'skips with a warning instead of throwing when unresolvable',
+      () async {
+        final warnings = <String>[];
+
+        final contexts = await resolveNativeSdkChangelogContexts(
+          [delta(targetVersion: '3.12.1')], // no current declaration
+          fetchChangelog: (_) async => throw StateError('should not be called'),
+          onWarning: warnings.add,
+        );
+
+        expect(contexts, isEmpty);
+        expect(warnings.single, contains('no resolvable current version'));
+      },
+    );
+
+    test('skips a delta with no target (no change this run)', () async {
+      final contexts = await resolveNativeSdkChangelogContexts(
+        [delta(currentDeclaration: '3.12.0')],
+        fetchChangelog: (_) async => throw StateError('should not be called'),
+        onWarning: (_) => fail('should not warn'),
+      );
+
+      expect(contexts, isEmpty);
+    });
+  });
+
+  group('generateChangelogEntries with native SDK contexts', () {
+    const context = NativeSdkChangelogContext(
+      displayName: 'Android',
+      targetVersion: '3.12.1',
+      entries: ['[FEATURE] Add UK1 site.'],
+      changelogUrl:
+          'https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md',
+    );
+
+    test(
+      'appends one entry per context, without running it through cleanup',
+      () async {
+        final client = FakeAiGatewayClient([
+          {
+            'entries': [
+              {'text': 'Adds UK1 site support.'},
+            ],
+          },
+        ]);
+
+        final result = await generateChangelogEntries(
+          client,
+          [],
+          nativeSdkContexts: [context],
+        );
+
+        expect(client.prompts, hasLength(1)); // no group/synthesize/cleanup
+        expect(result.features.single.text, contains(context.changelogUrl));
+        expect(result.features.single.subEntries, ['Adds UK1 site support.']);
+      },
+    );
+
+    test('a major implied bump files the entry as breaking', () async {
+      const majorContext = NativeSdkChangelogContext(
+        displayName: 'Android',
+        targetVersion: '4.0.0',
+        entries: ['[FEATURE] x'],
+        changelogUrl:
+            'https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md',
+        impliedBump: VersionBumpType.major,
+      );
+      final client = FakeAiGatewayClient([
+        {
+          'entries': [
+            {'text': 'x'},
+          ],
+        },
+      ]);
+
+      final result = await generateChangelogEntries(
+        client,
+        [],
+        nativeSdkContexts: [majorContext],
+      );
+
+      expect(result.breakingChanges, hasLength(1));
+      expect(result.features, isEmpty);
+    });
+
+    test('runs the PR pipeline and native SDK pass independently', () async {
+      final client = FakeAiGatewayClient([
+        // PR pipeline: group
+        {
+          'groups': [
+            {
+              'label': 'thing',
+              'prs': [
+                {'number': 1, 'title': 'feat: add a thing'},
+              ],
+            },
+          ],
+        },
+        // PR pipeline: synthesize
+        {
+          ..._emptyEntryList,
+          'features': [
+            {'text': 'Adds a thing.'},
+          ],
+        },
+        // PR pipeline: cleanup
+        {
+          ..._emptyEntryList,
+          'features': [
+            {'text': 'Adds a thing.'},
+          ],
+        },
+        // Native SDK sub-entries
+        {
+          'entries': [
+            {'text': 'Adds UK1 site support.'},
+          ],
+        },
+      ]);
+
+      final result = await generateChangelogEntries(
+        client,
+        [const PrDetails(number: 1, title: 'feat: add a thing', body: '')],
+        nativeSdkContexts: [context],
+      );
+
+      expect(result.features.map((e) => e.text), [
+        'Adds a thing.',
+        contains('Update to Android SDK'),
+      ]);
+    });
+  });
+
+  group('renderChangelogSection', () {
+    test('prints a maintenance placeholder when everything is empty', () {
+      expect(
+        renderChangelogSection(const ChangelogEntryList()),
+        '- Maintenance release; no significant changes.\n',
+      );
+    });
+
+    test('omits empty categories and renders the rest under their heading', () {
+      final rendered = renderChangelogSection(
+        const ChangelogEntryList(
+          breakingChanges: [ChangelogEntry('Removed X.')],
+          fixes: [ChangelogEntry('Fixed Y.'), ChangelogEntry('Fixed Z.')],
+        ),
+      );
+
+      expect(rendered, '''
+### Breaking Changes
+
+- Removed X.
+
+### Fixes
+
+- Fixed Y.
+- Fixed Z.''');
+    });
+
+    test('nests subEntries as indented sub-bullets', () {
+      final rendered = renderChangelogSection(
+        const ChangelogEntryList(
+          features: [
+            ChangelogEntry(
+              'Update to Android SDK 3.12.1. For a complete list of '
+              'changes, see the [Android SDK CHANGELOG](url).',
+              subEntries: ['Adds UK1 site support.', 'Fixes a crash.'],
+            ),
+          ],
+        ),
+      );
+
+      expect(rendered, '''
+### Features
+
+- Update to Android SDK 3.12.1. For a complete list of changes, see the [Android SDK CHANGELOG](url).
+  - Adds UK1 site support.
+  - Fixes a crash.''');
+    });
+  });
+}

--- a/tools/releaser/test/llm/changelog_test.dart
+++ b/tools/releaser/test/llm/changelog_test.dart
@@ -80,6 +80,77 @@ void main() {
 
       expect(() => runGroupedPrsPrompt(client, prs), throwsStateError);
     });
+
+    test('drops a PR repeated in a second group, and warns', () async {
+      // Every expected number is present, so a set comparison sees nothing
+      // wrong -- but left alone, pass 2 would write #2 up twice, from two
+      // angles. Recoverable, so it must not fail the release build.
+      final client = FakeAiGatewayClient([
+        {
+          'groups': [
+            {
+              'label': 'a thing',
+              'prs': [
+                {'number': 1, 'title': 'feat: add a thing'},
+                {'number': 2, 'title': 'fix: correct a bug'},
+              ],
+            },
+            {
+              'label': 'the same bug again',
+              'prs': [
+                {'number': 2, 'title': 'fix: correct a bug'},
+              ],
+            },
+          ],
+        },
+      ]);
+
+      final warnings = <String>[];
+      final result = await runGroupedPrsPrompt(
+        client,
+        prs,
+        onWarning: warnings.add,
+      );
+
+      // The second group held nothing but the repeat, so it falls away.
+      expect(result.groups, hasLength(1));
+      expect(result.groups.single.prs.map((p) => p.number), [1, 2]);
+      expect(
+        warnings,
+        contains(allOf(contains('more than one group'), contains('#2'))),
+      );
+    });
+
+    test(
+      'keeps the first group when a repeat leaves the second non-empty',
+      () async {
+        final client = FakeAiGatewayClient([
+          {
+            'groups': [
+              {
+                'label': 'a thing',
+                'prs': [
+                  {'number': 1, 'title': 'feat: add a thing'},
+                ],
+              },
+              {
+                'label': 'everything',
+                'prs': [
+                  {'number': 1, 'title': 'feat: add a thing'},
+                  {'number': 2, 'title': 'fix: correct a bug'},
+                ],
+              },
+            ],
+          },
+        ]);
+
+        final result = await runGroupedPrsPrompt(client, prs);
+
+        expect(result.groups.map((g) => g.label), ['a thing', 'everything']);
+        expect(result.groups[0].prs.map((p) => p.number), [1]);
+        expect(result.groups[1].prs.map((p) => p.number), [2]);
+      },
+    );
   });
 
   group('runChangelogEntryListPrompt', () {

--- a/tools/releaser/test/llm/prompt_test.dart
+++ b/tools/releaser/test/llm/prompt_test.dart
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:logging/logging.dart';
+import 'package:releaser/llm/ai_gateway.dart';
+import 'package:releaser/llm/costs.dart';
+import 'package:releaser/llm/prompt.dart';
+import 'package:test/test.dart';
+
+import 'support/fake_ai_gateway_client.dart';
+
+void main() {
+  group('runStructuredPrompt', () {
+    test('deserializes the response content via fromJson', () async {
+      final client = FakeAiGatewayClient([
+        {'greeting': 'hello'},
+      ]);
+
+      final result = await runStructuredPrompt(client, 'say hi', {
+        'type': 'object',
+      }, (json) => json['greeting'] as String);
+
+      expect(result, 'hello');
+      expect(client.prompts, ['say hi']);
+    });
+
+    test('records usage against the cost tracker when given one', () async {
+      final client = FakeAiGatewayClient(
+        [
+          {'greeting': 'hello'},
+        ],
+        usage: const LlmUsage(
+          model: 'claude-sonnet-4-6',
+          inputTokens: 100,
+          outputTokens: 50,
+        ),
+      );
+      final tracker = LlmCostTracker();
+
+      await runStructuredPrompt(
+        client,
+        'say hi',
+        {'type': 'object'},
+        (json) => json['greeting'] as String,
+        costTracker: tracker,
+        costLabel: 'Greeting',
+      );
+
+      final messages = <String>[];
+      tracker.printSummary(
+        Logger.detached('test')
+          ..onRecord.listen((r) => messages.add(r.message)),
+      );
+
+      expect(messages, [contains('100in + 50out'), contains('Estimated cost')]);
+    });
+
+    test('is a no-op on the cost tracker when none is given', () async {
+      final client = FakeAiGatewayClient([
+        {'greeting': 'hello'},
+      ]);
+
+      // Should not throw for lack of a cost tracker.
+      await runStructuredPrompt(client, 'say hi', {
+        'type': 'object',
+      }, (json) => json['greeting'] as String);
+    });
+  });
+}

--- a/tools/releaser/test/llm/prompt_test.dart
+++ b/tools/releaser/test/llm/prompt_test.dart
@@ -12,14 +12,18 @@ import 'support/fake_ai_gateway_client.dart';
 
 void main() {
   group('runStructuredPrompt', () {
+    Prompt<String> greetingPrompt() => Prompt(
+      text: 'say hi',
+      schema: {'type': 'object'},
+      fromJson: (json) => json['greeting'] as String,
+    );
+
     test('deserializes the response content via fromJson', () async {
       final client = FakeAiGatewayClient([
         {'greeting': 'hello'},
       ]);
 
-      final result = await runStructuredPrompt(client, 'say hi', {
-        'type': 'object',
-      }, (json) => json['greeting'] as String);
+      final result = await runStructuredPrompt(client, greetingPrompt());
 
       expect(result, 'hello');
       expect(client.prompts, ['say hi']);
@@ -40,9 +44,7 @@ void main() {
 
       await runStructuredPrompt(
         client,
-        'say hi',
-        {'type': 'object'},
-        (json) => json['greeting'] as String,
+        greetingPrompt(),
         costTracker: tracker,
         costLabel: 'Greeting',
       );
@@ -62,9 +64,7 @@ void main() {
       ]);
 
       // Should not throw for lack of a cost tracker.
-      await runStructuredPrompt(client, 'say hi', {
-        'type': 'object',
-      }, (json) => json['greeting'] as String);
+      await runStructuredPrompt(client, greetingPrompt());
     });
   });
 }

--- a/tools/releaser/test/llm/support/fake_ai_gateway_client.dart
+++ b/tools/releaser/test/llm/support/fake_ai_gateway_client.dart
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:releaser/llm/ai_gateway.dart';
+
+/// A canned-response [AiGatewayClient] for testing the LLM pipeline without
+/// a live token -- also a stand-in for [HttpAiGatewayClient] until P0's AI
+/// Gateway prerequisite is proven out for this repo (see
+/// `.plans/release-process-phases.md` P4).
+///
+/// Returns [responses] in call order; records every prompt it was sent so
+/// tests can assert on prompt content without re-deriving it.
+class FakeAiGatewayClient implements AiGatewayClient {
+  final List<Map<String, dynamic>> responses;
+  final List<String> prompts = [];
+  final LlmUsage usage;
+  var _index = 0;
+
+  FakeAiGatewayClient(
+    this.responses, {
+    this.usage = const LlmUsage(
+      model: 'fake-model',
+      inputTokens: 10,
+      outputTokens: 5,
+    ),
+  });
+
+  @override
+  Future<StructuredResponse> createStructuredMessage({
+    required String prompt,
+    required Map<String, dynamic> schema,
+    String model = defaultModel,
+    int maxTokens = 4096,
+  }) async {
+    prompts.add(prompt);
+    if (_index >= responses.length) {
+      throw StateError(
+        'FakeAiGatewayClient received more calls (${_index + 1}) than it '
+        'was given responses for (${responses.length}).',
+      );
+    }
+    return StructuredResponse(content: responses[_index++], usage: usage);
+  }
+}

--- a/tools/releaser/test/native_sdk_changelog_test.dart
+++ b/tools/releaser/test/native_sdk_changelog_test.dart
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:releaser/native_sdk.dart';
+import 'package:releaser/native_sdk_changelog.dart';
+import 'package:test/test.dart';
+
+// Trimmed real snippets from each SDK's actual CHANGELOG.md, kept verbatim
+// enough to exercise each heading style: iOS's "# X.Y.Z / DD-MM-YYYY" with
+// an "# Unreleased" section on top, Android's "# X.Y.Z / YYYY-MM-DD", and
+// C++'s "## X.Y.Z" with "###" sub-headings that must NOT be treated as
+// version boundaries.
+const _iosSnippet = '''
+# Unreleased
+
+- [FEATURE] Add remoteConfiguration. See [#2919][]
+
+# 3.16.0 / 19-08-2026
+
+- [FEATURE] Add an experimental Core Animation recording pipeline. See [#3127][]
+- [FIX] Fix EXC_BREAKPOINT crash. [#3134][]
+
+# 3.15.0 / 05-08-2026
+
+- [FEATURE] Add support for UK1 Datadog Site. See [#3087][]
+''';
+
+const _androidSnippet = '''
+# 3.12.1 / 2026-07-16
+
+* [BUGFIX] Fix R8 failures due to missing SourceLines annotation. See [#3642](url)
+
+# 3.12.0 / 2026-07-15
+
+* [FEATURE] Continuous Profiling. See [#3622](url)
+* [BUGFIX] Fix interop wireframe positioning. See [#3611](url)
+''';
+
+const _cppSnippet = '''
+## 0.7.0
+
+### Breaking Changes
+
+- The source value reported by the SDK has changed to cpp.
+
+## 0.6.0
+
+### Breaking Changes
+
+- dd_core_config_t now stores string fields in fixed-size inline buffers.
+
+### Features
+
+- TTID can now be reported by calling Rum::ReportAppDisplayInitialized().
+''';
+
+void main() {
+  group('parseChangelog', () {
+    test('iOS: drops Unreleased, keeps date suffix out of the version', () {
+      final sections = parseChangelog(_iosSnippet);
+
+      expect(sections.map((s) => s.version), ['3.16.0', '3.15.0']);
+      expect(sections[0].entries, [
+        '- [FEATURE] Add an experimental Core Animation recording pipeline. See [#3127][]',
+        '- [FIX] Fix EXC_BREAKPOINT crash. [#3134][]',
+      ]);
+    });
+
+    test(
+      'Android: parses the same heading shape with a different date format',
+      () {
+        final sections = parseChangelog(_androidSnippet);
+
+        expect(sections.map((s) => s.version), ['3.12.1', '3.12.0']);
+        expect(sections[1].entries, hasLength(2));
+      },
+    );
+
+    test(
+      'C++: a "##" version heading is a boundary, "###" sub-headings are not',
+      () {
+        final sections = parseChangelog(_cppSnippet);
+
+        expect(sections.map((s) => s.version), ['0.7.0', '0.6.0']);
+        // The 0.6.0 section folds both its Breaking Changes and Features
+        // sub-headings' lines into one entries list, not two sections.
+        expect(sections[1].entries, [
+          '### Breaking Changes',
+          '- dd_core_config_t now stores string fields in fixed-size inline buffers.',
+          '### Features',
+          '- TTID can now be reported by calling Rum::ReportAppDisplayInitialized().',
+        ]);
+      },
+    );
+
+    test('content with no version heading at all parses to no sections', () {
+      expect(
+        parseChangelog('# Unreleased\n\n- nothing shipped yet\n'),
+        isEmpty,
+      );
+    });
+  });
+
+  group('normalizeVersion', () {
+    test('strips a CocoaPods constraint operator', () {
+      expect(normalizeVersion('~> 3.5.0'), '3.5.0');
+    });
+
+    test('pulls the version out of an SPM version argument', () {
+      expect(normalizeVersion('from: "3.0.0"'), '3.0.0');
+    });
+
+    test('is a no-op on an already-bare version', () {
+      expect(normalizeVersion('3.5.0'), '3.5.0');
+    });
+
+    test('null in, null out', () {
+      expect(normalizeVersion(null), isNull);
+    });
+
+    test('null when nothing semver-shaped is present', () {
+      expect(normalizeVersion('develop'), isNull);
+    });
+  });
+
+  group('sectionsBetween', () {
+    final sections = parseChangelog(_iosSnippet);
+
+    test(
+      'slices from just after fromVersion (older) through toVersion (newer), inclusive',
+      () {
+        final result = sectionsBetween(
+          sections,
+          fromVersion: '3.15.0',
+          toVersion: '3.16.0',
+        );
+
+        expect(result?.map((s) => s.version), ['3.16.0']);
+      },
+    );
+
+    test('empty when fromVersion and toVersion are the same', () {
+      final result = sectionsBetween(
+        sections,
+        fromVersion: '3.16.0',
+        toVersion: '3.16.0',
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('null when fromVersion is not a heading in the changelog', () {
+      final result = sectionsBetween(
+        sections,
+        fromVersion: '9.9.9',
+        toVersion: '3.16.0',
+      );
+
+      expect(result, isNull);
+    });
+
+    test('null when toVersion is not a heading in the changelog', () {
+      final result = sectionsBetween(
+        sections,
+        fromVersion: '3.15.0',
+        toVersion: '9.9.9',
+      );
+
+      expect(result, isNull);
+    });
+
+    test('null when toVersion is older than fromVersion (misuse guard)', () {
+      final result = sectionsBetween(
+        sections,
+        fromVersion: '3.16.0',
+        toVersion: '3.15.0',
+      );
+
+      expect(result, isNull);
+    });
+  });
+
+  group('resolveNativeSdkChangelog', () {
+    Future<List<ChangelogSection>> fakeFetch(String repoSlug) async {
+      expect(repoSlug, NativeSdk.ios.repoSlug);
+      return parseChangelog(_iosSnippet);
+    }
+
+    test('resolves a normal bump to its sections', () async {
+      final result = await resolveNativeSdkChangelog(
+        NativeSdk.ios,
+        currentDeclaration: '~> 3.15.0',
+        targetVersion: '3.16.0',
+        fetchChangelog: fakeFetch,
+      );
+
+      expect(result.warning, isNull);
+      expect(result.sections?.map((s) => s.version), ['3.16.0']);
+    });
+
+    test(
+      'skips with a warning when there is no resolvable current version',
+      () async {
+        final result = await resolveNativeSdkChangelog(
+          NativeSdk.ios,
+          currentDeclaration: 'develop',
+          targetVersion: '3.16.0',
+          fetchChangelog: (_) async =>
+              throw StateError('fetchChangelog should not have been called'),
+        );
+
+        expect(result.sections, isNull);
+        expect(result.warning, contains('no resolvable current version'));
+      },
+    );
+
+    test(
+      'skips with a warning when neither version is found upstream',
+      () async {
+        final result = await resolveNativeSdkChangelog(
+          NativeSdk.ios,
+          currentDeclaration: '~> 1.0.0',
+          targetVersion: '3.16.0',
+          fetchChangelog: fakeFetch,
+        );
+
+        expect(result.sections, isNull);
+        expect(result.warning, contains('could not find'));
+      },
+    );
+  });
+}

--- a/tools/releaser/test/native_sdk_test.dart
+++ b/tools/releaser/test/native_sdk_test.dart
@@ -340,6 +340,26 @@ FetchContent_Declare(some_other_dep
     });
 
     test(
+      'on a patch branch, an already-pinned working tree is the target, '
+      'but does not trigger the "pinned" warning',
+      () async {
+        var onPinnedCalls = 0;
+        final target = await resolveNativeSdkTarget(
+          trigger: TriggerContext.patch,
+          override: null,
+          workingTreeDeclaration: '4.0.0',
+          fetchLatest: () =>
+              throw StateError('should not be called on a patch branch'),
+          releaseExists: (version) =>
+              throw StateError('should not be called with no override'),
+          onPinned: (_) => onPinnedCalls++,
+        );
+        expect(target, '4.0.0');
+        expect(onPinnedCalls, 0);
+      },
+    );
+
+    test(
       'on develop, no override means latest (and no releaseExists call)',
       () async {
         final target = await resolveNativeSdkTarget(

--- a/tools/releaser/test/native_sdk_test.dart
+++ b/tools/releaser/test/native_sdk_test.dart
@@ -207,7 +207,7 @@ FetchContent_Declare(some_other_dep
     });
   });
 
-  group('nativeSdkImpliedBump', () {
+  group('NativeSdkDelta.getImpliedBump', () {
     NativeSdkDelta delta({String? currentDeclaration, String? targetVersion}) =>
         NativeSdkDelta(
           sdk: NativeSdk.ios,
@@ -217,44 +217,48 @@ FetchContent_Declare(some_other_dep
 
     test('a minor native SDK bump implies a minor bump', () {
       expect(
-        nativeSdkImpliedBump(
-          delta(currentDeclaration: '3.10.0', targetVersion: '3.13.0'),
-        ),
+        delta(
+          currentDeclaration: '3.10.0',
+          targetVersion: '3.13.0',
+        ).getImpliedBump(),
         VersionBumpType.minor,
       );
     });
 
     test('a major native SDK bump implies a major bump', () {
       expect(
-        nativeSdkImpliedBump(
-          delta(currentDeclaration: '3.10.0', targetVersion: '4.0.0'),
-        ),
+        delta(
+          currentDeclaration: '3.10.0',
+          targetVersion: '4.0.0',
+        ).getImpliedBump(),
         VersionBumpType.major,
       );
     });
 
     test('a patch-only native SDK bump implies a patch bump', () {
       expect(
-        nativeSdkImpliedBump(
-          delta(currentDeclaration: '3.10.0', targetVersion: '3.10.5'),
-        ),
+        delta(
+          currentDeclaration: '3.10.0',
+          targetVersion: '3.10.5',
+        ).getImpliedBump(),
         VersionBumpType.patch,
       );
     });
 
     test('null with no target (no change this run)', () {
-      expect(nativeSdkImpliedBump(delta(currentDeclaration: '3.10.0')), isNull);
+      expect(delta(currentDeclaration: '3.10.0').getImpliedBump(), isNull);
     });
 
     test('null with no resolvable current version (never pinned before)', () {
-      expect(nativeSdkImpliedBump(delta(targetVersion: '3.13.0')), isNull);
+      expect(delta(targetVersion: '3.13.0').getImpliedBump(), isNull);
     });
 
     test('null when the target is not actually newer', () {
       expect(
-        nativeSdkImpliedBump(
-          delta(currentDeclaration: '3.13.0', targetVersion: '3.13.0'),
-        ),
+        delta(
+          currentDeclaration: '3.13.0',
+          targetVersion: '3.13.0',
+        ).getImpliedBump(),
         isNull,
       );
     });
@@ -290,6 +294,7 @@ FetchContent_Declare(some_other_dep
         final target = await resolveNativeSdkTarget(
           trigger: TriggerContext.mainline,
           override: '3.12.0',
+          workingTreeDeclaration: null,
           fetchLatest: () => Future.value('9.9.9'),
           releaseExists: (version) async => version == '3.12.0',
         );
@@ -302,6 +307,7 @@ FetchContent_Declare(some_other_dep
         resolveNativeSdkTarget(
           trigger: TriggerContext.mainline,
           override: 'not-a-real-version',
+          workingTreeDeclaration: null,
           fetchLatest: () => Future.value('9.9.9'),
           releaseExists: (version) async => false,
         ),
@@ -314,6 +320,7 @@ FetchContent_Declare(some_other_dep
       final target = await resolveNativeSdkTarget(
         trigger: TriggerContext.patch,
         override: null,
+        workingTreeDeclaration: null,
         fetchLatest: () => Future.value('9.9.9'),
         releaseExists: (version) =>
             throw StateError('should not be called with no override'),
@@ -325,6 +332,7 @@ FetchContent_Declare(some_other_dep
       final target = await resolveNativeSdkTarget(
         trigger: TriggerContext.patch,
         override: '3.12.1',
+        workingTreeDeclaration: null,
         fetchLatest: () => Future.value('9.9.9'),
         releaseExists: (version) async => true,
       );
@@ -337,6 +345,7 @@ FetchContent_Declare(some_other_dep
         final target = await resolveNativeSdkTarget(
           trigger: TriggerContext.mainline,
           override: null,
+          workingTreeDeclaration: null,
           fetchLatest: () => Future.value('3.13.0'),
           releaseExists: (version) =>
               throw StateError('should not be called with no override'),
@@ -349,11 +358,91 @@ FetchContent_Declare(some_other_dep
       final target = await resolveNativeSdkTarget(
         trigger: TriggerContext.preRelease,
         override: null,
+        workingTreeDeclaration: null,
         fetchLatest: () => Future.value('3.13.0'),
         releaseExists: (version) =>
             throw StateError('should not be called with no override'),
       );
       expect(target, '3.13.0');
+    });
+
+    test('a floating declaration still tracks the latest release', () async {
+      final target = await resolveNativeSdkTarget(
+        trigger: TriggerContext.mainline,
+        override: null,
+        workingTreeDeclaration: '~> 3',
+        fetchLatest: () => Future.value('3.13.0'),
+        releaseExists: (version) =>
+            throw StateError('should not be called with no override'),
+      );
+      expect(target, '3.13.0');
+    });
+
+    test(
+      'a pinned declaration is honoured without asking what is newest',
+      () async {
+        String? pinned;
+        final target = await resolveNativeSdkTarget(
+          trigger: TriggerContext.mainline,
+          override: null,
+          workingTreeDeclaration: '3.13.1',
+          fetchLatest: () => throw StateError(
+            'should not look for a newer release when pinned',
+          ),
+          releaseExists: (version) =>
+              throw StateError('should not be called with no override'),
+          onPinned: (pin) => pinned = pin,
+        );
+        expect(target, '3.13.1');
+        expect(pinned, '3.13.1', reason: 'the pin must be surfaced to a human');
+      },
+    );
+
+    test('an override beats a pin', () async {
+      String? pinned;
+      final target = await resolveNativeSdkTarget(
+        trigger: TriggerContext.mainline,
+        override: '3.16.0',
+        workingTreeDeclaration: '3.13.1',
+        fetchLatest: () => Future.value('9.9.9'),
+        releaseExists: (version) async => true,
+        onPinned: (pin) => pinned = pin,
+      );
+      expect(target, '3.16.0');
+      expect(pinned, isNull);
+    });
+  });
+
+  group('isPinnedDeclaration', () {
+    test('a complete version with no constraint operator is a pin', () {
+      // Gradle, CocoaPods, and a C++ GIT_TAG annotation respectively.
+      expect(isPinnedDeclaration('3.13.1'), isTrue);
+      expect(isPinnedDeclaration("'3.15.0'"), isTrue);
+      expect(isPinnedDeclaration('v1.4.0'), isTrue);
+    });
+
+    test('a full commit SHA is a pin', () {
+      expect(isPinnedDeclaration('a' * 40), isTrue);
+    });
+
+    test('a range or a moving ref is not a pin', () {
+      expect(isPinnedDeclaration('~> 3'), isFalse);
+      expect(isPinnedDeclaration('~> 3.15'), isFalse);
+      expect(isPinnedDeclaration('3+'), isFalse);
+      expect(isPinnedDeclaration('from: "3.0.0"'), isFalse);
+      expect(isPinnedDeclaration('branch: "develop"'), isFalse);
+      expect(isPinnedDeclaration('develop'), isFalse);
+      expect(isPinnedDeclaration('>= 3.0.0'), isFalse);
+    });
+
+    test('an incomplete version is a range, not a pin', () {
+      expect(isPinnedDeclaration('3'), isFalse);
+      expect(isPinnedDeclaration('3.15'), isFalse);
+    });
+
+    test('nothing declared is not a pin', () {
+      expect(isPinnedDeclaration(null), isFalse);
+      expect(isPinnedDeclaration('  '), isFalse);
     });
   });
 }

--- a/tools/releaser/test/native_sdk_test.dart
+++ b/tools/releaser/test/native_sdk_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 
 import 'package:releaser/native_sdk.dart';
 import 'package:releaser/trigger_context.dart';
+import 'package:releaser/version_bump.dart';
 
 const _iosPodspec = '''
 Pod::Spec.new do |s|
@@ -181,6 +182,104 @@ FetchContent_Declare(some_other_dep
 
     test('C++ is null with no content', () {
       expect(currentCppDeclaration(null), isNull);
+    });
+  });
+
+  group('normalizeVersion', () {
+    test('strips a CocoaPods constraint operator', () {
+      expect(normalizeVersion('~> 3.5.0'), '3.5.0');
+    });
+
+    test('pulls the version out of an SPM version argument', () {
+      expect(normalizeVersion('from: "3.0.0"'), '3.0.0');
+    });
+
+    test('is a no-op on an already-bare version', () {
+      expect(normalizeVersion('3.5.0'), '3.5.0');
+    });
+
+    test('null in, null out', () {
+      expect(normalizeVersion(null), isNull);
+    });
+
+    test('null when nothing semver-shaped is present', () {
+      expect(normalizeVersion('develop'), isNull);
+    });
+  });
+
+  group('nativeSdkImpliedBump', () {
+    NativeSdkDelta delta({String? currentDeclaration, String? targetVersion}) =>
+        NativeSdkDelta(
+          sdk: NativeSdk.ios,
+          targetVersion: targetVersion,
+          currentDeclaration: currentDeclaration,
+        );
+
+    test('a minor native SDK bump implies a minor bump', () {
+      expect(
+        nativeSdkImpliedBump(
+          delta(currentDeclaration: '3.10.0', targetVersion: '3.13.0'),
+        ),
+        VersionBumpType.minor,
+      );
+    });
+
+    test('a major native SDK bump implies a major bump', () {
+      expect(
+        nativeSdkImpliedBump(
+          delta(currentDeclaration: '3.10.0', targetVersion: '4.0.0'),
+        ),
+        VersionBumpType.major,
+      );
+    });
+
+    test('a patch-only native SDK bump implies a patch bump', () {
+      expect(
+        nativeSdkImpliedBump(
+          delta(currentDeclaration: '3.10.0', targetVersion: '3.10.5'),
+        ),
+        VersionBumpType.patch,
+      );
+    });
+
+    test('null with no target (no change this run)', () {
+      expect(nativeSdkImpliedBump(delta(currentDeclaration: '3.10.0')), isNull);
+    });
+
+    test('null with no resolvable current version (never pinned before)', () {
+      expect(nativeSdkImpliedBump(delta(targetVersion: '3.13.0')), isNull);
+    });
+
+    test('null when the target is not actually newer', () {
+      expect(
+        nativeSdkImpliedBump(
+          delta(currentDeclaration: '3.13.0', targetVersion: '3.13.0'),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('nativeSdkAggregateBump', () {
+    test('the highest bump across multiple deltas wins', () {
+      final deltas = [
+        NativeSdkDelta(
+          sdk: NativeSdk.ios,
+          currentDeclaration: '3.10.0',
+          targetVersion: '3.10.5', // patch
+        ),
+        NativeSdkDelta(
+          sdk: NativeSdk.android,
+          currentDeclaration: '3.10.0',
+          targetVersion: '4.0.0', // major
+        ),
+      ];
+
+      expect(nativeSdkAggregateBump(deltas), VersionBumpType.major);
+    });
+
+    test('null when nothing implies a bump', () {
+      expect(nativeSdkAggregateBump(const []), isNull);
     });
   });
 

--- a/tools/releaser/test/pr_resolution_test.dart
+++ b/tools/releaser/test/pr_resolution_test.dart
@@ -1,0 +1,67 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019-Present Datadog, Inc.
+
+import 'package:releaser/pr_resolution.dart';
+import 'package:test/test.dart';
+
+Future<ResolvedPr?> _neverCalled(String sha) =>
+    throw StateError('searchBySha should not have been called: $sha');
+
+void main() {
+  group('resolvePr', () {
+    test(
+      'parses a squash-merge (#N) suffix without calling searchBySha',
+      () async {
+        final resolved = await resolvePr(
+          'deadbeef',
+          'add frustration signal tracking (#482)',
+          _neverCalled,
+        );
+
+        expect(resolved?.number, 482);
+        expect(resolved?.title, 'add frustration signal tracking');
+      },
+    );
+
+    test('falls back to searchBySha when there is no suffix', () async {
+      final resolved = await resolvePr(
+        'deadbeef',
+        'add frustration signal tracking',
+        (sha) async {
+          expect(sha, 'deadbeef');
+          return const ResolvedPr(number: 17, title: 'From search');
+        },
+      );
+
+      expect(resolved?.number, 17);
+      expect(resolved?.title, 'From search');
+    });
+
+    test('returns null when searchBySha finds nothing', () async {
+      final resolved = await resolvePr(
+        'deadbeef',
+        'add frustration signal tracking',
+        (sha) async => null,
+      );
+
+      expect(resolved, isNull);
+    });
+  });
+
+  group('stripSquashSuffix', () {
+    test('strips a trailing (#N)', () {
+      expect(
+        stripSquashSuffix('add frustration signal tracking (#482)'),
+        'add frustration signal tracking',
+      );
+    });
+
+    test('is a no-op when there is no suffix', () {
+      expect(
+        stripSquashSuffix('add frustration signal tracking'),
+        'add frustration signal tracking',
+      );
+    });
+  });
+}

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-Present Datadog, Inc.
 
+import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
 import 'package:releaser/native_sdk.dart';
 import 'package:releaser/release_plan.dart';
@@ -9,6 +10,8 @@ import 'package:test/test.dart';
 import 'package:version/version.dart';
 
 import 'support/fixture_repo.dart';
+
+class MockNativeSdkGateways extends Mock implements NativeSdkGateways {}
 
 const _iosPodspecWithDatadogDependency = '''
 Pod::Spec.new do |s|
@@ -50,22 +53,14 @@ void main() {
   Future<ReleasePlan> plan(
     RunContext ctx, {
     Map<String, List<String>> published = const {},
-    Future<String> Function(String repoSlug)? fetchLatestNativeSdkVersion,
-    Future<String> Function(String repoSlug, String ref)? resolveCommitSha,
-    Future<bool> Function(String repoSlug, String version)? releaseExists,
+    NativeSdkGateways? gateways,
   }) async => computeReleasePlan(
     ctx,
     gitDir: await fixture.gitDir,
     publishedVersions: publishedAs(published),
-    nativeSdkGateways: NativeSdkGateways(
-      fetchLatest:
-          fetchLatestNativeSdkVersion ??
-          (repoSlug) => throw StateError('fetchLatest not stubbed'),
-      resolveCommitSha:
-          resolveCommitSha ??
-          (repoSlug, ref) => throw StateError('resolveCommitSha not stubbed'),
-      releaseExists: releaseExists ?? (repoSlug, version) async => true,
-    ),
+    // Nothing stubbed by default: reaching for the network in a test that
+    // didn't say to should fail the test, not pass quietly.
+    nativeSdkGateways: gateways ?? MockNativeSdkGateways(),
   );
 
   RunContext mainlineCtx({
@@ -300,7 +295,15 @@ void main() {
         );
         await fixture.commit('chore: add podspec fixture');
 
-        final result = await plan(mainlineCtx(iosSdkVersionOverride: '3.12.0'));
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.releaseExists(any(), any()),
+        ).thenAnswer((_) async => true);
+
+        final result = await plan(
+          mainlineCtx(iosSdkVersionOverride: '3.12.0'),
+          gateways: gateways,
+        );
         final names = result.packages.map((e) => e.package.name);
 
         expect(names, contains('datadog_flutter_plugin_ios'));
@@ -326,11 +329,17 @@ void main() {
           'chore: add a podspec fixture to a non-federated package',
         );
 
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.releaseExists(any(), any()),
+        ).thenAnswer((_) async => true);
+
         final result = await plan(
           mainlineCtx(
             requestedPackages: ['datadog_dio'],
             iosSdkVersionOverride: '3.12.0',
           ),
+          gateways: gateways,
         );
 
         // Explicitly requested, so it still appears in the plan -- just
@@ -461,12 +470,16 @@ void main() {
     test(
       'resolves a target, with no comparison against the current pin',
       () async {
+        // Stubbed for the iOS repo specifically -- asking about any other
+        // SDK is unstubbed, and so fails the test.
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.fetchLatest('DataDog/dd-sdk-ios'),
+        ).thenAnswer((_) async => '3.13.0');
+
         final result = await plan(
           mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
-          fetchLatestNativeSdkVersion: (repoSlug) async {
-            expect(repoSlug, 'DataDog/dd-sdk-ios');
-            return '3.13.0';
-          },
+          gateways: gateways,
         );
 
         final delta = result.packages.single.nativeSdkDeltas.single;
@@ -490,11 +503,17 @@ void main() {
         );
         await fixture.commit('chore: add Package.swift fixture');
 
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.releaseExists(any(), any()),
+        ).thenAnswer((_) async => true);
+
         final result = await plan(
           mainlineCtx(
             requestedPackages: ['datadog_flutter_plugin_ios'],
             iosSdkVersionOverride: '3.12.0',
           ),
+          gateways: gateways,
         );
 
         expect(
@@ -514,16 +533,22 @@ void main() {
       );
       await fixture.commit('chore: add CMakeLists fixture');
 
+      // Stubbed for this exact repo and ref: resolving anything else is
+      // unstubbed, and so fails the test.
+      final gateways = MockNativeSdkGateways();
+      when(
+        () => gateways.releaseExists(any(), any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => gateways.resolveCommitSha('DataDog/dd-sdk-cpp', 'v1.4.0'),
+      ).thenAnswer((_) async => 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2');
+
       final result = await plan(
         mainlineCtx(
           requestedPackages: ['datadog_flutter_plugin_desktop'],
           cppVersionOverride: 'v1.4.0',
         ),
-        resolveCommitSha: (repoSlug, ref) async {
-          expect(repoSlug, 'DataDog/dd-sdk-cpp');
-          expect(ref, 'v1.4.0');
-          return 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
-        },
+        gateways: gateways,
       );
 
       final delta = result.packages.single.nativeSdkDeltas.single;
@@ -552,12 +577,15 @@ void main() {
       );
       await fixture.commit('chore: float the constraint again post-release');
 
+      final gateways = MockNativeSdkGateways();
+      when(() => gateways.fetchLatest(any())).thenAnswer((_) async => '3.13.0');
+
       final result = await plan(
         mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
         published: {
           'datadog_flutter_plugin_ios': ['3.10.0'],
         },
-        fetchLatestNativeSdkVersion: (repoSlug) async => '3.13.0',
+        gateways: gateways,
       );
 
       final delta = result.packages.single.nativeSdkDeltas.single;
@@ -584,12 +612,15 @@ void main() {
       );
       await fixture.commit('chore: float the constraint again post-release');
 
+      final gateways = MockNativeSdkGateways();
+      when(() => gateways.fetchLatest(any())).thenAnswer((_) async => '3.13.0');
+
       final result = await plan(
         mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
         published: {
           'datadog_flutter_plugin_ios': ['3.10.0'],
         },
-        fetchLatestNativeSdkVersion: (repoSlug) async => '3.13.0',
+        gateways: gateways,
       );
 
       final packagePlan = result.packages.single;
@@ -600,6 +631,287 @@ void main() {
       expect(packagePlan.bumpLevel, VersionBumpType.minor);
       expect(packagePlan.newVersion, '3.11.0');
     });
+
+    test('a pin in the working tree is honoured without asking what is '
+        'newest, and still counts as a change', () async {
+      const iosPackage =
+          'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios';
+
+      fixture.writeFile(
+        '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+        "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '3.10.0'\nend\n",
+      );
+      await fixture.commit('chore: pin for the 3.10.0 release');
+      await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+      // Someone holds the dev line at 3.12.0 while working against it.
+      fixture.writeFile(
+        '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+        "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '3.12.0'\nend\n",
+      );
+      await fixture.commit('chore: hold the iOS SDK at 3.12.0');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
+        published: {
+          'datadog_flutter_plugin_ios': ['3.10.0'],
+        },
+        // Unstubbed: honouring a pin must not look for a newer release.
+      );
+
+      final packagePlan = result.packages.single;
+      expect(packagePlan.nativeSdkDeltas.single.targetVersion, '3.12.0');
+      // 3.10.0 -> 3.12.0 is still a real change for consumers.
+      expect(packagePlan.bumpLevel, VersionBumpType.minor);
+      expect(
+        packagePlan.warnings,
+        contains(allOf(contains('pinned at 3.12.0'), contains('iOS'))),
+      );
+    });
+
+    test('an override moves a pinned SDK anyway', () async {
+      const iosPackage =
+          'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios';
+
+      fixture.writeFile(
+        '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+        "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '3.10.0'\nend\n",
+      );
+      await fixture.commit('chore: hold the iOS SDK at 3.10.0');
+
+      final gateways = MockNativeSdkGateways();
+      when(
+        () => gateways.releaseExists(any(), any()),
+      ).thenAnswer((_) async => true);
+
+      final result = await plan(
+        mainlineCtx(
+          requestedPackages: ['datadog_flutter_plugin_ios'],
+          iosSdkVersionOverride: '3.16.0',
+        ),
+        gateways: gateways,
+      );
+
+      expect(
+        result.packages.single.nativeSdkDeltas.single.targetVersion,
+        '3.16.0',
+      );
+      expect(result.packages.single.warnings, isEmpty);
+      // Honouring an override must not also go asking what's newest.
+      verifyNever(() => gateways.fetchLatest(any()));
+    });
+
+    test(
+      'an unreadable baseline warns instead of silently adding nothing',
+      () async {
+        const androidPackage =
+            'packages/datadog_flutter_plugin/datadog_flutter_plugin_android';
+
+        // The pre-3.5 shape: a floating gradle constraint at the release tag.
+        fixture.writeFile(
+          '$androidPackage/android/build.gradle',
+          'ext.datadog_version = "3+"\n',
+        );
+        await fixture.commit('chore: the old floating android constraint');
+        await fixture.tag('datadog_flutter_plugin_android/v3.10.0');
+
+        fixture.writeFile(
+          '$androidPackage/android/build.gradle',
+          'ext.datadog_version = "3+"\n// touch\n',
+        );
+        await fixture.commit('chore: float again');
+
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.fetchLatest(any()),
+        ).thenAnswer((_) async => '3.13.0');
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_flutter_plugin_android']),
+          published: {
+            'datadog_flutter_plugin_android': ['3.10.0'],
+          },
+          gateways: gateways,
+        );
+
+        expect(
+          result.packages.single.warnings,
+          contains(allOf(contains('Android'), contains('"3+"'))),
+        );
+        // No bump signal from a baseline we can't read -- falls back to patch.
+        expect(result.packages.single.bumpLevel, VersionBumpType.patch);
+      },
+    );
+  });
+
+  group('native SDK baseline is the line being released', () {
+    const iosPackage =
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios';
+
+    String podspecPinnedAt(String version) =>
+        "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '$version'\nend\n";
+
+    test(
+      'a patch branch reads its own line\'s tag, not a newer line\'s',
+      () async {
+        // 3.10.x shipped iOS 3.10.0; a later 4.0.0 line moved to iOS 4.0.0.
+        // Reading 4.0.0's tag would compare against a disjoint branch -- and
+        // since 4.0.0 > the override, would report "no change" and wave a real
+        // minor bump through the patch-branch guard.
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('3.10.0'),
+        );
+        await fixture.commit('chore: pin for 3.10.0');
+        await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('4.0.0'),
+        );
+        await fixture.commit('chore: pin for 4.0.0');
+        await fixture.tag('datadog_flutter_plugin_ios/v4.0.0');
+
+        fixture.writeFile('$iosPackage/CHANGES', 'a fix');
+        await fixture.commit('fix: a cherry-picked fix');
+
+        final result = await plan(
+          RunContext(
+            repoRoot: fixture.root.path,
+            trigger: TriggerContext.patch,
+            currentBranch: 'release/datadog_flutter_plugin_ios/v3.10.x',
+          ),
+          published: {
+            'datadog_flutter_plugin_ios': ['3.10.0', '4.0.0'],
+          },
+        );
+
+        expect(
+          result.packages.single.nativeSdkDeltas.single.currentDeclaration,
+          '3.10.0',
+        );
+      },
+    );
+
+    test('a patch branch rejects an override implying a minor bump', () async {
+      fixture.writeFile(
+        '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+        podspecPinnedAt('3.10.0'),
+      );
+      await fixture.commit('chore: pin for 3.10.0');
+      await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+      fixture.writeFile('$iosPackage/CHANGES', 'a fix');
+      await fixture.commit('fix: a cherry-picked fix');
+
+      final gateways = MockNativeSdkGateways();
+      when(
+        () => gateways.releaseExists(any(), any()),
+      ).thenAnswer((_) async => true);
+
+      await expectLater(
+        plan(
+          RunContext(
+            repoRoot: fixture.root.path,
+            trigger: TriggerContext.patch,
+            currentBranch: 'release/datadog_flutter_plugin_ios/v3.10.x',
+            iosSdkVersionOverride: '3.16.0',
+          ),
+          published: {
+            'datadog_flutter_plugin_ios': ['3.10.0'],
+          },
+          gateways: gateways,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('minor change'),
+              contains('does not belong on a patch branch'),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test(
+      'a patch branch accepts an override implying only a patch bump',
+      () async {
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('3.10.0'),
+        );
+        await fixture.commit('chore: pin for 3.10.0');
+        await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+        fixture.writeFile('$iosPackage/CHANGES', 'a fix');
+        await fixture.commit('fix: a cherry-picked fix');
+
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.releaseExists(any(), any()),
+        ).thenAnswer((_) async => true);
+
+        final result = await plan(
+          RunContext(
+            repoRoot: fixture.root.path,
+            trigger: TriggerContext.patch,
+            currentBranch: 'release/datadog_flutter_plugin_ios/v3.10.x',
+            iosSdkVersionOverride: '3.10.4',
+          ),
+          published: {
+            'datadog_flutter_plugin_ios': ['3.10.0'],
+          },
+          gateways: gateways,
+        );
+
+        expect(result.packages.single.newVersion, '3.10.1');
+      },
+    );
+
+    test(
+      'mainline after a beta that already moved the pin still escalates',
+      () async {
+        // The mainline mirror of the bug that started all this: baselining at
+        // published.latest (the beta) makes the native major vanish, and a
+        // fix-only run ships 3.5.1 carrying a breaking native upgrade.
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('3.10.0'),
+        );
+        await fixture.commit('chore: pin for 3.5.0');
+        await fixture.tag('datadog_flutter_plugin_ios/v3.5.0');
+
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('4.0.0'),
+        );
+        await fixture.commit('chore: pin for the beta');
+        await fixture.tag('datadog_flutter_plugin_ios/v4.0.0-beta.1');
+
+        fixture.writeFile('$iosPackage/CHANGES', 'a fix');
+        await fixture.commit('fix: a small fix');
+
+        final gateways = MockNativeSdkGateways();
+        when(
+          () => gateways.fetchLatest(any()),
+        ).thenAnswer((_) async => '4.0.0');
+
+        final result = await plan(
+          mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
+          published: {
+            'datadog_flutter_plugin_ios': ['3.5.0', '4.0.0-beta.1'],
+          },
+          gateways: gateways,
+        );
+
+        final packagePlan = result.packages.single;
+        expect(packagePlan.nativeSdkDeltas.single.currentDeclaration, '3.10.0');
+        expect(packagePlan.bumpLevel, VersionBumpType.major);
+        expect(packagePlan.newVersion, '4.0.0');
+      },
+    );
   });
 
   group('missing tag for a published version', () {
@@ -668,6 +980,9 @@ void main() {
 
       expect(result.packages.single.newVersion, '2.1.3');
       expect(result.packages.single.bumpLevel, VersionBumpType.patch);
+      // The line's own last release, not the newest published anywhere --
+      // rendering "3.0.0 -> 2.1.3" names a version from another branch.
+      expect(result.packages.single.currentVersion, '2.1.2');
     });
 
     test(
@@ -759,10 +1074,15 @@ void main() {
       await fixture.commit('feat!: the federation rework');
     }
 
-    test('computes the target from the last stable release', () async {
-      // 3.5.0 + a breaking commit -> 4.0.0, then the label starts the counter.
-      // pubspec is never consulted for the target.
-      await breakingWorkSince3_5_0();
+    test('reads the target from pubspec, not from the commits', () async {
+      // Discriminating on purpose: only a `fix:` since 3.5.0, so a computed
+      // target would be 3.5.1. pubspec declares 4.0.0, and that wins.
+      await fixture.tag('datadog_flutter_plugin/v3.5.0');
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+        'a small fix',
+      );
+      await fixture.commit('fix: something small');
 
       final result = await plan(
         preReleaseCtx(prereleaseLabel: 'beta'),
@@ -773,6 +1093,31 @@ void main() {
 
       expect(result.packages.single.newVersion, '4.0.0-beta.1');
       expect(result.packages.single.bumpLevel, VersionBumpType.prerelease);
+      // Declaring a target ahead of the commits is the point of declaring
+      // one -- it must not be second-guessed.
+      expect(result.packages.single.warnings, isEmpty);
+    });
+
+    test('the declared target holds as the line progresses', () async {
+      // The regression that motivated all this: once a beta has absorbed the
+      // breaking change, a computed target collapses back onto the old
+      // stable line. A declared one can't.
+      await breakingWorkSince3_5_0();
+      await fixture.tag('datadog_flutter_plugin/v4.0.0-beta.1');
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+        'a fix after the first beta',
+      );
+      await fixture.commit('fix: tidy up after the beta');
+
+      final result = await plan(
+        preReleaseCtx(),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0', '4.0.0-beta.1'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '4.0.0-beta.2');
     });
 
     test('continues an existing counter', () async {
@@ -941,6 +1286,155 @@ void main() {
           ),
         ),
       );
+    });
+
+    test(
+      'a declared target that has already shipped stably is rejected',
+      () async {
+        await breakingWorkSince3_5_0();
+
+        await expectLater(
+          plan(
+            preReleaseCtx(prereleaseLabel: 'beta'),
+            published: {
+              'datadog_flutter_plugin': ['3.5.0', '4.0.0'],
+            },
+          ),
+          throwsA(
+            isA<StateError>()
+                .having(
+                  (e) => e.message,
+                  'names the package',
+                  contains('datadog_flutter_plugin'),
+                )
+                .having(
+                  (e) => e.message,
+                  'names the declared version',
+                  contains('4.0.0'),
+                )
+                .having(
+                  (e) => e.message,
+                  'says what to do',
+                  contains('bump pubspec.yaml'),
+                ),
+          ),
+        );
+      },
+    );
+
+    test('a declared target behind the newest stable is rejected', () async {
+      await breakingWorkSince3_5_0();
+
+      await expectLater(
+        plan(
+          preReleaseCtx(prereleaseLabel: 'beta'),
+          published: {
+            'datadog_flutter_plugin': ['3.5.0', '5.1.0'],
+          },
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'names the blocking release',
+            contains('5.1.0 is already published'),
+          ),
+        ),
+      );
+    });
+
+    test('one stale pubspec does not abort an --all run', () async {
+      // datadog_dio's pubspec is 2.3.0 and 2.3.0 is published, so it conflicts
+      // -- but nothing was committed against it, so it never reaches the
+      // check and the run plans datadog_flutter_plugin as normal.
+      await breakingWorkSince3_5_0();
+
+      final result = await plan(
+        preReleaseCtx(prereleaseLabel: 'beta', requestedPackages: const []),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0'],
+          'datadog_dio': ['2.3.0'],
+        },
+      );
+
+      final names = result.packages.map((e) => e.package.name);
+      expect(names, contains('datadog_flutter_plugin'));
+      expect(names, isNot(contains('datadog_dio')));
+    });
+
+    test('every offending package is reported in one error', () async {
+      // Both are explicitly requested, so both get past eligibility and both
+      // conflict -- the operator should see them together, not one per run.
+      await fixture.tag('datadog_dio/v2.3.0');
+      fixture.writeFile('packages/datadog_dio/CHANGES', 'work');
+      await fixture.commit('feat: dio work');
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/CHANGES',
+        'work',
+      );
+      await fixture.commit('feat: plugin work');
+
+      await expectLater(
+        plan(
+          preReleaseCtx(
+            prereleaseLabel: 'beta',
+            requestedPackages: const ['datadog_dio', 'datadog_flutter_plugin'],
+          ),
+          published: {
+            'datadog_dio': ['2.3.0'],
+            'datadog_flutter_plugin': ['4.0.0'],
+          },
+        ),
+        throwsA(
+          isA<StateError>()
+              .having((e) => e.message, 'lists dio', contains('datadog_dio'))
+              .having(
+                (e) => e.message,
+                'lists the plugin',
+                contains('datadog_flutter_plugin'),
+              ),
+        ),
+      );
+    });
+
+    test('warns when the declared target under-shoots the commits', () async {
+      // A breaking change landed, so the evidence says 4.0.0 -- but pubspec
+      // still declares the 3.x line. Ship as declared, and say so.
+      await breakingWorkSince3_5_0();
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin/pubspec.yaml',
+        'name: datadog_flutter_plugin\nversion: 3.6.0\n'
+            'environment:\n  sdk: ">=3.0.0 <4.0.0"\n',
+      );
+      await fixture.commit('chore: hold the 3.6 line');
+
+      final result = await plan(
+        preReleaseCtx(prereleaseLabel: 'beta'),
+        published: {
+          'datadog_flutter_plugin': ['3.5.0'],
+        },
+      );
+
+      expect(result.packages.single.newVersion, '3.6.0-beta.1');
+      expect(
+        result.packages.single.warnings,
+        contains(allOf(contains('targets 3.6.0'), contains('imply 4.0.0'))),
+      );
+    });
+
+    test('a never-published package gets no advisory', () async {
+      // lonely_ios has no stable release to measure an implied bump from.
+      fixture.writeFile('packages/lonely_ios/CHANGES', 'first work');
+      await fixture.commit('feat: the first release');
+
+      final result = await plan(
+        preReleaseCtx(
+          prereleaseLabel: 'beta',
+          requestedPackages: const ['lonely_ios'],
+        ),
+      );
+
+      expect(result.packages.single.newVersion, '1.0.0-beta.1');
+      expect(result.packages.single.warnings, isEmpty);
     });
   });
 

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -566,6 +566,40 @@ void main() {
       // working tree's current floating '~> 3'.
       expect(delta.currentDeclaration, '3.10.0');
     });
+
+    test('a minor native SDK bump escalates the package bump level even with '
+        'no qualifying commits of its own', () async {
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+            'datadog_flutter_plugin_ios.podspec',
+        "Pod::Spec.new do |s|\n  s.dependency 'DatadogCore', '3.10.0'\nend\n",
+      );
+      await fixture.commit('chore: pin for the 3.10.0 release');
+      await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+      fixture.writeFile(
+        'packages/datadog_flutter_plugin/datadog_flutter_plugin_ios/ios/'
+        'datadog_flutter_plugin_ios.podspec',
+        _iosPodspecWithDatadogDependency, // floats again, back to '~> 3'
+      );
+      await fixture.commit('chore: float the constraint again post-release');
+
+      final result = await plan(
+        mainlineCtx(requestedPackages: ['datadog_flutter_plugin_ios']),
+        published: {
+          'datadog_flutter_plugin_ios': ['3.10.0'],
+        },
+        fetchLatestNativeSdkVersion: (repoSlug) async => '3.13.0',
+      );
+
+      final packagePlan = result.packages.single;
+      // Nothing here is a qualifying commit (both are chores) -- absent
+      // the native SDK bump this would fall back to a patch, per
+      // _computeMainlinePlan's "explicitly requested with nothing
+      // detected" case.
+      expect(packagePlan.bumpLevel, VersionBumpType.minor);
+      expect(packagePlan.newVersion, '3.11.0');
+    });
   });
 
   group('missing tag for a published version', () {

--- a/tools/releaser/test/release_plan_test.dart
+++ b/tools/releaser/test/release_plan_test.dart
@@ -772,6 +772,14 @@ void main() {
         await fixture.commit('chore: pin for 4.0.0');
         await fixture.tag('datadog_flutter_plugin_ios/v4.0.0');
 
+        // Simulates checking out release/v3.10.x, which never saw the 4.0.0
+        // line's commit above -- this fixture's history is linear only
+        // because the test needs both tags reachable, not because a real
+        // 3.10.x branch would carry the 4.0.0 pin.
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('3.10.0'),
+        );
         fixture.writeFile('$iosPackage/CHANGES', 'a fix');
         await fixture.commit('fix: a cherry-picked fix');
 
@@ -834,6 +842,50 @@ void main() {
         ),
       );
     });
+
+    test(
+      'a patch branch rejects a major bump smuggled in via a cherry-picked '
+      'manifest edit, with no override involved',
+      () async {
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('3.10.0'),
+        );
+        await fixture.commit('chore: pin for 3.10.0');
+        await fixture.tag('datadog_flutter_plugin_ios/v3.10.0');
+
+        // A cherry-picked "fix" commit that also carries a manifest edit --
+        // e.g. it depends on a fix that only landed in the new native major.
+        fixture.writeFile(
+          '$iosPackage/ios/datadog_flutter_plugin_ios.podspec',
+          podspecPinnedAt('4.0.0'),
+        );
+        await fixture.commit('fix: needs the native fix from 4.0.0');
+
+        await expectLater(
+          plan(
+            RunContext(
+              repoRoot: fixture.root.path,
+              trigger: TriggerContext.patch,
+              currentBranch: 'release/datadog_flutter_plugin_ios/v3.10.x',
+            ),
+            published: {
+              'datadog_flutter_plugin_ios': ['3.10.0'],
+            },
+          ),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('major change'),
+                contains('does not belong on a patch branch'),
+              ),
+            ),
+          ),
+        );
+      },
+    );
 
     test(
       'a patch branch accepts an override implying only a patch bump',


### PR DESCRIPTION
### What and why?

Add support for generating a CHANGELOG for a package, based on the combined Conventional Commit message,  information contained in PRs, and the native CHANGELOG that is part of the upgrade.

Added a tool for testing the AI generation.

Output for Develop currently looks like this:
```
## 3.6.0

### Features

- Update to iOS SDK 3.17.0. For a complete list of changes, see the [iOS SDK CHANGELOG](https://github.com/DataDog/dd-sdk-ios/blob/HEAD/CHANGELOG.md).
  - Bumps minimum deployment targets to iOS 15.0, tvOS 15.0, and watchOS 9.0.
  - Adds `CrashReporting.Configuration.appHangBacktraceEnabled` to opt out of stack trace collection in App Hang errors while keeping Crash Reporting enabled.
  - Returns `nil` carrier info on iOS 16+ since `CTCarrier` is deprecated with no replacement.
  - Adds `disallowList` to `RUM.Configuration.URLSessionTracking` to exclude URLs from automatic RUM resource tracking, with `*` wildcard support.
  - Forwards `local_cache_hit` signal on RUM resources.
  - Fixes an `EXC_BREAKPOINT` crash that could occur when a log or RUM attribute's `encode(to:)` throws after partially encoding a value.
- Update to Android SDK 3.14.0. For a complete list of changes, see the [Android SDK CHANGELOG](https://github.com/DataDog/dd-sdk-android/blob/HEAD/CHANGELOG.md).
  - Adds partial RUM view updates support, reducing the payload size of view events sent to Datadog.
  - Adds APM client-side stats support via `statsComputationEnabled` in `TraceConfiguration`, enabling local aggregation of trace statistics.
  <snip>
### Fixes

- Fixes a potential crash (`SIGSEGV`) caused by a garbage-collected `Companion` object when using `setLogsEventMapper` on Android.
- Fixes WASM build failures caused by incorrect JS types in the tracing URL closure.

--- LLM cost summary ---

INFO:   claude-sonnet-4-6 (GroupedPrs): 605in + 94out = $0.0032
INFO:   claude-sonnet-4-6 (ChangelogEntryList(Android: Fix potential GC issue with Companion object)): 1197in + 57out = $0.0044
INFO:   claude-sonnet-4-6 (ChangelogEntryList(Web: Fix JS types in TracingUrl closure)): 1151in + 40out = $0.0041
INFO:   claude-sonnet-4-6 (Cleanup): 904in + 80out = $0.0039
INFO:   claude-sonnet-4-6 (NativeSdkChangelog(iOS)): 1128in + 213out = $0.0066
INFO:   claude-sonnet-4-6 (NativeSdkChangelog(Android)): 5269in + 528out = $0.0237
INFO:   Estimated cost: $0.0459 (6 LLM calls with 10254 input tokens, 1012 output tokens)
```

The number of changelog entries for native versions is a bit high, but we can see if we can tailor the prompt to get a slimmer set of results that only matter to Flutter in the future.

This PR also reworks how the Native SDK is determined after finding some edge cases as part of the release plan.  The plan now detects if the current SDK has "pinned" a specific version on the Native SDK - which can happen when we have an internal breaking change in one of the native SDKs and do not want to update to the next minor version.  When this happens, the release planner specifically does not upgrade that version of the native SDK.

Additionally, the native SDKs should now support release "lines", and look for the proper version of the last native SDK of the current "line" instead of the last version ever published.

### Review checklist

- [ ] This pull request has appropriate unit and / or integration tests 
- [ ] This pull request references a Github or JIRA issue
