### PR TITLE
fix(web): avoid createJSInteropWrapper crash in wasm dry-run

### DIFF
--- a/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/ddrum_web.dart
@@ -41,7 +41,7 @@ class DdRumWeb extends DdRumPlatform {
 
     _webPlugin = RumWebPluginImpl();
     final plugins = [
-      createJSInteropWrapper<RumWebPluginImpl>(_webPlugin!),
+      createRumWebPluginJs(_webPlugin!),
     ].toJS;
 
     DD_RUM?.init(

--- a/packages/datadog_flutter_plugin/lib/src/rum/web/rum_web_plugin.dart
+++ b/packages/datadog_flutter_plugin/lib/src/rum/web/rum_web_plugin.dart
@@ -12,7 +12,6 @@ import 'raw_events.dart';
 /// https://github.com/DataDog/browser-sdk/blob/bd6074ff1f33cb0b94acf7b6b7eae95180271475/packages/rum-core/src/domain/plugins.ts#L30
 ///
 /// Keep this class updated to match the original interface.
-@JSExport()
 abstract interface class RumWebPlugin {
   String get name;
 
@@ -28,7 +27,6 @@ abstract interface class RumWebPlugin {
   void onRumStart(OnRumStartOptions options) {}
 }
 
-@JSExport()
 class RumWebPluginImpl extends RumWebPlugin {
   @override
   String get name => 'DatadogFlutterWeb';
@@ -60,3 +58,18 @@ class RumWebPluginImpl extends RumWebPlugin {
 extension type OnRumStartOptions._(JSObject _) implements JSObject {
   external JSFunction addEvent;
 }
+
+@anonymous
+extension type _RumWebPluginJs._(JSObject _) implements JSObject {
+  external factory _RumWebPluginJs({
+    String name,
+    JSFunction getConfigurationTelemetry,
+    JSFunction onRumStart,
+  });
+}
+
+JSObject createRumWebPluginJs(RumWebPluginImpl plugin) => _RumWebPluginJs(
+      name: plugin.name,
+      getConfigurationTelemetry: plugin.getConfigurationTelemetry.toJS,
+      onRumStart: plugin.onRumStart.toJS,
+    );


### PR DESCRIPTION
## Summary

Fixes the wasm dry-run crash reported in #1127. The 3.5.1 fix (referenced in that issue) targeted the `allowedTracingUrls` `match:` closure in `ddrum_web.dart`, but bisection shows that was never the trigger — the crash persists even with that closure fully removed.

The actual trigger is:

```dart
createJSInteropWrapper<RumWebPluginImpl>(_webPlugin!)
```

`createJSInteropWrapper` (backed by `@JSExport` codegen in `dart:js_interop`) generates a `Function.toJS` conversion with no real source offset. `dart2wasm`'s dry-run diagnostic reporter (`_CollectingDiagnosticReporter.report` → `Component.getLocation`) isn't guarded against that sentinel offset (`-1`) and throws `RangeError` instead of reporting normally — aborting `flutter build web` even without `--wasm`, since Flutter runs this dry-run by default.

This likely also explains why an actual `--wasm` compile is unaffected (as noted in the issue thread): only the dry-run-only `DryRunSummarizer` path seems to eagerly resolve a location for every node.

## Change

Replace the `@JSExport`/`createJSInteropWrapper` wrapper for `RumWebPluginImpl` with a hand-written extension-type wrapper (`createRumWebPluginJs`) that tears off the real, user-authored methods directly (`plugin.name`, `plugin.getConfigurationTelemetry.toJS`, `plugin.onRumStart.toJS`). Same runtime behavior, but every node now has a proper source location, so the dry-run reporter no longer trips.

## Test plan

- [x] `flutter build web` (non-wasm target) in a downstream app with RUM + first-party hosts configured, previously crashing on 3.5.1 — now completes successfully.
- [x] The dry-run subsequently runs to completion and correctly reports an unrelated, genuine incompatibility elsewhere in the downstream app's dependency tree (`universal_html`'s `dart:html` usage), confirming the reporter itself works again rather than just having the crash suppressed.
- [x] `dart analyze` on the two changed files.

refs: #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)